### PR TITLE
feat(cloudfront): add CloudFront Function builder with recommended al…

### DIFF
--- a/packages/cloudfront/src/alarm-config.ts
+++ b/packages/cloudfront/src/alarm-config.ts
@@ -45,3 +45,60 @@ export interface DistributionAlarmConfig {
    */
   originLatency?: AlarmConfig | false;
 }
+
+/**
+ * Controls which recommended alarms are created for a CloudFront Function.
+ * All alarms are enabled by default with sensible thresholds. Set individual
+ * alarms to `false` to disable them, or provide an {@link AlarmConfig} to
+ * tune thresholds.
+ *
+ * CloudFront Function metrics are emitted in the `us-east-1` region only
+ * (since CloudFront is a global service). The alarms created by the builder
+ * live in the stack's region — if that is not `us-east-1`, the alarms will
+ * not receive data. To monitor CloudFront Functions across regions, deploy
+ * the parent stack to `us-east-1` or create the alarms manually in that
+ * region via a dedicated stack.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+ */
+export interface FunctionAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the function raises runtime exceptions while processing a
+   * viewer request or response.
+   *
+   * Metric: `AWS/CloudFront FunctionExecutionErrors`, statistic Sum,
+   * period 1 minute. Default threshold: > 0 errors.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+   */
+  executionErrors?: AlarmConfig | false;
+
+  /**
+   * Alarm when the function returns an event object that fails validation
+   * (e.g., malformed headers, unsupported response shape).
+   *
+   * Metric: `AWS/CloudFront FunctionValidationErrors`, statistic Sum,
+   * period 1 minute. Default threshold: > 0 errors.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+   */
+  validationErrors?: AlarmConfig | false;
+
+  /**
+   * Alarm when the function is throttled — typically because it exceeded
+   * the 1ms compute-utilization budget.
+   *
+   * Metric: `AWS/CloudFront FunctionThrottles`, statistic Sum,
+   * period 1 minute. Default threshold: > 0 throttles.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-function-restrictions.html
+   */
+  throttles?: AlarmConfig | false;
+}

--- a/packages/cloudfront/src/alarm-defaults.ts
+++ b/packages/cloudfront/src/alarm-defaults.ts
@@ -7,6 +7,13 @@ interface DistributionAlarmDefaults {
   originLatency: Required<AlarmConfig>;
 }
 
+interface FunctionAlarmDefaults {
+  enabled: true;
+  executionErrors: Required<AlarmConfig>;
+  validationErrors: Required<AlarmConfig>;
+  throttles: Required<AlarmConfig>;
+}
+
 /**
  * AWS-recommended default alarm configuration for CloudFront distributions.
  *
@@ -35,6 +42,41 @@ export const DISTRIBUTION_ALARM_DEFAULTS: DistributionAlarmDefaults = {
     threshold: 5000,
     evaluationPeriods: 5,
     datapointsToAlarm: 5,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};
+
+/**
+ * Default alarm configuration for CloudFront Functions. Any non-zero count
+ * of errors or throttles is worth investigating since a function executes
+ * on every viewer request/response event.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+ */
+export const FUNCTION_ALARM_DEFAULTS: FunctionAlarmDefaults = {
+  enabled: true,
+
+  /** Any execution error indicates a runtime fault on the edge; threshold 0. */
+  executionErrors: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any validation error indicates the function returned a bad event; threshold 0. */
+  validationErrors: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any throttle indicates the function exceeded its 1ms compute budget; threshold 0. */
+  throttles: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
     treatMissingData: TreatMissingData.NOT_BREACHING,
   },
 };

