### PR TITLE
feat(examples): add custom-domain website example (Route53 + ACM)

### DIFF
--- a/.github/cloudformation/github-oidc-role.yml
+++ b/.github/cloudformation/github-oidc-role.yml
@@ -237,6 +237,71 @@ Resources:
               StringLike:
                 aws:ResourceTag/aws:cloudformation:stack-name: ComposureCDK-*
 
+          # Route 53 — for the custom-domain example. Records are created
+          # in a pre-existing hosted zone brought in via HostedZone.fromLookup,
+          # plus the ACM DNS validation records. ListHostedZonesByName is
+          # required by fromLookup itself and cannot be scoped by zone.
+          - Sid: Route53Lookup
+            Effect: Allow
+            Action:
+              - route53:ListHostedZonesByName
+              - route53:ListHostedZones
+            Resource: "*"
+          - Sid: Route53Zone
+            Effect: Allow
+            Action:
+              - route53:ChangeResourceRecordSets
+              - route53:GetHostedZone
+              - route53:ListResourceRecordSets
+            Resource:
+              - !Sub arn:${AWS::Partition}:route53:::hostedzone/*
+          - Sid: Route53Change
+            Effect: Allow
+            Action:
+              - route53:GetChange
+            Resource:
+              - !Sub arn:${AWS::Partition}:route53:::change/*
+
+          # ACM — for the custom-domain example. Certificate actions do not
+          # support tag-based conditions consistently, so these are scoped
+          # to the sandbox account.
+          - Sid: ACM
+            Effect: Allow
+            Action:
+              - acm:RequestCertificate
+              - acm:DeleteCertificate
+              - acm:DescribeCertificate
+              - acm:GetCertificate
+              - acm:ListCertificates
+              - acm:AddTagsToCertificate
+              - acm:RemoveTagsFromCertificate
+              - acm:ListTagsForCertificate
+              - acm:UpdateCertificateOptions
+            Resource: "*"
+
+          # CloudFront — for the static-website and custom-domain examples.
+          # Distribution APIs largely lack resource-level tag conditions.
+          - Sid: CloudFront
+            Effect: Allow
+            Action:
+              - cloudfront:CreateDistribution
+              - cloudfront:CreateDistributionWithTags
+              - cloudfront:UpdateDistribution
+              - cloudfront:DeleteDistribution
+              - cloudfront:GetDistribution
+              - cloudfront:GetDistributionConfig
+              - cloudfront:ListDistributions
+              - cloudfront:TagResource
+              - cloudfront:UntagResource
+              - cloudfront:ListTagsForResource
+              - cloudfront:CreateOriginAccessControl
+              - cloudfront:DeleteOriginAccessControl
+              - cloudfront:GetOriginAccessControl
+              - cloudfront:GetOriginAccessControlConfig
+              - cloudfront:ListOriginAccessControls
+              - cloudfront:UpdateOriginAccessControl
+            Resource: "*"
+
           # CDK bootstrap roles — assumed by CDK CLI for asset publishing
           # and CloudFormation execution
           - Sid: CDKAssetRoles

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -64,6 +64,11 @@ jobs:
 
       - name: CDK Deploy
         working-directory: packages/examples
+        env:
+          # Opt-in: when set, enables the custom-domain-website example.
+          # Requires a pre-existing, delegated Route 53 hosted zone in the
+          # target account — see docs/ci.md.
+          COMPOSURECDK_DOMAIN: ${{ vars.COMPOSURECDK_DOMAIN }}
         run: npx cdk deploy --all --require-approval never
 
       - name: Smoke Test
@@ -73,6 +78,8 @@ jobs:
       - name: CDK Destroy
         if: always()
         working-directory: packages/examples
+        env:
+          COMPOSURECDK_DOMAIN: ${{ vars.COMPOSURECDK_DOMAIN }}
         run: |
           # Only destroy if AWS credentials were configured
           if ! aws sts get-caller-identity > /dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ If two components depend on each other, that is an architectural problem to be s
 | `@composurecdk/iam`        | IAM role and policy components                              |
 | `@composurecdk/apigateway` | API Gateway components                                      |
 | `@composurecdk/ec2`        | EC2 and VPC components                                      |
-| `@composurecdk/acm`        | ACM certificate components with DNS validation wiring       |
+| `@composurecdk/acm`        | ACM certificate components with DNS validation              |
+| `@composurecdk/route53`    | Route 53 hosted zones, records, and alias target helpers    |
 
 ## License
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -218,18 +218,48 @@ aws cloudformation describe-stacks \
 
 ### 3. Configure the GitHub Environment
 
-Create a GitHub Environment called `sandbox` on the repository with two variables:
+Create a GitHub Environment called `sandbox` on the repository with these variables:
 
-| Variable       | Value                                          |
-| -------------- | ---------------------------------------------- |
-| `AWS_ROLE_ARN` | The `RoleArn` output from the OIDC stack       |
-| `AWS_REGION`   | The region you bootstrapped (e.g. `eu-west-1`) |
+| Variable              | Required | Value                                                                         |
+| --------------------- | -------- | ----------------------------------------------------------------------------- |
+| `AWS_ROLE_ARN`        | Yes      | The `RoleArn` output from the OIDC stack                                      |
+| `AWS_REGION`          | Yes      | The region you bootstrapped (e.g. `eu-west-1`)                                |
+| `COMPOSURECDK_DOMAIN` | No       | Enables the custom-domain-website example — see section 5 for the full set-up |
 
 Optionally add protection rules (e.g. required reviewers) to control when deployments run.
 
 ### 4. Trigger the workflow
 
 Go to **Actions > Deploy Test > Run workflow**, select the `sandbox` environment, and run it.
+
+### 5. (Optional) Enable the custom-domain-website example
+
+The `custom-domain-website` example provisions an ACM certificate with DNS validation and wires a CloudFront distribution to apex A/AAAA alias records. ACM validation cannot complete unless the target hosted zone's nameservers are already delegated on the public internet, so the example is opt-in and requires a pre-existing hosted zone in the sandbox account.
+
+1. **Register a domain** you control (e.g. in Route 53, or at any registrar), or carve out a sub-domain of an existing domain (e.g. `sandbox.yourcompany.com`).
+2. **Create a public hosted zone** for the chosen domain in the sandbox AWS account:
+
+   ```sh
+   aws route53 create-hosted-zone \
+     --name sandbox.yourcompany.com \
+     --caller-reference "$(date +%s)"
+   ```
+
+3. **Delegate the nameservers** from the parent zone / registrar to the four NS records Route 53 assigned to the hosted zone. This is a one-time, manual step and must propagate on the public internet before ACM validation will succeed — typically minutes to hours.
+
+4. **Re-deploy the OIDC stack** so the role picks up the Route 53, ACM, and CloudFront permissions the example requires:
+
+   ```sh
+   aws cloudformation deploy \
+     --template-file .github/cloudformation/github-oidc-role.yml \
+     --stack-name github-actions-oidc \
+     --parameter-overrides GitHubOrg=laazyj RepoName=composureCDK \
+     --capabilities CAPABILITY_NAMED_IAM
+   ```
+
+5. **Add `COMPOSURECDK_DOMAIN`** to the `sandbox` GitHub Environment variables, set to the delegated domain (e.g. `sandbox.yourcompany.com`). The workflow threads this through to `cdk deploy`; when unset, the example is skipped entirely and nothing else is affected.
+
+Running locally follows the same contract: export `COMPOSURECDK_DOMAIN` (or pass `--context domain=…`) before `npx nx deploy examples`.
 
 ## Running locally
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1835,6 +1835,10 @@
       "resolved": "packages/logs",
       "link": true
     },
+    "node_modules/@composurecdk/route53": {
+      "resolved": "packages/route53",
+      "link": true
+    },
     "node_modules/@composurecdk/s3": {
       "resolved": "packages/s3",
       "link": true
@@ -7829,12 +7833,14 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
+        "@composurecdk/acm": "^0.3.0",
         "@composurecdk/apigateway": "^0.3.0",
         "@composurecdk/cloudformation": "^0.3.0",
         "@composurecdk/cloudfront": "^0.3.0",
         "@composurecdk/cloudwatch": "^0.3.0",
         "@composurecdk/core": "^0.3.0",
         "@composurecdk/lambda": "^0.3.0",
+        "@composurecdk/route53": "^0.3.0",
         "@composurecdk/s3": "^0.3.0",
         "@composurecdk/sns": "^0.3.0"
       }
@@ -7877,6 +7883,23 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
+      "version": "0.3.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "aws-cdk-lib": "^2.250.0",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@composurecdk/core": "^0.3.0",
+        "aws-cdk-lib": "^2.0.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "packages/route53": {
+      "name": "@composurecdk/route53",
       "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {

--- a/packages/examples/bin/app.ts
+++ b/packages/examples/bin/app.ts
@@ -19,7 +19,13 @@ createMockApiApp(app);
 createMultiStackApp(app);
 createOpenApiPetstoreApp(app);
 createStaticWebsiteApp(app);
-createCustomDomainWebsiteApp(app);
+// Opt-in: only synthesised when a pre-existing delegated hosted zone is
+// supplied via COMPOSURECDK_DOMAIN or --context domain=...; see
+// custom-domain-website/app.ts for the prerequisites.
+const domainContext: unknown = app.node.tryGetContext("domain");
+if (typeof domainContext === "string" || process.env.COMPOSURECDK_DOMAIN) {
+  createCustomDomainWebsiteApp(app);
+}
 createStrategyStackApp(app);
 
 app.synth();

--- a/packages/examples/bin/app.ts
+++ b/packages/examples/bin/app.ts
@@ -7,6 +7,7 @@ import { createMockApiApp } from "../src/mock-api-app.js";
 import { createMultiStackApp } from "../src/multi-stack-app.js";
 import { createOpenApiPetstoreApp } from "../src/openapi-petstore-app.js";
 import { createStaticWebsiteApp } from "../src/static-website/app.js";
+import { createCustomDomainWebsiteApp } from "../src/custom-domain-website/app.js";
 import { createStrategyStackApp } from "../src/strategy-stack-app.js";
 
 const app = new App();
@@ -18,6 +19,7 @@ createMockApiApp(app);
 createMultiStackApp(app);
 createOpenApiPetstoreApp(app);
 createStaticWebsiteApp(app);
+createCustomDomainWebsiteApp(app);
 createStrategyStackApp(app);
 
 app.synth();

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -22,12 +22,14 @@
     "constructs": "^10.6.0"
   },
   "peerDependencies": {
+    "@composurecdk/acm": "^0.3.0",
     "@composurecdk/apigateway": "^0.3.0",
     "@composurecdk/cloudformation": "^0.3.0",
     "@composurecdk/cloudwatch": "^0.3.0",
     "@composurecdk/cloudfront": "^0.3.0",
     "@composurecdk/core": "^0.3.0",
     "@composurecdk/lambda": "^0.3.0",
+    "@composurecdk/route53": "^0.3.0",
     "@composurecdk/s3": "^0.3.0",
     "@composurecdk/sns": "^0.3.0"
   },

--- a/packages/examples/src/custom-domain-website/app.ts
+++ b/packages/examples/src/custom-domain-website/app.ts
@@ -1,0 +1,106 @@
+import { App } from "aws-cdk-lib";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { compose, ref } from "@composurecdk/core";
+import { createStackBuilder, outputs } from "@composurecdk/cloudformation";
+import { createCertificateBuilder, type CertificateBuilderResult } from "@composurecdk/acm";
+import {
+  createDistributionBuilder,
+  type DistributionBuilderResult,
+} from "@composurecdk/cloudfront";
+import {
+  cloudfrontAliasTarget,
+  createAaaaRecordBuilder,
+  createARecordBuilder,
+  createHostedZoneBuilder,
+  type HostedZoneBuilderResult,
+} from "@composurecdk/route53";
+
+/**
+ * A CloudFront distribution exposed at a custom domain name, backed by a
+ * Route 53 public hosted zone and an ACM certificate with DNS validation.
+ *
+ * Demonstrates:
+ * - A fully-declarative composition: the hosted zone, DNS-validated
+ *   certificate, CloudFront distribution, and apex A/AAAA alias records are
+ *   all declared inside a single {@link compose} call with dependencies as
+ *   data.
+ * - Using the {@link cloudfrontAliasTarget} helper so the record targets are
+ *   produced at build time from the composed distribution.
+ *
+ * Note: CloudFront viewer certificates must live in `us-east-1`. This example
+ * places the whole stack in the default environment — in production, you'd
+ * either deploy the stack to `us-east-1` or split the certificate into a
+ * dedicated `us-east-1` stack and wire it across via cross-region references.
+ */
+export function createCustomDomainWebsiteApp(app = new App()) {
+  const { stack } = createStackBuilder()
+    .description("Static website at a custom domain with Route53 + ACM")
+    .build(app, "ComposureCDK-CustomDomainWebsiteStack");
+
+  const apexDomain = "example.com";
+  const wwwDomain = `www.${apexDomain}`;
+
+  compose(
+    {
+      zone: createHostedZoneBuilder()
+        .zoneName(apexDomain)
+        .comment("Primary customer-facing domain"),
+
+      certificate: createCertificateBuilder()
+        .domainName(apexDomain)
+        .subjectAlternativeNames([wwwDomain])
+        .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone)),
+
+      cdn: createDistributionBuilder()
+        .comment("Custom-domain static website")
+        .domainNames([apexDomain, wwwDomain])
+        .certificate(ref("certificate", (r: CertificateBuilderResult) => r.certificate))
+        .origin(new HttpOrigin("origin.internal.example.net")),
+
+      apexA: createARecordBuilder()
+        .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+        .target(
+          cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
+        ),
+
+      apexAaaa: createAaaaRecordBuilder()
+        .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+        .target(
+          cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
+        ),
+    },
+    {
+      zone: [],
+      certificate: ["zone"],
+      cdn: ["certificate"],
+      apexA: ["zone", "cdn"],
+      apexAaaa: ["zone", "cdn"],
+    },
+  )
+    .afterBuild(
+      outputs({
+        DomainUrl: {
+          value: `https://${apexDomain}`,
+          description: "Customer-facing URL",
+        },
+        DistributionDomainName: {
+          value: ref(
+            "cdn",
+            (r: DistributionBuilderResult) => r.distribution.distributionDomainName,
+          ),
+          description: "CloudFront-assigned domain name (alias target)",
+        },
+        HostedZoneId: {
+          value: ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone.hostedZoneId),
+          description: "Route 53 hosted zone ID (for NS delegation)",
+        },
+        CertificateArn: {
+          value: ref("certificate", (r: CertificateBuilderResult) => r.certificate.certificateArn),
+          description: "ACM certificate ARN",
+        },
+      }),
+    )
+    .build(stack, "CustomDomainWebsite");
+
+  return { stack };
+}

