### PR TITLE
feat(cloudfront): accept Resolvable&lt;ICertificate&gt; on DistributionBuilder

### DIFF
--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -4,6 +4,7 @@ import {
   type IOrigin,
   type AddBehaviorOptions,
 } from "aws-cdk-lib/aws-cloudfront";
+import { type ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type Bucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
 import { RemovalPolicy } from "aws-cdk-lib";
@@ -35,7 +36,7 @@ import { DISTRIBUTION_DEFAULTS } from "./defaults.js";
  */
 export interface DistributionBuilderProps extends Omit<
   DistributionProps,
-  "defaultBehavior" | "enableLogging"
+  "defaultBehavior" | "enableLogging" | "certificate"
 > {
   /**
    * Whether to automatically create an S3 bucket for CloudFront standard
@@ -53,6 +54,15 @@ export interface DistributionBuilderProps extends Omit<
    * bucket takes precedence.
    */
   accessLogging?: boolean;
+
+  /**
+   * The ACM certificate to associate with the distribution for HTTPS.
+   *
+   * Accepts a concrete {@link ICertificate} or a {@link Resolvable} —
+   * typically a {@link Ref} produced by a composed `@composurecdk/acm`
+   * certificate builder. The certificate must be issued in `us-east-1`.
+   */
+  certificate?: Resolvable<ICertificate>;
 
   /**
    * Options for the default cache behavior, excluding `origin`.
@@ -185,10 +195,12 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
 
     const {
       accessLogging,
+      certificate,
       defaultBehavior: userBehavior,
       recommendedAlarms: alarmConfig,
       ...distProps
     } = this.props;
+    const resolvedCertificate = certificate ? resolve(certificate, context ?? {}) : undefined;
     const {
       accessLogging: defaultAccessLogging,
       defaultBehavior: defaultBehavior,
@@ -217,6 +229,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
       ...cdkDefaults,
       ...accessLogProps,
       ...distProps,
+      ...(resolvedCertificate ? { certificate: resolvedCertificate } : {}),
       defaultBehavior: {
         ...defaultBehavior,
         ...userBehavior,

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -329,5 +329,64 @@ describe("DistributionBuilder", () => {
         }),
       });
     });
+
+    it("resolves certificate from context when using a Ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const cert = Certificate.fromCertificateArn(
+        stack,
+        "Cert",
+        "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+      );
+
+      const builder = createDistributionBuilder()
+        .origin(withBucketOrigin(stack))
+        .certificate(ref<{ certificate: typeof cert }>("tls").map((r) => r.certificate))
+        .domainNames(["example.com"])
+        .accessLogging(false);
+
+      const result = builder.build(stack, "TestDistribution", {
+        tls: { certificate: cert },
+      });
+
+      expect(result.distribution).toBeDefined();
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Aliases: ["example.com"],
+          ViewerCertificate: Match.objectLike({
+            AcmCertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+          }),
+        }),
+      });
+    });
+
+    it("accepts a concrete certificate without a Ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const cert = Certificate.fromCertificateArn(
+        stack,
+        "Cert",
+        "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+      );
+
+      const builder = createDistributionBuilder()
+        .origin(withBucketOrigin(stack))
+        .certificate(cert)
+        .domainNames(["example.com"])
+        .accessLogging(false);
+
+      const result = builder.build(stack, "TestDistribution");
+
+      expect(result.distribution).toBeDefined();
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          ViewerCertificate: Match.objectLike({
+            AcmCertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+          }),
+        }),
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to laazyj/composurecdk#21. Extends `DistributionBuilder` so `certificate` accepts a `Resolvable<ICertificate>`, enabling a CloudFront distribution to be composed directly with a `@composurecdk/acm` certificate builder via `ref()`. This was called out as the main known limitation of the ACM/Route 53 PR: the example there has to build the certificate eagerly before composing the CDN.

## Changes

- `DistributionBuilderProps` now omits `certificate` from `DistributionProps` and redeclares it as `Resolvable<ICertificate>`, consistent with how `origin` is already modelled on this builder.
- `build()` resolves the certificate through the composition context before constructing the `Distribution`.
- Concrete `ICertificate` values continue to work unchanged — the existing certificate test still passes.

## Test plan

- [x] `npx nx test cloudfront` — 39 tests pass (2 new: Ref-based certificate resolution, concrete certificate still supported)
- [x] `npm run verify` — lint, format, build, and full monorepo test suite all green
- [x] Existing `TLS 1.2 minimum protocol version` test continues to pass, proving the concrete-certificate path is untouched

## Notes

- Once merged, the `custom-domain-website` example from laazyj/composurecdk#21 can be simplified to compose the hosted zone, certificate, distribution, and records in a single `compose({ ... })` graph. Happy to open a small follow-up to do that sweep after both PRs land.