--- a/packages/cloudfront/src/defaults.ts
+++ b/packages/cloudfront/src/defaults.ts
@@ -1,4 +1,5 @@
 import {
+  FunctionRuntime,
   HttpVersion,
   PriceClass,
   ResponseHeadersPolicy,
@@ -6,6 +7,7 @@ import {
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
 import type { DistributionBuilderProps } from "./distribution-builder.js";
+import type { FunctionBuilderProps } from "./function-builder.js";
 
 /**
  * Secure, AWS-recommended defaults applied to every CloudFront distribution
@@ -66,4 +68,19 @@ export const DISTRIBUTION_DEFAULTS: Partial<DistributionBuilderProps> = {
      */
     responseHeadersPolicy: ResponseHeadersPolicy.SECURITY_HEADERS,
   },
+};
+
+/**
+ * Defaults applied to every CloudFront Function built with
+ * {@link createFunctionBuilder}. Each property can be individually overridden
+ * via the builder's fluent API.
+ */
+export const FUNCTION_DEFAULTS: Partial<FunctionBuilderProps> = {
+  /**
+   * Use the `cloudfront-js-2.0` runtime by default. It is the currently
+   * recommended runtime and is a superset of `cloudfront-js-1.0` features
+   * (async/await, `crypto.subtle`, KeyValueStore support).
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-20.html
+   */
+  runtime: FunctionRuntime.JS_2_0,
 };

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -3,6 +3,9 @@ import {
   type DistributionProps,
   type IOrigin,
   type AddBehaviorOptions,
+  type FunctionAssociation,
+  type FunctionEventType,
+  type IFunctionRef,
 } from "aws-cdk-lib/aws-cloudfront";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type Bucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
@@ -33,6 +36,30 @@ import { DISTRIBUTION_DEFAULTS } from "./defaults.js";
  * The `enableLogging` CDK prop is replaced by {@link accessLogging}, which
  * auto-creates a logging bucket with secure defaults when enabled.
  */
+/**
+ * A {@link FunctionAssociation} whose `function` may be either a concrete
+ * {@link IFunctionRef} or a {@link Ref} that resolves to one at build time.
+ *
+ * Enables declarative cross-component wiring between a
+ * {@link createFunctionBuilder | CloudFront Function} and a distribution
+ * behavior when composing a system.
+ */
+export interface ResolvableFunctionAssociation {
+  /** The CloudFront function that will be invoked, or a Ref resolving to one. */
+  readonly function: Resolvable<IFunctionRef>;
+  /** The type of event which should invoke the function. */
+  readonly eventType: FunctionEventType;
+}
+
+/**
+ * Variant of {@link AddBehaviorOptions} that allows {@link ResolvableFunctionAssociation}s
+ * in place of concrete {@link FunctionAssociation}s. Concrete values still
+ * work — `resolve()` is a no-op on non-Ref inputs.
+ */
+export type ResolvableAddBehaviorOptions = Omit<AddBehaviorOptions, "functionAssociations"> & {
+  functionAssociations?: ResolvableFunctionAssociation[];
+};
+
 export interface DistributionBuilderProps extends Omit<
   DistributionProps,
   "defaultBehavior" | "enableLogging"
@@ -61,8 +88,12 @@ export interface DistributionBuilderProps extends Omit<
    * method and injected at build time. All other behavior options (cache
    * policy, function associations, viewer protocol policy, etc.) can be
    * configured here.
+   *
+   * Each entry in `functionAssociations.function` may be either a concrete
+   * {@link IFunctionRef} or a {@link Ref} resolved at build time — this
+   * enables composing a CloudFront Function component with the distribution.
    */