--- a/packages/examples/src/custom-domain-website/app.ts
+++ b/packages/examples/src/custom-domain-website/app.ts
@@ -1,5 +1,6 @@
 import { App } from "aws-cdk-lib";
 import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HostedZone } from "aws-cdk-lib/aws-route53";
 import { compose, ref } from "@composurecdk/core";
 import { createStackBuilder, outputs } from "@composurecdk/cloudformation";
 import { createCertificateBuilder, type CertificateBuilderResult } from "@composurecdk/acm";
@@ -11,45 +12,82 @@ import {
   cloudfrontAliasTarget,
   createAaaaRecordBuilder,
   createARecordBuilder,
-  createHostedZoneBuilder,
-  type HostedZoneBuilderResult,
 } from "@composurecdk/route53";
 
 /**
  * A CloudFront distribution exposed at a custom domain name, backed by a
- * Route 53 public hosted zone and an ACM certificate with DNS validation.
+ * pre-existing Route 53 public hosted zone and an ACM certificate with DNS
+ * validation.
  *
- * Demonstrates:
- * - A fully-declarative composition: the hosted zone, DNS-validated
- *   certificate, CloudFront distribution, and apex A/AAAA alias records are
- *   all declared inside a single {@link compose} call with dependencies as
- *   data.
- * - Using the {@link cloudfrontAliasTarget} helper so the record targets are
+ * ## Prerequisites (one-time, per AWS account)
+ *
+ * 1. **Pre-existing hosted zone.** Create a public hosted zone in Route 53
+ *    for a domain you control (e.g. `example.yourcompany.com`). This example
+ *    looks the zone up at synth time via {@link HostedZone.fromLookup} — it
+ *    does not create the zone. ACM's DNS validation challenge can only be
+ *    answered by a zone whose nameservers are already published on the
+ *    public internet, which is an out-of-band step that can't reliably be
+ *    automated inside the same stack.
+ * 2. **NS delegation.** At your domain registrar (or in the parent zone),
+ *    delegate the sub-domain to the four nameservers Route 53 assigned to
+ *    the hosted zone. Until the delegation is live on the public internet,
+ *    `cdk deploy` will stall indefinitely on ACM validation.
+ * 3. **`COMPOSURECDK_DOMAIN` env var** (or `--context domain=...`). The
+ *    example reads the apex domain from context first, env var second. Tests
+ *    set the env var; the CI workflow passes it via `cdk deploy --context`.
+ * 4. **Account + region.** `HostedZone.fromLookup` cannot run in an
+ *    environment-agnostic stack, so `CDK_DEFAULT_ACCOUNT` and
+ *    `CDK_DEFAULT_REGION` must resolve (the CDK CLI sets these from your
+ *    AWS credentials).
+ *
+ * See `docs/ci.md` for the one-time CI setup (IAM permissions, GitHub
+ * Environment variable, hosted-zone provisioning).
+ *
+ * ## What this shows
+ *
+ * - Bringing an external, pre-existing Route 53 hosted zone into a
+ *   composition via `HostedZone.fromLookup` and passing it directly into
+ *   the certificate + record builders.
+ * - Declaring the DNS-validated certificate, CloudFront distribution, and
+ *   apex A/AAAA alias records inside a single {@link compose} call, with
+ *   dependencies as data.
+ * - Using the {@link cloudfrontAliasTarget} helper so record targets are
  *   produced at build time from the composed distribution.
  *
- * Note: CloudFront viewer certificates must live in `us-east-1`. This example
- * places the whole stack in the default environment — in production, you'd
+ * CloudFront viewer certificates must live in `us-east-1`. This example
+ * places the whole stack in the caller's default region — in production,
  * either deploy the stack to `us-east-1` or split the certificate into a
- * dedicated `us-east-1` stack and wire it across via cross-region references.
+ * dedicated `us-east-1` stack and wire it across via cross-region
+ * references.
  */
 export function createCustomDomainWebsiteApp(app = new App()) {
+  const domainContext: unknown = app.node.tryGetContext("domain");
+  const apexDomain: string | undefined =
+    typeof domainContext === "string" ? domainContext : process.env.COMPOSURECDK_DOMAIN;
+  if (!apexDomain) {
+    throw new Error(
+      "custom-domain-website example requires a domain. Set COMPOSURECDK_DOMAIN " +
+        "or pass --context domain=<your-domain>. See custom-domain-website/app.ts for setup.",
+    );
+  }
+  const wwwDomain = `www.${apexDomain}`;
+
   const { stack } = createStackBuilder()
     .description("Static website at a custom domain with Route53 + ACM")
+    .env({
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION,
+    })
     .build(app, "ComposureCDK-CustomDomainWebsiteStack");
 
-  const apexDomain = "example.composurecdk.com";
-  const wwwDomain = `www.${apexDomain}`;
+  const hostedZone = HostedZone.fromLookup(stack, "Zone", { domainName: apexDomain });
 
   compose(
     {
-      zone: createHostedZoneBuilder()
-        .zoneName(apexDomain)
-        .comment("Primary customer-facing domain"),
-
       certificate: createCertificateBuilder()
         .domainName(apexDomain)
         .subjectAlternativeNames([wwwDomain])
-        .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone)),
+        .validationZone(hostedZone),
 
       cdn: createDistributionBuilder()
         .comment("Custom-domain static website")
@@ -58,23 +96,22 @@ export function createCustomDomainWebsiteApp(app = new App()) {
         .origin(new HttpOrigin("origin.internal.example.net")),
 
       apexA: createARecordBuilder()
-        .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+        .zone(hostedZone)
         .target(
           cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
         ),
 
       apexAaaa: createAaaaRecordBuilder()
-        .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+        .zone(hostedZone)
         .target(
           cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)),
         ),
     },
     {
-      zone: [],
-      certificate: ["zone"],
+      certificate: [],
       cdn: ["certificate"],
-      apexA: ["zone", "cdn"],
-      apexAaaa: ["zone", "cdn"],
+      apexA: ["cdn"],
+      apexAaaa: ["cdn"],
     },
   )
     .afterBuild(
@@ -91,8 +128,8 @@ export function createCustomDomainWebsiteApp(app = new App()) {
           description: "CloudFront-assigned domain name (alias target)",
         },
         HostedZoneId: {
-          value: ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone.hostedZoneId),
-          description: "Route 53 hosted zone ID (for NS delegation)",
+          value: hostedZone.hostedZoneId,
+          description: "Route 53 hosted zone ID",
         },
         CertificateArn: {
           value: ref("certificate", (r: CertificateBuilderResult) => r.certificate.certificateArn),

--- a/packages/examples/src/custom-domain-website/app.ts
+++ b/packages/examples/src/custom-domain-website/app.ts
@@ -37,7 +37,7 @@ export function createCustomDomainWebsiteApp(app = new App()) {
     .description("Static website at a custom domain with Route53 + ACM")
     .build(app, "ComposureCDK-CustomDomainWebsiteStack");
 
-  const apexDomain = "example.com";
+  const apexDomain = "example.composurecdk.com";
   const wwwDomain = `www.${apexDomain}`;
 
   compose(

--- a/packages/examples/test/custom-domain-website-app.test.ts
+++ b/packages/examples/test/custom-domain-website-app.test.ts
@@ -13,7 +13,7 @@ describe("custom-domain-website-app", () => {
       const template = synthTemplate();
       template.resourceCountIs("AWS::Route53::HostedZone", 1);
       template.hasResourceProperties("AWS::Route53::HostedZone", {
-        Name: "example.com.",
+        Name: "example.composurecdk.com.",
       });
     });
 
@@ -40,8 +40,8 @@ describe("custom-domain-website-app", () => {
       const template = synthTemplate();
       template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
       template.hasResourceProperties("AWS::CertificateManager::Certificate", {
-        DomainName: "example.com",
-        SubjectAlternativeNames: ["www.example.com"],
+        DomainName: "example.composurecdk.com",
+        SubjectAlternativeNames: ["www.example.composurecdk.com"],
         ValidationMethod: "DNS",
       });
     });
@@ -52,7 +52,7 @@ describe("custom-domain-website-app", () => {
       const template = synthTemplate();
       template.hasResourceProperties("AWS::CloudFront::Distribution", {
         DistributionConfig: Match.objectLike({
-          Aliases: ["example.com", "www.example.com"],
+          Aliases: ["example.composurecdk.com", "www.example.composurecdk.com"],
           ViewerCertificate: Match.objectLike({
             AcmCertificateArn: Match.anyValue(),
           }),

--- a/packages/examples/test/custom-domain-website-app.test.ts
+++ b/packages/examples/test/custom-domain-website-app.test.ts
@@ -1,20 +1,38 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { createCustomDomainWebsiteApp } from "../src/custom-domain-website/app.js";
 
-function synthTemplate(): Template {
-  const { stack } = createCustomDomainWebsiteApp();
-  return Template.fromStack(stack);
-}
+const TEST_DOMAIN = "example.composurecdk.test";
 
 describe("custom-domain-website-app", () => {
-  describe("Route 53 hosted zone", () => {
-    it("creates exactly one public hosted zone for the apex", () => {
+  let originalDomain: string | undefined;
+  let originalAccount: string | undefined;
+  let originalRegion: string | undefined;
+
+  beforeAll(() => {
+    originalDomain = process.env.COMPOSURECDK_DOMAIN;
+    originalAccount = process.env.CDK_DEFAULT_ACCOUNT;
+    originalRegion = process.env.CDK_DEFAULT_REGION;
+    process.env.COMPOSURECDK_DOMAIN = TEST_DOMAIN;
+    process.env.CDK_DEFAULT_ACCOUNT = "123456789012";
+    process.env.CDK_DEFAULT_REGION = "us-east-1";
+  });
+
+  afterAll(() => {
+    process.env.COMPOSURECDK_DOMAIN = originalDomain;
+    process.env.CDK_DEFAULT_ACCOUNT = originalAccount;
+    process.env.CDK_DEFAULT_REGION = originalRegion;
+  });
+
+  function synthTemplate(): Template {
+    const { stack } = createCustomDomainWebsiteApp();
+    return Template.fromStack(stack);
+  }
+
+  describe("Route 53", () => {
+    it("does not create a hosted zone — fromLookup brings in a pre-existing one", () => {
       const template = synthTemplate();
-      template.resourceCountIs("AWS::Route53::HostedZone", 1);
-      template.hasResourceProperties("AWS::Route53::HostedZone", {
-        Name: "example.composurecdk.com.",
-      });
+      template.resourceCountIs("AWS::Route53::HostedZone", 0);
     });
 
     it("creates apex A and AAAA alias records pointing at the CloudFront distribution", () => {
@@ -40,8 +58,8 @@ describe("custom-domain-website-app", () => {
       const template = synthTemplate();
       template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
       template.hasResourceProperties("AWS::CertificateManager::Certificate", {
-        DomainName: "example.composurecdk.com",
-        SubjectAlternativeNames: ["www.example.composurecdk.com"],
+        DomainName: TEST_DOMAIN,
+        SubjectAlternativeNames: [`www.${TEST_DOMAIN}`],
         ValidationMethod: "DNS",
       });
     });
@@ -52,7 +70,7 @@ describe("custom-domain-website-app", () => {
       const template = synthTemplate();
       template.hasResourceProperties("AWS::CloudFront::Distribution", {
         DistributionConfig: Match.objectLike({
-          Aliases: ["example.composurecdk.com", "www.example.composurecdk.com"],
+          Aliases: [TEST_DOMAIN, `www.${TEST_DOMAIN}`],
           ViewerCertificate: Match.objectLike({
             AcmCertificateArn: Match.anyValue(),
           }),
@@ -67,6 +85,16 @@ describe("custom-domain-website-app", () => {
       expect(template.toJSON().Description).toBe(
         "Static website at a custom domain with Route53 + ACM",
       );
+    });
+
+    it("throws when no domain is configured", () => {
+      const saved = process.env.COMPOSURECDK_DOMAIN;
+      delete process.env.COMPOSURECDK_DOMAIN;
+      try {
+        expect(() => createCustomDomainWebsiteApp()).toThrow(/requires a domain/);
+      } finally {
+        process.env.COMPOSURECDK_DOMAIN = saved;
+      }
     });
   });
 });

--- a/packages/examples/test/custom-domain-website-app.test.ts
+++ b/packages/examples/test/custom-domain-website-app.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { createCustomDomainWebsiteApp } from "../src/custom-domain-website/app.js";
+
+function synthTemplate(): Template {
+  const { stack } = createCustomDomainWebsiteApp();
+  return Template.fromStack(stack);
+}
+
+describe("custom-domain-website-app", () => {
+  describe("Route 53 hosted zone", () => {
+    it("creates exactly one public hosted zone for the apex", () => {
+      const template = synthTemplate();
+      template.resourceCountIs("AWS::Route53::HostedZone", 1);
+      template.hasResourceProperties("AWS::Route53::HostedZone", {
+        Name: "example.com.",
+      });
+    });
+
+    it("creates apex A and AAAA alias records pointing at the CloudFront distribution", () => {
+      const template = synthTemplate();
+      template.resourceCountIs("AWS::Route53::RecordSet", 2);
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Type: "A",
+        AliasTarget: Match.objectLike({
+          DNSName: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["DomainName"]) }),
+        }),
+      });
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Type: "AAAA",
+        AliasTarget: Match.objectLike({
+          DNSName: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["DomainName"]) }),
+        }),
+      });
+    });
+  });
+
+  describe("ACM certificate", () => {
+    it("creates a single DNS-validated certificate covering apex + www", () => {
+      const template = synthTemplate();
+      template.resourceCountIs("AWS::CertificateManager::Certificate", 1);
+      template.hasResourceProperties("AWS::CertificateManager::Certificate", {
+        DomainName: "example.com",
+        SubjectAlternativeNames: ["www.example.com"],
+        ValidationMethod: "DNS",
+      });
+    });
+  });
+
+  describe("CloudFront distribution", () => {
+    it("exposes both domain aliases and is wired to the ACM certificate", () => {
+      const template = synthTemplate();
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Aliases: ["example.com", "www.example.com"],
+          ViewerCertificate: Match.objectLike({
+            AcmCertificateArn: Match.anyValue(),
+          }),
+        }),
+      });
+    });
+  });
+
+  describe("stack", () => {
+    it("has a descriptive stack description", () => {
+      const template = synthTemplate();
+      expect(template.toJSON().Description).toBe(
+        "Static website at a custom domain with Route53 + ACM",
+      );
+    });
+  });
+});

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/route53/README.md
+++ b/packages/route53/README.md
@@ -1,0 +1,122 @@
+# @composurecdk/route53
+
+Route 53 hosted zone and record builders for [ComposureCDK](../../README.md).
+
+This package provides fluent builders for Route 53 public hosted zones and for the record types most commonly needed when fronting an AWS workload (A/AAAA alias, CNAME, TXT). It wraps the CDK [aws-route53](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_route53-readme.html) constructs — refer to the CDK documentation for the full set of configurable properties.
+
+## Hosted Zone Builder
+
+```ts
+import { createHostedZoneBuilder } from "@composurecdk/route53";
+
+const zone = createHostedZoneBuilder()
+  .zoneName("example.com")
+  .comment("Primary customer-facing domain")
+  .build(stack, "SiteZone");
+```
+
+Every [PublicHostedZoneProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_route53.PublicHostedZoneProps.html) property is available as a fluent setter on the builder.
+
+### Query logging
+
+Route 53 is a global service, but DNS query logs are emitted in `us-east-1` only — the CloudWatch log group that receives them must live there regardless of where the hosted zone is declared. This is an AWS service constraint, not a restriction on where your hosted zone or records can live.
+
+Supply a pre-configured log group via `.queryLogsLogGroupArn(arn)`. The log group must:
+
+- Be in `us-east-1`.
+- Have a resource policy granting `route53.amazonaws.com` permission to `logs:PutLogEvents` and `logs:CreateLogStream`.
+
+Auto-creating the log group and resource policy on the user's behalf is planned — see [#44](https://github.com/laazyj/composureCDK/issues/44). Once implemented, enabling query logging will become a single opt-in property with the log group + resource policy wired by default.
+
+## Record Builders
+
+```ts
+import {
+  createARecordBuilder,
+  createAaaaRecordBuilder,
+  createCnameRecordBuilder,
+  createTxtRecordBuilder,
+  cloudfrontAliasTarget,
+} from "@composurecdk/route53";
+
+createARecordBuilder()
+  .zone(zone)
+  .target(cloudfrontAliasTarget(distribution))
+  .build(stack, "ApexAlias");
+
+createTxtRecordBuilder()
+  .zone(zone)
+  .recordName("_dmarc")
+  .values(["v=DMARC1; p=reject"])
+  .build(stack, "Dmarc");
+```
+
+### Alias targets
+
+For AWS-service records, prefer A/AAAA alias records over CNAMEs. Alias records:
+
+- Are free to resolve (CNAMEs are billed per query).
+- Work at the zone apex (CNAMEs cannot coexist with the mandatory apex SOA/NS records).
+- Resolve in a single hop (CNAMEs chain to a second lookup).
+- Track AWS-managed DNS changes automatically (CNAMEs must be updated manually if the target's DNS name changes).
+- Support both IPv4 (A) and IPv6 (AAAA) from the same alias target.
+
+Use `createCnameRecordBuilder` only when the target is not an AWS resource (or the AWS resource does not expose an alias target), and never at the zone apex.
+
+| Helper                                | Points at                                        |
+| ------------------------------------- | ------------------------------------------------ |
+| `cloudfrontAliasTarget(distribution)` | A `cloudfront.IDistribution`                     |
+| `apiGatewayAliasTarget(api)`          | An `apigateway.RestApiBase` with a custom domain |
+| `apiGatewayDomainAliasTarget(domain)` | A shared `apigateway.DomainName`                 |
+
+Each helper accepts a `Resolvable`, so targets produced by other composed components (e.g. `@composurecdk/cloudfront`) can be wired in via `ref()`.
+
+## Secure Defaults
+
+| Builder                    | Property         | Default               | Rationale                                               |
+| -------------------------- | ---------------- | --------------------- | ------------------------------------------------------- |
+| `createHostedZoneBuilder`  | `addTrailingDot` | `true`                | Matches RFC 1035 and the CDK default; unambiguous apex. |
+| `createARecordBuilder`     | `ttl`            | `Duration.minutes(5)` | Balances propagation latency against DNS cache churn.   |
+| `createAaaaRecordBuilder`  | `ttl`            | `Duration.minutes(5)` | Same rationale as A records.                            |
+| `createCnameRecordBuilder` | `ttl`            | `Duration.minutes(5)` | Same rationale as A records.                            |
+| `createTxtRecordBuilder`   | `ttl`            | `Duration.minutes(5)` | Same rationale as A records.                            |
+
+The defaults are exported as `HOSTED_ZONE_DEFAULTS`, `A_RECORD_DEFAULTS`, `AAAA_RECORD_DEFAULTS`, `CNAME_RECORD_DEFAULTS`, and `TXT_RECORD_DEFAULTS` for visibility and testing.
+
+## Recommended Alarms
+
+Route 53 health checks expose a `HealthCheckStatus` metric that [AWS recommends alarming on](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53). This package does not yet expose a `HealthCheckBuilder`; once it does, the recommended alarm will be enabled by default alongside the health check. Tracked in [#45](https://github.com/laazyj/composureCDK/issues/45).
+
+## Composing with ACM and CloudFront
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createCertificateBuilder, type CertificateBuilderResult } from "@composurecdk/acm";
+import {
+  createDistributionBuilder,
+  type DistributionBuilderResult,
+} from "@composurecdk/cloudfront";
+import {
+  createHostedZoneBuilder,
+  createARecordBuilder,
+  cloudfrontAliasTarget,
+  type HostedZoneBuilderResult,
+} from "@composurecdk/route53";
+
+compose(
+  {
+    zone: createHostedZoneBuilder().zoneName("example.com"),
+    cert: createCertificateBuilder()
+      .domainName("example.com")
+      .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone)),
+    cdn: createDistributionBuilder()
+      .domainNames(["example.com"])
+      .certificate(ref("cert", (r: CertificateBuilderResult) => r.certificate))
+      .origin(/* ... */),
+    apex: createARecordBuilder()
+      .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+      .target(cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution))),
+  },
+  { zone: [], cert: ["zone"], cdn: ["cert"], apex: ["zone", "cdn"] },
+).build(stack, "Site");
+```

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@composurecdk/route53",
+  "version": "0.3.3",
+  "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/route53"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "peerDependencies": {
+    "@composurecdk/core": "^0.3.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "aws-cdk-lib": "^2.250.0",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/route53/src/a-record-builder.ts
+++ b/packages/route53/src/a-record-builder.ts
@@ -74,11 +74,13 @@ class ARecordBuilder implements Lifecycle<ARecordBuilderResult> {
     }
 
     const resolvedContext = context ?? {};
+    const resolvedTarget = resolve(target, resolvedContext);
+    const isAlias = resolvedTarget.aliasTarget !== undefined;
     const mergedProps = {
-      ...A_RECORD_DEFAULTS,
+      ...(isAlias ? {} : A_RECORD_DEFAULTS),
       ...rest,
       zone: resolve(zone, resolvedContext),
-      target: resolve(target, resolvedContext),
+      target: resolvedTarget,
     } as ARecordProps;
 
     const record = new ARecord(scope, id, mergedProps);

--- a/packages/route53/src/a-record-builder.ts
+++ b/packages/route53/src/a-record-builder.ts
@@ -1,0 +1,96 @@
+import {
+  ARecord,
+  type ARecordProps,
+  type IHostedZone,
+  type RecordTarget,
+} from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { A_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 A record builder.
+ *
+ * Extends the CDK {@link ARecordProps} but replaces `zone` and `target` with
+ * {@link Resolvable} variants so they can be wired from other components in a
+ * composed system via {@link ref}.
+ */
+export interface ARecordBuilderProps extends Omit<ARecordProps, "zone" | "target"> {
+  /**
+   * The hosted zone in which to create the record. Accepts a {@link Resolvable}
+   * so a zone produced by a composed {@link createHostedZoneBuilder} can be
+   * wired in via {@link ref}.
+   */
+  zone?: Resolvable<IHostedZone>;
+
+  /**
+   * The record target. Accepts a {@link Resolvable} so alias targets derived
+   * from composed components (e.g. a CloudFront distribution) can be wired in
+   * via {@link ref} or the helpers in `./alias-targets.js`.
+   */
+  target?: Resolvable<RecordTarget>;
+}
+
+/**
+ * The build output of an {@link IARecordBuilder}.
+ */
+export interface ARecordBuilderResult {
+  /** The Route53 A record construct created by the builder. */
+  record: ARecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 A record (typically
+ * an alias record pointing at a CloudFront distribution, ALB, API Gateway
+ * custom domain, or another A-record-capable target).
+ *
+ * @example
+ * ```ts
+ * const apex = createARecordBuilder()
+ *   .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+ *   .target(cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)));
+ * ```
+ */
+export type IARecordBuilder = IBuilder<ARecordBuilderProps, ARecordBuilder>;
+
+class ARecordBuilder implements Lifecycle<ARecordBuilderResult> {
+  props: Partial<ARecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): ARecordBuilderResult {
+    const { zone, target, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(`ARecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`);
+    }
+    if (!target) {
+      throw new Error(
+        `ARecordBuilder "${id}" requires a target. Call .target() with a RecordTarget.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...A_RECORD_DEFAULTS,
+      ...rest,
+      zone: resolve(zone, resolvedContext),
+      target: resolve(target, resolvedContext),
+    } as ARecordProps;
+
+    const record = new ARecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link IARecordBuilder} for configuring a Route53 A record.
+ *
+ * @returns A fluent builder for a Route53 A record.
+ */
+export function createARecordBuilder(): IARecordBuilder {
+  return Builder<ARecordBuilderProps, ARecordBuilder>(ARecordBuilder);
+}

