### PR TITLE
refactor(examples): wire custom-domain-website as a single compose graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ If two components depend on each other, that is an architectural problem to be s
 | `@composurecdk/iam`        | IAM role and policy components                              |
 | `@composurecdk/apigateway` | API Gateway components                                      |
 | `@composurecdk/ec2`        | EC2 and VPC components                                      |
+| `@composurecdk/acm`        | ACM certificate components with DNS validation              |
+| `@composurecdk/route53`    | Route 53 hosted zones, records, and alias target helpers    |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,6 +1795,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@composurecdk/acm": {
+      "resolved": "packages/acm",
+      "link": true
+    },
     "node_modules/@composurecdk/apigateway": {
       "resolved": "packages/apigateway",
       "link": true
@@ -1825,6 +1829,10 @@
     },
     "node_modules/@composurecdk/logs": {
       "resolved": "packages/logs",
+      "link": true
+    },
+    "node_modules/@composurecdk/route53": {
+      "resolved": "packages/route53",
       "link": true
     },
     "node_modules/@composurecdk/s3": {
@@ -7750,6 +7758,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/acm": {
+      "name": "@composurecdk/acm",
+      "version": "0.3.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "aws-cdk-lib": "^2.245.0",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.2"
+      },
+      "peerDependencies": {
+        "@composurecdk/core": "^0.3.0",
+        "aws-cdk-lib": "^2.0.0",
+        "constructs": "^10.0.0"
+      }
+    },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
       "version": "0.3.0",
@@ -7852,12 +7877,14 @@
         "vitest": "^4.1.2"
       },
       "peerDependencies": {
+        "@composurecdk/acm": "^0.3.0",
         "@composurecdk/apigateway": "^0.3.0",
         "@composurecdk/cloudformation": "^0.3.0",
         "@composurecdk/cloudfront": "^0.3.0",
         "@composurecdk/cloudwatch": "^0.3.0",
         "@composurecdk/core": "^0.3.0",
         "@composurecdk/lambda": "^0.3.0",
+        "@composurecdk/route53": "^0.3.0",
         "@composurecdk/s3": "^0.3.0",
         "@composurecdk/sns": "^0.3.0"
       }
@@ -7883,6 +7910,23 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
+      "version": "0.3.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "aws-cdk-lib": "^2.245.0",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.2"
+      },
+      "peerDependencies": {
+        "@composurecdk/core": "^0.3.0",
+        "aws-cdk-lib": "^2.0.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "packages/route53": {
+      "name": "@composurecdk/route53",
       "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {

--- a/packages/acm/README.md
+++ b/packages/acm/README.md
@@ -1,0 +1,56 @@
+# @composurecdk/acm
+
+AWS Certificate Manager builder for [ComposureCDK](../../README.md).
+
+This package provides a fluent builder for ACM certificates with secure, AWS-recommended defaults and first-class DNS validation wiring. It wraps the CDK [Certificate](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager.Certificate.html) construct — refer to the CDK documentation for the full set of configurable properties.
+
+## Certificate Builder
+
+```ts
+import { createCertificateBuilder } from "@composurecdk/acm";
+import { createHostedZoneBuilder, type HostedZoneBuilderResult } from "@composurecdk/route53";
+import { compose, ref } from "@composurecdk/core";
+
+const zone = createHostedZoneBuilder().zoneName("example.com");
+const cert = createCertificateBuilder()
+  .domainName("example.com")
+  .subjectAlternativeNames(["www.example.com"])
+  .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone));
+
+compose({ zone, cert }, { zone: [], cert: ["zone"] }).build(stack, "Site");
+```
+
+Every [CertificateProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager.CertificateProps.html) property is available as a fluent setter on the builder.
+
+## Secure Defaults
+
+`createCertificateBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.
+
+| Property                     | Default                 | Rationale                                                                     |
+| ---------------------------- | ----------------------- | ----------------------------------------------------------------------------- |
+| `keyAlgorithm`               | `KeyAlgorithm.RSA_2048` | Broadest client and AWS service compatibility (CloudFront, API Gateway, ALB). |
+| `transparencyLoggingEnabled` | `true`                  | Required by modern browsers; enables public detection of mis-issuance.        |
+
+The defaults are exported as `CERTIFICATE_DEFAULTS` for visibility and testing:
+
+```ts
+import { CERTIFICATE_DEFAULTS } from "@composurecdk/acm";
+```
+
+## DNS Validation
+
+Email-based validation is not used by default — it blocks stack creation until a human clicks a link in an email. The builder requires one of:
+
+- `validationZone(zone)` — the hosted zone that owns every domain on the certificate.
+- `validationZones({ "apex.com": apexZone, "alt.net": altZone })` — when domains span multiple zones.
+- `validation(CertificateValidation.fromEmail())` — explicit opt-in to email validation (not recommended).
+
+`validationZone` / `validationZones` accept a `Resolvable<IHostedZone>`, so a hosted zone produced by a composed `@composurecdk/route53` component can be wired via `ref()`.
+
+## CloudFront certificates
+
+CloudFront viewer certificates must live in `us-east-1`. If your application stack is in another region, place the ACM certificate in a dedicated `us-east-1` stack (e.g. via `createStackBuilder()` with an `env`) and import it into the CloudFront stack through composed dependencies or cross-region references.
+
+## Examples
+
+- [StaticWebsiteStack](../examples/src/static-website/app.ts) — also consult the custom-domain variant for end-to-end ACM + Route53 + CloudFront composition.

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@composurecdk/acm",
+  "version": "0.3.0",
+  "description": "Composable AWS Certificate Manager builder with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/acm"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "peerDependencies": {
+    "@composurecdk/core": "^0.3.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "aws-cdk-lib": "^2.245.0",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/acm/src/certificate-builder.ts
+++ b/packages/acm/src/certificate-builder.ts
@@ -1,0 +1,188 @@
+import {
+  Certificate,
+  CertificateValidation,
+  type CertificateProps,
+} from "aws-cdk-lib/aws-certificatemanager";
+import type { IHostedZone } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { CERTIFICATE_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the ACM certificate builder.
+ *
+ * Extends the CDK {@link CertificateProps} with additional builder-specific
+ * options. The `validation` field is augmented by {@link validationZone} /
+ * {@link validationZones}, which accept {@link Resolvable} hosted zones for
+ * cross-component wiring (e.g. from `@composurecdk/route53`).
+ *
+ * If neither `validation`, `validationZone`, nor `validationZones` is set,
+ * the builder fails fast — falling back to ACM's email-based validation would
+ * stall stack creation waiting on a human to click a link.
+ */
+export interface CertificateBuilderProps extends CertificateProps {
+  /**
+   * The hosted zone used to automatically create DNS validation records
+   * for every domain on the certificate. Accepts a {@link Resolvable} so a
+   * zone from a {@link Lifecycle | composed} route53 component can be
+   * wired in via {@link ref}.
+   *
+   * Mutually exclusive with {@link validationZones} and {@link CertificateProps.validation}.
+   * When set, the builder configures
+   * {@link CertificateValidation.fromDns | CertificateValidation.fromDns(zone)}.
+   */
+  validationZone?: Resolvable<IHostedZone>;
+
+  /**
+   * A map of domain name to hosted zone, used when the apex and subject
+   * alternative names live in different zones. Each value accepts a
+   * {@link Resolvable}. When set, the builder configures
+   * {@link CertificateValidation.fromDnsMultiZone}.
+   *
+   * Mutually exclusive with {@link validationZone} and {@link CertificateProps.validation}.
+   */
+  validationZones?: Record<string, Resolvable<IHostedZone>>;
+}
+
+/**
+ * The build output of an {@link ICertificateBuilder}. Contains the CDK
+ * constructs created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface CertificateBuilderResult {
+  /** The ACM certificate construct created by the builder. */
+  certificate: Certificate;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS Certificate Manager
+ * certificate.
+ *
+ * Each configuration property from the CDK {@link CertificateProps} is
+ * exposed as an overloaded method: call with a value to set it (returns the
+ * builder for chaining), or call with no arguments to read the current value.
+ *
+ * Validation is DNS-based by default — set
+ * {@link CertificateBuilderProps.validationZone | validationZone} (or
+ * {@link CertificateBuilderProps.validationZones | validationZones}) with the
+ * hosted zone(s) that own the certificate's domains. Accepts a
+ * {@link Resolvable} so zones produced by a composed route53 component can
+ * be wired in via {@link ref}.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates
+ * an ACM certificate with the configured properties and returns a
+ * {@link CertificateBuilderResult}.
+ *
+ * ## CloudFront caveat
+ *
+ * CloudFront viewer certificates must live in `us-east-1`. Place the ACM
+ * component in a stack that targets `us-east-1` (the cheapest way is to
+ * compose a dedicated stack via `@composurecdk/cloudformation`).
+ *
+ * @example
+ * ```ts
+ * const cert = createCertificateBuilder()
+ *   .domainName("example.com")
+ *   .subjectAlternativeNames(["www.example.com"])
+ *   .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone));
+ * ```
+ */
+export type ICertificateBuilder = IBuilder<CertificateBuilderProps, CertificateBuilder>;
+
+class CertificateBuilder implements Lifecycle<CertificateBuilderResult> {
+  props: Partial<CertificateBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): CertificateBuilderResult {
+    const {
+      validationZone,
+      validationZones,
+      validation: userValidation,
+      ...certProps
+    } = this.props;
+
+    if (!certProps.domainName) {
+      throw new Error(
+        `CertificateBuilder "${id}" requires a domainName. ` +
+          `Call .domainName() with the fully-qualified domain.`,
+      );
+    }
+
+    if ([userValidation, validationZone, validationZones].filter(Boolean).length > 1) {
+      throw new Error(
+        `CertificateBuilder "${id}": 'validation', 'validationZone', and 'validationZones' ` +
+          `are mutually exclusive. Set exactly one.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    let validation: CertificateValidation;
+
+    if (userValidation) {
+      validation = userValidation;
+    } else if (validationZones) {
+      const resolvedZones = Object.fromEntries(
+        Object.entries(validationZones).map(([domain, zone]) => [
+          domain,
+          resolve(zone, resolvedContext),
+        ]),
+      );
+      validation = CertificateValidation.fromDnsMultiZone(resolvedZones);
+    } else if (validationZone) {
+      validation = CertificateValidation.fromDns(resolve(validationZone, resolvedContext));
+    } else {
+      throw new Error(
+        `CertificateBuilder "${id}" requires DNS validation to be configured. ` +
+          `Call .validationZone() with the hosted zone for the certificate's domain, ` +
+          `or .validationZones() when domains span multiple zones, ` +
+          `or .validation() to configure an explicit CertificateValidation. ` +
+          `Email validation is not enabled by default because it blocks stack creation.`,
+      );
+    }
+
+    const mergedProps = {
+      ...CERTIFICATE_DEFAULTS,
+      ...certProps,
+      validation,
+    } as CertificateProps;
+
+    const certificate = new Certificate(scope, id, mergedProps);
+
+    return { certificate };
+  }
+}
+
+/**
+ * Creates a new {@link ICertificateBuilder} for configuring an ACM certificate.
+ *
+ * This is the entry point for defining an ACM certificate component. The
+ * returned builder exposes every {@link CertificateBuilderProps} property as
+ * a fluent setter/getter and implements {@link Lifecycle} for use with
+ * {@link compose}.
+ *
+ * @returns A fluent builder for an ACM certificate.
+ *
+ * @example
+ * ```ts
+ * const cert = createCertificateBuilder()
+ *   .domainName("example.com")
+ *   .validationZone(zone);
+ *
+ * // Use standalone:
+ * const result = cert.build(stack, "SiteCert");
+ *
+ * // Or compose into a system:
+ * const system = compose(
+ *   { zone: createHostedZoneBuilder().zoneName("example.com"), cert },
+ *   { zone: [], cert: ["zone"] },
+ * );
+ * ```
+ */
+export function createCertificateBuilder(): ICertificateBuilder {
+  return Builder<CertificateBuilderProps, CertificateBuilder>(CertificateBuilder);
+}

