### PR TITLE
feat(sns): add TopicBuilder.addSubscription via ITopicSubscription.bind()

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -126,6 +126,45 @@ for (const alarm of Object.values(result.alarms)) {
 }
 ```
 
+## Adding Subscriptions to a Topic
+
+For the common case where a topic and its subscriptions are declared together, use `addSubscription` on the topic builder. It accepts any CDK [`ITopicSubscription`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.ITopicSubscription.html) (e.g. `EmailSubscription`, `LambdaSubscription`, `SqsSubscription`) and binds it via `ITopicSubscription.bind(topic)` — the same path CDK uses for `topic.addSubscription(...)`, so endpoint-specific wire-up (Lambda invoke permission, SQS queue policy, KMS decrypt policy) happens automatically.
+
+```ts
+import { createTopicBuilder } from "@composurecdk/sns";
+import { EmailSubscription, LambdaSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+
+const result = createTopicBuilder()
+  .topicName("alerts")
+  .addSubscription("ops", new EmailSubscription("ops@example.com"))
+  .addSubscription("handler", new LambdaSubscription(alertHandler))
+  .build(stack, "Alerts");
+
+result.subscriptions.ops; // AWS SNS Subscription construct
+```
+
+Each subscription is exposed on `result.subscriptions` under the key supplied to `addSubscription`.
+
+Cross-component subscriptions can be declared with `ref(...)` so the subscription's endpoint is resolved from another component's build output:
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createTopicBuilder } from "@composurecdk/sns";
+import { createFunctionBuilder, type FunctionBuilderResult } from "@composurecdk/lambda";
+import { LambdaSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+
+const system = compose(
+  {
+    handler: createFunctionBuilder()./* ... */,
+    alerts: createTopicBuilder().addSubscription(
+      "handler",
+      ref("handler", (r: FunctionBuilderResult) => new LambdaSubscription(r.function)),
+    ),
+  },
+  { handler: [], alerts: ["handler"] },
+);
+```
+
 ## Subscription Builder
 
 ```ts

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -145,7 +145,7 @@ result.subscriptions.ops; // AWS SNS Subscription construct
 
 Each subscription is exposed on `result.subscriptions` under the key supplied to `addSubscription`.
 
-Cross-component subscriptions can be declared with `ref(...)` so the subscription's endpoint is resolved from another component's build output:
+Cross-component subscriptions can be declared with `ref(...)` inside a [`compose`](../core/README.md) system, so the subscription's endpoint is resolved from another component's build output at build time:
 
 ```ts
 import { compose, ref } from "@composurecdk/core";

--- a/packages/sns/src/topic-builder.ts
+++ b/packages/sns/src/topic-builder.ts
@@ -135,11 +135,17 @@ class TopicBuilder implements Lifecycle<TopicBuilderResult> {
    * {@link TopicBuilderResult.subscriptions} under `key`.
    */
   addSubscription(key: string, subscription: Resolvable<ITopicSubscription>): this {
+    if (this._subscriptions.some((s) => s.key === key)) {
+      throw new Error(
+        `TopicBuilder.addSubscription: duplicate key "${key}". ` +
+          `Each subscription must use a unique key.`,
+      );
+    }
     this._subscriptions.push({ key, subscription });
     return this;
   }
 
-  build(scope: IConstruct, id: string, context: Record<string, object> = {}): TopicBuilderResult {
+  build(scope: IConstruct, id: string, context?: Record<string, object>): TopicBuilderResult {
     const { recommendedAlarms: alarmConfig, ...topicProps } = this.props;
 
     const mergedProps = {
@@ -153,9 +159,10 @@ class TopicBuilder implements Lifecycle<TopicBuilderResult> {
 
     const subscriptions: Record<string, Subscription> = {};
     for (const entry of this._subscriptions) {
-      const resolvedSub = resolve(entry.subscription, context);
+      const resolvedSub = resolve(entry.subscription, context ?? {});
       const subscriptionConfig = resolvedSub.bind(topic);
-      subscriptions[entry.key] = new Subscription(scope, `${id}${entry.key}`, {
+      const subscriptionId = `${id}${entry.key[0].toUpperCase()}${entry.key.slice(1)}Subscription`;
+      subscriptions[entry.key] = new Subscription(scope, subscriptionId, {
         topic,
         ...subscriptionConfig,
       });

--- a/packages/sns/src/topic-builder.ts
+++ b/packages/sns/src/topic-builder.ts
@@ -1,7 +1,19 @@
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
-import { type ITopic, Topic, type TopicProps } from "aws-cdk-lib/aws-sns";
+import {
+  type ITopic,
+  type ITopicSubscription,
+  Subscription,
+  Topic,
+  type TopicProps,
+} from "aws-cdk-lib/aws-sns";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { TopicAlarmConfig } from "./topic-alarm-config.js";
 import { createTopicAlarms } from "./topic-alarms.js";
@@ -50,6 +62,15 @@ export interface TopicBuilderResult {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SNS
    */
   alarms: Record<string, Alarm>;
+
+  /**
+   * Subscriptions added to the topic via
+   * {@link ITopicBuilder.addSubscription}, keyed by the name supplied to
+   * that call.
+   *
+   * Always present — `{}` when no subscriptions were added.
+   */
+  subscriptions: Record<string, Subscription>;
 }
 
 /**
@@ -79,9 +100,15 @@ export interface TopicBuilderResult {
  */
 export type ITopicBuilder = IBuilder<TopicBuilderProps, TopicBuilder>;
 
+interface SubscriptionEntry {
+  key: string;
+  subscription: Resolvable<ITopicSubscription>;
+}
+
 class TopicBuilder implements Lifecycle<TopicBuilderResult> {
   props: Partial<TopicBuilderProps> = {};
   private readonly customAlarms: AlarmDefinitionBuilder<ITopic>[] = [];
+  private readonly _subscriptions: SubscriptionEntry[] = [];
 
   addAlarm(
     key: string,
@@ -91,7 +118,28 @@ class TopicBuilder implements Lifecycle<TopicBuilderResult> {
     return this;
   }
 
-  build(scope: IConstruct, id: string): TopicBuilderResult {
+  /**
+   * Register a subscription to be attached to the topic at build time.
+   *
+   * Accepts any {@link ITopicSubscription} (e.g. `EmailSubscription`,
+   * `LambdaSubscription`, `SqsSubscription`) or a {@link Resolvable} so
+   * subscriptions wiring cross-component references (such as a Lambda
+   * function built by a sibling component) can be declared at configuration
+   * time.
+   *
+   * The subscription is bound via `ITopicSubscription.bind(topic)`, which
+   * performs the IAM/resource-policy wire-up required by the endpoint (for
+   * example, `LambdaSubscription.bind` grants the topic permission to
+   * invoke the function; `SqsSubscription.bind` adds the matching SQS queue
+   * policy). The resulting {@link Subscription} construct is exposed on
+   * {@link TopicBuilderResult.subscriptions} under `key`.
+   */
+  addSubscription(key: string, subscription: Resolvable<ITopicSubscription>): this {
+    this._subscriptions.push({ key, subscription });
+    return this;
+  }
+
+  build(scope: IConstruct, id: string, context: Record<string, object> = {}): TopicBuilderResult {
     const { recommendedAlarms: alarmConfig, ...topicProps } = this.props;
 
     const mergedProps = {
@@ -103,7 +151,17 @@ class TopicBuilder implements Lifecycle<TopicBuilderResult> {
 
     const alarms = createTopicAlarms(scope, id, topic, alarmConfig, this.customAlarms);
 
-    return { topic, alarms };
+    const subscriptions: Record<string, Subscription> = {};
+    for (const entry of this._subscriptions) {
+      const resolvedSub = resolve(entry.subscription, context);
+      const subscriptionConfig = resolvedSub.bind(topic);
+      subscriptions[entry.key] = new Subscription(scope, `${id}${entry.key}`, {
+        topic,
+        ...subscriptionConfig,
+      });
+    }
+
+    return { topic, alarms, subscriptions };
   }
 }
 

--- a/packages/sns/test/topic-builder.test.ts
+++ b/packages/sns/test/topic-builder.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import {
+  EmailSubscription,
+  LambdaSubscription,
+  SqsSubscription,
+} from "aws-cdk-lib/aws-sns-subscriptions";
+import { ref } from "@composurecdk/core";
 import { createTopicBuilder } from "../src/topic-builder.js";
 
 function synthTemplate(
@@ -69,6 +77,103 @@ describe("TopicBuilder", () => {
         FifoTopic: true,
         ContentBasedDeduplication: true,
       });
+    });
+  });
+
+  describe("addSubscription", () => {
+    it("returns {} for subscriptions when none are added", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createTopicBuilder().build(stack, "TestTopic");
+
+      expect(result.subscriptions).toEqual({});
+    });
+
+    it("creates a Subscription resource for an EmailSubscription", () => {
+      const template = synthTemplate((b) =>
+        b.addSubscription("ops", new EmailSubscription("ops@example.com")),
+      );
+
+      template.resourceCountIs("AWS::SNS::Subscription", 1);
+      template.hasResourceProperties("AWS::SNS::Subscription", {
+        Protocol: "email",
+        Endpoint: "ops@example.com",
+      });
+    });
+
+    it("wires lambda invoke permission for a LambdaSubscription", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const fn = new LambdaFunction(stack, "Handler", {
+        runtime: Runtime.NODEJS_20_X,
+        handler: "index.handler",
+        code: Code.fromInline("exports.handler = async () => {};"),
+      });
+
+      createTopicBuilder()
+        .addSubscription("handler", new LambdaSubscription(fn))
+        .build(stack, "TestTopic");
+
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::SNS::Subscription", 1);
+      template.hasResourceProperties("AWS::Lambda::Permission", {
+        Action: "lambda:InvokeFunction",
+        Principal: "sns.amazonaws.com",
+      });
+    });
+
+    it("wires the SQS queue policy for an SqsSubscription", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const queue = new Queue(stack, "Q");
+
+      createTopicBuilder()
+        .addSubscription("queue", new SqsSubscription(queue))
+        .build(stack, "TestTopic");
+
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::SNS::Subscription", 1);
+      template.hasResourceProperties("AWS::SQS::QueuePolicy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Action: "sqs:SendMessage",
+              Principal: { Service: "sns.amazonaws.com" },
+            }),
+          ]),
+        }),
+      });
+    });
+
+    it("exposes each subscription in the result keyed by name", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createTopicBuilder()
+        .addSubscription("ops", new EmailSubscription("ops@example.com"))
+        .addSubscription("oncall", new EmailSubscription("oncall@example.com"))
+        .build(stack, "TestTopic");
+
+      expect(Object.keys(result.subscriptions).sort()).toEqual(["oncall", "ops"]);
+    });
+
+    it("resolves a Resolvable<ITopicSubscription> from the compose context", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const fn = new LambdaFunction(stack, "Handler", {
+        runtime: Runtime.NODEJS_20_X,
+        handler: "index.handler",
+        code: Code.fromInline("exports.handler = async () => {};"),
+      });
+
+      createTopicBuilder()
+        .addSubscription(
+          "handler",
+          ref("handler", (r: { function: LambdaFunction }) => new LambdaSubscription(r.function)),
+        )
+        .build(stack, "TestTopic", { handler: { function: fn } });
+
+      Template.fromStack(stack).resourceCountIs("AWS::SNS::Subscription", 1);
     });
   });
 