--- a/packages/route53/src/aaaa-record-builder.ts
+++ b/packages/route53/src/aaaa-record-builder.ts
@@ -1,0 +1,85 @@
+import {
+  AaaaRecord,
+  type AaaaRecordProps,
+  type IHostedZone,
+  type RecordTarget,
+} from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { AAAA_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 AAAA (IPv6) record builder.
+ *
+ * Extends the CDK {@link AaaaRecordProps} but replaces `zone` and `target`
+ * with {@link Resolvable} variants so they can be wired from other components
+ * in a composed system.
+ */
+export interface AaaaRecordBuilderProps extends Omit<AaaaRecordProps, "zone" | "target"> {
+  /** The hosted zone in which to create the record. */
+  zone?: Resolvable<IHostedZone>;
+  /** The record target. */
+  target?: Resolvable<RecordTarget>;
+}
+
+/**
+ * The build output of an {@link IAaaaRecordBuilder}.
+ */
+export interface AaaaRecordBuilderResult {
+  /** The Route53 AAAA record construct created by the builder. */
+  record: AaaaRecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 AAAA (IPv6) record.
+ *
+ * Use this alongside an A record to expose a CloudFront distribution or ALB
+ * over both IPv4 and IPv6 — AWS alias targets support both families from a
+ * single resource.
+ */
+export type IAaaaRecordBuilder = IBuilder<AaaaRecordBuilderProps, AaaaRecordBuilder>;
+
+class AaaaRecordBuilder implements Lifecycle<AaaaRecordBuilderResult> {
+  props: Partial<AaaaRecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): AaaaRecordBuilderResult {
+    const { zone, target, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(
+        `AaaaRecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`,
+      );
+    }
+    if (!target) {
+      throw new Error(
+        `AaaaRecordBuilder "${id}" requires a target. Call .target() with a RecordTarget.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...AAAA_RECORD_DEFAULTS,
+      ...rest,
+      zone: resolve(zone, resolvedContext),
+      target: resolve(target, resolvedContext),
+    } as AaaaRecordProps;
+
+    const record = new AaaaRecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link IAaaaRecordBuilder} for configuring a Route53 AAAA
+ * (IPv6) record.
+ *
+ * @returns A fluent builder for a Route53 AAAA record.
+ */
+export function createAaaaRecordBuilder(): IAaaaRecordBuilder {
+  return Builder<AaaaRecordBuilderProps, AaaaRecordBuilder>(AaaaRecordBuilder);
+}

--- a/packages/route53/src/aaaa-record-builder.ts
+++ b/packages/route53/src/aaaa-record-builder.ts
@@ -62,11 +62,13 @@ class AaaaRecordBuilder implements Lifecycle<AaaaRecordBuilderResult> {
     }
 
     const resolvedContext = context ?? {};
+    const resolvedTarget = resolve(target, resolvedContext);
+    const isAlias = resolvedTarget.aliasTarget !== undefined;
     const mergedProps = {
-      ...AAAA_RECORD_DEFAULTS,
+      ...(isAlias ? {} : AAAA_RECORD_DEFAULTS),
       ...rest,
       zone: resolve(zone, resolvedContext),
-      target: resolve(target, resolvedContext),
+      target: resolvedTarget,
     } as AaaaRecordProps;
 
     const record = new AaaaRecord(scope, id, mergedProps);

--- a/packages/route53/src/alias-targets.ts
+++ b/packages/route53/src/alias-targets.ts
@@ -1,0 +1,53 @@
+import { type IDistribution } from "aws-cdk-lib/aws-cloudfront";
+import { type IDomainName, type RestApiBase } from "aws-cdk-lib/aws-apigateway";
+import { RecordTarget } from "aws-cdk-lib/aws-route53";
+import { ApiGateway, ApiGatewayDomain, CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Builds an alias {@link RecordTarget} for a CloudFront distribution, usable
+ * as the `target` of an A or AAAA record. Accepts a {@link Resolvable} so a
+ * distribution produced by a composed `@composurecdk/cloudfront` component
+ * can be wired in via {@link ref}.
+ *
+ * @example
+ * ```ts
+ * createARecordBuilder()
+ *   .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+ *   .target(cloudfrontAliasTarget(
+ *     ref("cdn", (r: DistributionBuilderResult) => r.distribution),
+ *   ));
+ * ```
+ */
+export function cloudfrontAliasTarget(
+  distribution: Resolvable<IDistribution>,
+): Resolvable<RecordTarget> {
+  return isRef(distribution)
+    ? distribution.map((d) => RecordTarget.fromAlias(new CloudFrontTarget(d)))
+    : RecordTarget.fromAlias(new CloudFrontTarget(distribution));
+}
+
+/**
+ * Builds an alias {@link RecordTarget} for an API Gateway REST API that has a
+ * custom domain name configured via {@link RestApiBase}. Accepts a
+ * {@link Resolvable}.
+ */
+export function apiGatewayAliasTarget(api: Resolvable<RestApiBase>): Resolvable<RecordTarget> {
+  return isRef(api)
+    ? api.map((a) => RecordTarget.fromAlias(new ApiGateway(a)))
+    : RecordTarget.fromAlias(new ApiGateway(api));
+}
+
+/**
+ * Builds an alias {@link RecordTarget} for an API Gateway custom domain name
+ * (`apigateway.DomainName`). Use this when you manage the domain name resource
+ * separately from the REST API (e.g. to share a custom domain across multiple
+ * APIs). Accepts a {@link Resolvable}.
+ */
+export function apiGatewayDomainAliasTarget(
+  domain: Resolvable<IDomainName>,
+): Resolvable<RecordTarget> {
+  return isRef(domain)
+    ? domain.map((d) => RecordTarget.fromAlias(new ApiGatewayDomain(d)))
+    : RecordTarget.fromAlias(new ApiGatewayDomain(domain));
+}

--- a/packages/route53/src/cname-record-builder.ts
+++ b/packages/route53/src/cname-record-builder.ts
@@ -1,0 +1,86 @@
+import { CnameRecord, type CnameRecordProps, type IHostedZone } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { CNAME_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 CNAME record builder.
+ *
+ * Extends the CDK {@link CnameRecordProps} but replaces `zone` with a
+ * {@link Resolvable} so it can be wired from composed components.
+ */
+export interface CnameRecordBuilderProps extends Omit<CnameRecordProps, "zone"> {
+  /** The hosted zone in which to create the record. */
+  zone?: Resolvable<IHostedZone>;
+}
+
+/**
+ * The build output of an {@link ICnameRecordBuilder}.
+ */
+export interface CnameRecordBuilderResult {
+  /** The Route53 CNAME record construct created by the builder. */
+  record: CnameRecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 CNAME record.
+ *
+ * Prefer {@link createARecordBuilder | A / AAAA alias records} when pointing
+ * at AWS resources — alias records are free, resolve in one hop, and can be
+ * used at the apex. Use CNAME for non-AWS targets or for sub-domain
+ * redirections where an alias is not available.
+ */
+export type ICnameRecordBuilder = IBuilder<CnameRecordBuilderProps, CnameRecordBuilder>;
+
+class CnameRecordBuilder implements Lifecycle<CnameRecordBuilderResult> {
+  props: Partial<CnameRecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): CnameRecordBuilderResult {
+    const { zone, domainName, recordName, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(
+        `CnameRecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`,
+      );
+    }
+    if (!domainName) {
+      throw new Error(
+        `CnameRecordBuilder "${id}" requires a domainName. ` +
+          `Call .domainName() with the target host (what the CNAME points to).`,
+      );
+    }
+    if (!recordName) {
+      throw new Error(
+        `CnameRecordBuilder "${id}" requires a recordName. ` +
+          `Call .recordName() with the subdomain — CNAME records cannot be at the zone apex.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...CNAME_RECORD_DEFAULTS,
+      ...rest,
+      domainName,
+      recordName,
+      zone: resolve(zone, resolvedContext),
+    } as CnameRecordProps;
+
+    const record = new CnameRecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link ICnameRecordBuilder} for configuring a Route53 CNAME
+ * record.
+ *
+ * @returns A fluent builder for a Route53 CNAME record.
+ */
+export function createCnameRecordBuilder(): ICnameRecordBuilder {
+  return Builder<CnameRecordBuilderProps, CnameRecordBuilder>(CnameRecordBuilder);
+}

--- a/packages/route53/src/defaults.ts
+++ b/packages/route53/src/defaults.ts
@@ -36,6 +36,8 @@ const DEFAULT_RECORD_TTL = Duration.minutes(5);
 
 /**
  * Defaults for {@link createARecordBuilder}. Overridable via the fluent API.
+ * The builder skips the `ttl` default for alias targets — AWS ignores TTL on
+ * alias records and CDK emits a warning when one is set.
  */
 export const A_RECORD_DEFAULTS: Partial<ARecordBuilderProps> = {
   ttl: DEFAULT_RECORD_TTL,
@@ -43,6 +45,7 @@ export const A_RECORD_DEFAULTS: Partial<ARecordBuilderProps> = {
 
 /**
  * Defaults for {@link createAaaaRecordBuilder}. Overridable via the fluent API.
+ * Same alias-target caveat as {@link A_RECORD_DEFAULTS}.
  */
 export const AAAA_RECORD_DEFAULTS: Partial<AaaaRecordBuilderProps> = {
   ttl: DEFAULT_RECORD_TTL,

--- a/packages/route53/src/defaults.ts
+++ b/packages/route53/src/defaults.ts
@@ -1,0 +1,63 @@
+import { Duration } from "aws-cdk-lib";
+import type { HostedZoneBuilderProps } from "./hosted-zone-builder.js";
+import type { ARecordBuilderProps } from "./a-record-builder.js";
+import type { AaaaRecordBuilderProps } from "./aaaa-record-builder.js";
+import type { CnameRecordBuilderProps } from "./cname-record-builder.js";
+import type { TxtRecordBuilderProps } from "./txt-record-builder.js";
+
+/**
+ * Secure, AWS-recommended defaults applied to every public hosted zone built
+ * with {@link createHostedZoneBuilder}. Each property can be individually
+ * overridden via the builder's fluent API.
+ *
+ * Query logging is not enabled by default: Route53 query logs must be written
+ * to a CloudWatch log group in `us-east-1` with a resource policy granting
+ * `route53.amazonaws.com` write access. Opt in explicitly by calling
+ * `.queryLogsLogGroupArn(...)` with a pre-configured log group.
+ */
+export const HOSTED_ZONE_DEFAULTS: Partial<HostedZoneBuilderProps> = {
+  /**
+   * Add a trailing dot to the zone name so the apex is an unambiguous
+   * fully-qualified domain. Matches the CDK default and RFC 1035.
+   */
+  addTrailingDot: true,
+};
+
+/**
+ * Default TTL applied to records built by this package when no TTL is set.
+ *
+ * Five minutes balances propagation latency against downstream DNS cache
+ * churn. For alias records pointing at dynamic AWS resources (CloudFront,
+ * ALB), this matches AWS guidance.
+ *
+ * @see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-cloudfront-distribution.html
+ */
+const DEFAULT_RECORD_TTL = Duration.minutes(5);
+
+/**
+ * Defaults for {@link createARecordBuilder}. Overridable via the fluent API.
+ */
+export const A_RECORD_DEFAULTS: Partial<ARecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};
+
+/**
+ * Defaults for {@link createAaaaRecordBuilder}. Overridable via the fluent API.
+ */
+export const AAAA_RECORD_DEFAULTS: Partial<AaaaRecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};
+
+/**
+ * Defaults for {@link createCnameRecordBuilder}. Overridable via the fluent API.
+ */
+export const CNAME_RECORD_DEFAULTS: Partial<CnameRecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};
+
+/**
+ * Defaults for {@link createTxtRecordBuilder}. Overridable via the fluent API.
+ */
+export const TXT_RECORD_DEFAULTS: Partial<TxtRecordBuilderProps> = {
+  ttl: DEFAULT_RECORD_TTL,
+};

--- a/packages/route53/src/hosted-zone-builder.ts
+++ b/packages/route53/src/hosted-zone-builder.ts
@@ -1,0 +1,98 @@
+import { PublicHostedZone, type PublicHostedZoneProps } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { HOSTED_ZONE_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 public hosted zone builder.
+ *
+ * Aliases the CDK {@link PublicHostedZoneProps} so every zone property is
+ * available as a fluent setter on the builder. No additional builder-specific
+ * options are defined today — query logging requires a pre-configured log
+ * group (see {@link PublicHostedZoneProps.queryLogsLogGroupArn | queryLogsLogGroupArn})
+ * which the user supplies directly.
+ */
+export type HostedZoneBuilderProps = PublicHostedZoneProps;
+
+/**
+ * The build output of an {@link IHostedZoneBuilder}. Contains the CDK
+ * constructs created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface HostedZoneBuilderResult {
+  /** The Route53 public hosted zone construct created by the builder. */
+  hostedZone: PublicHostedZone;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 public hosted zone.
+ *
+ * Each configuration property from the CDK {@link PublicHostedZoneProps} is
+ * exposed as an overloaded method: call with a value to set it (returns the
+ * builder for chaining), or call with no arguments to read the current value.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates a
+ * public hosted zone with the configured properties and returns a
+ * {@link HostedZoneBuilderResult}.
+ *
+ * @example
+ * ```ts
+ * const zone = createHostedZoneBuilder()
+ *   .zoneName("example.com")
+ *   .comment("Primary customer-facing domain");
+ * ```
+ */
+export type IHostedZoneBuilder = IBuilder<HostedZoneBuilderProps, HostedZoneBuilder>;
+
+class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
+  props: Partial<HostedZoneBuilderProps> = {};
+
+  build(scope: IConstruct, id: string): HostedZoneBuilderResult {
+    if (!this.props.zoneName) {
+      throw new Error(
+        `HostedZoneBuilder "${id}" requires a zoneName. ` +
+          `Call .zoneName() with a fully-qualified domain.`,
+      );
+    }
+
+    const mergedProps = {
+      ...HOSTED_ZONE_DEFAULTS,
+      ...this.props,
+    } as PublicHostedZoneProps;
+
+    const hostedZone = new PublicHostedZone(scope, id, mergedProps);
+
+    return { hostedZone };
+  }
+}
+
+/**
+ * Creates a new {@link IHostedZoneBuilder} for configuring a Route53 public
+ * hosted zone.
+ *
+ * This is the entry point for defining a public hosted zone component. The
+ * returned builder exposes every {@link HostedZoneBuilderProps} property as a
+ * fluent setter/getter and implements {@link Lifecycle} for use with
+ * {@link compose}.
+ *
+ * @returns A fluent builder for a Route53 public hosted zone.
+ *
+ * @example
+ * ```ts
+ * const zone = createHostedZoneBuilder().zoneName("example.com");
+ *
+ * // Use standalone:
+ * const result = zone.build(stack, "SiteZone");
+ *
+ * // Or compose into a system:
+ * const system = compose(
+ *   { zone, cert: createCertificateBuilder()
+ *       .domainName("example.com")
+ *       .validationZone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone)) },
+ *   { zone: [], cert: ["zone"] },
+ * );
+ * ```
+ */
+export function createHostedZoneBuilder(): IHostedZoneBuilder {
+  return Builder<HostedZoneBuilderProps, HostedZoneBuilder>(HostedZoneBuilder);
+}

--- a/packages/route53/src/index.ts
+++ b/packages/route53/src/index.ts
@@ -1,0 +1,37 @@
+export {
+  createHostedZoneBuilder,
+  type HostedZoneBuilderResult,
+  type IHostedZoneBuilder,
+} from "./hosted-zone-builder.js";
+export {
+  createARecordBuilder,
+  type ARecordBuilderResult,
+  type IARecordBuilder,
+} from "./a-record-builder.js";
+export {
+  createAaaaRecordBuilder,
+  type AaaaRecordBuilderResult,
+  type IAaaaRecordBuilder,
+} from "./aaaa-record-builder.js";
+export {
+  createCnameRecordBuilder,
+  type CnameRecordBuilderResult,
+  type ICnameRecordBuilder,
+} from "./cname-record-builder.js";
+export {
+  createTxtRecordBuilder,
+  type TxtRecordBuilderResult,
+  type ITxtRecordBuilder,
+} from "./txt-record-builder.js";
+export {
+  cloudfrontAliasTarget,
+  apiGatewayAliasTarget,
+  apiGatewayDomainAliasTarget,
+} from "./alias-targets.js";
+export {
+  HOSTED_ZONE_DEFAULTS,
+  A_RECORD_DEFAULTS,
+  AAAA_RECORD_DEFAULTS,
+  CNAME_RECORD_DEFAULTS,
+  TXT_RECORD_DEFAULTS,
+} from "./defaults.js";

--- a/packages/route53/src/txt-record-builder.ts
+++ b/packages/route53/src/txt-record-builder.ts
@@ -1,0 +1,75 @@
+import { TxtRecord, type TxtRecordProps, type IHostedZone } from "aws-cdk-lib/aws-route53";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { TXT_RECORD_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route53 TXT record builder.
+ *
+ * Extends the CDK {@link TxtRecordProps} but replaces `zone` with a
+ * {@link Resolvable} so it can be wired from composed components.
+ */
+export interface TxtRecordBuilderProps extends Omit<TxtRecordProps, "zone"> {
+  /** The hosted zone in which to create the record. */
+  zone?: Resolvable<IHostedZone>;
+}
+
+/**
+ * The build output of an {@link ITxtRecordBuilder}.
+ */
+export interface TxtRecordBuilderResult {
+  /** The Route53 TXT record construct created by the builder. */
+  record: TxtRecord;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route53 TXT record.
+ *
+ * Commonly used for SPF, DKIM, DMARC, and domain-verification tokens.
+ */
+export type ITxtRecordBuilder = IBuilder<TxtRecordBuilderProps, TxtRecordBuilder>;
+
+class TxtRecordBuilder implements Lifecycle<TxtRecordBuilderResult> {
+  props: Partial<TxtRecordBuilderProps> = {};
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): TxtRecordBuilderResult {
+    const { zone, values, ...rest } = this.props;
+    if (!zone) {
+      throw new Error(
+        `TxtRecordBuilder "${id}" requires a zone. Call .zone() with an IHostedZone.`,
+      );
+    }
+    if (!values || values.length === 0) {
+      throw new Error(
+        `TxtRecordBuilder "${id}" requires non-empty values. ` +
+          `Call .values() with one or more TXT record strings.`,
+      );
+    }
+
+    const resolvedContext = context ?? {};
+    const mergedProps = {
+      ...TXT_RECORD_DEFAULTS,
+      ...rest,
+      values,
+      zone: resolve(zone, resolvedContext),
+    } as TxtRecordProps;
+
+    const record = new TxtRecord(scope, id, mergedProps);
+    return { record };
+  }
+}
+
+/**
+ * Creates a new {@link ITxtRecordBuilder} for configuring a Route53 TXT record.
+ *
+ * @returns A fluent builder for a Route53 TXT record.
+ */
+export function createTxtRecordBuilder(): ITxtRecordBuilder {
+  return Builder<TxtRecordBuilderProps, TxtRecordBuilder>(TxtRecordBuilder);
+}

--- a/packages/route53/test/a-record-builder.test.ts
+++ b/packages/route53/test/a-record-builder.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Distribution } from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { PublicHostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { compose, ref } from "@composurecdk/core";
+import { createARecordBuilder } from "../src/a-record-builder.js";
+import { cloudfrontAliasTarget } from "../src/alias-targets.js";
+import {
+  createHostedZoneBuilder,
+  type HostedZoneBuilderResult,
+} from "../src/hosted-zone-builder.js";
+
+describe("ARecordBuilder", () => {
+  it("throws when zone is not set", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    expect(() =>
+      createARecordBuilder().target(RecordTarget.fromValues("1.2.3.4")).build(stack, "TestRecord"),
+    ).toThrow(/requires a zone/);
+  });
+
+  it("throws when target is not set", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+    expect(() => createARecordBuilder().zone(zone).build(stack, "TestRecord")).toThrow(
+      /requires a target/,
+    );
+  });
+
+  it("synthesises a value A record with the configured TTL and values", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+
+    createARecordBuilder()
+      .zone(zone)
+      .recordName("api")
+      .target(RecordTarget.fromValues("1.2.3.4"))
+      .ttl(Duration.minutes(10))
+      .build(stack, "TestRecord");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "A",
+      Name: "api.example.com.",
+      ResourceRecords: ["1.2.3.4"],
+      TTL: "600",
+    });
+  });
+
+  it("synthesises a CloudFront alias record via the cloudfrontAliasTarget helper", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+    const distribution = new Distribution(stack, "Dist", {
+      defaultBehavior: { origin: new HttpOrigin("origin.example.net") },
+    });
+
+    createARecordBuilder()
+      .zone(zone)
+      .target(cloudfrontAliasTarget(distribution))
+      .build(stack, "ApexAlias");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "A",
+      AliasTarget: Match.objectLike({
+        DNSName: Match.objectLike({ "Fn::GetAtt": ["DistB3B78991", "DomainName"] }),
+      }),
+    });
+  });
+
+  it("resolves a Ref-based target when used inside compose()", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const distribution = new Distribution(stack, "Dist", {
+      defaultBehavior: { origin: new HttpOrigin("origin.example.net") },
+    });
+
+    compose(
+      {
+        zone: createHostedZoneBuilder().zoneName("example.com"),
+        apex: createARecordBuilder()
+          .zone(ref("zone", (r: HostedZoneBuilderResult) => r.hostedZone))
+          .target(cloudfrontAliasTarget(distribution)),
+      },
+      { zone: [], apex: ["zone"] },
+    ).build(stack, "Site");
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::Route53::HostedZone", 1);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "A",
+      AliasTarget: Match.objectLike({
+        DNSName: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["DomainName"]) }),
+      }),
+    });
+  });
+});