--- a/packages/acm/src/defaults.ts
+++ b/packages/acm/src/defaults.ts
@@ -1,0 +1,26 @@
+import { KeyAlgorithm } from "aws-cdk-lib/aws-certificatemanager";
+import type { CertificateBuilderProps } from "./certificate-builder.js";
+
+/**
+ * Secure, AWS-recommended defaults applied to every ACM certificate built
+ * with {@link createCertificateBuilder}. Each property can be individually
+ * overridden via the builder's fluent API.
+ */
+export const CERTIFICATE_DEFAULTS: Partial<CertificateBuilderProps> = {
+  /**
+   * Use RSA-2048 as the key algorithm. Widest client/CDN compatibility
+   * (CloudFront, API Gateway, ALB) and sufficient for TLS 1.2 and 1.3.
+   * For newer workloads, `KeyAlgorithm.EC_PRIME256V1` offers smaller
+   * signatures at comparable security — override via `.keyAlgorithm()`.
+   * @see https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html#algorithms.title
+   */
+  keyAlgorithm: KeyAlgorithm.RSA_2048,
+
+  /**
+   * Publish certificates to the public Certificate Transparency (CT) logs.
+   * CT logging is required by modern browsers to trust a certificate and
+   * enables detection of mis-issuance.
+   * @see https://docs.aws.amazon.com/acm/latest/userguide/acm-bestpractices.html#best-practices-transparency
+   */
+  transparencyLoggingEnabled: true,
+};

--- a/packages/acm/src/index.ts
+++ b/packages/acm/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  createCertificateBuilder,
+  type CertificateBuilderProps,
+  type CertificateBuilderResult,
+  type ICertificateBuilder,
+} from "./certificate-builder.js";
+export { CERTIFICATE_DEFAULTS } from "./defaults.js";

--- a/packages/acm/test/certificate-builder.test.ts
+++ b/packages/acm/test/certificate-builder.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { CertificateValidation, KeyAlgorithm } from "aws-cdk-lib/aws-certificatemanager";
+import { PublicHostedZone } from "aws-cdk-lib/aws-route53";
+import { ref } from "@composurecdk/core";
+import { createCertificateBuilder } from "../src/certificate-builder.js";
+import { CERTIFICATE_DEFAULTS } from "../src/defaults.js";
+
+function newStack(): Stack {
+  const app = new App();
+  return new Stack(app, "TestStack");
+}
+
+function buildWithZone(
+  configureFn?: (builder: ReturnType<typeof createCertificateBuilder>) => void,
+): { template: Template; stack: Stack; zone: PublicHostedZone } {
+  const stack = newStack();
+  const zone = new PublicHostedZone(stack, "TestZone", { zoneName: "example.com" });
+  const builder = createCertificateBuilder().domainName("example.com").validationZone(zone);
+  configureFn?.(builder);
+  builder.build(stack, "TestCertificate");
+  return { template: Template.fromStack(stack), stack, zone };
+}
+
+describe("CertificateBuilder", () => {
+  describe("build", () => {
+    it("returns a CertificateBuilderResult with a certificate property", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+      const result = createCertificateBuilder()
+        .domainName("example.com")
+        .validationZone(zone)
+        .build(stack, "TestCertificate");
+
+      expect(result).toBeDefined();
+      expect(result.certificate).toBeDefined();
+    });
+
+    it("throws when domainName is not set", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+      expect(() =>
+        createCertificateBuilder().validationZone(zone).build(stack, "TestCertificate"),
+      ).toThrow(/requires a domainName/);
+    });
+
+    it("throws when no validation is configured", () => {
+      const stack = newStack();
+      expect(() =>
+        createCertificateBuilder().domainName("example.com").build(stack, "TestCertificate"),
+      ).toThrow(/requires DNS validation/);
+    });
+
+    it("throws when validation, validationZone, and validationZones are combined", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+      expect(() =>
+        createCertificateBuilder()
+          .domainName("example.com")
+          .validationZone(zone)
+          .validation(CertificateValidation.fromDns(zone))
+          .build(stack, "TestCertificate"),
+      ).toThrow(/mutually exclusive/);
+    });
+
+    it("resolves validationZone when supplied as a Ref via build context", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+
+      createCertificateBuilder()
+        .domainName("example.com")
+        .validationZone(ref("zone", (r: { hostedZone: PublicHostedZone }) => r.hostedZone))
+        .build(stack, "TestCertificate", { zone: { hostedZone: zone } });
+
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
+    });
+  });
+
+  describe("synthesised output", () => {
+    it("creates exactly one ACM certificate", () => {
+      const { template } = buildWithZone();
+      template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
+    });
+
+    it("uses DNS validation wired to the provided hosted zone", () => {
+      const { template } = buildWithZone();
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        ValidationMethod: "DNS",
+        DomainValidationOptions: Match.arrayWith([
+          Match.objectLike({
+            DomainName: "example.com",
+            HostedZoneId: Match.anyValue(),
+          }),
+        ]),
+      });
+    });
+
+    it("applies the RSA_2048 key algorithm default", () => {
+      const { template } = buildWithZone();
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        KeyAlgorithm: "RSA_2048",
+      });
+      expect(CERTIFICATE_DEFAULTS.keyAlgorithm).toBe(KeyAlgorithm.RSA_2048);
+    });
+
+    it("includes subject alternative names when provided", () => {
+      const { template } = buildWithZone((b) => {
+        b.subjectAlternativeNames(["www.example.com", "api.example.com"]);
+      });
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        SubjectAlternativeNames: ["www.example.com", "api.example.com"],
+      });
+    });
+
+    it("supports multi-zone validation", () => {
+      const stack = newStack();
+      const apex = new PublicHostedZone(stack, "Apex", { zoneName: "example.com" });
+      const other = new PublicHostedZone(stack, "Other", { zoneName: "example.net" });
+
+      createCertificateBuilder()
+        .domainName("example.com")
+        .subjectAlternativeNames(["www.example.net"])
+        .validationZones({
+          "example.com": apex,
+          "www.example.net": other,
+        })
+        .build(stack, "MultiCert");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        DomainValidationOptions: Match.arrayWith([
+          Match.objectLike({ DomainName: "example.com" }),
+          Match.objectLike({ DomainName: "www.example.net" }),
+        ]),
+      });
+    });
+
+    it("allows overriding defaults via the fluent API", () => {
+      const { template } = buildWithZone((b) => {
+        b.keyAlgorithm(KeyAlgorithm.EC_PRIME256V1);
+        b.transparencyLoggingEnabled(false);
+      });
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        KeyAlgorithm: "EC_prime256v1",
+        CertificateTransparencyLoggingPreference: "DISABLED",
+      });
+    });
+  });
+});

