### PR TITLE
feat(iam): add RoleBuilder, ManagedPolicyBuilder, and StatementBuilder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,6 +1819,10 @@
       "resolved": "packages/examples",
       "link": true
     },
+    "node_modules/@composurecdk/iam": {
+      "resolved": "packages/iam",
+      "link": true
+    },
     "node_modules/@composurecdk/lambda": {
       "resolved": "packages/lambda",
       "link": true
@@ -7860,6 +7864,23 @@
         "@composurecdk/lambda": "^0.3.0",
         "@composurecdk/s3": "^0.3.0",
         "@composurecdk/sns": "^0.3.0"
+      }
+    },
+    "packages/iam": {
+      "name": "@composurecdk/iam",
+      "version": "0.3.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "aws-cdk-lib": "^2.245.0",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.2"
+      },
+      "peerDependencies": {
+        "@composurecdk/core": "^0.3.0",
+        "aws-cdk-lib": "^2.0.0",
+        "constructs": "^10.0.0"
       }
     },
     "packages/lambda": {

--- a/packages/iam/README.md
+++ b/packages/iam/README.md
@@ -1,0 +1,91 @@
+# @composurecdk/iam
+
+IAM role, customer-managed policy, and policy-statement builders for [ComposureCDK](../../README.md).
+
+This package provides fluent builders for the most commonly configured IAM resources and centralises least-privilege guardrails so that consuming packages (Lambda, Budgets, SNS topic policies, …) do not have to reinvent them.
+
+## Role Builder
+
+```ts
+import { createRoleBuilder, createStatementBuilder } from "@composurecdk/iam";
+import { ServicePrincipal } from "aws-cdk-lib/aws-iam";
+
+const role = createRoleBuilder()
+  .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+  .description("Execution role for the budget remediation Lambda")
+  .addInlinePolicyStatements("StopEC2", [
+    createStatementBuilder()
+      .allow()
+      .actions(["ec2:StopInstances", "ec2:DescribeInstances"])
+      .resources(["*"])
+      .allowWildcardResources(true),
+  ])
+  .build(stack, "StopEC2Role");
+```
+
+Every [RoleProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_iam.RoleProps.html) property is available as a fluent setter. `permissionsBoundary` additionally accepts a `Resolvable<IManagedPolicy>` so a sibling component can supply a boundary policy via `ref(...)`.
+
+### Defaults
+
+| Property             | Default             | Rationale                                                                                                     |
+| -------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `maxSessionDuration` | `Duration.hours(1)` | Short-lived credentials reduce the blast radius of leaked sessions. See AWS Well-Architected Security pillar. |
+
+Exported as `ROLE_DEFAULTS`.
+
+### Result
+
+```ts
+interface RoleBuilderResult {
+  role: Role;
+  inlinePolicies: Record<string, PolicyDocument>; // keyed by the name passed to addInlinePolicyStatements
+}
+```
+
+Inline policies are embedded in the underlying `AWS::IAM::Role` resource via its native `Policies` array — no separate `AWS::IAM::Policy` resources are created.
+
+## Managed Policy Builder
+
+```ts
+import { createManagedPolicyBuilder } from "@composurecdk/iam";
+
+const boundary = createManagedPolicyBuilder()
+  .managedPolicyName("ops-boundary")
+  .addStatements([
+    createStatementBuilder()
+      .allow()
+      .actions(["s3:GetObject"])
+      .resources(["arn:aws:s3:::my-bucket/*"]),
+  ])
+  .build(stack, "OpsBoundary");
+```
+
+## Statement Builder
+
+`createStatementBuilder()` is a fluent wrapper around the CDK [PolicyStatement](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_iam.PolicyStatement.html). Unlike the other builders in this package it is **not** a `Lifecycle` — its `build()` method returns a `PolicyStatement` synchronously.
+
+### Wildcard guard
+
+By default, `Allow` statements with `resources: ["*"]` fail with `WildcardResourceError`. Opt in explicitly with `.allowWildcardResources(true)` when an action genuinely requires unrestricted scope (such as `ec2:DescribeInstances`, which does not support resource-level permissions).
+
+```ts
+createStatementBuilder()
+  .allow()
+  .actions(["ec2:DescribeInstances"])
+  .resources(["*"])
+  .allowWildcardResources(true);
+```
+
+## Service Role Helper
+
+```ts
+import { createServiceRoleBuilder } from "@composurecdk/iam";
+
+const lambdaRole = createServiceRoleBuilder("lambda.amazonaws.com")
+  .description("Execution role for StopEC2 Lambda")
+  .addInlinePolicyStatements("StopEC2", [
+    /* statements */
+  ]);
+```
+
+Thin sugar over `createRoleBuilder().assumedBy(new ServicePrincipal(...))`.

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@composurecdk/iam",
+  "version": "0.3.0",
+  "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/iam"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "peerDependencies": {
+    "@composurecdk/core": "^0.3.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "aws-cdk-lib": "^2.245.0",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -1,0 +1,13 @@
+export { createRoleBuilder, type IRoleBuilder, type RoleBuilderResult } from "./role-builder.js";
+export { ROLE_DEFAULTS } from "./role-defaults.js";
+export {
+  createManagedPolicyBuilder,
+  type IManagedPolicyBuilder,
+  type ManagedPolicyBuilderResult,
+} from "./managed-policy-builder.js";
+export { createServiceRoleBuilder } from "./service-role-builder.js";
+export {
+  createStatementBuilder,
+  StatementBuilder,
+  WildcardResourceError,
+} from "./statement-builder.js";

--- a/packages/iam/src/managed-policy-builder.ts
+++ b/packages/iam/src/managed-policy-builder.ts
@@ -1,0 +1,82 @@
+import { ManagedPolicy, type ManagedPolicyProps, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import type { IConstruct } from "constructs";
+import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { StatementBuilder } from "./statement-builder.js";
+
+/**
+ * Configuration properties for the customer-managed IAM policy builder.
+ *
+ * Extends the CDK {@link ManagedPolicyProps} unchanged — the builder adds
+ * an {@link IManagedPolicyBuilder.addStatements | addStatements} method that
+ * accepts either {@link PolicyStatement} or {@link StatementBuilder}.
+ */
+export type ManagedPolicyBuilderProps = ManagedPolicyProps;
+
+/**
+ * The build output of an {@link IManagedPolicyBuilder}.
+ */
+export interface ManagedPolicyBuilderResult {
+  /** The customer-managed policy created by the builder. */
+  policy: ManagedPolicy;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS IAM
+ * customer-managed policy.
+ *
+ * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_iam.ManagedPolicy.html
+ *
+ * @example
+ * ```ts
+ * const boundary = createManagedPolicyBuilder()
+ *   .managedPolicyName("ops-boundary")
+ *   .addStatements([
+ *     createStatementBuilder()
+ *       .allow()
+ *       .actions(["s3:GetObject"])
+ *       .resources(["arn:aws:s3:::my-bucket/*"]),
+ *   ]);
+ * ```
+ */
+export type IManagedPolicyBuilder = IBuilder<ManagedPolicyBuilderProps, ManagedPolicyBuilder>;
+
+class ManagedPolicyBuilder implements Lifecycle<ManagedPolicyBuilderResult> {
+  props: Partial<ManagedPolicyBuilderProps> = {};
+  private readonly _extraStatements: (PolicyStatement | StatementBuilder)[] = [];
+
+  /**
+   * Append policy statements to the managed policy.
+   *
+   * Accepts either {@link PolicyStatement} or {@link StatementBuilder}.
+   * Statement builders are resolved during {@link build} so wildcard-resource
+   * validation runs at the composition boundary.
+   */
+  addStatements(statements: (PolicyStatement | StatementBuilder)[]): this {
+    this._extraStatements.push(...statements);
+    return this;
+  }
+
+  build(scope: IConstruct, id: string): ManagedPolicyBuilderResult {
+    const resolvedExtras = this._extraStatements.map((s) =>
+      s instanceof StatementBuilder ? s.build() : s,
+    );
+
+    const mergedProps: ManagedPolicyProps = {
+      ...this.props,
+      statements: [...(this.props.statements ?? []), ...resolvedExtras],
+    };
+
+    const policy = new ManagedPolicy(scope, id, mergedProps);
+    return { policy };
+  }
+}
+
+/**
+ * Creates a new {@link IManagedPolicyBuilder} for configuring an AWS IAM
+ * customer-managed policy.
+ *
+ * @returns A fluent builder for a customer-managed policy.
+ */
+export function createManagedPolicyBuilder(): IManagedPolicyBuilder {
+  return Builder<ManagedPolicyBuilderProps, ManagedPolicyBuilder>(ManagedPolicyBuilder);
+}

--- a/packages/iam/src/role-builder.ts
+++ b/packages/iam/src/role-builder.ts
@@ -1,0 +1,187 @@
+import {
+  type IManagedPolicy,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  type RoleProps,
+} from "aws-cdk-lib/aws-iam";
+import type { IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { ROLE_DEFAULTS } from "./role-defaults.js";
+import { StatementBuilder } from "./statement-builder.js";
+
+/**
+ * Configuration properties for the IAM role builder.
+ *
+ * Extends the CDK {@link RoleProps} with builder-specific options for
+ * cross-component wiring: `permissionsBoundary` accepts a {@link Resolvable}
+ * so boundary policies built by sibling components can be referenced at
+ * configuration time.
+ */
+interface RoleBuilderProps extends Omit<RoleProps, "permissionsBoundary"> {
+  /**
+   * A permissions boundary that caps the maximum permissions this role
+   * can ever grant, regardless of inline or managed policies attached.
+   *
+   * Accepts a concrete {@link IManagedPolicy} or a {@link Resolvable} for
+   * cross-component wiring (e.g. `ref("boundary", r => r.policy)`).
+   *
+   * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+   */
+  permissionsBoundary?: Resolvable<IManagedPolicy>;
+}
+
+/**
+ * The build output of an {@link IRoleBuilder}.
+ *
+ * Exposes every CDK construct the builder creates so consumers can reference,
+ * extend, or attach additional policies to them.
+ */
+export interface RoleBuilderResult {
+  /** The IAM role construct created by the builder. */
+  role: Role;
+
+  /**
+   * Inline {@link PolicyDocument}s created for each
+   * {@link IRoleBuilder.addInlinePolicyStatements} call, keyed by the
+   * policy name supplied to the call.
+   *
+   * The documents are embedded in the underlying `AWS::IAM::Role`
+   * resource via the native `Policies` array — no separate
+   * `AWS::IAM::Policy` resources are created.
+   *
+   * Inline policies supplied directly via the native `inlinePolicies`
+   * prop on {@link RoleProps} do not appear in this map.
+   */
+  inlinePolicies: Record<string, PolicyDocument>;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS IAM role.
+ *
+ * Each configuration property from the CDK {@link RoleProps} is exposed as
+ * an overloaded method: call with a value to set it, or with no arguments
+ * to read the current value.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built it creates
+ * an IAM role with well-architected defaults ({@link ROLE_DEFAULTS}) and
+ * returns a {@link RoleBuilderResult}.
+ *
+ * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_iam.Role.html
+ *
+ * @example
+ * ```ts
+ * const role = createRoleBuilder()
+ *   .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+ *   .description("Execution role for the budget remediation Lambda")
+ *   .addInlinePolicyStatements("StopEC2", [
+ *     createStatementBuilder()
+ *       .allow()
+ *       .actions(["ec2:StopInstances", "ec2:DescribeInstances"])
+ *       .resources(["*"])
+ *       .allowWildcardResources(true)
+ *       .build(),
+ *   ]);
+ * ```
+ */
+export type IRoleBuilder = IBuilder<RoleBuilderProps, RoleBuilder>;
+
+interface InlinePolicyEntry {
+  name: string;
+  statements: (PolicyStatement | StatementBuilder)[];
+}
+
+class RoleBuilder implements Lifecycle<RoleBuilderResult> {
+  props: Partial<RoleBuilderProps> = {};
+  private readonly _inlinePolicies: InlinePolicyEntry[] = [];
+
+  /**
+   * Append an inline policy to the role, embedded in the underlying
+   * `AWS::IAM::Role` resource's `Policies` array. The policy name becomes
+   * the key under which the resulting {@link PolicyDocument} appears in
+   * {@link RoleBuilderResult.inlinePolicies}.
+   *
+   * Accepts either {@link PolicyStatement} instances or
+   * {@link StatementBuilder}s (which are built lazily during {@link build}
+   * so that wildcard-resource validation runs at the composition boundary
+   * rather than at configuration time).
+   */
+  addInlinePolicyStatements(
+    name: string,
+    statements: (PolicyStatement | StatementBuilder)[],
+  ): this {
+    this._inlinePolicies.push({ name, statements });
+    return this;
+  }
+
+  build(scope: IConstruct, id: string, context: Record<string, object> = {}): RoleBuilderResult {
+    const {
+      permissionsBoundary,
+      assumedBy,
+      inlinePolicies: propsInlinePolicies,
+      ...rest
+    } = this.props;
+
+    if (!assumedBy) {
+      throw new Error(
+        `RoleBuilder "${id}": assumedBy(...) must be called before build(). ` +
+          `An IAM role requires a trust policy principal.`,
+      );
+    }
+
+    const resolvedBoundary = permissionsBoundary
+      ? resolve(permissionsBoundary, context)
+      : undefined;
+
+    const addedInlinePolicies: Record<string, PolicyDocument> = {};
+    for (const entry of this._inlinePolicies) {
+      const resolvedStatements = entry.statements.map((s) =>
+        s instanceof StatementBuilder ? s.build() : s,
+      );
+      addedInlinePolicies[entry.name] = new PolicyDocument({ statements: resolvedStatements });
+    }
+
+    const mergedInlinePolicies: Record<string, PolicyDocument> = {
+      ...(propsInlinePolicies ?? {}),
+      ...addedInlinePolicies,
+    };
+
+    const mergedProps: RoleProps = {
+      ...ROLE_DEFAULTS,
+      ...rest,
+      assumedBy,
+      ...(Object.keys(mergedInlinePolicies).length > 0
+        ? { inlinePolicies: mergedInlinePolicies }
+        : {}),
+      ...(resolvedBoundary ? { permissionsBoundary: resolvedBoundary } : {}),
+    };
+
+    const role = new Role(scope, id, mergedProps);
+
+    return { role, inlinePolicies: addedInlinePolicies };
+  }
+}
+
+/**
+ * Creates a new {@link IRoleBuilder} for configuring an AWS IAM role.
+ *
+ * @returns A fluent builder for an AWS IAM role.
+ *
+ * @example
+ * ```ts
+ * const role = createRoleBuilder()
+ *   .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+ *   .description("Lambda execution role")
+ *   .build(stack, "LambdaRole");
+ * ```
+ */
+export function createRoleBuilder(): IRoleBuilder {
+  return Builder<RoleBuilderProps, RoleBuilder>(RoleBuilder);
+}

--- a/packages/iam/src/role-defaults.ts
+++ b/packages/iam/src/role-defaults.ts
@@ -1,0 +1,22 @@
+import { Duration } from "aws-cdk-lib";
+import type { RoleProps } from "aws-cdk-lib/aws-iam";
+
+/**
+ * Secure, AWS-recommended defaults applied to every IAM role built with
+ * {@link createRoleBuilder}. Each property can be individually overridden
+ * via the builder's fluent API.
+ */
+export const ROLE_DEFAULTS: Partial<RoleProps> = {
+  /**
+   * Cap the session duration to one hour by default.
+   *
+   * Short-lived credentials reduce the blast radius of leaked or misused
+   * role sessions. Callers that genuinely need longer sessions (for
+   * example, long-running batch jobs that assume the role once) should
+   * override via {@link IRoleBuilder.maxSessionDuration}.
+   *
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_permissions_define_guardrails.html
+   * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html
+   */
+  maxSessionDuration: Duration.hours(1),
+};

--- a/packages/iam/src/service-role-builder.ts
+++ b/packages/iam/src/service-role-builder.ts
@@ -1,0 +1,27 @@
+import { ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { createRoleBuilder, type IRoleBuilder } from "./role-builder.js";
+
+/**
+ * Creates a pre-configured {@link IRoleBuilder} whose trust policy allows
+ * the given AWS service principal to assume the role.
+ *
+ * Thin sugar over {@link createRoleBuilder} for the most common role shape:
+ * a service-assumable role (Lambda, EC2, Budgets, etc.) with no extra
+ * trust-policy conditions. Any property set by the caller afterwards
+ * (including `assumedBy`) still wins, because the underlying builder
+ * simply records the last value written.
+ *
+ * @param servicePrincipal - The service identifier, e.g.
+ *   `"lambda.amazonaws.com"` or `"budgets.amazonaws.com"`.
+ * @returns A role builder with `assumedBy` preset to the given service.
+ *
+ * @example
+ * ```ts
+ * const role = createServiceRoleBuilder("lambda.amazonaws.com")
+ *   .description("Execution role for StopEC2 Lambda")
+ *   .addInlinePolicyStatements("StopEC2", [ ... ]);
+ * ```
+ */
+export function createServiceRoleBuilder(servicePrincipal: string): IRoleBuilder {
+  return createRoleBuilder().assumedBy(new ServicePrincipal(servicePrincipal));
+}

--- a/packages/iam/src/statement-builder.ts
+++ b/packages/iam/src/statement-builder.ts
@@ -1,0 +1,178 @@
+import {
+  Effect,
+  type IPrincipal,
+  PolicyStatement,
+  type PolicyStatementProps,
+} from "aws-cdk-lib/aws-iam";
+
+/**
+ * Thrown when a {@link StatementBuilder} is built with an `Allow` effect and
+ * an unrestricted resource (`"*"`) without the caller having explicitly
+ * opted in via {@link StatementBuilder.allowWildcardResources}.
+ *
+ * Wildcard-resource allow statements grant the widest possible permission
+ * surface and should be an intentional choice, not an accident.
+ *
+ * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/permissions-management.html
+ */
+export class WildcardResourceError extends Error {
+  constructor(sid?: string) {
+    super(
+      `PolicyStatement${sid ? ` "${sid}"` : ""} has Effect=Allow with a wildcard resource ("*"). ` +
+        `Scope the resources or call allowWildcardResources(true) to opt in explicitly.`,
+    );
+    this.name = "WildcardResourceError";
+  }
+}
+
+/**
+ * Fluent wrapper around the CDK {@link PolicyStatement}.
+ *
+ * Unlike other ComposureCDK builders this one is **not** a
+ * {@link Lifecycle} — a policy statement is inline data attached to a Role,
+ * ManagedPolicy, or resource policy rather than a standalone CDK construct,
+ * so there is nothing to attach to a scope.
+ *
+ * The builder exists to:
+ * - centralise least-privilege validation (wildcard-resource guard,
+ *   {@link WildcardResourceError}),
+ * - give every consumer (Role, ManagedPolicy, SNS TopicPolicy, future
+ *   SQS/S3 bucket policies) one fluent API,
+ * - remain interchangeable with raw {@link PolicyStatement} instances via
+ *   {@link StatementBuilder.build}.
+ *
+ * @example
+ * ```ts
+ * const stmt = createStatementBuilder()
+ *   .sid("StopDevInstances")
+ *   .allow()
+ *   .actions(["ec2:StopInstances", "ec2:DescribeInstances"])
+ *   .resources(["*"])
+ *   .allowWildcardResources(true)
+ *   .build();
+ * ```
+ */
+export class StatementBuilder {
+  private _sid?: string;
+  private _effect: Effect = Effect.ALLOW;
+  private _actions: string[] = [];
+  private _notActions: string[] = [];
+  private _resources: string[] = [];
+  private _notResources: string[] = [];
+  private _principals: IPrincipal[] = [];
+  private _notPrincipals: IPrincipal[] = [];
+  private _conditions?: Record<string, Record<string, unknown>>;
+  private _allowWildcardResources = false;
+
+  sid(sid: string): this {
+    this._sid = sid;
+    return this;
+  }
+
+  allow(): this {
+    this._effect = Effect.ALLOW;
+    return this;
+  }
+
+  deny(): this {
+    this._effect = Effect.DENY;
+    return this;
+  }
+
+  effect(effect: Effect): this {
+    this._effect = effect;
+    return this;
+  }
+
+  actions(actions: string[]): this {
+    this._actions = [...actions];
+    return this;
+  }
+
+  notActions(actions: string[]): this {
+    this._notActions = [...actions];
+    return this;
+  }
+
+  resources(resources: string[]): this {
+    this._resources = [...resources];
+    return this;
+  }
+
+  notResources(resources: string[]): this {
+    this._notResources = [...resources];
+    return this;
+  }
+
+  principals(principals: IPrincipal[]): this {
+    this._principals = [...principals];
+    return this;
+  }
+
+  notPrincipals(principals: IPrincipal[]): this {
+    this._notPrincipals = [...principals];
+    return this;
+  }
+
+  conditions(conditions: Record<string, Record<string, unknown>>): this {
+    this._conditions = { ...conditions };
+    return this;
+  }
+
+  /**
+   * Opt in to Effect=Allow statements with wildcard resources (`"*"`).
+   *
+   * The builder rejects wildcard resources by default to surface
+   * least-privilege violations; call this to acknowledge that the
+   * statement genuinely needs unrestricted scope (for example actions
+   * such as `ec2:DescribeInstances` that do not support resource-level
+   * permissions).
+   *
+   * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html
+   */
+  allowWildcardResources(allow = true): this {
+    this._allowWildcardResources = allow;
+    return this;
+  }
+
+  /**
+   * Construct and return a {@link PolicyStatement} from the configured state.
+   *
+   * @throws {WildcardResourceError} when the statement is an Allow with a
+   *   wildcard resource and wildcard resources have not been opted in to.
+   */
+  build(): PolicyStatement {
+    if (
+      this._effect === Effect.ALLOW &&
+      !this._allowWildcardResources &&
+      this._resources.some((r) => r === "*")
+    ) {
+      throw new WildcardResourceError(this._sid);
+    }
+
+    const props: PolicyStatementProps = {
+      sid: this._sid,
+      effect: this._effect,
+      actions: this._actions.length > 0 ? this._actions : undefined,
+      notActions: this._notActions.length > 0 ? this._notActions : undefined,
+      resources: this._resources.length > 0 ? this._resources : undefined,
+      notResources: this._notResources.length > 0 ? this._notResources : undefined,
+      principals: this._principals.length > 0 ? this._principals : undefined,
+      notPrincipals: this._notPrincipals.length > 0 ? this._notPrincipals : undefined,
+      conditions: this._conditions,
+    };
+
+    return new PolicyStatement(props);
+  }
+}
+
+/**
+ * Creates a new {@link StatementBuilder} for configuring an IAM
+ * {@link PolicyStatement} with least-privilege guardrails.
+ *
+ * @returns A fluent builder that produces a {@link PolicyStatement} when
+ *   {@link StatementBuilder.build} is called.
+ */
+export function createStatementBuilder(): StatementBuilder {
+  return new StatementBuilder();
+}

--- a/packages/iam/test/managed-policy-builder.test.ts
+++ b/packages/iam/test/managed-policy-builder.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { createManagedPolicyBuilder } from "../src/managed-policy-builder.js";
+import { createStatementBuilder } from "../src/statement-builder.js";
+
+function synth(configureFn: (b: ReturnType<typeof createManagedPolicyBuilder>) => void): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createManagedPolicyBuilder();
+  configureFn(builder);
+  builder.build(stack, "TestPolicy");
+  return Template.fromStack(stack);
+}
+
+describe("ManagedPolicyBuilder", () => {
+  it("creates a customer-managed policy with the supplied statements", () => {
+    const template = synth((b) =>
+      b.managedPolicyName("ops-boundary").statements([
+        new PolicyStatement({
+          actions: ["s3:GetObject"],
+          resources: ["arn:aws:s3:::my-bucket/*"],
+        }),
+      ]),
+    );
+
+    template.resourceCountIs("AWS::IAM::ManagedPolicy", 1);
+    template.hasResourceProperties("AWS::IAM::ManagedPolicy", {
+      ManagedPolicyName: "ops-boundary",
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::my-bucket/*",
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("appends statements added via addStatements to those from props", () => {
+    const template = synth((b) =>
+      b
+        .statements([
+          new PolicyStatement({
+            actions: ["s3:GetObject"],
+            resources: ["arn:aws:s3:::bucket-a/*"],
+          }),
+        ])
+        .addStatements([
+          createStatementBuilder()
+            .allow()
+            .actions(["s3:PutObject"])
+            .resources(["arn:aws:s3:::bucket-b/*"]),
+        ]),
+    );
+
+    template.hasResourceProperties("AWS::IAM::ManagedPolicy", {
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({ Action: "s3:GetObject" }),
+          Match.objectLike({ Action: "s3:PutObject" }),
+        ]),
+      }),
+    });
+  });
+});

--- a/packages/iam/test/role-builder.test.ts
+++ b/packages/iam/test/role-builder.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { ManagedPolicy, PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { createRoleBuilder } from "../src/role-builder.js";
+import { createStatementBuilder, WildcardResourceError } from "../src/statement-builder.js";
+
+function synth(configureFn?: (builder: ReturnType<typeof createRoleBuilder>) => void): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createRoleBuilder().assumedBy(new ServicePrincipal("lambda.amazonaws.com"));
+  configureFn?.(builder);
+  builder.build(stack, "TestRole");
+  return Template.fromStack(stack);
+}
+
+describe("RoleBuilder", () => {
+  describe("build", () => {
+    it("returns a RoleBuilderResult with role and inlinePolicies fields", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createRoleBuilder()
+        .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+        .build(stack, "TestRole");
+
+      expect(result.role).toBeDefined();
+      expect(result.inlinePolicies).toEqual({});
+    });
+
+    it("throws when assumedBy is not configured", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const builder = createRoleBuilder();
+
+      expect(() => builder.build(stack, "TestRole")).toThrow(/assumedBy/);
+    });
+
+    it("creates exactly one IAM role", () => {
+      const template = synth();
+      template.resourceCountIs("AWS::IAM::Role", 1);
+    });
+  });
+
+  describe("defaults", () => {
+    it("caps max session duration at one hour by default", () => {
+      const template = synth();
+      template.hasResourceProperties("AWS::IAM::Role", {
+        MaxSessionDuration: 3600,
+      });
+    });
+
+    it("applies the trust policy from assumedBy", () => {
+      const template = synth();
+      template.hasResourceProperties("AWS::IAM::Role", {
+        AssumeRolePolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Principal: { Service: "lambda.amazonaws.com" },
+              Action: "sts:AssumeRole",
+            }),
+          ]),
+        }),
+      });
+    });
+
+    it("allows the caller to override maxSessionDuration", () => {
+      const template = synth((b) => b.maxSessionDuration(Duration.hours(4)));
+      template.hasResourceProperties("AWS::IAM::Role", {
+        MaxSessionDuration: 14400,
+      });
+    });
+  });
+
+  describe("addInlinePolicyStatements", () => {
+    it("embeds the statements in the Role as a truly inline policy", () => {
+      const template = synth((b) =>
+        b.addInlinePolicyStatements("StopEC2", [
+          new PolicyStatement({
+            actions: ["ec2:StopInstances"],
+            resources: ["*"],
+          }),
+        ]),
+      );
+
+      template.resourceCountIs("AWS::IAM::Policy", 0);
+      template.hasResourceProperties("AWS::IAM::Role", {
+        Policies: Match.arrayWith([
+          Match.objectLike({
+            PolicyName: "StopEC2",
+            PolicyDocument: Match.objectLike({
+              Statement: Match.arrayWith([
+                Match.objectLike({
+                  Effect: "Allow",
+                  Action: "ec2:StopInstances",
+                  Resource: "*",
+                }),
+              ]),
+            }),
+          }),
+        ]),
+      });
+    });
+
+    it("accepts StatementBuilders and resolves them at build time", () => {
+      const template = synth((b) =>
+        b.addInlinePolicyStatements("StopEC2", [
+          createStatementBuilder()
+            .allow()
+            .actions(["ec2:StopInstances", "ec2:DescribeInstances"])
+            .resources(["*"])
+            .allowWildcardResources(true),
+        ]),
+      );
+
+      template.hasResourceProperties("AWS::IAM::Role", {
+        Policies: Match.arrayWith([Match.objectLike({ PolicyName: "StopEC2" })]),
+      });
+    });
+
+    it("propagates StatementBuilder wildcard errors at build time", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const builder = createRoleBuilder()
+        .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+        .addInlinePolicyStatements("TooBroad", [
+          createStatementBuilder().allow().actions(["ec2:DescribeInstances"]).resources(["*"]),
+        ]);
+
+      expect(() => builder.build(stack, "TestRole")).toThrow(WildcardResourceError);
+    });
+
+    it("exposes each inline policy in the result, keyed by name", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createRoleBuilder()
+        .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+        .addInlinePolicyStatements("PolicyA", [
+          new PolicyStatement({ actions: ["s3:GetObject"], resources: ["*"] }),
+        ])
+        .addInlinePolicyStatements("PolicyB", [
+          new PolicyStatement({ actions: ["s3:PutObject"], resources: ["*"] }),
+        ])
+        .build(stack, "TestRole");
+
+      expect(Object.keys(result.inlinePolicies).sort()).toEqual(["PolicyA", "PolicyB"]);
+    });
+  });
+
+  describe("managed policies", () => {
+    it("attaches managed policies passed via managedPolicies", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const managed = ManagedPolicy.fromAwsManagedPolicyName(
+        "service-role/AWSLambdaBasicExecutionRole",
+      );
+      createRoleBuilder()
+        .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+        .managedPolicies([managed])
+        .build(stack, "TestRole");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::IAM::Role", {
+        ManagedPolicyArns: Match.arrayWith([
+          Match.objectLike({
+            "Fn::Join": Match.arrayWith([
+              Match.arrayWith([Match.stringLikeRegexp("AWSLambdaBasicExecutionRole")]),
+            ]),
+          }),
+        ]),
+      });
+    });
+  });
+});

--- a/packages/iam/test/statement-builder.test.ts
+++ b/packages/iam/test/statement-builder.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { Effect } from "aws-cdk-lib/aws-iam";
+import { createStatementBuilder, WildcardResourceError } from "../src/statement-builder.js";
+
+describe("StatementBuilder", () => {
+  describe("build", () => {
+    it("produces a PolicyStatement with the configured values", () => {
+      const stmt = createStatementBuilder()
+        .sid("AllowS3Read")
+        .allow()
+        .actions(["s3:GetObject"])
+        .resources(["arn:aws:s3:::my-bucket/*"])
+        .build();
+
+      const rendered = stmt.toJSON() as {
+        Sid: string;
+        Effect: string;
+        Action: string | string[];
+        Resource: string | string[];
+      };
+      expect(rendered.Sid).toBe("AllowS3Read");
+      expect(rendered.Effect).toBe("Allow");
+      expect(rendered.Action).toBe("s3:GetObject");
+      expect(rendered.Resource).toBe("arn:aws:s3:::my-bucket/*");
+    });
+
+    it("defaults Effect to Allow", () => {
+      const stmt = createStatementBuilder()
+        .actions(["s3:GetObject"])
+        .resources(["arn:aws:s3:::bucket/key"])
+        .build();
+
+      expect(stmt.effect).toBe(Effect.ALLOW);
+    });
+
+    it("supports Deny statements", () => {
+      const stmt = createStatementBuilder()
+        .deny()
+        .actions(["s3:DeleteObject"])
+        .resources(["*"])
+        .build();
+
+      expect(stmt.effect).toBe(Effect.DENY);
+    });
+  });
+
+  describe("wildcard guard", () => {
+    it("throws WildcardResourceError for Allow with resources ['*']", () => {
+      const builder = createStatementBuilder()
+        .sid("TooBroad")
+        .allow()
+        .actions(["ec2:DescribeInstances"])
+        .resources(["*"]);
+
+      expect(() => builder.build()).toThrow(WildcardResourceError);
+    });
+
+    it("allows Allow + '*' when allowWildcardResources(true) is set", () => {
+      const stmt = createStatementBuilder()
+        .allow()
+        .actions(["ec2:DescribeInstances"])
+        .resources(["*"])
+        .allowWildcardResources(true)
+        .build();
+
+      expect(stmt.resources).toEqual(["*"]);
+    });
+
+    it("does not throw for Deny with wildcard resources", () => {
+      expect(() =>
+        createStatementBuilder().deny().actions(["s3:*"]).resources(["*"]).build(),
+      ).not.toThrow();
+    });
+  });
+
+  describe("conditions", () => {
+    it("passes conditions through to the PolicyStatement", () => {
+      const stmt = createStatementBuilder()
+        .allow()
+        .actions(["s3:GetObject"])
+        .resources(["arn:aws:s3:::my-bucket/*"])
+        .conditions({ StringEquals: { "aws:ResourceTag/Env": "dev" } })
+        .build();
+
+      const rendered = stmt.toJSON() as { Condition: Record<string, unknown> };
+      expect(rendered.Condition).toEqual({
+        StringEquals: { "aws:ResourceTag/Env": "dev" },
+      });
+    });
+  });
+});

--- a/packages/iam/tsconfig.build.json
+++ b/packages/iam/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/iam/tsconfig.json
+++ b/packages/iam/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Second revision of the IAM builder changes, split out of #20 so each concern gets a focused review. Introduces `@composurecdk/iam` with four fluent builders:

- **`createRoleBuilder()`** — Lifecycle builder for `iam.Role` with a one-hour default `maxSessionDuration` (Well-Architected SEC), `Resolvable<IManagedPolicy>` `permissionsBoundary` for cross-component wiring, and `addInlinePolicyStatements(name, statements)`.
- **`createManagedPolicyBuilder()`** — Lifecycle builder for customer-managed `ManagedPolicy` with `addStatements()`.
- **`createStatementBuilder()`** — fluent `PolicyStatement` wrapper (not a Lifecycle) with a least-privilege guardrail that throws `WildcardResourceError` on `Effect=Allow` + `resources: ["*"]` unless the caller opts in via `.allowWildcardResources(true)`.
- **`createServiceRoleBuilder(service)`** — sugar over `createRoleBuilder().assumedBy(new ServicePrincipal(...))`.

## Changes from #20

Addresses IAM-package review feedback from #20:

- **Review fix — `addInlinePolicyStatements` now produces truly inline policies.** Previously it created a separate `AWS::IAM::Policy` and called `.attachToRole()`, which is an attached policy in CloudFormation terms. Now the statements are passed via `RoleProps.inlinePolicies` and embedded in the `AWS::IAM::Role.Policies` array. `RoleBuilderResult.inlinePolicies` type changed from `Record<string, Policy>` → `Record<string, PolicyDocument>`.
- **Review fix — removed `RoleBuilderProps` and `ManagedPolicyBuilderProps` from public exports.** These are internal builder-construction types, not part of the consumer API.
- **Review fix — removed the empty `MANAGED_POLICY_DEFAULTS` file/export.** No current defaults; avoids adding a public API surface with no value.

Closes #28
Closes #29

## Test plan

- [x] `npx nx test iam` (20/20 pass)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx nx run-many --target=test` (all packages pass)