--- a/packages/route53/test/a-record-builder.test.ts
+++ b/packages/route53/test/a-record-builder.test.ts
@@ -73,6 +73,26 @@ describe("ARecordBuilder", () => {
     });
   });
 
+  it("omits the default TTL on alias targets so CDK does not warn", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+    const distribution = new Distribution(stack, "Dist", {
+      defaultBehavior: { origin: new HttpOrigin("origin.example.net") },
+    });
+
+    createARecordBuilder()
+      .zone(zone)
+      .target(cloudfrontAliasTarget(distribution))
+      .build(stack, "ApexAlias");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "A",
+      TTL: Match.absent(),
+    });
+  });
+
   it("resolves a Ref-based target when used inside compose()", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");

--- a/packages/route53/test/hosted-zone-builder.test.ts
+++ b/packages/route53/test/hosted-zone-builder.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { createHostedZoneBuilder } from "../src/hosted-zone-builder.js";
+
+function synth(configure: (b: ReturnType<typeof createHostedZoneBuilder>) => void): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createHostedZoneBuilder();
+  configure(builder);
+  builder.build(stack, "TestZone");
+  return Template.fromStack(stack);
+}
+
+describe("HostedZoneBuilder", () => {
+  it("throws when zoneName is not set", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    expect(() => createHostedZoneBuilder().build(stack, "TestZone")).toThrow(/requires a zoneName/);
+  });
+
+  it("returns a HostedZoneBuilderResult with a hostedZone property", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const result = createHostedZoneBuilder().zoneName("example.com").build(stack, "TestZone");
+    expect(result.hostedZone).toBeDefined();
+  });
+
+  it("synthesises a Route53 hosted zone with the provided zone name", () => {
+    const template = synth((b) => b.zoneName("example.com"));
+    template.resourceCountIs("AWS::Route53::HostedZone", 1);
+    template.hasResourceProperties("AWS::Route53::HostedZone", {
+      Name: "example.com.",
+    });
+  });
+
+  it("forwards the comment property", () => {
+    const template = synth((b) => {
+      b.zoneName("example.com");
+      b.comment("primary customer domain");
+    });
+    template.hasResourceProperties("AWS::Route53::HostedZone", {
+      HostedZoneConfig: { Comment: "primary customer domain" },
+    });
+  });
+
+  it("forwards a pre-configured query-log group ARN", () => {
+    const template = synth((b) => {
+      b.zoneName("example.com");
+      b.queryLogsLogGroupArn(
+        "arn:aws:logs:us-east-1:111122223333:log-group:/aws/route53/example.com",
+      );
+    });
+    template.hasResourceProperties("AWS::Route53::HostedZone", {
+      QueryLoggingConfig: {
+        CloudWatchLogsLogGroupArn:
+          "arn:aws:logs:us-east-1:111122223333:log-group:/aws/route53/example.com",
+      },
+    });
+  });
+});