--- a/packages/acm/tsconfig.build.json
+++ b/packages/acm/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/acm/tsconfig.json
+++ b/packages/acm/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -4,6 +4,7 @@ import {
   type IOrigin,
   type AddBehaviorOptions,
 } from "aws-cdk-lib/aws-cloudfront";
+import { type ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type Bucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
 import { RemovalPolicy } from "aws-cdk-lib";
@@ -35,7 +36,7 @@ import { DISTRIBUTION_DEFAULTS } from "./defaults.js";
  */
 export interface DistributionBuilderProps extends Omit<
   DistributionProps,
-  "defaultBehavior" | "enableLogging"
+  "defaultBehavior" | "enableLogging" | "certificate"
 > {
   /**
    * Whether to automatically create an S3 bucket for CloudFront standard
@@ -53,6 +54,15 @@ export interface DistributionBuilderProps extends Omit<
    * bucket takes precedence.
    */
   accessLogging?: boolean;
+
+  /**
+   * The ACM certificate to associate with the distribution for HTTPS.
+   *
+   * Accepts a concrete {@link ICertificate} or a {@link Resolvable} —
+   * typically a {@link Ref} produced by a composed `@composurecdk/acm`
+   * certificate builder. The certificate must be issued in `us-east-1`.
+   */
+  certificate?: Resolvable<ICertificate>;
 
   /**
    * Options for the default cache behavior, excluding `origin`.
@@ -185,10 +195,12 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
 
     const {
       accessLogging,
+      certificate,
       defaultBehavior: userBehavior,
       recommendedAlarms: alarmConfig,
       ...distProps
     } = this.props;
+    const resolvedCertificate = certificate ? resolve(certificate, context ?? {}) : undefined;
     const {
       accessLogging: defaultAccessLogging,
       defaultBehavior: defaultBehavior,
@@ -217,6 +229,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
       ...cdkDefaults,
       ...accessLogProps,
       ...distProps,
+      ...(resolvedCertificate ? { certificate: resolvedCertificate } : {}),
       defaultBehavior: {
         ...defaultBehavior,
         ...userBehavior,

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -329,5 +329,64 @@ describe("DistributionBuilder", () => {
         }),
       });
     });
+
+    it("resolves certificate from context when using a Ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const cert = Certificate.fromCertificateArn(
+        stack,
+        "Cert",
+        "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+      );
+
+      const builder = createDistributionBuilder()
+        .origin(withBucketOrigin(stack))
+        .certificate(ref<{ certificate: typeof cert }>("tls").map((r) => r.certificate))
+        .domainNames(["example.com"])
+        .accessLogging(false);
+
+      const result = builder.build(stack, "TestDistribution", {
+        tls: { certificate: cert },
+      });
+
+      expect(result.distribution).toBeDefined();
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Aliases: ["example.com"],
+          ViewerCertificate: Match.objectLike({
+            AcmCertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+          }),
+        }),
+      });
+    });
+
+    it("accepts a concrete certificate without a Ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const cert = Certificate.fromCertificateArn(
+        stack,
+        "Cert",
+        "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+      );
+
+      const builder = createDistributionBuilder()
+        .origin(withBucketOrigin(stack))
+        .certificate(cert)
+        .domainNames(["example.com"])
+        .accessLogging(false);
+
+      const result = builder.build(stack, "TestDistribution");
+
+      expect(result.distribution).toBeDefined();
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          ViewerCertificate: Match.objectLike({
+            AcmCertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+          }),
+        }),
+      });
+    });
   });
 });

--- a/packages/examples/bin/app.ts
+++ b/packages/examples/bin/app.ts
@@ -7,6 +7,7 @@ import { createMockApiApp } from "../src/mock-api-app.js";
 import { createMultiStackApp } from "../src/multi-stack-app.js";
 import { createOpenApiPetstoreApp } from "../src/openapi-petstore-app.js";
 import { createStaticWebsiteApp } from "../src/static-website/app.js";
+import { createCustomDomainWebsiteApp } from "../src/custom-domain-website/app.js";
 import { createStrategyStackApp } from "../src/strategy-stack-app.js";
 
 const app = new App();
@@ -18,6 +19,7 @@ createMockApiApp(app);
 createMultiStackApp(app);
 createOpenApiPetstoreApp(app);
 createStaticWebsiteApp(app);
+createCustomDomainWebsiteApp(app);
 createStrategyStackApp(app);
 
 app.synth();

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -22,12 +22,14 @@
     "constructs": "^10.6.0"
   },
   "peerDependencies": {
+    "@composurecdk/acm": "^0.3.0",
     "@composurecdk/apigateway": "^0.3.0",
     "@composurecdk/cloudformation": "^0.3.0",
     "@composurecdk/cloudwatch": "^0.3.0",
     "@composurecdk/cloudfront": "^0.3.0",
     "@composurecdk/core": "^0.3.0",
     "@composurecdk/lambda": "^0.3.0",
+    "@composurecdk/route53": "^0.3.0",
     "@composurecdk/s3": "^0.3.0",
     "@composurecdk/sns": "^0.3.0"
   },

--- a/packages/examples/src/custom-domain-website/app.ts
+++ b/packages/examples/src/custom-domain-website/app.ts
@@ -1,0 +1,107 @@
+import { App } from "aws-cdk-lib";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { compose, ref } from "@composurecdk/core";
+import { createStackBuilder, outputs } from "@composurecdk/cloudformation";
+import { createCertificateBuilder } from "@composurecdk/acm";
+import {
+  createDistributionBuilder,
+  type DistributionBuilderResult,
+} from "@composurecdk/cloudfront";
+import {
+  cloudfrontAliasTarget,
+  createAaaaRecordBuilder,
+  createARecordBuilder,
+  createHostedZoneBuilder,
+} from "@composurecdk/route53";
+
+/**
+ * A CloudFront distribution exposed at a custom domain name, backed by a
+ * Route 53 public hosted zone and an ACM certificate with DNS validation.
+ *
+ * Demonstrates:
+ * - Building a Route 53 hosted zone and an ACM certificate with DNS
+ *   validation wired to that zone.
+ * - Composing a CloudFront distribution plus apex A/AAAA alias records as a
+ *   single system — the records depend on the distribution, enforced by the
+ *   dependency graph.
+ * - Using the {@link cloudfrontAliasTarget} helper so the record targets are
+ *   produced at build time from the composed distribution.
+ *
+ * Note: CloudFront viewer certificates must live in `us-east-1`. This example
+ * places the whole stack in the default environment — in production, you'd
+ * either deploy the stack to `us-east-1` or split the certificate into a
+ * dedicated `us-east-1` stack and wire it across via cross-region references.
+ */
+export function createCustomDomainWebsiteApp(app = new App()) {
+  const { stack } = createStackBuilder()
+    .description("Static website at a custom domain with Route53 + ACM")
+    .build(app, "ComposureCDK-CustomDomainWebsiteStack");
+
+  const apexDomain = "example.com";
+  const wwwDomain = `www.${apexDomain}`;
+
+  // Route 53 hosted zone and ACM certificate are built eagerly — the
+  // CloudFront distribution builder accepts a concrete `ICertificate`, so we
+  // resolve the cert before handing it off.
+  const { hostedZone } = createHostedZoneBuilder()
+    .zoneName(apexDomain)
+    .comment("Primary customer-facing domain")
+    .build(stack, "Zone");
+
+  const { certificate } = createCertificateBuilder()
+    .domainName(apexDomain)
+    .subjectAlternativeNames([wwwDomain])
+    .validationZone(hostedZone)
+    .build(stack, "Certificate");
+
+  // The distribution and its apex alias records are wired through a composed
+  // system so the records are created only after the distribution exists.
+  compose(
+    {
+      cdn: createDistributionBuilder()
+        .comment("Custom-domain static website")
+        .domainNames([apexDomain, wwwDomain])
+        .certificate(certificate)
+        .origin(new HttpOrigin("origin.internal.example.net")),
+
+      apexA: createARecordBuilder()
+        .zone(hostedZone)
+        .target(
+          cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
+        ),
+
+      apexAaaa: createAaaaRecordBuilder()
+        .zone(hostedZone)
+        .target(
+          cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
+        ),
+    },
+    { cdn: [], apexA: ["cdn"], apexAaaa: ["cdn"] },
+  )
+    .afterBuild(
+      outputs({
+        DomainUrl: {
+          value: `https://${apexDomain}`,
+          description: "Customer-facing URL",
+        },
+        DistributionDomainName: {
+          value: ref(
+            "cdn",
+            (r: DistributionBuilderResult) => r.distribution.distributionDomainName,
+          ),
+          description: "CloudFront-assigned domain name (alias target)",
+        },
+        HostedZoneId: {
+          value: hostedZone.hostedZoneId,
+          description: "Route 53 hosted zone ID (for NS delegation)",
+        },
+        CertificateArn: {
+          value: certificate.certificateArn,
+          description: "ACM certificate ARN",
+        },
+      }),
+    )
+    .build(stack, "CustomDomainWebsite");
+
+  return { stack };
+}

--- a/packages/examples/src/custom-domain-website/app.ts
+++ b/packages/examples/src/custom-domain-website/app.ts
@@ -2,7 +2,7 @@ import { App } from "aws-cdk-lib";
 import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { compose, ref } from "@composurecdk/core";
 import { createStackBuilder, outputs } from "@composurecdk/cloudformation";
-import { createCertificateBuilder } from "@composurecdk/acm";
+import { createCertificateBuilder, type CertificateBuilderResult } from "@composurecdk/acm";
 import {
   createDistributionBuilder,
   type DistributionBuilderResult,
@@ -12,6 +12,7 @@ import {
   createAaaaRecordBuilder,
   createARecordBuilder,
   createHostedZoneBuilder,
+  type HostedZoneBuilderResult,
 } from "@composurecdk/route53";
 
 /**
@@ -19,12 +20,10 @@ import {
  * Route 53 public hosted zone and an ACM certificate with DNS validation.
  *
  * Demonstrates:
- * - Building a Route 53 hosted zone and an ACM certificate with DNS
- *   validation wired to that zone.
- * - Composing a CloudFront distribution plus apex A/AAAA alias records as a
- *   single system — the records depend on the distribution, enforced by the
- *   dependency graph.
- * - Using the {@link cloudfrontAliasTarget} helper so the record targets are
+ * - A single {@link compose} graph wiring a Route 53 hosted zone, an ACM
+ *   DNS-validated certificate, a CloudFront distribution, and apex A/AAAA
+ *   alias records — with every cross-component link declared as a {@link ref}.
+ * - The {@link cloudfrontAliasTarget} helper so the record targets are
  *   produced at build time from the composed distribution.
  *
  * Note: CloudFront viewer certificates must live in `us-east-1`. This example
@@ -40,43 +39,42 @@ export function createCustomDomainWebsiteApp(app = new App()) {
   const apexDomain = "example.com";
   const wwwDomain = `www.${apexDomain}`;
 
-  // Route 53 hosted zone and ACM certificate are built eagerly — the
-  // CloudFront distribution builder accepts a concrete `ICertificate`, so we
-  // resolve the cert before handing it off.
-  const { hostedZone } = createHostedZoneBuilder()
-    .zoneName(apexDomain)
-    .comment("Primary customer-facing domain")
-    .build(stack, "Zone");
-
-  const { certificate } = createCertificateBuilder()
-    .domainName(apexDomain)
-    .subjectAlternativeNames([wwwDomain])
-    .validationZone(hostedZone)
-    .build(stack, "Certificate");
-
-  // The distribution and its apex alias records are wired through a composed
-  // system so the records are created only after the distribution exists.
   compose(
     {
+      zone: createHostedZoneBuilder()
+        .zoneName(apexDomain)
+        .comment("Primary customer-facing domain"),
+
+      certificate: createCertificateBuilder()
+        .domainName(apexDomain)
+        .subjectAlternativeNames([wwwDomain])
+        .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone)),
+
       cdn: createDistributionBuilder()
         .comment("Custom-domain static website")
         .domainNames([apexDomain, wwwDomain])
-        .certificate(certificate)
+        .certificate(ref("certificate", (r: CertificateBuilderResult) => r.certificate))
         .origin(new HttpOrigin("origin.internal.example.net")),
 
       apexA: createARecordBuilder()
-        .zone(hostedZone)
+        .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
         .target(
           cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
         ),
 
       apexAaaa: createAaaaRecordBuilder()
-        .zone(hostedZone)
+        .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
         .target(
           cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
         ),
     },
-    { cdn: [], apexA: ["cdn"], apexAaaa: ["cdn"] },
+    {
+      zone: [],
+      certificate: ["zone"],
+      cdn: ["certificate"],
+      apexA: ["zone", "cdn"],
+      apexAaaa: ["zone", "cdn"],
+    },
   )
     .afterBuild(
       outputs({
@@ -92,11 +90,11 @@ export function createCustomDomainWebsiteApp(app = new App()) {
           description: "CloudFront-assigned domain name (alias target)",
         },
         HostedZoneId: {
-          value: hostedZone.hostedZoneId,
+          value: ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone.hostedZoneId),
           description: "Route 53 hosted zone ID (for NS delegation)",
         },
         CertificateArn: {
-          value: certificate.certificateArn,
+          value: ref("certificate", (r: CertificateBuilderResult) => r.certificate.certificateArn),
           description: "ACM certificate ARN",
         },
       }),

--- a/packages/examples/test/custom-domain-website-app.test.ts
+++ b/packages/examples/test/custom-domain-website-app.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { createCustomDomainWebsiteApp } from "../src/custom-domain-website/app.js";
+
+function synthTemplate(): Template {
+  const { stack } = createCustomDomainWebsiteApp();
+  return Template.fromStack(stack);
+}
+
+describe("custom-domain-website-app", () => {
+  describe("Route 53 hosted zone", () => {
+    it("creates exactly one public hosted zone for the apex", () => {
+      const template = synthTemplate();
+      template.resourceCountIs("AWS::Route53::HostedZone", 1);
+      template.hasResourceProperties("AWS::Route53::HostedZone", {
+        Name: "example.com.",
+      });
+    });
+
+    it("creates apex A and AAAA alias records pointing at the CloudFront distribution", () => {
+      const template = synthTemplate();
+      template.resourceCountIs("AWS::Route53::RecordSet", 2);
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Type: "A",
+        AliasTarget: Match.objectLike({
+          DNSName: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["DomainName"]) }),
+        }),
+      });
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Type: "AAAA",
+        AliasTarget: Match.objectLike({
+          DNSName: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["DomainName"]) }),
+        }),
+      });
+    });
+  });
+
+  describe("ACM certificate", () => {
+    it("creates a single DNS-validated certificate covering apex + www", () => {
+      const template = synthTemplate();
+      template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        DomainName: "example.com",
+        SubjectAlternativeNames: ["www.example.com"],
+        ValidationMethod: "DNS",
+      });
+    });
+  });
+
+  describe("CloudFront distribution", () => {
+    it("exposes both domain aliases and is wired to the ACM certificate", () => {
+      const template = synthTemplate();
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Aliases: ["example.com", "www.example.com"],
+          ViewerCertificate: Match.objectLike({
+            AcmCertificateArn: Match.anyValue(),
+          }),
+        }),
+      });
+    });
+  });
+
+  describe("stack", () => {
+    it("has a descriptive stack description", () => {
+      const template = synthTemplate();
+      expect(template.toJSON().Description).toBe(
+        "Static website at a custom domain with Route53 + ACM",
+      );
+    });
+  });
+});

--- a/packages/route53/README.md
+++ b/packages/route53/README.md
@@ -1,0 +1,103 @@
+# @composurecdk/route53
+
+Route 53 hosted zone and record builders for [ComposureCDK](../../README.md).
+
+This package provides fluent builders for Route 53 public hosted zones and for the record types most commonly needed when fronting an AWS workload (A/AAAA alias, CNAME, TXT). It wraps the CDK [aws-route53](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_route53-readme.html) constructs — refer to the CDK documentation for the full set of configurable properties.
+
+## Hosted Zone Builder
+
+```ts
+import { createHostedZoneBuilder } from "@composurecdk/route53";
+
+const zone = createHostedZoneBuilder()
+  .zoneName("example.com")
+  .comment("Primary customer-facing domain")
+  .build(stack, "SiteZone");
+```
+
+Every [PublicHostedZoneProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_route53.PublicHostedZoneProps.html) property is available as a fluent setter on the builder.
+
+### Query logging
+
+Route 53 query logs must be written to a CloudWatch log group in `us-east-1` with a resource policy granting `route53.amazonaws.com`. The builder does not auto-create this log group today — supply one via `.queryLogsLogGroupArn(arn)`.
+
+## Record Builders
+
+```ts
+import {
+  createARecordBuilder,
+  createAaaaRecordBuilder,
+  createCnameRecordBuilder,
+  createTxtRecordBuilder,
+  cloudfrontAliasTarget,
+} from "@composurecdk/route53";
+
+createARecordBuilder()
+  .zone(zone)
+  .target(cloudfrontAliasTarget(distribution))
+  .build(stack, "ApexAlias");
+
+createTxtRecordBuilder()
+  .zone(zone)
+  .recordName("_dmarc")
+  .values(["v=DMARC1; p=reject"])
+  .build(stack, "Dmarc");
+```
+
+### Alias targets
+
+For AWS-service alias records, prefer A/AAAA records with an alias target over CNAMEs. Alias records are free, work at the zone apex, and follow AWS-managed DNS changes automatically.
+
+| Helper                                | Points at                                        |
+| ------------------------------------- | ------------------------------------------------ |
+| `cloudfrontAliasTarget(distribution)` | A `cloudfront.IDistribution`                     |
+| `apiGatewayAliasTarget(api)`          | An `apigateway.RestApiBase` with a custom domain |
+| `apiGatewayDomainAliasTarget(domain)` | A shared `apigateway.DomainName`                 |
+
+Each helper accepts a `Resolvable`, so targets produced by other composed components (e.g. `@composurecdk/cloudfront`) can be wired in via `ref()`.
+
+## Secure Defaults
+
+| Builder                    | Property         | Default               | Rationale                                               |
+| -------------------------- | ---------------- | --------------------- | ------------------------------------------------------- |
+| `createHostedZoneBuilder`  | `addTrailingDot` | `true`                | Matches RFC 1035 and the CDK default; unambiguous apex. |
+| `createARecordBuilder`     | `ttl`            | `Duration.minutes(5)` | Balances propagation latency against DNS cache churn.   |
+| `createAaaaRecordBuilder`  | `ttl`            | `Duration.minutes(5)` | Same rationale as A records.                            |
+| `createCnameRecordBuilder` | `ttl`            | `Duration.minutes(5)` | Same rationale as A records.                            |
+| `createTxtRecordBuilder`   | `ttl`            | `Duration.minutes(5)` | Same rationale as A records.                            |
+
+The defaults are exported as `HOSTED_ZONE_DEFAULTS`, `A_RECORD_DEFAULTS`, `AAAA_RECORD_DEFAULTS`, `CNAME_RECORD_DEFAULTS`, and `TXT_RECORD_DEFAULTS` for visibility and testing.
+
+## Composing with ACM and CloudFront
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createCertificateBuilder, type CertificateBuilderResult } from "@composurecdk/acm";
+import {
+  createDistributionBuilder,
+  type DistributionBuilderResult,
+} from "@composurecdk/cloudfront";
+import {
+  createHostedZoneBuilder,
+  createARecordBuilder,
+  cloudfrontAliasTarget,
+  type HostedZoneBuilderResult,
+} from "@composurecdk/route53";
+
+compose(
+  {
+    zone: createHostedZoneBuilder().zoneName("example.com"),
+    cert: createCertificateBuilder()
+      .domainName("example.com")
+      .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone)),
+    cdn: createDistributionBuilder()
+      .domainNames(["example.com"])
+      .certificate(ref("cert", (r: CertificateBuilderResult) => r.certificate))
+      .origin(/* ... */),
+    apex: createARecordBuilder()
+      .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+      .target(cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution))),
+  },
+  { zone: [], cert: ["zone"], cdn: ["cert"], apex: ["zone", "cdn"] },
+).build(stack, "Site");
+```

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@composurecdk/route53",
+  "version": "0.3.0",
+  "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/route53"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "peerDependencies": {
+    "@composurecdk/core": "^0.3.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "aws-cdk-lib": "^2.245.0",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/route53/src/a-record-builder.ts
+++ b/packages/route53/src/a-record-builder.ts
@@ -1,0 +1,96 @@
+import {
+  ARecord,
+  type ARecordProps,
+  type IHostedZone,
+  type RecordTarget,
+} from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { A_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 A record builder.
+ *
+ * Extends the CDK {@link ARecordProps} but replaces `zone` and `target` with
+ * {@link Resolvable} variants so they can be wired from other components in a
+ * composed system via {@link ref}.
+ */
+export interface ARecordBuilderProps extends Omit<ARecordProps, "zone" | "target"> {
+  /**
+   * The hosted zone in which to create the record. Accepts a {@link Resolvable}
+   * so a zone produced by a composed {@link createHostedZoneBuilder} can be
+   * wired in via {@link ref}.
+   */
+  zone?: Resolvable<IHostedZone>;
+
+  /**
+   * The record target. Accepts a {@link Resolvable} so alias targets derived
+   * from composed components (e.g. a CloudFront distribution) can be wired in
+   * via {@link ref} or the helpers in `./alias-targets.js`.
+   */
+  target?: Resolvable<RecordTarget>;
+}
+
+/**
+ * The build output of an {@link IARecordBuilder}.
+ */
+export interface ARecordBuilderResult {
+  /** The Route53 A record construct created by the builder. */
+  record: ARecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 A record (typically
+ * an alias record pointing at a CloudFront distribution, ALB, API Gateway
+ * custom domain, or another A-record-capable target).
+ *
+ * @example
+ * ```ts
+ * const apex = createARecordBuilder()
+ *   .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+ *   .target(cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)));
+ * ```
+ */
+export type IARecordBuilder = IBuilder<ARecordBuilderProps, ARecordBuilder>;
+
+class ARecordBuilder implements Lifecycle<ARecordBuilderResult> {
+  props: Partial<ARecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): ARecordBuilderResult {
+    const { zone, target, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(`ARecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`);
+    }
+    if (!target) {
+      throw new Error(
+        `ARecordBuilder "${id}" requires a target. Call .target() with a RecordTarget.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...A_RECORD_DEFAULTS,
+      ...rest,
+      zone: resolve(zone, resolvedContext),
+      target: resolve(target, resolvedContext),
+    } as ARecordProps;
+
+    const record = new ARecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link IARecordBuilder} for configuring a Route53 A record.
+ *
+ * @returns A fluent builder for a Route53 A record.
+ */
+export function createARecordBuilder(): IARecordBuilder {
+  return Builder<ARecordBuilderProps, ARecordBuilder>(ARecordBuilder);
+}