-  defaultBehavior?: AddBehaviorOptions;
+  defaultBehavior?: ResolvableAddBehaviorOptions;
 
   /**
    * Configuration for AWS-recommended CloudWatch alarms.
@@ -213,6 +244,12 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
       };
     }
 
+    const resolvedFunctionAssociations: FunctionAssociation[] | undefined =
+      userBehavior?.functionAssociations?.map((fa) => ({
+        function: resolve(fa.function, context ?? {}),
+        eventType: fa.eventType,
+      }));
+
     const mergedProps = {
       ...cdkDefaults,
       ...accessLogProps,
@@ -220,6 +257,9 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
       defaultBehavior: {
         ...defaultBehavior,
         ...userBehavior,
+        ...(resolvedFunctionAssociations
+          ? { functionAssociations: resolvedFunctionAssociations }
+          : {}),
         origin: resolvedOrigin,
       },
     } as DistributionProps;

--- a/packages/cloudfront/src/function-alarms.ts
+++ b/packages/cloudfront/src/function-alarms.ts
@@ -1,0 +1,127 @@
+import { Duration } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import type { Function as CfFunction } from "aws-cdk-lib/aws-cloudfront";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { FunctionAlarmConfig } from "./alarm-config.js";
+import { FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.minutes(1);
+const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+
+/**
+ * Creates a CloudFront Function metric with the correct namespace and
+ * dimensions (FunctionName + Region=Global).
+ *
+ * CloudFront Function metrics are only emitted to the `us-east-1` region.
+ * Consumers should deploy their alarms to that region.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+ */
+function functionMetric(fn: CfFunction, metricName: string, statistic: string): Metric {
+  return new Metric({
+    namespace: "AWS/CloudFront",
+    metricName,
+    dimensionsMap: {
+      FunctionName: fn.functionName,
+      Region: "Global",
+    },
+    statistic,
+    period: METRIC_PERIOD,
+  });
+}
+
+/**
+ * Resolves the recommended alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s for a CloudFront Function.
+ */
+export function resolveFunctionAlarmDefinitions(
+  fn: CfFunction,
+  config: FunctionAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.executionErrors !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.executionErrors,
+      FUNCTION_ALARM_DEFAULTS.executionErrors,
+    );
+    definitions.push({
+      key: "executionErrors",
+      metric: functionMetric(fn, "FunctionExecutionErrors", Stats.SUM),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `CloudFront Function is raising execution errors. Threshold: > ${String(cfg.threshold)} errors in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.validationErrors !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.validationErrors,
+      FUNCTION_ALARM_DEFAULTS.validationErrors,
+    );
+    definitions.push({
+      key: "validationErrors",
+      metric: functionMetric(fn, "FunctionValidationErrors", Stats.SUM),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `CloudFront Function is producing validation errors. Threshold: > ${String(cfg.threshold)} errors in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.throttles !== false) {
+    const cfg = resolveAlarmConfig(config?.throttles, FUNCTION_ALARM_DEFAULTS.throttles);
+    definitions.push({
+      key: "throttles",
+      metric: functionMetric(fn, "FunctionThrottles", Stats.SUM),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `CloudFront Function is being throttled — likely exceeding its 1ms compute budget. Threshold: > ${String(cfg.threshold)} throttles in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates recommended CloudWatch alarms for a CloudFront Function, merging
+ * recommended definitions with any custom alarm builders.
+ *
+ * @param scope - CDK construct scope for creating alarm constructs.
+ * @param id - Base identifier for alarm construct ids.
+ * @param fn - The CloudFront Function to create alarms for.
+ * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @returns A record mapping alarm keys to their created Alarm constructs.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+ */
+export function createFunctionAlarms(
+  scope: IConstruct,
+  id: string,
+  fn: CfFunction,
+  config: FunctionAlarmConfig | false | undefined,
+  customAlarms: AlarmDefinitionBuilder<CfFunction>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? FUNCTION_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveFunctionAlarmDefinitions(fn, config);
+  const custom = customAlarms.map((b) => b.resolve(fn));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/cloudfront/src/function-builder.ts
+++ b/packages/cloudfront/src/function-builder.ts
@@ -1,0 +1,166 @@
+import { Function as CfFunction, type FunctionProps } from "aws-cdk-lib/aws-cloudfront";
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { type IConstruct } from "constructs";
+import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { FunctionAlarmConfig } from "./alarm-config.js";
+import { createFunctionAlarms } from "./function-alarms.js";
+import { FUNCTION_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the CloudFront Function builder.
+ *
+ * Extends the CDK {@link FunctionProps} with additional builder-specific
+ * options. The `code` property is still required — CloudFront Functions take
+ * a single JS source string (via `FunctionCode.fromInline` or `fromFile`) and
+ * are not bundled.
+ */
+export interface FunctionBuilderProps extends FunctionProps {
+  /**
+   * Configuration for recommended CloudWatch alarms.
+   *
+   * By default, the builder creates alarms for execution errors, validation
+   * errors, and throttles. Individual alarms can be customized or disabled.
+   * Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification methods
+   * are user-specific. Access alarms from the build result or use an
+   * `afterBuild` hook to apply actions.
+   *
+   * CloudFront Function metrics are only emitted to `us-east-1`. Alarms
+   * created here live in the stack's region — if that is not `us-east-1`,
+   * the alarms will not receive data.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+   */
+  recommendedAlarms?: FunctionAlarmConfig | false;
+}
+
+/**
+ * The build output of an {@link IFunctionBuilder}. Contains the CDK
+ * constructs created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface FunctionBuilderResult {
+  /** The CloudFront Function construct created by the builder. */
+  function: CfFunction;
+
+  /**
+   * CloudWatch alarms created for the function, keyed by alarm name.
+   *
+   * Includes both recommended alarms and any custom alarms added via
+   * {@link IFunctionBuilder.addAlarm}. Access individual alarms by key
+   * (e.g., `result.alarms.executionErrors`).
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for configuring and creating a CloudFront Function.
+ *
+ * CloudFront Functions are lightweight JavaScript functions that run at the
+ * edge for viewer-request / viewer-response events. They differ substantially
+ * from Lambda: a custom JS runtime (`cloudfront-js-2.0`), a 1ms compute
+ * budget, no network or filesystem access, and no CloudWatch Logs — only
+ * metrics. The builder accordingly does not create a LogGroup.
+ *
+ * Each configuration property from the CDK {@link FunctionProps} is exposed
+ * as an overloaded method: call with a value to set it (returns the builder
+ * for chaining), or call with no arguments to read the current value.
+ *
+ * The builder implements {@link Lifecycle} so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates a
+ * CloudFront Function with the configured properties and returns a
+ * {@link FunctionBuilderResult}.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html
+ *
+ * @example
+ * ```ts
+ * const rewrite = createFunctionBuilder()
+ *   .code(FunctionCode.fromFile({ filePath: "src/edge/rewrite.js" }))
+ *   .comment("Normalises viewer request URIs");
+ * ```
+ */
+export type IFunctionBuilder = IBuilder<FunctionBuilderProps, FunctionBuilder>;
+
+class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
+  props: Partial<FunctionBuilderProps> = {};
+  private readonly customAlarms: AlarmDefinitionBuilder<CfFunction>[] = [];
+
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<CfFunction>) => AlarmDefinitionBuilder<CfFunction>,
+  ): this {
+    this.customAlarms.push(configure(new AlarmDefinitionBuilder<CfFunction>(key)));
+    return this;
+  }
+
+  build(scope: IConstruct, id: string): FunctionBuilderResult {
+    if (!this.props.code) {
+      throw new Error(
+        `FunctionBuilder "${id}" requires code. ` +
+          `Call .code() with FunctionCode.fromInline() or FunctionCode.fromFile().`,
+      );
+    }
+
+    const { recommendedAlarms: alarmConfig, ...functionProps } = this.props;
+
+    const mergedProps = {
+      ...FUNCTION_DEFAULTS,
+      ...functionProps,
+    } as FunctionProps;
+
+    const fn = new CfFunction(scope, id, mergedProps);
+
+    const alarms = createFunctionAlarms(scope, id, fn, alarmConfig, this.customAlarms);
+
+    return { function: fn, alarms };
+  }
+}
+
+/**
+ * Creates a new {@link IFunctionBuilder} for configuring a CloudFront Function.
+ *
+ * This is the entry point for defining a CloudFront Function component. The
+ * returned builder exposes every {@link FunctionBuilderProps} property as a
+ * fluent setter/getter and implements {@link Lifecycle} for use with
+ * {@link compose}.
+ *
+ * @returns A fluent builder for a CloudFront Function.
+ *
+ * @example
+ * ```ts
+ * const rewrite = createFunctionBuilder()
+ *   .code(FunctionCode.fromInline(`
+ *     async function handler(event) {
+ *       if (!event.request.uri.includes(".")) {
+ *         event.request.uri = event.request.uri.replace(/\\/$/, "") + "/index.html";
+ *       }
+ *       return event.request;
+ *     }
+ *   `));
+ *
+ * // Use standalone:
+ * const result = rewrite.build(stack, "Rewrite");
+ *
+ * // Or compose with a distribution:
+ * const system = compose(
+ *   {
+ *     rewrite,
+ *     site: createBucketBuilder(),
+ *     cdn: createDistributionBuilder()
+ *       .origin(ref("site", (r) => S3BucketOrigin.withOriginAccessControl(r.bucket)))
+ *       .defaultBehavior({
+ *         functionAssociations: [{
+ *           function: ref<FunctionBuilderResult>("rewrite", (r) => r.function),
+ *           eventType: FunctionEventType.VIEWER_REQUEST,
+ *         }],
+ *       }),
+ *   },
+ *   { rewrite: [], site: [], cdn: ["site", "rewrite"] },
+ * );
+ * ```
+ */
+export function createFunctionBuilder(): IFunctionBuilder {
+  return Builder<FunctionBuilderProps, FunctionBuilder>(FunctionBuilder);
+}

--- a/packages/cloudfront/src/index.ts
+++ b/packages/cloudfront/src/index.ts
@@ -2,7 +2,14 @@ export {
   createDistributionBuilder,
   type DistributionBuilderResult,
   type IDistributionBuilder,
+  type ResolvableFunctionAssociation,
+  type ResolvableAddBehaviorOptions,
 } from "./distribution-builder.js";
-export { DISTRIBUTION_DEFAULTS } from "./defaults.js";
-export { type DistributionAlarmConfig } from "./alarm-config.js";
-export { DISTRIBUTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
+export {
+  createFunctionBuilder,
+  type FunctionBuilderResult,
+  type IFunctionBuilder,
+} from "./function-builder.js";
+export { DISTRIBUTION_DEFAULTS, FUNCTION_DEFAULTS } from "./defaults.js";
+export { type DistributionAlarmConfig, type FunctionAlarmConfig } from "./alarm-config.js";
+export { DISTRIBUTION_ALARM_DEFAULTS, FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -3,11 +3,18 @@ import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
-import { CachePolicy, PriceClass, ViewerProtocolPolicy } from "aws-cdk-lib/aws-cloudfront";
+import {
+  CachePolicy,
+  FunctionCode,
+  FunctionEventType,
+  PriceClass,
+  ViewerProtocolPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { ref } from "@composurecdk/core";
 import { type BucketBuilderResult } from "@composurecdk/s3";
 import { createDistributionBuilder } from "../src/distribution-builder.js";
+import { createFunctionBuilder, type FunctionBuilderResult } from "../src/function-builder.js";
 
 function synthTemplate(
   configureFn: (builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) => void,
@@ -326,6 +333,78 @@ describe("DistributionBuilder", () => {
               S3OriginConfig: Match.anyValue(),
             }),
           ]),
+        }),
+      });
+    });
+
+    it("resolves functionAssociations.function from context when using a Ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const bucket = new Bucket(stack, "TestBucket");
+
+      const functionResult = createFunctionBuilder()
+        .code(FunctionCode.fromInline("async function handler(e){return e.request}"))
+        .recommendedAlarms(false)
+        .build(stack, "Rewrite");
+
+      const builder = createDistributionBuilder()
+        .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+        .accessLogging(false)
+        .defaultBehavior({
+          functionAssociations: [
+            {
+              function: ref<FunctionBuilderResult>("rewrite").map((r) => r.function),
+              eventType: FunctionEventType.VIEWER_REQUEST,
+            },
+          ],
+        });
+
+      const result = builder.build(stack, "TestDistribution", {
+        rewrite: functionResult,
+      });
+
+      expect(result.distribution).toBeDefined();
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({
+                EventType: "viewer-request",
+                FunctionARN: Match.anyValue(),
+              }),
+            ]),
+          }),
+        }),
+      });
+    });
+
+    it("accepts a concrete IFunctionRef in functionAssociations (non-Ref)", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const bucket = new Bucket(stack, "TestBucket");
+
+      const { function: fn } = createFunctionBuilder()
+        .code(FunctionCode.fromInline("async function handler(e){return e.request}"))
+        .recommendedAlarms(false)
+        .build(stack, "Rewrite");
+
+      createDistributionBuilder()
+        .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+        .accessLogging(false)
+        .defaultBehavior({
+          functionAssociations: [{ function: fn, eventType: FunctionEventType.VIEWER_RESPONSE }],
+        })
+        .build(stack, "TestDistribution");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({ EventType: "viewer-response" }),
+            ]),
+          }),
         }),
       });
     });

--- a/packages/cloudfront/test/function-alarms.test.ts
+++ b/packages/cloudfront/test/function-alarms.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { FunctionCode } from "aws-cdk-lib/aws-cloudfront";
+import { createFunctionBuilder } from "../src/function-builder.js";
+
+const INLINE_CODE = `
+  async function handler(event) {
+    return event.request;
+  }
+`;
+
+function buildResult(
+  configureFn: (builder: ReturnType<typeof createFunctionBuilder>, stack: Stack) => void,
+) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createFunctionBuilder();
+  configureFn(builder, stack);
+  const result = builder.build(stack, "TestFunction");
+  return { result, template: Template.fromStack(stack) };
+}
+
+function withCode(builder: ReturnType<typeof createFunctionBuilder>) {
+  builder.code(FunctionCode.fromInline(INLINE_CODE));
+}
+
+describe("recommended alarms", () => {
+  describe("defaults", () => {
+    it("creates executionErrors, validationErrors and throttles alarms by default", () => {
+      const { result, template } = buildResult((b) => {
+        withCode(b);
+      });
+
+      expect(result.alarms.executionErrors).toBeDefined();
+      expect(result.alarms.validationErrors).toBeDefined();
+      expect(result.alarms.throttles).toBeDefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 3);
+    });
+
+    it("creates executionErrors alarm with threshold > 0", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionExecutionErrors",
+        Namespace: "AWS/CloudFront",
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        Statistic: "Sum",
+        Period: 60,
+        TreatMissingData: "notBreaching",
+      });
+    });
+
+    it("creates validationErrors alarm with threshold > 0", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionValidationErrors",
+        Namespace: "AWS/CloudFront",
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        Statistic: "Sum",
+        Period: 60,
+      });
+    });
+
+    it("creates throttles alarm with threshold > 0", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionThrottles",
+        Namespace: "AWS/CloudFront",
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        Statistic: "Sum",
+      });
+    });
+
+    it("includes FunctionName and Region=Global dimensions", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionExecutionErrors",
+        Dimensions: Match.arrayWith([
+          Match.objectLike({ Name: "FunctionName" }),
+          Match.objectLike({ Name: "Region", Value: "Global" }),
+        ]),
+      });
+    });
+  });
+
+  describe("customization", () => {
+    it("allows customizing executionErrors threshold", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+        b.recommendedAlarms({ executionErrors: { threshold: 5 } });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionExecutionErrors",
+        Threshold: 5,
+      });
+    });
+
+    it("allows customizing evaluation periods", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+        b.recommendedAlarms({
+          throttles: { evaluationPeriods: 3, datapointsToAlarm: 2 },
+        });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionThrottles",
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 2,
+      });
+    });
+
+    it("allows customizing treatMissingData", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+        b.recommendedAlarms({
+          validationErrors: { treatMissingData: TreatMissingData.BREACHING },
+        });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionValidationErrors",
+        TreatMissingData: "breaching",
+      });
+    });
+  });
+
+  describe("disabling alarms", () => {
+    it("disables all alarms when recommendedAlarms is false", () => {
+      const { result, template } = buildResult((b) => {
+        withCode(b);
+        b.recommendedAlarms(false);
+      });
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all alarms when enabled is false", () => {
+      const { result, template } = buildResult((b) => {
+        withCode(b);
+        b.recommendedAlarms({ enabled: false });
+      });
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables individual alarms when set to false", () => {
+      const { result, template } = buildResult((b) => {
+        withCode(b);
+        b.recommendedAlarms({ executionErrors: false });
+      });
+
+      expect(result.alarms.executionErrors).toBeUndefined();
+      expect(result.alarms.validationErrors).toBeDefined();
+      expect(result.alarms.throttles).toBeDefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+  });
+
+  describe("no default actions", () => {
+    it("creates alarms with no alarm actions", () => {
+      const { template } = buildResult((b) => {
+        withCode(b);
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "FunctionExecutionErrors",
+        AlarmActions: Match.absent(),
+      });
+    });
+  });
+});
+
+describe("addAlarm", () => {
+  it("creates a custom alarm alongside recommended alarms", () => {
+    const { result, template } = buildResult((b) => {
+      withCode(b);
+      b.addAlarm("computeUtilization", (alarm) =>
+        alarm
+          .metric(
+            (fn) =>
+              new Metric({
+                namespace: "AWS/CloudFront",
+                metricName: "FunctionComputeUtilization",
+                dimensionsMap: {
+                  FunctionName: fn.functionName,
+                  Region: "Global",
+                },
+                statistic: "Average",
+                period: Duration.minutes(1),
+              }),
+          )
+          .threshold(80)
+          .greaterThan()
+          .description("CloudFront function compute utilization is high"),
+      );
+    });
+
+    expect(result.alarms.computeUtilization).toBeDefined();
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FunctionComputeUtilization",
+      Threshold: 80,
+    });
+  });
+
+  it("throws on duplicate key with recommended alarm", () => {
+    expect(() =>
+      buildResult((b) => {
+        withCode(b);
+        b.addAlarm("executionErrors", (alarm) =>
+          alarm
+            .metric(
+              (fn) =>
+                new Metric({
+                  namespace: "AWS/CloudFront",
+                  metricName: "FunctionExecutionErrors",
+                  dimensionsMap: {
+                    FunctionName: fn.functionName,
+                    Region: "Global",
+                  },
+                  period: Duration.minutes(1),
+                }),
+            )
+            .description("Duplicate"),
+        );
+      }),
+    ).toThrow(/Duplicate alarm key "executionErrors"/);
+  });
+});

--- a/packages/cloudfront/test/function-builder.test.ts
+++ b/packages/cloudfront/test/function-builder.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import {
+  FunctionCode,
+  FunctionRuntime,
+  KeyValueStore,
+  ImportSource,
+} from "aws-cdk-lib/aws-cloudfront";
+import { createFunctionBuilder } from "../src/function-builder.js";
+
+const INLINE_CODE = `
+  async function handler(event) {
+    return event.request;
+  }
+`;
+
+function synthTemplate(
+  configureFn: (builder: ReturnType<typeof createFunctionBuilder>, stack: Stack) => void,
+): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createFunctionBuilder();
+  configureFn(builder, stack);
+  builder.build(stack, "TestFunction");
+  return Template.fromStack(stack);
+}
+
+describe("FunctionBuilder", () => {
+  describe("build", () => {
+    it("returns a FunctionBuilderResult with a function property", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createFunctionBuilder()
+        .code(FunctionCode.fromInline(INLINE_CODE))
+        .build(stack, "TestFunction");
+
+      expect(result).toBeDefined();
+      expect(result.function).toBeDefined();
+    });
+
+    it("throws when no code is provided", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const builder = createFunctionBuilder();
+
+      expect(() => builder.build(stack, "TestFunction")).toThrow(/requires code/);
+    });
+  });
+
+  describe("synthesised output", () => {
+    it("creates a CloudFront Function", () => {
+      const template = synthTemplate((b) => b.code(FunctionCode.fromInline(INLINE_CODE)));
+      template.resourceCountIs("AWS::CloudFront::Function", 1);
+    });
+
+    it("applies the provided inline code", () => {
+      const template = synthTemplate((b) => b.code(FunctionCode.fromInline(INLINE_CODE)));
+
+      template.hasResourceProperties("AWS::CloudFront::Function", {
+        FunctionCode: Match.stringLikeRegexp("handler"),
+      });
+    });
+
+    it("applies a provided comment", () => {
+      const template = synthTemplate((b) =>
+        b.code(FunctionCode.fromInline(INLINE_CODE)).comment("URI rewrite for SPA"),
+      );
+
+      template.hasResourceProperties("AWS::CloudFront::Function", {
+        FunctionConfig: Match.objectLike({
+          Comment: "URI rewrite for SPA",
+        }),
+      });
+    });
+
+    it("applies a provided functionName", () => {
+      const template = synthTemplate((b) =>
+        b.code(FunctionCode.fromInline(INLINE_CODE)).functionName("MyRewriteFn"),
+      );
+
+      template.hasResourceProperties("AWS::CloudFront::Function", {
+        Name: "MyRewriteFn",
+      });
+    });
+  });
+
+  describe("secure defaults", () => {
+    it("uses the cloudfront-js-2.0 runtime by default", () => {
+      const template = synthTemplate((b) => b.code(FunctionCode.fromInline(INLINE_CODE)));
+
+      template.hasResourceProperties("AWS::CloudFront::Function", {
+        FunctionConfig: Match.objectLike({
+          Runtime: "cloudfront-js-2.0",
+        }),
+      });
+    });
+
+    it("allows the user to override the runtime", () => {
+      const template = synthTemplate((b) =>
+        b.code(FunctionCode.fromInline(INLINE_CODE)).runtime(FunctionRuntime.JS_1_0),
+      );
+
+      template.hasResourceProperties("AWS::CloudFront::Function", {
+        FunctionConfig: Match.objectLike({
+          Runtime: "cloudfront-js-1.0",
+        }),
+      });
+    });
+  });
+
+  describe("keyValueStore pass-through", () => {
+    it("associates the provided KVS with the function", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const kvs = new KeyValueStore(stack, "Kvs", {
+        source: ImportSource.fromInline(JSON.stringify({ data: [{ key: "a", value: "b" }] })),
+      });
+
+      createFunctionBuilder()
+        .code(FunctionCode.fromInline(INLINE_CODE))
+        .keyValueStore(kvs)
+        .build(stack, "TestFunction");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Function", {
+        FunctionConfig: Match.objectLike({
+          Runtime: "cloudfront-js-2.0",
+          KeyValueStoreAssociations: Match.arrayWith([
+            Match.objectLike({ KeyValueStoreARN: Match.anyValue() }),
+          ]),
+        }),
+      });
+    });
+  });
+});


### PR DESCRIPTION
…arms

Introduces createFunctionBuilder() alongside the existing distribution builder, since CloudFront Functions are a distinct CDK construct with a custom JS runtime, 1ms compute budget, and no CloudWatch Logs — not just a constrained Lambda. Defaults to the cloudfront-js-2.0 runtime and creates executionErrors / validationErrors / throttles alarms with standard FunctionName + Region=Global dimensions. KeyValueStore is supported as a pass-through prop.

Also extends DistributionBuilder.defaultBehavior.functionAssociations to accept Resolvable<IFunctionRef>, so a function component can be wired to a distribution via ref() within compose(), mirroring the existing origin resolution.

Resolves #32