--- a/packages/route53/test/record-variants.test.ts
+++ b/packages/route53/test/record-variants.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { PublicHostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { createAaaaRecordBuilder } from "../src/aaaa-record-builder.js";
+import { createCnameRecordBuilder } from "../src/cname-record-builder.js";
+import { createTxtRecordBuilder } from "../src/txt-record-builder.js";
+
+function setup(): { stack: Stack; zone: PublicHostedZone } {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+  return { stack, zone };
+}
+
+describe("AaaaRecordBuilder", () => {
+  it("synthesises an AAAA record", () => {
+    const { stack, zone } = setup();
+    createAaaaRecordBuilder()
+      .zone(zone)
+      .recordName("v6")
+      .target(RecordTarget.fromIpAddresses("2001:db8::1"))
+      .build(stack, "Aaaa");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "AAAA",
+      Name: "v6.example.com.",
+    });
+  });
+});
+
+describe("CnameRecordBuilder", () => {
+  it("requires a recordName", () => {
+    const { stack, zone } = setup();
+    expect(() =>
+      createCnameRecordBuilder().zone(zone).domainName("target.example.net").build(stack, "Cname"),
+    ).toThrow(/requires a recordName/);
+  });
+
+  it("requires a domainName", () => {
+    const { stack, zone } = setup();
+    expect(() =>
+      createCnameRecordBuilder().zone(zone).recordName("sub").build(stack, "Cname"),
+    ).toThrow(/requires a domainName/);
+  });
+
+  it("synthesises a CNAME record", () => {
+    const { stack, zone } = setup();
+    createCnameRecordBuilder()
+      .zone(zone)
+      .recordName("sub")
+      .domainName("target.example.net")
+      .build(stack, "Cname");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "CNAME",
+      Name: "sub.example.com.",
+      ResourceRecords: ["target.example.net"],
+    });
+  });
+});
+
+describe("TxtRecordBuilder", () => {
+  it("requires non-empty values", () => {
+    const { stack, zone } = setup();
+    expect(() => createTxtRecordBuilder().zone(zone).values([]).build(stack, "Txt")).toThrow(
+      /requires non-empty values/,
+    );
+  });
+
+  it("synthesises a TXT record", () => {
+    const { stack, zone } = setup();
+    createTxtRecordBuilder()
+      .zone(zone)
+      .recordName("_dmarc")
+      .values(["v=DMARC1; p=reject"])
+      .build(stack, "Txt");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "TXT",
+      Name: "_dmarc.example.com.",
+    });
+  });
+});