--- a/packages/route53/src/aaaa-record-builder.ts
+++ b/packages/route53/src/aaaa-record-builder.ts
@@ -1,0 +1,85 @@
+import {
+  AaaaRecord,
+  type AaaaRecordProps,
+  type IHostedZone,
+  type RecordTarget,
+} from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { AAAA_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 AAAA (IPv6) record builder.
+ *
+ * Extends the CDK {@link AaaaRecordProps} but replaces `zone` and `target`
+ * with {@link Resolvable} variants so they can be wired from other components
+ * in a composed system.
+ */
+export interface AaaaRecordBuilderProps extends Omit<AaaaRecordProps, "zone" | "target"> {
+  /** The hosted zone in which to create the record. */
+  zone?: Resolvable<IHostedZone>;
+  /** The record target. */
+  target?: Resolvable<RecordTarget>;
+}
+
+/**
+ * The build output of an {@link IAaaaRecordBuilder}.
+ */
+export interface AaaaRecordBuilderResult {
+  /** The Route53 AAAA record construct created by the builder. */
+  record: AaaaRecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 AAAA (IPv6) record.
+ *
+ * Use this alongside an A record to expose a CloudFront distribution or ALB
+ * over both IPv4 and IPv6 — AWS alias targets support both families from a
+ * single resource.
+ */
+export type IAaaaRecordBuilder = IBuilder<AaaaRecordBuilderProps, AaaaRecordBuilder>;
+
+class AaaaRecordBuilder implements Lifecycle<AaaaRecordBuilderResult> {
+  props: Partial<AaaaRecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): AaaaRecordBuilderResult {
+    const { zone, target, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(
+        `AaaaRecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`,
+      );
+    }
+    if (!target) {
+      throw new Error(
+        `AaaaRecordBuilder "${id}" requires a target. Call .target() with a RecordTarget.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...AAAA_RECORD_DEFAULTS,
+      ...rest,
+      zone: resolve(zone, resolvedContext),
+      target: resolve(target, resolvedContext),
+    } as AaaaRecordProps;
+
+    const record = new AaaaRecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link IAaaaRecordBuilder} for configuring a Route53 AAAA
+ * (IPv6) record.
+ *
+ * @returns A fluent builder for a Route53 AAAA record.
+ */
+export function createAaaaRecordBuilder(): IAaaaRecordBuilder {
+  return Builder<AaaaRecordBuilderProps, AaaaRecordBuilder>(AaaaRecordBuilder);
+}

--- a/packages/route53/src/alias-targets.ts
+++ b/packages/route53/src/alias-targets.ts
@@ -1,0 +1,53 @@
+import { type IDistribution } from "aws-cdk-lib/aws-cloudfront";
+import { type IDomainName, type RestApiBase } from "aws-cdk-lib/aws-apigateway";
+import { RecordTarget } from "aws-cdk-lib/aws-route53";
+import { ApiGateway, ApiGatewayDomain, CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Builds an alias {@link RecordTarget} for a CloudFront distribution, usable
+ * as the `target` of an A or AAAA record. Accepts a {@link Resolvable} so a
+ * distribution produced by a composed `@composurecdk/cloudfront` component
+ * can be wired in via {@link ref}.
+ *
+ * @example
+ * ```ts
+ * createARecordBuilder()
+ *   .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+ *   .target(cloudfrontAliasTarget(
+ *     ref("cdn", (r: DistributionBuilderResult) => r.distribution),
+ *   ));
+ * ```
+ */
+export function cloudfrontAliasTarget(
+  distribution: Resolvable<IDistribution>,
+): Resolvable<RecordTarget> {
+  return isRef(distribution)
+    ? distribution.map((d) => RecordTarget.fromAlias(new CloudFrontTarget(d)))
+    : RecordTarget.fromAlias(new CloudFrontTarget(distribution));
+}
+
+/**
+ * Builds an alias {@link RecordTarget} for an API Gateway REST API that has a
+ * custom domain name configured via {@link RestApiBase}. Accepts a
+ * {@link Resolvable}.
+ */
+export function apiGatewayAliasTarget(api: Resolvable<RestApiBase>): Resolvable<RecordTarget> {
+  return isRef(api)
+    ? api.map((a) => RecordTarget.fromAlias(new ApiGateway(a)))
+    : RecordTarget.fromAlias(new ApiGateway(api));
+}
+
+/**
+ * Builds an alias {@link RecordTarget} for an API Gateway custom domain name
+ * (`apigateway.DomainName`). Use this when you manage the domain name resource
+ * separately from the REST API (e.g. to share a custom domain across multiple
+ * APIs). Accepts a {@link Resolvable}.
+ */
+export function apiGatewayDomainAliasTarget(
+  domain: Resolvable<IDomainName>,
+): Resolvable<RecordTarget> {
+  return isRef(domain)
+    ? domain.map((d) => RecordTarget.fromAlias(new ApiGatewayDomain(d)))
+    : RecordTarget.fromAlias(new ApiGatewayDomain(domain));
+}

--- a/packages/route53/src/cname-record-builder.ts
+++ b/packages/route53/src/cname-record-builder.ts
@@ -1,0 +1,86 @@
+import { CnameRecord, type CnameRecordProps, type IHostedZone } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { CNAME_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 CNAME record builder.
+ *
+ * Extends the CDK {@link CnameRecordProps} but replaces `zone` with a
+ * {@link Resolvable} so it can be wired from composed components.
+ */
+export interface CnameRecordBuilderProps extends Omit<CnameRecordProps, "zone"> {
+  /** The hosted zone in which to create the record. */
+  zone?: Resolvable<IHostedZone>;
+}
+
+/**
+ * The build output of an {@link ICnameRecordBuilder}.
+ */
+export interface CnameRecordBuilderResult {
+  /** The Route53 CNAME record construct created by the builder. */
+  record: CnameRecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 CNAME record.
+ *
+ * Prefer {@link createARecordBuilder | A / AAAA alias records} when pointing
+ * at AWS resources — alias records are free, resolve in one hop, and can be
+ * used at the apex. Use CNAME for non-AWS targets or for sub-domain
+ * redirections where an alias is not available.
+ */
+export type ICnameRecordBuilder = IBuilder<CnameRecordBuilderProps, CnameRecordBuilder>;
+
+class CnameRecordBuilder implements Lifecycle<CnameRecordBuilderResult> {
+  props: Partial<CnameRecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): CnameRecordBuilderResult {
+    const { zone, domainName, recordName, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(
+        `CnameRecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`,
+      );
+    }
+    if (!domainName) {
+      throw new Error(
+        `CnameRecordBuilder "${id}" requires a domainName. ` +
+          `Call .domainName() with the target host (what the CNAME points to).`,
+      );
+    }
+    if (!recordName) {
+      throw new Error(
+        `CnameRecordBuilder "${id}" requires a recordName. ` +
+          `Call .recordName() with the subdomain — CNAME records cannot be at the zone apex.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...CNAME_RECORD_DEFAULTS,
+      ...rest,
+      domainName,
+      recordName,
+      zone: resolve(zone, resolvedContext),
+    } as CnameRecordProps;
+
+    const record = new CnameRecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link ICnameRecordBuilder} for configuring a Route53 CNAME
+ * record.
+ *
+ * @returns A fluent builder for a Route53 CNAME record.
+ */
+export function createCnameRecordBuilder(): ICnameRecordBuilder {
+  return Builder<CnameRecordBuilderProps, CnameRecordBuilder>(CnameRecordBuilder);
+}

--- a/packages/route53/src/defaults.ts
+++ b/packages/route53/src/defaults.ts
@@ -1,0 +1,63 @@
+import { Duration } from "aws-cdk-lib";
+import type { HostedZoneBuilderProps } from "./hosted-zone-builder.js";
+import type { ARecordBuilderProps } from "./a-record-builder.js";
+import type { AaaaRecordBuilderProps } from "./aaaa-record-builder.js";
+import type { CnameRecordBuilderProps } from "./cname-record-builder.js";
+import type { TxtRecordBuilderProps } from "./txt-record-builder.js";
+
+/**
+ * Secure, AWS-recommended defaults applied to every public hosted zone built
+ * with {@link createHostedZoneBuilder}. Each property can be individually
+ * overridden via the builder's fluent API.
+ *
+ * Query logging is not enabled by default: Route53 query logs must be written
+ * to a CloudWatch log group in `us-east-1` with a resource policy granting
+ * `route53.amazonaws.com` write access. Opt in explicitly by calling
+ * `.queryLogsLogGroupArn(...)` with a pre-configured log group.
+ */
+export const HOSTED_ZONE_DEFAULTS: Partial<HostedZoneBuilderProps> = {
+  /**
+   * Add a trailing dot to the zone name so the apex is an unambiguous
+   * fully-qualified domain. Matches the CDK default and RFC 1035.
+   */
+  addTrailingDot: true,
+};
+
+/**
+ * Default TTL applied to records built by this package when no TTL is set.
+ *
+ * Five minutes balances propagation latency against downstream DNS cache
+ * churn. For alias records pointing at dynamic AWS resources (CloudFront,
+ * ALB), this matches AWS guidance.
+ *
+ * @see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-cloudfront-distribution.html
+ */
+const DEFAULT_RECORD_TTL = Duration.minutes(5);
+
+/**
+ * Defaults for {@link createARecordBuilder}. Overridable via the fluent API.
+ */
+export const A_RECORD_DEFAULTS: Partial<ARecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};
+
+/**
+ * Defaults for {@link createAaaaRecordBuilder}. Overridable via the fluent API.
+ */
+export const AAAA_RECORD_DEFAULTS: Partial<AaaaRecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};
+
+/**
+ * Defaults for {@link createCnameRecordBuilder}. Overridable via the fluent API.
+ */
+export const CNAME_RECORD_DEFAULTS: Partial<CnameRecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};
+
+/**
+ * Defaults for {@link createTxtRecordBuilder}. Overridable via the fluent API.
+ */
+export const TXT_RECORD_DEFAULTS: Partial<TxtRecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};

