### PR TITLE
feat(acm): add CertificateBuilder with DaysToExpiry alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If two components depend on each other, that is an architectural problem to be s
 | `@composurecdk/iam`        | IAM role and policy components                              |
 | `@composurecdk/apigateway` | API Gateway components                                      |
 | `@composurecdk/ec2`        | EC2 and VPC components                                      |
+| `@composurecdk/acm`        | ACM certificate components with DNS validation wiring       |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,6 +1795,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@composurecdk/acm": {
+      "resolved": "packages/acm",
+      "link": true
+    },
     "node_modules/@composurecdk/apigateway": {
       "resolved": "packages/apigateway",
       "link": true
@@ -7703,6 +7707,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/acm": {
+      "name": "@composurecdk/acm",
+      "version": "0.3.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "aws-cdk-lib": "^2.250.0",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@composurecdk/cloudwatch": "^0.3.0",
+        "@composurecdk/core": "^0.3.0",
+        "aws-cdk-lib": "^2.0.0",
+        "constructs": "^10.0.0"
       }
     },
     "packages/apigateway": {

--- a/packages/acm/README.md
+++ b/packages/acm/README.md
@@ -1,0 +1,144 @@
+# @composurecdk/acm
+
+AWS Certificate Manager builder for [ComposureCDK](../../README.md).
+
+This package provides a fluent builder for ACM certificates with secure, AWS-recommended defaults, first-class DNS validation wiring, and a recommended `DaysToExpiry` alarm. It wraps the CDK [Certificate](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager.Certificate.html) construct — refer to the CDK documentation for the full set of configurable properties.
+
+## Certificate Builder
+
+```ts
+import { createCertificateBuilder } from "@composurecdk/acm";
+import { HostedZone } from "aws-cdk-lib/aws-route53";
+
+const zone = HostedZone.fromLookup(stack, "Zone", { domainName: "example.com" });
+
+const { certificate } = createCertificateBuilder()
+  .domainName("example.com")
+  .subjectAlternativeNames(["www.example.com"])
+  .validationZone(zone)
+  .build(stack, "SiteCert");
+```
+
+Every [CertificateProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager.CertificateProps.html) property is available as a fluent setter on the builder.
+
+## Secure Defaults
+
+`createCertificateBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.
+
+| Property                     | Default                 | Rationale                                                                     |
+| ---------------------------- | ----------------------- | ----------------------------------------------------------------------------- |
+| `keyAlgorithm`               | `KeyAlgorithm.RSA_2048` | Broadest client and AWS service compatibility (CloudFront, API Gateway, ALB). |
+| `transparencyLoggingEnabled` | `true`                  | Required by modern browsers; enables public detection of mis-issuance.        |
+
+These defaults are guided by the [AWS ACM Best Practices](https://docs.aws.amazon.com/acm/latest/userguide/acm-bestpractices.html).
+
+The defaults are exported as `CERTIFICATE_DEFAULTS` for visibility and testing:
+
+```ts
+import { CERTIFICATE_DEFAULTS } from "@composurecdk/acm";
+```
+
+## DNS Validation
+
+Email-based validation is not used by default — it blocks stack creation until a human clicks a link in an email. The builder requires one of:
+
+- `validationZone(zone)` — the hosted zone that owns every domain on the certificate.
+- `validationZones({ "apex.com": apexZone, "alt.net": altZone })` — when domains span multiple zones.
+- `validation(CertificateValidation.fromEmail())` — explicit opt-in to email validation (not recommended).
+
+`validationZone` / `validationZones` accept a `Resolvable<IHostedZone>`, so a hosted zone produced by a sibling component can be wired via `ref()`.
+
+## Certificate Lifetime
+
+ACM-issued public certificates are valid for [395 days](https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html) and auto-renew starting ~60 days before expiry, provided the DNS validation records remain published. Renewal is therefore the happy path — the `daysToExpiry` alarm below is a safety net for the cases where it can't complete (records removed, zone delegation broken, etc.). For imported certificates, which do not auto-renew, `daysToExpiry` is the primary expiry control.
+
+## Recommended Alarms
+
+The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CertificateManager) by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.
+
+| Alarm          | Metric                        | Default threshold |
+| -------------- | ----------------------------- | ----------------- |
+| `daysToExpiry` | DaysToExpiry (Minimum, 1 day) | ≤ 45 days         |
+
+`treatMissingData` defaults to `notBreaching`: once a certificate has effectively expired, ACM stops emitting `DaysToExpiry`, and there is nothing left to alarm about.
+
+The defaults are exported as `CERTIFICATE_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { CERTIFICATE_ALARM_DEFAULTS } from "@composurecdk/acm";
+```
+
+### Customizing thresholds
+
+Override individual alarm properties via `recommendedAlarms`. Unspecified fields keep their defaults.
+
+```ts
+const cert = createCertificateBuilder()
+  .domainName("example.com")
+  .validationZone(zone)
+  .recommendedAlarms({
+    daysToExpiry: { threshold: 30 },
+  });
+```
+
+### Disabling alarms
+
+Disable all recommended alarms:
+
+```ts
+builder.recommendedAlarms(false);
+// or
+builder.recommendedAlarms({ enabled: false });
+```
+
+Disable the daysToExpiry alarm individually:
+
+```ts
+builder.recommendedAlarms({ daysToExpiry: false });
+```
+
+### Custom alarms
+
+Add custom alarms alongside the recommended ones via `addAlarm`. The callback receives an `AlarmDefinitionBuilder` typed to `ICertificate`, so the metric factory has access to the certificate at build time.
+
+```ts
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Duration } from "aws-cdk-lib";
+
+const cert = createCertificateBuilder()
+  .domainName("example.com")
+  .validationZone(zone)
+  .addAlarm("urgentExpiry", (alarm) =>
+    alarm
+      .metric(
+        (c) =>
+          new Metric({
+            namespace: "AWS/CertificateManager",
+            metricName: "DaysToExpiry",
+            dimensionsMap: { CertificateArn: c.certificateArn },
+            statistic: "Minimum",
+            period: Duration.days(1),
+          }),
+      )
+      .threshold(10)
+      .lessThanOrEqual()
+      .description("Certificate very close to expiry — page oncall"),
+  );
+```
+
+### Applying alarm actions
+
+Alarms are returned in the build result as `Record<string, Alarm>`:
+
+```ts
+const result = cert.build(stack, "SiteCert");
+
+const alertTopic = new Topic(stack, "AlertTopic");
+for (const alarm of Object.values(result.alarms)) {
+  alarm.addAlarmAction(new SnsAction(alertTopic));
+}
+```
+
+## CloudFront certificates
+
+CloudFront viewer certificates must live in `us-east-1`. The ACM builder cannot enforce this on its own — certificates in other regions are perfectly valid for ALB, API Gateway, and other services. The constraint is enforced by CloudFront at association time, so if your certificate is for CloudFront, place the builder in a stack that targets `us-east-1` (e.g. via [`createStackBuilder`](../cloudformation/README.md) with an `env`).

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@composurecdk/acm",
+  "version": "0.3.2",
+  "description": "Composable AWS Certificate Manager builder with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/acm"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "peerDependencies": {
+    "@composurecdk/cloudwatch": "^0.3.0",
+    "@composurecdk/core": "^0.3.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "aws-cdk-lib": "^2.250.0",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/acm/src/alarm-config.ts
+++ b/packages/acm/src/alarm-config.ts
@@ -1,0 +1,35 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for an ACM certificate.
+ * All applicable alarms are enabled by default with AWS-recommended thresholds.
+ * Set individual alarms to `false` to disable them, or provide an
+ * {@link AlarmConfig} to tune thresholds.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CertificateManager
+ */
+export interface CertificateAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the certificate is approaching expiry.
+   *
+   * ACM public certificates auto-renew, so this alarm is primarily a
+   * safety net for the edge cases where renewal cannot complete (for
+   * example, when DNS validation records have been removed from the
+   * zone). For imported certificates, which do not auto-renew, this
+   * alarm is the primary expiry control.
+   *
+   * Metric: `AWS/CertificateManager DaysToExpiry`, statistic Minimum,
+   * period 1 day, dimension `CertificateArn`.
+   * Default threshold: &le; 45 days.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CertificateManager
+   */
+  daysToExpiry?: AlarmConfig | false;
+}

--- a/packages/acm/src/alarm-defaults.ts
+++ b/packages/acm/src/alarm-defaults.ts
@@ -1,0 +1,33 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+interface CertificateAlarmDefaults {
+  enabled: true;
+  daysToExpiry: Required<AlarmConfig>;
+}
+
+/**
+ * AWS-recommended default alarm configuration for ACM certificates.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CertificateManager
+ */
+export const CERTIFICATE_ALARM_DEFAULTS: CertificateAlarmDefaults = {
+  enabled: true,
+
+  /**
+   * Alarm 45 days before expiry — AWS's recommended threshold. For public
+   * certificates, ACM begins auto-renewal attempts around 60 days out, so
+   * 45 days leaves a two-week window to investigate renewal failures
+   * before the certificate expires.
+   *
+   * `treatMissingData: notBreaching` avoids false alarms after a
+   * certificate has effectively expired — at that point ACM stops
+   * emitting DaysToExpiry, and there is nothing left to alarm about.
+   */
+  daysToExpiry: {
+    threshold: 45,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};

--- a/packages/acm/src/certificate-alarms.ts
+++ b/packages/acm/src/certificate-alarms.ts
@@ -1,0 +1,70 @@
+import { Duration } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
+import type { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { CertificateAlarmConfig } from "./alarm-config.js";
+import { CERTIFICATE_ALARM_DEFAULTS } from "./alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.days(1);
+
+/**
+ * Resolves the recommended alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s for an ACM certificate.
+ */
+export function resolveCertificateAlarmDefinitions(
+  certificate: ICertificate,
+  config: CertificateAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.daysToExpiry !== false) {
+    const cfg = resolveAlarmConfig(config?.daysToExpiry, CERTIFICATE_ALARM_DEFAULTS.daysToExpiry);
+    definitions.push({
+      key: "daysToExpiry",
+      metric: certificate.metricDaysToExpiry({ period: METRIC_PERIOD }),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `ACM certificate is approaching expiry. Threshold: <= ${String(cfg.threshold)} days remaining.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates AWS-recommended CloudWatch alarms for an ACM certificate,
+ * merging recommended definitions with any custom alarm builders.
+ *
+ * @param scope - CDK construct scope for creating alarm constructs.
+ * @param id - Base identifier for alarm construct ids.
+ * @param certificate - The ACM certificate to create alarms for.
+ * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @returns A record mapping alarm keys to their created Alarm constructs.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CertificateManager
+ */
+export function createCertificateAlarms(
+  scope: IConstruct,
+  id: string,
+  certificate: ICertificate,
+  config: CertificateAlarmConfig | false | undefined,
+  customAlarms: AlarmDefinitionBuilder<ICertificate>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? CERTIFICATE_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveCertificateAlarmDefinitions(certificate, config);
+  const custom = customAlarms.map((b) => b.resolve(certificate));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/acm/src/certificate-builder.ts
+++ b/packages/acm/src/certificate-builder.ts
@@ -1,0 +1,226 @@
+import {
+  Certificate,
+  CertificateValidation,
+  type CertificateProps,
+  type ICertificate,
+} from "aws-cdk-lib/aws-certificatemanager";
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import type { IHostedZone } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { CertificateAlarmConfig } from "./alarm-config.js";
+import { createCertificateAlarms } from "./certificate-alarms.js";
+import { CERTIFICATE_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the ACM certificate builder.
+ *
+ * Extends the CDK {@link CertificateProps} with additional builder-specific
+ * options. The `validation` field is augmented by {@link validationZone} /
+ * {@link validationZones}, which accept {@link Resolvable} hosted zones so
+ * the validation zone can come from a composed component.
+ *
+ * If neither `validation`, `validationZone`, nor `validationZones` is set,
+ * the builder fails fast — falling back to ACM's email-based validation would
+ * stall stack creation waiting on a human to click a link.
+ */
+interface CertificateBuilderProps extends CertificateProps {
+  /**
+   * The hosted zone used to automatically create DNS validation records
+   * for every domain on the certificate. Accepts a {@link Resolvable} so
+   * a zone produced by a sibling component can be wired in via `ref`.
+   *
+   * Mutually exclusive with {@link validationZones} and {@link CertificateProps.validation}.
+   * When set, the builder configures
+   * {@link CertificateValidation.fromDns | CertificateValidation.fromDns(zone)}.
+   */
+  validationZone?: Resolvable<IHostedZone>;
+
+  /**
+   * A map of domain name to hosted zone, used when the apex and subject
+   * alternative names live in different zones. Each value accepts a
+   * {@link Resolvable}. When set, the builder configures
+   * {@link CertificateValidation.fromDnsMultiZone}.
+   *
+   * Mutually exclusive with {@link validationZone} and {@link CertificateProps.validation}.
+   */
+  validationZones?: Record<string, Resolvable<IHostedZone>>;
+
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates a recommended `daysToExpiry` alarm
+   * at 45 days. The alarm can be customized or disabled. Set to `false`
+   * to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification
+   * methods are user-specific. Access alarms from the build result
+   * or use an `afterBuild` hook to apply actions.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CertificateManager
+   */
+  recommendedAlarms?: CertificateAlarmConfig | false;
+}
+
+/**
+ * The build output of an {@link ICertificateBuilder}. Contains the CDK
+ * constructs created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface CertificateBuilderResult {
+  /** The ACM certificate construct created by the builder. */
+  certificate: Certificate;
+
+  /**
+   * CloudWatch alarms created for the certificate, keyed by alarm name.
+   *
+   * Includes both AWS-recommended alarms and any custom alarms added
+   * via {@link ICertificateBuilder.addAlarm}. Access individual alarms
+   * by key (e.g., `result.alarms.daysToExpiry`).
+   *
+   * No alarm actions are configured — apply them via the result or an
+   * `afterBuild` hook.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CertificateManager
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS Certificate Manager
+ * certificate.
+ *
+ * Each configuration property from the CDK {@link CertificateProps} is
+ * exposed as an overloaded method: call with a value to set it (returns the
+ * builder for chaining), or call with no arguments to read the current value.
+ *
+ * Validation is DNS-based by default — set
+ * {@link CertificateBuilderProps.validationZone | validationZone} (or
+ * {@link CertificateBuilderProps.validationZones | validationZones}) with the
+ * hosted zone(s) that own the certificate's domains. Accepts a
+ * {@link Resolvable} so zones produced by a composed component can be
+ * wired in via `ref`.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates
+ * an ACM certificate with the configured properties and returns a
+ * {@link CertificateBuilderResult}.
+ *
+ * The builder also creates AWS-recommended CloudWatch alarms by default
+ * (`daysToExpiry` at 45 days). Alarms can be customized or disabled via the
+ * `recommendedAlarms` property.
+ *
+ * @example
+ * ```ts
+ * const cert = createCertificateBuilder()
+ *   .domainName("example.com")
+ *   .subjectAlternativeNames(["www.example.com"])
+ *   .validationZone(zone);
+ * ```
+ */
+export type ICertificateBuilder = IBuilder<CertificateBuilderProps, CertificateBuilder>;
+
+class CertificateBuilder implements Lifecycle<CertificateBuilderResult> {
+  props: Partial<CertificateBuilderProps> = {};
+  private readonly customAlarms: AlarmDefinitionBuilder<ICertificate>[] = [];
+
+  addAlarm(
+    key: string,
+    configure: (
+      alarm: AlarmDefinitionBuilder<ICertificate>,
+    ) => AlarmDefinitionBuilder<ICertificate>,
+  ): this {
+    this.customAlarms.push(configure(new AlarmDefinitionBuilder<ICertificate>(key)));
+    return this;
+  }
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): CertificateBuilderResult {
+    const {
+      validationZone,
+      validationZones,
+      validation: userValidation,
+      recommendedAlarms: alarmConfig,
+      ...certProps
+    } = this.props;
+
+    if (!certProps.domainName) {
+      throw new Error(
+        `CertificateBuilder "${id}" requires a domainName. ` +
+          `Call .domainName() with the fully-qualified domain.`,
+      );
+    }
+
+    if ([userValidation, validationZone, validationZones].filter(Boolean).length > 1) {
+      throw new Error(
+        `CertificateBuilder "${id}": 'validation', 'validationZone', and 'validationZones' ` +
+          `are mutually exclusive. Set exactly one.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    let validation: CertificateValidation;
+
+    if (userValidation) {
+      validation = userValidation;
+    } else if (validationZones) {
+      const resolvedZones = Object.fromEntries(
+        Object.entries(validationZones).map(([domain, zone]) => [
+          domain,
+          resolve(zone, resolvedContext),
+        ]),
+      );
+      validation = CertificateValidation.fromDnsMultiZone(resolvedZones);
+    } else if (validationZone) {
+      validation = CertificateValidation.fromDns(resolve(validationZone, resolvedContext));
+    } else {
+      throw new Error(
+        `CertificateBuilder "${id}" requires DNS validation to be configured. ` +
+          `Call .validationZone() with the hosted zone for the certificate's domain, ` +
+          `or .validationZones() when domains span multiple zones, ` +
+          `or .validation() to configure an explicit CertificateValidation. ` +
+          `Email validation is not enabled by default because it blocks stack creation.`,
+      );
+    }
+
+    const mergedProps = {
+      ...CERTIFICATE_DEFAULTS,
+      ...certProps,
+      validation,
+    } as CertificateProps;
+
+    const certificate = new Certificate(scope, id, mergedProps);
+
+    const alarms = createCertificateAlarms(scope, id, certificate, alarmConfig, this.customAlarms);
+
+    return { certificate, alarms };
+  }
+}
+
+/**
+ * Creates a new {@link ICertificateBuilder} for configuring an ACM certificate.
+ *
+ * This is the entry point for defining an ACM certificate component. The
+ * returned builder exposes every {@link CertificateBuilderProps} property as
+ * a fluent setter/getter and implements {@link Lifecycle} for use with
+ * {@link compose}.
+ *
+ * @returns A fluent builder for an ACM certificate.
+ *
+ * @example
+ * ```ts
+ * const cert = createCertificateBuilder()
+ *   .domainName("example.com")
+ *   .validationZone(zone);
+ *
+ * const result = cert.build(stack, "SiteCert");
+ * ```
+ */
+export function createCertificateBuilder(): ICertificateBuilder {
+  return Builder<CertificateBuilderProps, CertificateBuilder>(CertificateBuilder);
+}

--- a/packages/acm/src/defaults.ts
+++ b/packages/acm/src/defaults.ts
@@ -1,0 +1,25 @@
+import { KeyAlgorithm, type CertificateProps } from "aws-cdk-lib/aws-certificatemanager";
+
+/**
+ * Secure, AWS-recommended defaults applied to every ACM certificate built
+ * with {@link createCertificateBuilder}. Each property can be individually
+ * overridden via the builder's fluent API.
+ */
+export const CERTIFICATE_DEFAULTS: Partial<CertificateProps> = {
+  /**
+   * Use RSA-2048 as the key algorithm. Widest client/CDN compatibility
+   * (CloudFront, API Gateway, ALB) and sufficient for TLS 1.2 and 1.3.
+   * For newer workloads, `KeyAlgorithm.EC_PRIME256V1` offers smaller
+   * signatures at comparable security — override via `.keyAlgorithm()`.
+   * @see https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html#algorithms.title
+   */
+  keyAlgorithm: KeyAlgorithm.RSA_2048,
+
+  /**
+   * Publish certificates to the public Certificate Transparency (CT) logs.
+   * CT logging is required by modern browsers to trust a certificate and
+   * enables detection of mis-issuance.
+   * @see https://docs.aws.amazon.com/acm/latest/userguide/acm-bestpractices.html#best-practices-transparency
+   */
+  transparencyLoggingEnabled: true,
+};

--- a/packages/acm/src/index.ts
+++ b/packages/acm/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  createCertificateBuilder,
+  type CertificateBuilderResult,
+  type ICertificateBuilder,
+} from "./certificate-builder.js";
+export { CERTIFICATE_DEFAULTS } from "./defaults.js";
+export { type CertificateAlarmConfig } from "./alarm-config.js";
+export { CERTIFICATE_ALARM_DEFAULTS } from "./alarm-defaults.js";