--- a/packages/route53/tsconfig.build.json
+++ b/packages/route53/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/route53/tsconfig.json
+++ b/packages/route53/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a deployable `custom-domain-website` example that wires a CloudFront distribution to a custom domain via Route 53 apex A/AAAA alias records and an ACM DNS-validated certificate.
- Brings the hosted zone in via `HostedZone.fromLookup` against a pre-existing, externally-delegated zone — so ACM validation can actually complete in a single deploy.
- Opt-in: synthesises only when `COMPOSURECDK_DOMAIN` or `--context domain=...` is set, so the rest of the examples still synth/deploy without it.
- CI: adds Route 53, ACM, and CloudFront permissions to the OIDC role (scoped to `hostedzone/*` + `change/*` where AWS supports it, sandbox-account-wide otherwise); threads `vars.COMPOSURECDK_DOMAIN` through the deploy-test workflow; `docs/ci.md` §5 covers the one-time setup (register a domain, create the hosted zone, delegate NSes, redeploy the OIDC stack, set the env var).

**Depends on** the Route 53 package landing in #46. This branch carries those commits too so it can be deployed stand-alone while #46 is in review — rebase onto main once #46 merges.

## Background — why `fromLookup` and not `createHostedZoneBuilder`

The earlier version of this example created the hosted zone inline. That ran into two deployment issues that could not be automated away from inside the stack:

1. **ACM validation stall.** A freshly-created zone has no NS delegation on the public internet, so ACM's DNS validation challenge is unanswerable and the stack hangs at `PENDING_VALIDATION` until CFN times out. Delegation is an out-of-band, registrar-level step.
2. **Hosted-zone teardown failure.** CloudFormation refuses to delete a zone that contains records it doesn't own, which can happen during a mid-deploy rollback. `clean-desk-policy` can't fix this — the orphan records aren't CDK resources to inject a removal policy onto.

Bringing the zone in via `fromLookup` keeps it external to the stack: deploy only creates/destroys records inside it, teardown never tries to delete it, and delegation happens once at the domain level (matching how this is done in real projects).

## Costs

ACM certificates are non-exportable public certificates (the CloudFormation default). These are **$0** — no issuance or renewal fees. Exportable certs are a separate 2025 opt-in that requires explicit configuration and is never set here.

## Test plan

- [ ] Local synth with `COMPOSURECDK_DOMAIN` unset — example is skipped, other examples synth.
- [ ] Local synth with `COMPOSURECDK_DOMAIN=<your-domain>` — custom-domain stack materialises.
- [ ] Deploy against a real, delegated hosted zone — certificate validates, alias records resolve, teardown completes cleanly.
- [ ] Re-deploy the OIDC stack in the sandbox to pick up the new Route 53 / ACM / CloudFront permissions.
- [ ] Set `COMPOSURECDK_DOMAIN` in the `sandbox` GitHub Environment and run the deploy-test workflow end-to-end.