--- a/packages/route53/src/hosted-zone-builder.ts
+++ b/packages/route53/src/hosted-zone-builder.ts
@@ -1,0 +1,98 @@
+import { PublicHostedZone, type PublicHostedZoneProps } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { HOSTED_ZONE_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 public hosted zone builder.
+ *
+ * Aliases the CDK {@link PublicHostedZoneProps} so every zone property is
+ * available as a fluent setter on the builder. No additional builder-specific
+ * options are defined today — query logging requires a pre-configured log
+ * group (see {@link PublicHostedZoneProps.queryLogsLogGroupArn | queryLogsLogGroupArn})
+ * which the user supplies directly.
+ */
+export type HostedZoneBuilderProps = PublicHostedZoneProps;
+
+/**
+ * The build output of an {@link IHostedZoneBuilder}. Contains the CDK
+ * constructs created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface HostedZoneBuilderResult {
+  /** The Route53 public hosted zone construct created by the builder. */
+  hostedZone: PublicHostedZone;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 public hosted zone.
+ *
+ * Each configuration property from the CDK {@link PublicHostedZoneProps} is
+ * exposed as an overloaded method: call with a value to set it (returns the
+ * builder for chaining), or call with no arguments to read the current value.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates a
+ * public hosted zone with the configured properties and returns a
+ * {@link HostedZoneBuilderResult}.
+ *
+ * @example
+ * ```ts
+ * const zone = createHostedZoneBuilder()
+ *   .zoneName("example.com")
+ *   .comment("Primary customer-facing domain");
+ * ```
+ */
+export type IHostedZoneBuilder = IBuilder<HostedZoneBuilderProps, HostedZoneBuilder>;
+
+class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
+  props: Partial<HostedZoneBuilderProps> = {};
+
+  build(scope: IConstruct, id: string): HostedZoneBuilderResult {
+    if (!this.props.zoneName) {
+      throw new Error(
+        `HostedZoneBuilder "${id}" requires a zoneName. ` +
+          `Call .zoneName() with a fully-qualified domain.`,
+      );
+    }
+
+    const mergedProps = {
+      ...HOSTED_ZONE_DEFAULTS,
+      ...this.props,
+    } as PublicHostedZoneProps;
+
+    const hostedZone = new PublicHostedZone(scope, id, mergedProps);
+
+    return { hostedZone };
+  }
+}
+
+/**
+ * Creates a new {@link IHostedZoneBuilder} for configuring a Route53 public
+ * hosted zone.
+ *
+ * This is the entry point for defining a public hosted zone component. The
+ * returned builder exposes every {@link HostedZoneBuilderProps} property as a
+ * fluent setter/getter and implements {@link Lifecycle} for use with
+ * {@link compose}.
+ *
+ * @returns A fluent builder for a Route53 public hosted zone.
+ *
+ * @example
+ * ```ts
+ * const zone = createHostedZoneBuilder().zoneName("example.com");
+ *
+ * // Use standalone:
+ * const result = zone.build(stack, "SiteZone");
+ *
+ * // Or compose into a system:
+ * const system = compose(
+ *   { zone, cert: createCertificateBuilder()
+ *       .domainName("example.com")
+ *       .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone)) },
+ *   { zone: [], cert: ["zone"] },
+ * );
+ * ```
+ */
+export function createHostedZoneBuilder(): IHostedZoneBuilder {
+  return Builder<HostedZoneBuilderProps, HostedZoneBuilder>(HostedZoneBuilder);
+}