--- a/packages/sns/test/topic-builder.test.ts
+++ b/packages/sns/test/topic-builder.test.ts
@@ -157,6 +157,17 @@ describe("TopicBuilder", () => {
       expect(Object.keys(result.subscriptions).sort()).toEqual(["oncall", "ops"]);
     });
 
+    it("throws when the same key is used twice", () => {
+      const builder = createTopicBuilder().addSubscription(
+        "ops",
+        new EmailSubscription("ops@example.com"),
+      );
+
+      expect(() =>
+        builder.addSubscription("ops", new EmailSubscription("other@example.com")),
+      ).toThrow(/duplicate key "ops"/);
+    });
+
     it("resolves a Resolvable<ITopicSubscription> from the compose context", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");


### PR DESCRIPTION
## Summary

Ports the one genuinely valuable addition from the SNS commit in #20 to the version of the SNS package that shipped via #19: co-located subscription declarations on `TopicBuilder`.

- `TopicBuilder.addSubscription(key, subscription)` accepts any `ITopicSubscription` (or `Resolvable<ITopicSubscription>`) and binds it via `ITopicSubscription.bind(topic)` — the same path CDK's own `topic.addSubscription(...)` uses, so endpoint-specific IAM/resource-policy wire-up happens automatically.
- `TopicBuilderResult.subscriptions: Record<string, Subscription>` exposes each created subscription, keyed by the name passed to `addSubscription` (`{}` when none).
- No change to `TOPIC_DEFAULTS`, recommended alarms, or the standalone `SubscriptionBuilder`.

## Differences from #20's implementation

- #20's reviewer flagged that `ITopic.addSubscription()` returns `void`, not `Subscription` — that implementation was relying on `skipLibCheck` to compile. This PR instead constructs the `Subscription` explicitly via `new Subscription(scope, id, { topic, ...sub.bind(topic) })`, which is the fix the reviewer suggested.
- The standalone `SubscriptionBuilder` from #20 is not ported here — main's `Builder()`-wrapped, protocol/endpoint-based `SubscriptionBuilder` (from #19) already addresses the other #20 feedback point (missing `Builder` wrapper).

## Known follow-up

Filed #38 for a separate IAM-correctness gap in the standalone `SubscriptionBuilder`: when targeting Lambda/SQS with a raw `protocol` + `endpoint`, the required `AWS::Lambda::Permission` / `AWS::SQS::QueuePolicy` are not emitted. This PR sidesteps that by giving the common case (co-located subscriptions) a correct `bind()`-based path; the fix for the standalone builder is a breaking-change decision worth handling on its own.

## Test plan

- [x] `npx nx test sns` (46/46 pass, 6 new)
- [x] `AWS::SNS::Subscription` created for `EmailSubscription`
- [x] `AWS::Lambda::Permission` (Action: `lambda:InvokeFunction`, Principal: `sns.amazonaws.com`) emitted for `LambdaSubscription`
- [x] `AWS::SQS::QueuePolicy` (Allow `sqs:SendMessage`, Principal: `sns.amazonaws.com`) emitted for `SqsSubscription`
- [x] `Resolvable<ITopicSubscription>` resolves from the compose context
- [x] `npm run lint`, `npm run format:check`