--- a/packages/acm/test/certificate-alarms.test.ts
+++ b/packages/acm/test/certificate-alarms.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
+import { PublicHostedZone } from "aws-cdk-lib/aws-route53";
+import { createCertificateBuilder } from "../src/certificate-builder.js";
+
+function buildResult(configureFn?: (builder: ReturnType<typeof createCertificateBuilder>) => void) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+  const builder = createCertificateBuilder().domainName("example.com").validationZone(zone);
+  configureFn?.(builder);
+  const result = builder.build(stack, "TestCertificate");
+  return { result, template: Template.fromStack(stack) };
+}
+
+describe("recommended alarms", () => {
+  describe("defaults", () => {
+    it("creates the daysToExpiry alarm by default", () => {
+      const { result, template } = buildResult();
+
+      expect(result.alarms.daysToExpiry).toBeDefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("creates daysToExpiry with AWS-recommended 45-day threshold", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "DaysToExpiry",
+        Namespace: "AWS/CertificateManager",
+        Threshold: 45,
+        ComparisonOperator: "LessThanOrEqualToThreshold",
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        TreatMissingData: "notBreaching",
+        Statistic: "Minimum",
+        Period: 86400,
+        Dimensions: Match.arrayWith([Match.objectLike({ Name: "CertificateArn" })]),
+      });
+    });
+
+    it("includes threshold justification in the alarm description", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "DaysToExpiry",
+        AlarmDescription: Match.stringLikeRegexp("45"),
+      });
+    });
+  });
+
+  describe("customisation", () => {
+    it("honours a custom threshold", () => {
+      const { template } = buildResult((b) => {
+        b.recommendedAlarms({ daysToExpiry: { threshold: 30 } });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "DaysToExpiry",
+        Threshold: 30,
+      });
+    });
+
+    it("preserves unspecified fields when threshold is overridden", () => {
+      const { template } = buildResult((b) => {
+        b.recommendedAlarms({ daysToExpiry: { threshold: 30 } });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "DaysToExpiry",
+        EvaluationPeriods: 1,
+        TreatMissingData: "notBreaching",
+      });
+    });
+
+    it("disables the daysToExpiry alarm when set to false", () => {
+      const { result, template } = buildResult((b) => {
+        b.recommendedAlarms({ daysToExpiry: false });
+      });
+
+      expect(result.alarms.daysToExpiry).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all alarms when recommendedAlarms is false", () => {
+      const { result, template } = buildResult((b) => {
+        b.recommendedAlarms(false);
+      });
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all alarms when enabled is false", () => {
+      const { result, template } = buildResult((b) => {
+        b.recommendedAlarms({ enabled: false });
+      });
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("custom alarms", () => {
+    it("creates a custom alarm alongside the recommended alarms", () => {
+      const { result, template } = buildResult((b) => {
+        b.addAlarm("custom", (alarm) =>
+          alarm
+            .metric(
+              (cert: ICertificate) =>
+                new Metric({
+                  namespace: "AWS/CertificateManager",
+                  metricName: "DaysToExpiry",
+                  dimensionsMap: { CertificateArn: cert.certificateArn },
+                  statistic: "Minimum",
+                  period: Duration.days(1),
+                }),
+            )
+            .threshold(10)
+            .lessThanOrEqual()
+            .description("Certificate very close to expiry"),
+        );
+      });
+
+      expect(result.alarms.custom).toBeDefined();
+      expect(result.alarms.daysToExpiry).toBeDefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+
+    it("rejects a custom alarm that collides with a recommended alarm key", () => {
+      expect(() =>
+        buildResult((b) => {
+          b.addAlarm("daysToExpiry", (alarm) =>
+            alarm
+              .metric(
+                (cert: ICertificate) =>
+                  new Metric({
+                    namespace: "AWS/CertificateManager",
+                    metricName: "DaysToExpiry",
+                    dimensionsMap: { CertificateArn: cert.certificateArn },
+                    statistic: "Minimum",
+                    period: Duration.days(1),
+                  }),
+              )
+              .threshold(10)
+              .lessThanOrEqual(),
+          );
+        }),
+      ).toThrow(/Duplicate alarm key/);
+    });
+  });
+
+  describe("treatMissingData semantics", () => {
+    it("uses NOT_BREACHING by default so expired certs do not stay alarmed", () => {
+      const { template } = buildResult();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "DaysToExpiry",
+        TreatMissingData: "notBreaching",
+      });
+
+      // Sanity: the public enum value we rely on resolves to 'notBreaching'.
+      expect(TreatMissingData.NOT_BREACHING).toBe("notBreaching");
+    });
+  });
+});

--- a/packages/acm/test/certificate-builder.test.ts
+++ b/packages/acm/test/certificate-builder.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { CertificateValidation, KeyAlgorithm } from "aws-cdk-lib/aws-certificatemanager";
+import { PublicHostedZone } from "aws-cdk-lib/aws-route53";
+import { ref } from "@composurecdk/core";
+import { createCertificateBuilder } from "../src/certificate-builder.js";
+import { CERTIFICATE_DEFAULTS } from "../src/defaults.js";
+
+function newStack(): Stack {
+  const app = new App();
+  return new Stack(app, "TestStack");
+}
+
+function buildWithZone(
+  configureFn?: (builder: ReturnType<typeof createCertificateBuilder>) => void,
+): { template: Template; stack: Stack; zone: PublicHostedZone } {
+  const stack = newStack();
+  const zone = new PublicHostedZone(stack, "TestZone", { zoneName: "example.com" });
+  const builder = createCertificateBuilder()
+    .domainName("example.com")
+    .validationZone(zone)
+    .recommendedAlarms(false);
+  configureFn?.(builder);
+  builder.build(stack, "TestCertificate");
+  return { template: Template.fromStack(stack), stack, zone };
+}
+
+describe("CertificateBuilder", () => {
+  describe("build", () => {
+    it("returns a CertificateBuilderResult with a certificate property", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+      const result = createCertificateBuilder()
+        .domainName("example.com")
+        .validationZone(zone)
+        .recommendedAlarms(false)
+        .build(stack, "TestCertificate");
+
+      expect(result).toBeDefined();
+      expect(result.certificate).toBeDefined();
+      expect(result.alarms).toEqual({});
+    });
+
+    it("throws when domainName is not set", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+      expect(() =>
+        createCertificateBuilder().validationZone(zone).build(stack, "TestCertificate"),
+      ).toThrow(/requires a domainName/);
+    });
+
+    it("throws when no validation is configured", () => {
+      const stack = newStack();
+      expect(() =>
+        createCertificateBuilder().domainName("example.com").build(stack, "TestCertificate"),
+      ).toThrow(/requires DNS validation/);
+    });
+
+    it("throws when validation, validationZone, and validationZones are combined", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+      expect(() =>
+        createCertificateBuilder()
+          .domainName("example.com")
+          .validationZone(zone)
+          .validation(CertificateValidation.fromDns(zone))
+          .build(stack, "TestCertificate"),
+      ).toThrow(/mutually exclusive/);
+    });
+
+    it("resolves validationZone when supplied as a Ref via build context", () => {
+      const stack = newStack();
+      const zone = new PublicHostedZone(stack, "Z", { zoneName: "example.com" });
+
+      createCertificateBuilder()
+        .domainName("example.com")
+        .validationZone(ref("zone", (r: { hostedZone: PublicHostedZone }) => r.hostedZone))
+        .recommendedAlarms(false)
+        .build(stack, "TestCertificate", { zone: { hostedZone: zone } });
+
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
+    });
+  });
+
+  describe("synthesised output", () => {
+    it("creates exactly one ACM certificate", () => {
+      const { template } = buildWithZone();
+      template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
+    });
+
+    it("uses DNS validation wired to the provided hosted zone", () => {
+      const { template } = buildWithZone();
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        ValidationMethod: "DNS",
+        DomainValidationOptions: Match.arrayWith([
+          Match.objectLike({
+            DomainName: "example.com",
+            HostedZoneId: Match.anyValue(),
+          }),
+        ]),
+      });
+    });
+
+    it("applies the RSA_2048 key algorithm default", () => {
+      const { template } = buildWithZone();
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        KeyAlgorithm: "RSA_2048",
+      });
+      expect(CERTIFICATE_DEFAULTS.keyAlgorithm).toBe(KeyAlgorithm.RSA_2048);
+    });
+
+    it("includes subject alternative names when provided", () => {
+      const { template } = buildWithZone((b) => {
+        b.subjectAlternativeNames(["www.example.com", "api.example.com"]);
+      });
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        SubjectAlternativeNames: ["www.example.com", "api.example.com"],
+      });
+    });
+
+    it("supports multi-zone validation", () => {
+      const stack = newStack();
+      const apex = new PublicHostedZone(stack, "Apex", { zoneName: "example.com" });
+      const other = new PublicHostedZone(stack, "Other", { zoneName: "example.net" });
+
+      createCertificateBuilder()
+        .domainName("example.com")
+        .subjectAlternativeNames(["www.example.net"])
+        .validationZones({
+          "example.com": apex,
+          "www.example.net": other,
+        })
+        .recommendedAlarms(false)
+        .build(stack, "MultiCert");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        DomainValidationOptions: Match.arrayWith([
+          Match.objectLike({ DomainName: "example.com" }),
+          Match.objectLike({ DomainName: "www.example.net" }),
+        ]),
+      });
+    });
+
+    it("allows overriding defaults via the fluent API", () => {
+      const { template } = buildWithZone((b) => {
+        b.keyAlgorithm(KeyAlgorithm.EC_PRIME256V1);
+        b.transparencyLoggingEnabled(false);
+      });
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        KeyAlgorithm: "EC_prime256v1",
+        CertificateTransparencyLoggingPreference: "DISABLED",
+      });
+    });
+  });
+});