--- a/packages/route53/src/index.ts
+++ b/packages/route53/src/index.ts
@@ -1,0 +1,42 @@
+export {
+  createHostedZoneBuilder,
+  type HostedZoneBuilderProps,
+  type HostedZoneBuilderResult,
+  type IHostedZoneBuilder,
+} from "./hosted-zone-builder.js";
+export {
+  createARecordBuilder,
+  type ARecordBuilderProps,
+  type ARecordBuilderResult,
+  type IARecordBuilder,
+} from "./a-record-builder.js";
+export {
+  createAaaaRecordBuilder,
+  type AaaaRecordBuilderProps,
+  type AaaaRecordBuilderResult,
+  type IAaaaRecordBuilder,
+} from "./aaaa-record-builder.js";
+export {
+  createCnameRecordBuilder,
+  type CnameRecordBuilderProps,
+  type CnameRecordBuilderResult,
+  type ICnameRecordBuilder,
+} from "./cname-record-builder.js";
+export {
+  createTxtRecordBuilder,
+  type TxtRecordBuilderProps,
+  type TxtRecordBuilderResult,
+  type ITxtRecordBuilder,
+} from "./txt-record-builder.js";
+export {
+  cloudfrontAliasTarget,
+  apiGatewayAliasTarget,
+  apiGatewayDomainAliasTarget,
+} from "./alias-targets.js";
+export {
+  HOSTED_ZONE_DEFAULTS,
+  A_RECORD_DEFAULTS,
+  AAAA_RECORD_DEFAULTS,
+  CNAME_RECORD_DEFAULTS,
+  TXT_RECORD_DEFAULTS,
+} from "./defaults.js";

--- a/packages/route53/src/txt-record-builder.ts
+++ b/packages/route53/src/txt-record-builder.ts
@@ -1,0 +1,75 @@
+import { TxtRecord, type TxtRecordProps, type IHostedZone } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { TXT_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 TXT record builder.
+ *
+ * Extends the CDK {@link TxtRecordProps} but replaces `zone` with a
+ * {@link Resolvable} so it can be wired from composed components.
+ */
+export interface TxtRecordBuilderProps extends Omit<TxtRecordProps, "zone"> {
+  /** The hosted zone in which to create the record. */
+  zone?: Resolvable<IHostedZone>;
+}
+
+/**
+ * The build output of an {@link ITxtRecordBuilder}.
+ */
+export interface TxtRecordBuilderResult {
+  /** The Route53 TXT record construct created by the builder. */
+  record: TxtRecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 TXT record.
+ *
+ * Commonly used for SPF, DKIM, DMARC, and domain-verification tokens.
+ */
+export type ITxtRecordBuilder = IBuilder<TxtRecordBuilderProps, TxtRecordBuilder>;
+
+class TxtRecordBuilder implements Lifecycle<TxtRecordBuilderResult> {
+  props: Partial<TxtRecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): TxtRecordBuilderResult {
+    const { zone, values, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(
+        `TxtRecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`,
+      );
+    }
+    if (!values || values.length === 0) {
+      throw new Error(
+        `TxtRecordBuilder "${id}" requires non-empty values. ` +
+          `Call .values() with one or more TXT record strings.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...TXT_RECORD_DEFAULTS,
+      ...rest,
+      values,
+      zone: resolve(zone, resolvedContext),
+    } as TxtRecordProps;
+
+    const record = new TxtRecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link ITxtRecordBuilder} for configuring a Route53 TXT record.
+ *
+ * @returns A fluent builder for a Route53 TXT record.
+ */
+export function createTxtRecordBuilder(): ITxtRecordBuilder {
+  return Builder<TxtRecordBuilderProps, TxtRecordBuilder>(TxtRecordBuilder);
+}

--- a/packages/route53/test/a-record-builder.test.ts
+++ b/packages/route53/test/a-record-builder.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Distribution } from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { PublicHostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { compose, ref } from "@composurecdk/core";
+import { createARecordBuilder } from "../src/a-record-builder.js";
+import { cloudfrontAliasTarget } from "../src/alias-targets.js";
+import {
+  createHostedZoneBuilder,
+  type HostedZoneBuilderResult,
+} from "../src/hosted-zone-builder.js";
+
+describe("ARecordBuilder", () => {
+  it("throws when zone is not set", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    expect(() =>
+      createARecordBuilder().target(RecordTarget.fromValues("1.2.3.4")).build(stack, "TestRecord"),
+    ).toThrow(/requires a zone/);
+  });
+
+  it("throws when target is not set", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+    expect(() => createARecordBuilder().zone(zone).build(stack, "TestRecord")).toThrow(
+      /requires a target/,
+    );
+  });
+
+  it("synthesises a value A record with the configured TTL and values", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+
+    createARecordBuilder()
+      .zone(zone)
+      .recordName("api")
+      .target(RecordTarget.fromValues("1.2.3.4"))
+      .ttl(Duration.minutes(10))
+      .build(stack, "TestRecord");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "A",
+      Name: "api.example.com.",
+      ResourceRecords: ["1.2.3.4"],
+      TTL: "600",
+    });
+  });
+
+  it("synthesises a CloudFront alias record via the cloudfrontAliasTarget helper", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+    const distribution = new Distribution(stack, "Dist", {
+      defaultBehavior: { origin: new HttpOrigin("origin.example.net") },
+    });
+
+    createARecordBuilder()
+      .zone(zone)
+      .target(cloudfrontAliasTarget(distribution))
+      .build(stack, "ApexAlias");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "A",
+      AliasTarget: Match.objectLike({
+        DNSName: Match.objectLike({ "Fn::GetAtt": ["DistB3B78991", "DomainName"] }),
+      }),
+    });
+  });
+
+  it("resolves a Ref-based target when used inside compose()", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const distribution = new Distribution(stack, "Dist", {
+      defaultBehavior: { origin: new HttpOrigin("origin.example.net") },
+    });
+
+    compose(
+      {
+        zone: createHostedZoneBuilder().zoneName("example.com"),
+        apex: createARecordBuilder()
+          .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+          .target(cloudfrontAliasTarget(distribution)),
+      },
+      { zone: [], apex: ["zone"] },
+    ).build(stack, "Site");
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::Route53::HostedZone", 1);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "A",
+      AliasTarget: Match.objectLike({
+        DNSName: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["DomainName"]) }),
+      }),
+    });
+  });
+});

--- a/packages/route53/test/hosted-zone-builder.test.ts
+++ b/packages/route53/test/hosted-zone-builder.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { createHostedZoneBuilder } from "../src/hosted-zone-builder.js";
+
+function synth(configure: (b: ReturnType<typeof createHostedZoneBuilder>) => void): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createHostedZoneBuilder();
+  configure(builder);
+  builder.build(stack, "TestZone");
+  return Template.fromStack(stack);
+}
+
+describe("HostedZoneBuilder", () => {
+  it("throws when zoneName is not set", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    expect(() => createHostedZoneBuilder().build(stack, "TestZone")).toThrow(/requires a zoneName/);
+  });
+
+  it("returns a HostedZoneBuilderResult with a hostedZone property", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const result = createHostedZoneBuilder().zoneName("example.com").build(stack, "TestZone");
+    expect(result.hostedZone).toBeDefined();
+  });
+
+  it("synthesises a Route53 hosted zone with the provided zone name", () => {
+    const template = synth((b) => b.zoneName("example.com"));
+    template.resourceCountIs("AWS::Route53::HostedZone", 1);
+    template.hasResourceProperties("AWS::Route53::HostedZone", {
+      Name: "example.com.",
+    });
+  });
+
+  it("forwards the comment property", () => {
+    const template = synth((b) => {
+      b.zoneName("example.com");
+      b.comment("primary customer domain");
+    });
+    template.hasResourceProperties("AWS::Route53::HostedZone", {
+      HostedZoneConfig: { Comment: "primary customer domain" },
+    });
+  });
+
+  it("forwards a pre-configured query-log group ARN", () => {
+    const template = synth((b) => {
+      b.zoneName("example.com");
+      b.queryLogsLogGroupArn(
+        "arn:aws:logs:us-east-1:111122223333:log-group:/aws/route53/example.com",
+      );
+    });
+    template.hasResourceProperties("AWS::Route53::HostedZone", {
+      QueryLoggingConfig: {
+        CloudWatchLogsLogGroupArn:
+          "arn:aws:logs:us-east-1:111122223333:log-group:/aws/route53/example.com",
+      },
+    });
+  });
+});

--- a/packages/route53/test/record-variants.test.ts
+++ b/packages/route53/test/record-variants.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { PublicHostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { createAaaaRecordBuilder } from "../src/aaaa-record-builder.js";
+import { createCnameRecordBuilder } from "../src/cname-record-builder.js";
+import { createTxtRecordBuilder } from "../src/txt-record-builder.js";
+
+function setup(): { stack: Stack; zone: PublicHostedZone } {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+  return { stack, zone };
+}
+
+describe("AaaaRecordBuilder", () => {
+  it("synthesises an AAAA record", () => {
+    const { stack, zone } = setup();
+    createAaaaRecordBuilder()
+      .zone(zone)
+      .recordName("v6")
+      .target(RecordTarget.fromIpAddresses("2001:db8::1"))
+      .build(stack, "Aaaa");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "AAAA",
+      Name: "v6.example.com.",
+    });
+  });
+});
+
+describe("CnameRecordBuilder", () => {
+  it("requires a recordName", () => {
+    const { stack, zone } = setup();
+    expect(() =>
+      createCnameRecordBuilder().zone(zone).domainName("target.example.net").build(stack, "Cname"),
+    ).toThrow(/requires a recordName/);
+  });
+
+  it("requires a domainName", () => {
+    const { stack, zone } = setup();
+    expect(() =>
+      createCnameRecordBuilder().zone(zone).recordName("sub").build(stack, "Cname"),
+    ).toThrow(/requires a domainName/);
+  });
+
+  it("synthesises a CNAME record", () => {
+    const { stack, zone } = setup();
+    createCnameRecordBuilder()
+      .zone(zone)
+      .recordName("sub")
+      .domainName("target.example.net")
+      .build(stack, "Cname");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "CNAME",
+      Name: "sub.example.com.",
+      ResourceRecords: ["target.example.net"],
+    });
+  });
+});
+
+describe("TxtRecordBuilder", () => {
+  it("requires non-empty values", () => {
+    const { stack, zone } = setup();
+    expect(() => createTxtRecordBuilder().zone(zone).values([]).build(stack, "Txt")).toThrow(
+      /requires non-empty values/,
+    );
+  });
+
+  it("synthesises a TXT record", () => {
+    const { stack, zone } = setup();
+    createTxtRecordBuilder()
+      .zone(zone)
+      .recordName("_dmarc")
+      .values(["v=DMARC1; p=reject"])
+      .build(stack, "Txt");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "TXT",
+      Name: "_dmarc.example.com.",
+    });
+  });
+});

--- a/packages/route53/tsconfig.build.json
+++ b/packages/route53/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/route53/tsconfig.json
+++ b/packages/route53/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closing in favour of a replacement PR that consolidates `static-website` and `custom-domain-website` into a single example — the custom-domain wiring simplification shown here is preserved in the merged example.