--- a/packages/acm/tsconfig.build.json
+++ b/packages/acm/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/acm/tsconfig.json
+++ b/packages/acm/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds `@composurecdk/acm` — a fluent `CertificateBuilder` wrapping `aws-certificatemanager.Certificate`. This is a re-scoped take on #21, addressing the review comments and dropping the Route 53 work so it can ship independently.

- DNS validation is required by default. `validationZone` / `validationZones` accept `Resolvable<IHostedZone>` so the zone can come from a composed component (or be supplied directly). Email validation must be opted into explicitly via `.validation(CertificateValidation.fromEmail())`.
- Secure defaults: `KeyAlgorithm.RSA_2048`, `transparencyLoggingEnabled: true` — guided by the [AWS ACM best practices](https://docs.aws.amazon.com/acm/latest/userguide/acm-bestpractices.html).
- Recommended `DaysToExpiry` alarm at a 45-day threshold (AWS Best Practice Recommended Alarm), using the same `recommendedAlarms` / `addAlarm` API as the SNS and CloudFront builders.

### Changes from #21

- **ACM-only** — the Route 53 package and the `custom-domain-website` example are dropped from this PR and will land separately.
- **`DaysToExpiry` alarm added** (#21 comment) using the AWS-recommended ≤ 45-day threshold with `notBreaching` missing-data handling.
- **`CertificateBuilderProps` no longer exported** (#21 comment) — the type is internal to the fluent builder.
- **Version bumped** (#21 comment) — ACM package ships at `0.3.2` to match the other packages on main.
- **Certificate lifetime documented** (#21 comment) — README explains ACM public-cert auto-renewal (395 days, ~60-day renewal window) and positions `DaysToExpiry` as a safety net for renewal failures / primary control for imported certs.
- **CloudFront `us-east-1` claim softened** (#21 comment) — removed from the builder docstring since the ACM layer can't enforce region (certs are valid for ALB/API Gateway/etc. in any region). Enforcement naturally happens at CloudFront association time; the README documents this and points at `@composurecdk/cloudformation` for dedicated-stack placement.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx nx test acm` — 22 tests pass (builder, validation/mutex, defaults, SAN, multi-zone, `Ref`-based composition, alarm defaults/customisation/disable, custom alarms, duplicate-key guard)
- [x] `npm run verify` — all packages green