### PR TITLE
feat(cloudfront): first-class cache behaviors and inline functions

### DIFF
--- a/packages/cloudfront/src/alarm-config.ts
+++ b/packages/cloudfront/src/alarm-config.ts
@@ -6,9 +6,8 @@ import type { AlarmConfig } from "@composurecdk/cloudwatch";
  * Set individual alarms to `false` to disable them, or provide an
  * {@link AlarmConfig} to tune thresholds.
  *
- * Function-level alarms (FunctionValidationErrors, FunctionExecutionErrors,
- * FunctionThrottles) require per-function dimensions and are not created
- * automatically. Use {@link IDistributionBuilder.addAlarm} to add them.
+ * Function-level alarms are created automatically for every inline function
+ * declared on a behavior — see {@link FunctionAlarmConfig} to tune them.
  *
  * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CloudFront
  */
@@ -44,4 +43,58 @@ export interface DistributionAlarmConfig {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CloudFront
    */
   originLatency?: AlarmConfig | false;
+}
+
+/**
+ * Controls which recommended alarms are created for a CloudFront Function
+ * declared inline on a cache behavior. All alarms are enabled by default
+ * with AWS-recommended thresholds. Set individual alarms to `false` to
+ * disable them, or provide an {@link AlarmConfig} to tune thresholds.
+ *
+ * CloudFront Function metrics are emitted in the `us-east-1` region only
+ * (CloudFront is a global service). The alarms live in the stack's region —
+ * if that is not `us-east-1`, the alarms will not receive data.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+ */
+export interface FunctionAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms for
+   * this function. Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the function raises runtime exceptions while processing a
+   * viewer request or response.
+   *
+   * Metric: `AWS/CloudFront FunctionExecutionErrors`, statistic Sum,
+   * period 1 minute. Default threshold: > 0 errors.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+   */
+  executionErrors?: AlarmConfig | false;
+
+  /**
+   * Alarm when the function returns an event object that fails validation
+   * (e.g. malformed headers, unsupported response shape).
+   *
+   * Metric: `AWS/CloudFront FunctionValidationErrors`, statistic Sum,
+   * period 1 minute. Default threshold: > 0 errors.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+   */
+  validationErrors?: AlarmConfig | false;
+
+  /**
+   * Alarm when the function is throttled — typically because it exceeded
+   * the 1ms compute-utilization budget.
+   *
+   * Metric: `AWS/CloudFront FunctionThrottles`, statistic Sum,
+   * period 1 minute. Default threshold: > 0 throttles.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-function-restrictions.html
+   */
+  throttles?: AlarmConfig | false;
 }

--- a/packages/cloudfront/src/alarm-defaults.ts
+++ b/packages/cloudfront/src/alarm-defaults.ts
@@ -7,6 +7,13 @@ interface DistributionAlarmDefaults {
   originLatency: Required<AlarmConfig>;
 }
 
+interface FunctionAlarmDefaults {
+  enabled: true;
+  executionErrors: Required<AlarmConfig>;
+  validationErrors: Required<AlarmConfig>;
+  throttles: Required<AlarmConfig>;
+}
+
 /**
  * AWS-recommended default alarm configuration for CloudFront distributions.
  *
@@ -35,6 +42,41 @@ export const DISTRIBUTION_ALARM_DEFAULTS: DistributionAlarmDefaults = {
     threshold: 5000,
     evaluationPeriods: 5,
     datapointsToAlarm: 5,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};
+
+/**
+ * Default alarm configuration for CloudFront Functions declared inline on
+ * a cache behavior. Any non-zero count of errors or throttles is worth
+ * investigating since a function executes on every viewer request/response.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+ */
+export const FUNCTION_ALARM_DEFAULTS: FunctionAlarmDefaults = {
+  enabled: true,
+
+  /** Any execution error indicates a runtime fault on the edge; threshold 0. */
+  executionErrors: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any validation error indicates the function returned a bad event; threshold 0. */
+  validationErrors: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any throttle indicates the function exceeded its 1ms compute budget; threshold 0. */
+  throttles: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
     treatMissingData: TreatMissingData.NOT_BREACHING,
   },
 };

--- a/packages/cloudfront/src/behavior-function-alarms.ts
+++ b/packages/cloudfront/src/behavior-function-alarms.ts
@@ -1,0 +1,166 @@
+import { Duration } from "aws-cdk-lib";
+import { ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import type { Function as CfFunction, FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { FunctionAlarmConfig } from "./alarm-config.js";
+import { FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.minutes(1);
+const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+
+/**
+ * CloudFront Function metrics are emitted in the `us-east-1` region only
+ * (CloudFront is a global service). Metric dimensions are
+ * `FunctionName` + `Region=Global`.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+ */
+function functionMetric(fn: CfFunction, metricName: string): Metric {
+  return new Metric({
+    namespace: "AWS/CloudFront",
+    metricName,
+    dimensionsMap: {
+      FunctionName: fn.functionName,
+      Region: "Global",
+    },
+    statistic: Stats.SUM,
+    period: METRIC_PERIOD,
+  });
+}
+
+/**
+ * Converts a CloudFront cache-behavior path pattern into a PascalCase slug
+ * suitable for alarm keys and CDK construct ids. A single leading `/` is
+ * dropped (the common case), interior `/` becomes `Slash` so sibling patterns
+ * don't collide, `*` becomes `Star`, and `?` becomes `Q`. Other
+ * non-alphanumeric characters are stripped.
+ *
+ * Examples:
+ * - `/api/*` → `ApiSlashStar`
+ * - `/api*`  → `ApiStar` (distinct from `/api/*`)
+ * - `*.html` → `StarHtml`
+ * - `images/*` → `ImagesSlashStar`
+ *
+ * @internal
+ */
+export function pathPatternSlug(pattern: string): string {
+  const stripped = pattern.startsWith("/") ? pattern.slice(1) : pattern;
+  return stripped
+    .replace(/\//g, " Slash ")
+    .replace(/\*/g, " Star ")
+    .replace(/\?/g, " Q ")
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+/**
+ * Converts a {@link FunctionEventType} value (e.g. `"viewer-request"`) into
+ * PascalCase (e.g. `"ViewerRequest"`) for use in alarm keys and construct ids.
+ *
+ * @internal
+ */
+export function eventTypePascal(eventType: FunctionEventType): string {
+  return eventType
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+/**
+ * Builds the prefix used for every alarm key produced for a given inline
+ * function — e.g. `defaultBehaviorViewerRequest` or `behaviorApiStarViewerRequest`.
+ * Pass `null` for the default behavior.
+ *
+ * @internal
+ */
+export function behaviorFunctionKeyPrefix(
+  pathPattern: string | null,
+  eventType: FunctionEventType,
+): string {
+  const scope =
+    pathPattern === null ? "defaultBehavior" : `behavior${pathPatternSlug(pathPattern)}`;
+  return `${scope}${eventTypePascal(eventType)}`;
+}
+
+function behaviorFunctionScopeLabel(
+  pathPattern: string | null,
+  eventType: FunctionEventType,
+): string {
+  const scope = pathPattern === null ? "default behavior" : `behavior "${pathPattern}"`;
+  return `${scope} (${eventType})`;
+}
+
+/**
+ * Produces fully-resolved {@link AlarmDefinition}s for the three AWS-recommended
+ * CloudFront Function alarms — execution errors, validation errors, throttles —
+ * scoped to a single behavior + event type so the keys and descriptions stay
+ * actionable when the same underlying function is used on multiple behaviors.
+ *
+ * @internal
+ */
+export function resolveBehaviorFunctionAlarmDefinitions(
+  pathPattern: string | null,
+  eventType: FunctionEventType,
+  fn: CfFunction,
+  config: FunctionAlarmConfig | false | undefined,
+): AlarmDefinition[] {
+  if (config === false) return [];
+  if (config?.enabled === false) return [];
+
+  const keyPrefix = behaviorFunctionKeyPrefix(pathPattern, eventType);
+  const scopeLabel = behaviorFunctionScopeLabel(pathPattern, eventType);
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.executionErrors !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.executionErrors,
+      FUNCTION_ALARM_DEFAULTS.executionErrors,
+    );
+    definitions.push({
+      key: `${keyPrefix}ExecutionErrors`,
+      metric: functionMetric(fn, "FunctionExecutionErrors"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `CloudFront Function on ${scopeLabel} is raising execution errors. Threshold: > ${String(cfg.threshold)} errors in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.validationErrors !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.validationErrors,
+      FUNCTION_ALARM_DEFAULTS.validationErrors,
+    );
+    definitions.push({
+      key: `${keyPrefix}ValidationErrors`,
+      metric: functionMetric(fn, "FunctionValidationErrors"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `CloudFront Function on ${scopeLabel} is producing validation errors. Threshold: > ${String(cfg.threshold)} errors in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.throttles !== false) {
+    const cfg = resolveAlarmConfig(config?.throttles, FUNCTION_ALARM_DEFAULTS.throttles);
+    definitions.push({
+      key: `${keyPrefix}Throttles`,
+      metric: functionMetric(fn, "FunctionThrottles"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `CloudFront Function on ${scopeLabel} is being throttled — likely exceeding its 1ms compute budget. Threshold: > ${String(cfg.threshold)} throttles in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  return definitions;
+}

--- a/packages/cloudfront/src/defaults.ts
+++ b/packages/cloudfront/src/defaults.ts
@@ -1,11 +1,12 @@
 import {
+  FunctionRuntime,
   HttpVersion,
   PriceClass,
   ResponseHeadersPolicy,
   SecurityPolicyProtocol,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
-import type { DistributionBuilderProps } from "./distribution-builder.js";
+import type { DistributionBuilderProps, InlineFunctionDefinition } from "./distribution-builder.js";
 
 /**
  * Secure, AWS-recommended defaults applied to every CloudFront distribution
@@ -66,4 +67,17 @@ export const DISTRIBUTION_DEFAULTS: Partial<DistributionBuilderProps> = {
      */
     responseHeadersPolicy: ResponseHeadersPolicy.SECURITY_HEADERS,
   },
+};
+
+/**
+ * Defaults applied to every inline CloudFront Function declared on a cache
+ * behavior. User-provided properties take precedence.
+ */
+export const INLINE_FUNCTION_DEFAULTS: Partial<InlineFunctionDefinition> = {
+  /**
+   * Use the `cloudfront-js-2.0` runtime by default. It is a superset of
+   * `cloudfront-js-1.0` (async/await, `crypto.subtle`, KeyValueStore support).
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-20.html
+   */
+  runtime: FunctionRuntime.JS_2_0,
 };

--- a/packages/cloudfront/src/distribution-alarms.ts
+++ b/packages/cloudfront/src/distribution-alarms.ts
@@ -1,9 +1,8 @@
 import { Duration } from "aws-cdk-lib";
-import { type Alarm, ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import { ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
 import type { Distribution } from "aws-cdk-lib/aws-cloudfront";
-import type { IConstruct } from "constructs";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
-import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import { resolveAlarmConfig } from "@composurecdk/cloudwatch";
 import type { DistributionAlarmConfig } from "./alarm-config.js";
 import { DISTRIBUTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
 
@@ -75,35 +74,4 @@ export function resolveDistributionAlarmDefinitions(
   }
 
   return definitions;
-}
-
-/**
- * Creates AWS-recommended CloudWatch alarms for a CloudFront distribution,
- * merging recommended definitions with any custom alarm builders.
- *
- * @param scope - CDK construct scope for creating alarm constructs.
- * @param id - Base identifier for alarm construct ids.
- * @param distribution - The CloudFront distribution to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
- * @param customAlarms - Custom alarm builders added via `addAlarm()`.
- * @returns A record mapping alarm keys to their created Alarm constructs.
- *
- * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CloudFront
- */
-export function createDistributionAlarms(
-  scope: IConstruct,
-  id: string,
-  distribution: Distribution,
-  config: DistributionAlarmConfig | false | undefined,
-  customAlarms: AlarmDefinitionBuilder<Distribution>[] = [],
-): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? DISTRIBUTION_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveDistributionAlarmDefinitions(distribution, config);
-  const custom = customAlarms.map((b) => b.resolve(distribution));
-
-  return createAlarms(scope, id, [...recommended, ...custom]);
 }

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -3,11 +3,17 @@ import {
   type DistributionProps,
   type IOrigin,
   type AddBehaviorOptions,
+  type BehaviorOptions,
+  type Function as CfFunction,
+  type FunctionCode,
+  type FunctionEventType,
+  type FunctionRuntime,
+  type IKeyValueStore,
 } from "aws-cdk-lib/aws-cloudfront";
 import { type ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type Bucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
-import { RemovalPolicy } from "aws-cdk-lib";
+import { Annotations, RemovalPolicy, Stack, Token } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
 import {
   Builder,
@@ -16,27 +22,120 @@ import {
   resolve,
   type Resolvable,
 } from "@composurecdk/core";
-import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
 import { createBucketBuilder } from "@composurecdk/s3";
-import type { DistributionAlarmConfig } from "./alarm-config.js";
-import { createDistributionAlarms } from "./distribution-alarms.js";
+import type { DistributionAlarmConfig, FunctionAlarmConfig } from "./alarm-config.js";
+import { resolveDistributionAlarmDefinitions } from "./distribution-alarms.js";
 import { DISTRIBUTION_DEFAULTS } from "./defaults.js";
+import { resolveBehaviors } from "./resolve-behaviors.js";
+
+/**
+ * A CloudFront Function declared inline on a cache behavior. The distribution
+ * builder creates the underlying {@link CfFunction} construct and wires it
+ * into the behavior's function associations. Recommended alarms for the
+ * function are emitted automatically, scoped to the behavior's path pattern.
+ *
+ * Only inline declarations are supported — there is no "bring your own
+ * function" escape hatch, because the whole point of owning the function is
+ * to emit path-scoped `FunctionExecutionErrors` / `FunctionValidationErrors`
+ * / `FunctionThrottles` alarms that couldn't be emitted from an external
+ * `IFunctionRef` (which exposes only an ARN, not a function name).
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html
+ */
+export interface InlineFunctionDefinition {
+  /** The viewer event that should invoke the function. */
+  eventType: FunctionEventType;
+
+  /** The source for the function — `FunctionCode.fromInline()` or `.fromFile()`. */
+  code: FunctionCode;
+
+  /**
+   * JavaScript runtime.
+   * @default FunctionRuntime.JS_2_0
+   */
+  runtime?: FunctionRuntime;
+
+  /** Optional comment stored on the function resource. */
+  comment?: string;
+
+  /**
+   * Key-value store to associate with the function. Only supported on the
+   * `cloudfront-js-2.0` runtime.
+   */
+  keyValueStore?: IKeyValueStore;
+
+  /**
+   * Per-function alarm configuration. Defaults to the three AWS-recommended
+   * alarms (execution errors, validation errors, throttles) each with
+   * threshold 0. Set to `false` to disable all alarms for this function, or
+   * override individual alarms via their config entry.
+   *
+   * **Region requirement:** CloudFront metrics are emitted in `us-east-1`
+   * only. CloudWatch alarms are regional, so these alarms will only fire if
+   * the containing stack is deployed in `us-east-1`. The builder emits a
+   * synth-time warning if this isn't the case.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-functions.html
+   */
+  recommendedAlarms?: FunctionAlarmConfig | false;
+}
+
+/**
+ * Configuration for the distribution's default cache behavior.
+ *
+ * The origin is set separately via {@link IDistributionBuilder.origin}. The
+ * `functionAssociations` field from {@link AddBehaviorOptions} is replaced by
+ * {@link functions}, which takes {@link InlineFunctionDefinition}s — the
+ * builder owns the CloudFront Function constructs so it can emit alarms for
+ * them.
+ */
+export interface DefaultBehaviorConfig extends Omit<AddBehaviorOptions, "functionAssociations"> {
+  /**
+   * CloudFront Functions to associate with the default behavior. At most one
+   * function per {@link FunctionEventType} is allowed.
+   */
+  functions?: InlineFunctionDefinition[];
+}
+
+/**
+ * Configuration for a path-pattern cache behavior attached to the distribution
+ * via {@link IDistributionBuilder.behavior}.
+ *
+ * Unlike {@link DefaultBehaviorConfig}, `origin` is required. It may be a
+ * concrete {@link IOrigin} or a {@link Resolvable} (typically a {@link ref})
+ * for cross-component wiring.
+ */
+export interface AdditionalBehaviorConfig extends Omit<
+  BehaviorOptions,
+  "origin" | "functionAssociations"
+> {
+  /** The origin for this behavior, concrete or resolved at build time. */
+  origin: Resolvable<IOrigin>;
+
+  /**
+   * CloudFront Functions to associate with this behavior. At most one
+   * function per {@link FunctionEventType} is allowed.
+   */
+  functions?: InlineFunctionDefinition[];
+}
 
 /**
  * Configuration properties for the CloudFront distribution builder.
  *
  * Extends the CDK {@link DistributionProps} with additional builder-specific
- * options. The `defaultBehavior` field is replaced with {@link AddBehaviorOptions}
- * (which excludes `origin`) because the origin is set separately via the
- * {@link IDistributionBuilder.origin | origin()} method, which supports
- * {@link Resolvable} for cross-component wiring.
+ * options. `defaultBehavior` accepts a {@link DefaultBehaviorConfig} with
+ * inline function definitions; additional behaviors are added via the
+ * {@link IDistributionBuilder.behavior} method rather than the raw
+ * `additionalBehaviors` record.
  *
  * The `enableLogging` CDK prop is replaced by {@link accessLogging}, which
  * auto-creates a logging bucket with secure defaults when enabled.
  */
 export interface DistributionBuilderProps extends Omit<
   DistributionProps,
-  "defaultBehavior" | "enableLogging" | "certificate"
+  "defaultBehavior" | "additionalBehaviors" | "enableLogging" | "certificate"
 > {
   /**
    * Whether to automatically create an S3 bucket for CloudFront standard
@@ -65,29 +164,52 @@ export interface DistributionBuilderProps extends Omit<
   certificate?: Resolvable<ICertificate>;
 
   /**
-   * Options for the default cache behavior, excluding `origin`.
-   *
-   * The origin is set via the {@link IDistributionBuilder.origin | origin()}
-   * method and injected at build time. All other behavior options (cache
-   * policy, function associations, viewer protocol policy, etc.) can be
-   * configured here.
+   * Configuration for the default cache behavior. The origin is set via
+   * {@link IDistributionBuilder.origin}. Inline CloudFront Functions declared
+   * in `functions` are created by the builder and receive path-scoped alarms
+   * automatically.
    */
-  defaultBehavior?: AddBehaviorOptions;
+  defaultBehavior?: DefaultBehaviorConfig;
 
   /**
-   * Configuration for AWS-recommended CloudWatch alarms.
+   * Configuration for AWS-recommended CloudWatch alarms at the **distribution**
+   * level (5xx error rate, origin latency).
    *
-   * By default, the builder creates recommended alarms for 5xx error rate
-   * and origin latency. Individual alarms can be customized or disabled.
-   * Set to `false` to disable all alarms.
+   * Scope: this setting controls *distribution-level* alarms only. Per-function
+   * alarms (`FunctionExecutionErrors`, `FunctionValidationErrors`,
+   * `FunctionThrottles`) are configured independently via each
+   * {@link InlineFunctionDefinition.recommendedAlarms}, because their
+   * correct disposition depends on the behavior the function is attached to.
    *
-   * No alarm actions are configured by default since notification
-   * methods are user-specific. Access alarms from the build result
-   * or use an `afterBuild` hook to apply actions.
+   * **Region requirement:** CloudFront metrics are emitted in `us-east-1`
+   * only. CloudWatch alarms are regional, so *every* alarm created by this
+   * builder (distribution-level and per-function) will only fire if the
+   * containing stack is deployed in `us-east-1`. The builder emits a
+   * synth-time warning if this isn't the case.
    *
-   * Function-level alarms (FunctionValidationErrors, FunctionExecutionErrors,
-   * FunctionThrottles) require per-function dimensions. Use
-   * {@link IDistributionBuilder.addAlarm} to add them.
+   * By default, the builder creates recommended distribution alarms.
+   * Individual alarms can be customized or disabled; set to `false` to
+   * disable all distribution-level alarms — **function alarms remain
+   * enabled**. To disable function alarms, set `recommendedAlarms: false`
+   * on the corresponding {@link InlineFunctionDefinition}.
+   *
+   * No alarm actions are configured by default since notification methods
+   * are user-specific. Access alarms from the build result or use an
+   * `afterBuild` hook to apply actions.
+   *
+   * @example
+   * ```ts
+   * createDistributionBuilder()
+   *   .origin(siteOrigin)
+   *   .recommendedAlarms(false)          // disables distribution alarms only
+   *   .defaultBehavior({
+   *     functions: [{
+   *       eventType: FunctionEventType.VIEWER_REQUEST,
+   *       code,
+   *       recommendedAlarms: false,      // must also disable function alarms explicitly
+   *     }],
+   *   });
+   * ```
    *
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CloudFront
    */
@@ -95,8 +217,8 @@ export interface DistributionBuilderProps extends Omit<
 }
 
 /**
- * The build output of a {@link IDistributionBuilder}. Contains the CDK constructs
- * created during {@link Lifecycle.build}, keyed by role.
+ * The build output of an {@link IDistributionBuilder}. Contains the CDK
+ * constructs created during {@link Lifecycle.build}, keyed by role.
  */
 export interface DistributionBuilderResult {
   /** The CloudFront distribution construct created by the builder. */
@@ -109,16 +231,22 @@ export interface DistributionBuilderResult {
   accessLogsBucket?: Bucket;
 
   /**
-   * CloudWatch alarms created for the distribution, keyed by alarm name.
+   * CloudFront Functions created by the builder for inline function
+   * definitions, keyed by `<behaviorScope><EventType>` —
+   * e.g. `defaultBehaviorViewerRequest`, `behaviorApiStarViewerRequest`.
    *
-   * Includes both AWS-recommended alarms and any custom alarms added
-   * via {@link IDistributionBuilder.addAlarm}. Access individual alarms
-   * by key (e.g., `result.alarms.errorRate`).
+   * Empty if no inline functions were declared.
+   */
+  functions: Record<string, CfFunction>;
+
+  /**
+   * CloudWatch alarms created for the distribution and its inline functions,
+   * keyed by alarm name. Distribution-level keys: `errorRate`, `originLatency`.
+   * Function-level keys are prefixed by behavior scope and event type —
+   * e.g. `defaultBehaviorViewerRequestExecutionErrors`.
    *
-   * No alarm actions are configured — apply them via the result or an
-   * `afterBuild` hook.
-   *
-   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#CloudFront
+   * Includes both recommended alarms and custom alarms added via
+   * {@link IDistributionBuilder.addAlarm}. No alarm actions are configured.
    */
   alarms: Record<string, Alarm>;
 }
@@ -126,33 +254,63 @@ export interface DistributionBuilderResult {
 /**
  * A fluent builder for configuring and creating a CloudFront distribution.
  *
- * Configuration properties from CDK {@link DistributionProps} are exposed as
- * overloaded getter/setter methods via the builder proxy. The origin is set
- * via the {@link origin} method, which accepts a concrete {@link IOrigin} or
- * a {@link Ref} for cross-component wiring.
+ * Properties from CDK {@link DistributionProps} are exposed as overloaded
+ * getter/setter methods. The origin is set via {@link origin}, which accepts
+ * a concrete {@link IOrigin} or a {@link Ref} for cross-component wiring.
+ * Additional cache behaviors are added via {@link behavior}, which takes a
+ * path pattern and a config including its own origin and inline functions.
  *
  * The builder implements {@link Lifecycle}, so it can be used directly as a
- * component in a {@link compose | composed system}. When built, it creates
- * a CloudFront distribution with the configured properties and returns a
- * {@link DistributionBuilderResult}.
+ * component in a {@link compose | composed system}. When built, it creates a
+ * CloudFront distribution, any inline CloudFront Functions declared on its
+ * behaviors, and AWS-recommended alarms scoped per-behavior.
  *
  * @example
  * ```ts
  * const cdn = createDistributionBuilder()
- *   .origin(ref("site", (r: BucketBuilderResult) =>
- *     S3BucketOrigin.withOriginAccessControl(r.bucket)))
- *   .errorResponses([{
- *     httpStatus: 404,
- *     responsePagePath: "/index.html",
- *     responseHttpStatus: 200,
- *   }]);
+ *   .origin(siteOrigin)
+ *   .defaultBehavior({
+ *     functions: [{
+ *       eventType: FunctionEventType.VIEWER_REQUEST,
+ *       code: FunctionCode.fromFile({ filePath: "src/edge/rewrite.js" }),
+ *     }],
+ *   })
+ *   .behavior("/api/*", {
+ *     origin: apiOrigin,
+ *     cachePolicy: CachePolicy.CACHING_DISABLED,
+ *     functions: [{
+ *       eventType: FunctionEventType.VIEWER_REQUEST,
+ *       code: FunctionCode.fromFile({ filePath: "src/edge/api-auth.js" }),
+ *     }],
+ *   });
  * ```
  */
 export type IDistributionBuilder = IBuilder<DistributionBuilderProps, DistributionBuilder>;
 
+/**
+ * CloudFront metrics are emitted in `us-east-1` only. CloudWatch alarms are
+ * regional, so alarms created in any other region will never receive data
+ * and will never fire. Warn (don't error) the user if this builder is used
+ * from a stack deployed outside `us-east-1`, unless the region is an
+ * unresolved token (env-agnostic stack — user knows best).
+ */
+function warnIfNotUsEast1(scope: IConstruct): void {
+  const region = Stack.of(scope).region;
+  if (Token.isUnresolved(region)) return;
+  if (region === "us-east-1") return;
+  Annotations.of(scope).addWarningV2(
+    "@composurecdk/cloudfront:alarm-region",
+    `CloudFront metrics are emitted in us-east-1 only, but this stack is deployed ` +
+      `in "${region}". CloudWatch alarms created here will not fire. Deploy the ` +
+      `stack in us-east-1, or disable recommended alarms and wire up a cross-region ` +
+      `alarm pattern yourself.`,
+  );
+}
+
 class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
   props: Partial<DistributionBuilderProps> = {};
   #origin?: Resolvable<IOrigin>;
+  readonly #additionalBehaviors = new Map<string, AdditionalBehaviorConfig>();
   readonly #customAlarms: AlarmDefinitionBuilder<Distribution>[] = [];
 
   addAlarm(
@@ -176,6 +334,24 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
    */
   origin(origin: Resolvable<IOrigin>): this {
     this.#origin = origin;
+    return this;
+  }
+
+  /**
+   * Adds an additional cache behavior for a path pattern. The behavior's
+   * origin is required (concrete or Resolvable). Any inline functions are
+   * created by the builder and receive per-behavior alarms scoped to the
+   * path pattern.
+   *
+   * @throws If a behavior for the same path pattern has already been added.
+   */
+  behavior(pathPattern: string, config: AdditionalBehaviorConfig): this {
+    if (this.#additionalBehaviors.has(pathPattern)) {
+      throw new Error(
+        `DistributionBuilder: behavior for path pattern "${pathPattern}" is already defined.`,
+      );
+    }
+    this.#additionalBehaviors.set(pathPattern, config);
     return this;
   }
 
@@ -203,7 +379,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
     const resolvedCertificate = certificate ? resolve(certificate, context ?? {}) : undefined;
     const {
       accessLogging: defaultAccessLogging,
-      defaultBehavior: defaultBehavior,
+      defaultBehavior: defaultBehaviorDefaults,
       ...cdkDefaults
     } = DISTRIBUTION_DEFAULTS;
     const autoAccessLog = (accessLogging ?? defaultAccessLogging) && !distProps.logBucket;
@@ -225,16 +401,25 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
       };
     }
 
+    const behaviors = resolveBehaviors({
+      scope,
+      id,
+      context: context ?? {},
+      defaultOrigin: resolvedOrigin,
+      defaultBehavior: userBehavior,
+      defaultBehaviorDefaults: defaultBehaviorDefaults ?? {},
+      additionalBehaviors: this.#additionalBehaviors,
+    });
+
     const mergedProps = {
       ...cdkDefaults,
       ...accessLogProps,
       ...distProps,
       ...(resolvedCertificate ? { certificate: resolvedCertificate } : {}),
-      defaultBehavior: {
-        ...defaultBehavior,
-        ...userBehavior,
-        origin: resolvedOrigin,
-      },
+      defaultBehavior: behaviors.defaultBehavior,
+      ...(Object.keys(behaviors.additionalBehaviors).length > 0
+        ? { additionalBehaviors: behaviors.additionalBehaviors }
+        : {}),
     } as DistributionProps;
 
     const distribution = new Distribution(scope, id, mergedProps);
@@ -245,17 +430,28 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
       distribution.node.addDependency(accessLogsBucket);
     }
 
-    const alarms = createDistributionAlarms(
-      scope,
-      id,
-      distribution,
-      alarmConfig,
-      this.#customAlarms,
-    );
+    const distributionAlarmDefs: AlarmDefinition[] =
+      alarmConfig === false || alarmConfig?.enabled === false
+        ? []
+        : resolveDistributionAlarmDefinitions(distribution, alarmConfig);
+    const customAlarmDefs = this.#customAlarms.map((b) => b.resolve(distribution));
+
+    const allAlarmDefs = [
+      ...distributionAlarmDefs,
+      ...behaviors.alarmDefinitions,
+      ...customAlarmDefs,
+    ];
+
+    if (allAlarmDefs.length > 0) {
+      warnIfNotUsEast1(scope);
+    }
+
+    const alarms = createAlarms(scope, id, allAlarmDefs);
 
     return {
       distribution,
       accessLogsBucket,
+      functions: behaviors.functions,
       alarms,
     };
   }
@@ -267,26 +463,27 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
  * This is the entry point for defining a CloudFront distribution component.
  * The returned builder exposes every {@link DistributionBuilderProps} property
  * as a fluent setter/getter, plus {@link IDistributionBuilder.origin | origin()}
- * for setting the default origin with Ref support. It implements {@link Lifecycle}
- * for use with {@link compose}.
+ * for setting the default origin with Ref support and
+ * {@link IDistributionBuilder.behavior | behavior()} for path-pattern behaviors.
+ * It implements {@link Lifecycle} for use with {@link compose}.
  *
  * @returns A fluent builder for a CloudFront distribution.
  *
  * @example
  * ```ts
  * const cdn = createDistributionBuilder()
- *   .origin(ref("site", (r: BucketBuilderResult) =>
+ *   .origin(ref<BucketBuilderResult>("site", (r) =>
  *     S3BucketOrigin.withOriginAccessControl(r.bucket)))
- *   .comment("Community website CDN");
- *
- * // Use standalone:
- * const result = cdn.build(stack, "CDN");
- *
- * // Or compose into a system:
- * const system = compose(
- *   { site: createBucketBuilder(), cdn },
- *   { site: [], cdn: ["site"] },
- * );
+ *   .defaultBehavior({
+ *     functions: [{
+ *       eventType: FunctionEventType.VIEWER_REQUEST,
+ *       code: FunctionCode.fromFile({ filePath: "src/edge/rewrite.js" }),
+ *     }],
+ *   })
+ *   .behavior("/api/*", {
+ *     origin: apiOrigin,
+ *     cachePolicy: CachePolicy.CACHING_DISABLED,
+ *   });
  * ```
  */
 export function createDistributionBuilder(): IDistributionBuilder {

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -29,6 +29,7 @@ import type { DistributionAlarmConfig, FunctionAlarmConfig } from "./alarm-confi
 import { resolveDistributionAlarmDefinitions } from "./distribution-alarms.js";
 import { DISTRIBUTION_DEFAULTS } from "./defaults.js";
 import { resolveBehaviors } from "./resolve-behaviors.js";
+import { pathPatternSlug } from "./behavior-function-alarms.js";
 
 /**
  * A CloudFront Function declared inline on a cache behavior. The distribution
@@ -50,6 +51,13 @@ export interface InlineFunctionDefinition {
 
   /** The source for the function — `FunctionCode.fromInline()` or `.fromFile()`. */
   code: FunctionCode;
+
+  /**
+   * Explicit physical name for the function. Useful when operators search
+   * CloudWatch logs or metrics by function name rather than by ARN. If omitted,
+   * CDK generates a name derived from the construct path.
+   */
+  functionName?: string;
 
   /**
    * JavaScript runtime.
@@ -311,6 +319,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
   props: Partial<DistributionBuilderProps> = {};
   #origin?: Resolvable<IOrigin>;
   readonly #additionalBehaviors = new Map<string, AdditionalBehaviorConfig>();
+  readonly #behaviorSlugs = new Map<string, string>();
   readonly #customAlarms: AlarmDefinitionBuilder<Distribution>[] = [];
 
   addAlarm(
@@ -351,6 +360,19 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
         `DistributionBuilder: behavior for path pattern "${pathPattern}" is already defined.`,
       );
     }
+    // Alarm keys and Function construct ids are derived from a PascalCase slug
+    // of the path pattern. Patterns that differ only by stripped characters
+    // (e.g. `/*.html` vs `*.html`) would collide downstream at createAlarms() —
+    // surface the collision here with the patterns named.
+    const slug = pathPatternSlug(pathPattern);
+    const existingPattern = this.#behaviorSlugs.get(slug);
+    if (existingPattern !== undefined) {
+      throw new Error(
+        `DistributionBuilder: path pattern "${pathPattern}" produces the same alarm/construct ` +
+          `slug ("${slug}") as "${existingPattern}". Pick distinct patterns.`,
+      );
+    }
+    this.#behaviorSlugs.set(slug, pathPattern);
     this.#additionalBehaviors.set(pathPattern, config);
     return this;
   }

--- a/packages/cloudfront/src/index.ts
+++ b/packages/cloudfront/src/index.ts
@@ -3,7 +3,10 @@ export {
   type DistributionBuilderProps,
   type DistributionBuilderResult,
   type IDistributionBuilder,
+  type DefaultBehaviorConfig,
+  type AdditionalBehaviorConfig,
+  type InlineFunctionDefinition,
 } from "./distribution-builder.js";
-export { DISTRIBUTION_DEFAULTS } from "./defaults.js";
-export { type DistributionAlarmConfig } from "./alarm-config.js";
-export { DISTRIBUTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
+export { DISTRIBUTION_DEFAULTS, INLINE_FUNCTION_DEFAULTS } from "./defaults.js";
+export { type DistributionAlarmConfig, type FunctionAlarmConfig } from "./alarm-config.js";
+export { DISTRIBUTION_ALARM_DEFAULTS, FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";

--- a/packages/cloudfront/src/resolve-behaviors.ts
+++ b/packages/cloudfront/src/resolve-behaviors.ts
@@ -1,0 +1,187 @@
+import {
+  type AddBehaviorOptions,
+  type BehaviorOptions,
+  Function as CfFunction,
+  type FunctionAssociation,
+  type FunctionEventType,
+  type FunctionProps,
+  FunctionRuntime,
+  type IOrigin,
+} from "aws-cdk-lib/aws-cloudfront";
+import type { IConstruct } from "constructs";
+import { resolve } from "@composurecdk/core";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import {
+  behaviorFunctionKeyPrefix,
+  eventTypePascal,
+  pathPatternSlug,
+  resolveBehaviorFunctionAlarmDefinitions,
+} from "./behavior-function-alarms.js";
+import { INLINE_FUNCTION_DEFAULTS } from "./defaults.js";
+import type {
+  AdditionalBehaviorConfig,
+  DefaultBehaviorConfig,
+  InlineFunctionDefinition,
+} from "./distribution-builder.js";
+
+/**
+ * Input required to resolve the default behavior, all additional behaviors,
+ * and any inline CloudFront Functions into concrete CDK objects.
+ */
+export interface ResolveBehaviorsInput {
+  /** The construct scope under which functions and behaviors are created. */
+  scope: IConstruct;
+
+  /** The distribution's construct id — used as a prefix for Function ids. */
+  id: string;
+
+  /** Compose context forwarded to {@link resolve}. Empty record if unused. */
+  context: Record<string, object>;
+
+  /** The already-resolved default origin. */
+  defaultOrigin: IOrigin;
+
+  /** User-provided default-behavior config (may be undefined). */
+  defaultBehavior: DefaultBehaviorConfig | undefined;
+
+  /** The builder's default-behavior defaults, applied before user props. */
+  defaultBehaviorDefaults: Partial<AddBehaviorOptions>;
+
+  /**
+   * Ordered map of path-pattern → config for additional behaviors. Origins
+   * are resolved here via {@link resolve}.
+   */
+  additionalBehaviors: Map<string, AdditionalBehaviorConfig>;
+}
+
+/**
+ * Output of {@link resolveBehaviors}: concrete behavior options ready to pass
+ * to the CDK `Distribution` constructor, plus any owned {@link CfFunction}
+ * instances and their alarm definitions.
+ */
+export interface ResolveBehaviorsResult {
+  /** Concrete `BehaviorOptions` for the default cache behavior. */
+  defaultBehavior: BehaviorOptions;
+
+  /** Concrete `BehaviorOptions` keyed by path pattern, in insertion order. */
+  additionalBehaviors: Record<string, BehaviorOptions>;
+
+  /**
+   * Owned inline CloudFront Functions, keyed by
+   * `<behaviorScope><EventType>` — e.g. `defaultBehaviorViewerRequest`.
+   */
+  functions: Record<string, CfFunction>;
+
+  /** Alarm definitions for the owned inline functions. */
+  alarmDefinitions: AlarmDefinition[];
+}
+
+function scopeLabel(pathPattern: string | null): string {
+  return pathPattern === null ? "default behavior" : `behavior "${pathPattern}"`;
+}
+
+function behaviorIdScope(pathPattern: string | null): string {
+  return pathPattern === null ? "DefaultBehavior" : `Behavior${pathPatternSlug(pathPattern)}`;
+}
+
+function assertUniqueEventTypes(
+  functions: InlineFunctionDefinition[],
+  pathPattern: string | null,
+): void {
+  const seen = new Set<FunctionEventType>();
+  for (const fn of functions) {
+    if (seen.has(fn.eventType)) {
+      throw new Error(
+        `DistributionBuilder: ${scopeLabel(pathPattern)} has multiple functions for eventType "${fn.eventType}". ` +
+          `CloudFront allows at most one function per event type per behavior.`,
+      );
+    }
+    seen.add(fn.eventType);
+  }
+}
+
+function assertKeyValueStoreRuntime(
+  def: InlineFunctionDefinition,
+  pathPattern: string | null,
+): void {
+  if (!def.keyValueStore) return;
+  const effectiveRuntime = def.runtime ?? INLINE_FUNCTION_DEFAULTS.runtime;
+  if (effectiveRuntime !== FunctionRuntime.JS_2_0) {
+    throw new Error(
+      `DistributionBuilder: ${scopeLabel(pathPattern)} function (${def.eventType}) uses a ` +
+        `keyValueStore, which requires FunctionRuntime.JS_2_0.`,
+    );
+  }
+}
+
+/**
+ * Materializes the default and additional cache behaviors into CDK-ready
+ * `BehaviorOptions`, creating any inline CloudFront Functions along the way
+ * and producing their path-scoped alarm definitions.
+ *
+ * Enforces CloudFront invariants at configure time: at most one function per
+ * event type per behavior, and `keyValueStore` requires `FunctionRuntime.JS_2_0`.
+ */
+export function resolveBehaviors(input: ResolveBehaviorsInput): ResolveBehaviorsResult {
+  const { scope, id, context, defaultOrigin, defaultBehavior, defaultBehaviorDefaults } = input;
+
+  const functions: Record<string, CfFunction> = {};
+  const alarmDefinitions: AlarmDefinition[] = [];
+
+  const buildInlineFunctions = (
+    pathPattern: string | null,
+    definitions: InlineFunctionDefinition[] | undefined,
+  ): FunctionAssociation[] => {
+    if (!definitions || definitions.length === 0) return [];
+    assertUniqueEventTypes(definitions, pathPattern);
+    const scopeId = behaviorIdScope(pathPattern);
+    const associations: FunctionAssociation[] = [];
+    for (const def of definitions) {
+      assertKeyValueStoreRuntime(def, pathPattern);
+      const { eventType, recommendedAlarms, ...rest } = def;
+      const fnId = `${id}${scopeId}${eventTypePascal(eventType)}Fn`;
+      const fn = new CfFunction(scope, fnId, {
+        ...INLINE_FUNCTION_DEFAULTS,
+        ...rest,
+      } as FunctionProps);
+      functions[behaviorFunctionKeyPrefix(pathPattern, eventType)] = fn;
+      associations.push({ function: fn, eventType });
+      alarmDefinitions.push(
+        ...resolveBehaviorFunctionAlarmDefinitions(pathPattern, eventType, fn, recommendedAlarms),
+      );
+    }
+    return associations;
+  };
+
+  const defaultAssociations = buildInlineFunctions(null, defaultBehavior?.functions);
+  const { functions: _defaultInlineFns, ...userDefaultBehavior } = defaultBehavior ?? {};
+  void _defaultInlineFns;
+
+  const resolvedDefaultBehavior: BehaviorOptions = {
+    ...defaultBehaviorDefaults,
+    ...userDefaultBehavior,
+    ...(defaultAssociations.length > 0 ? { functionAssociations: defaultAssociations } : {}),
+    origin: defaultOrigin,
+  };
+
+  const resolvedAdditionalBehaviors: Record<string, BehaviorOptions> = {};
+  for (const [pathPattern, config] of input.additionalBehaviors) {
+    const resolvedOrigin = resolve(config.origin, context);
+    const associations = buildInlineFunctions(pathPattern, config.functions);
+    const { functions: _inlineFns, origin: _origin, ...rest } = config;
+    void _inlineFns;
+    void _origin;
+    resolvedAdditionalBehaviors[pathPattern] = {
+      ...rest,
+      origin: resolvedOrigin,
+      ...(associations.length > 0 ? { functionAssociations: associations } : {}),
+    };
+  }
+
+  return {
+    defaultBehavior: resolvedDefaultBehavior,
+    additionalBehaviors: resolvedAdditionalBehaviors,
+    functions,
+    alarmDefinitions,
+  };
+}

--- a/packages/cloudfront/src/resolve-behaviors.ts
+++ b/packages/cloudfront/src/resolve-behaviors.ts
@@ -100,6 +100,15 @@ function assertUniqueEventTypes(
   }
 }
 
+function omit<T extends object, K extends keyof T>(obj: T, ...keys: K[]): Omit<T, K> {
+  const skip = new Set<PropertyKey>(keys);
+  const out: Record<PropertyKey, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (!skip.has(k)) out[k] = v;
+  }
+  return out as Omit<T, K>;
+}
+
 function assertKeyValueStoreRuntime(
   def: InlineFunctionDefinition,
   pathPattern: string | null,
@@ -138,24 +147,28 @@ export function resolveBehaviors(input: ResolveBehaviorsInput): ResolveBehaviors
     const associations: FunctionAssociation[] = [];
     for (const def of definitions) {
       assertKeyValueStoreRuntime(def, pathPattern);
-      const { eventType, recommendedAlarms, ...rest } = def;
+      const { eventType } = def;
       const fnId = `${id}${scopeId}${eventTypePascal(eventType)}Fn`;
       const fn = new CfFunction(scope, fnId, {
         ...INLINE_FUNCTION_DEFAULTS,
-        ...rest,
+        ...omit(def, "eventType", "recommendedAlarms"),
       } as FunctionProps);
       functions[behaviorFunctionKeyPrefix(pathPattern, eventType)] = fn;
       associations.push({ function: fn, eventType });
       alarmDefinitions.push(
-        ...resolveBehaviorFunctionAlarmDefinitions(pathPattern, eventType, fn, recommendedAlarms),
+        ...resolveBehaviorFunctionAlarmDefinitions(
+          pathPattern,
+          eventType,
+          fn,
+          def.recommendedAlarms,
+        ),
       );
     }
     return associations;
   };
 
   const defaultAssociations = buildInlineFunctions(null, defaultBehavior?.functions);
-  const { functions: _defaultInlineFns, ...userDefaultBehavior } = defaultBehavior ?? {};
-  void _defaultInlineFns;
+  const userDefaultBehavior = omit(defaultBehavior ?? {}, "functions");
 
   const resolvedDefaultBehavior: BehaviorOptions = {
     ...defaultBehaviorDefaults,
@@ -168,11 +181,8 @@ export function resolveBehaviors(input: ResolveBehaviorsInput): ResolveBehaviors
   for (const [pathPattern, config] of input.additionalBehaviors) {
     const resolvedOrigin = resolve(config.origin, context);
     const associations = buildInlineFunctions(pathPattern, config.functions);
-    const { functions: _inlineFns, origin: _origin, ...rest } = config;
-    void _inlineFns;
-    void _origin;
     resolvedAdditionalBehaviors[pathPattern] = {
-      ...rest,
+      ...omit(config, "functions", "origin"),
       origin: resolvedOrigin,
       ...(associations.length > 0 ? { functionAssociations: associations } : {}),
     };

--- a/packages/cloudfront/test/behavior-function-alarms.test.ts
+++ b/packages/cloudfront/test/behavior-function-alarms.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { S3BucketOrigin, HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { FunctionCode, FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
+import { createDistributionBuilder } from "../src/distribution-builder.js";
+
+const INLINE_CODE = `
+  async function handler(event) {
+    return event.request;
+  }
+`;
+
+function buildResult(
+  configureFn: (builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) => void,
+) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createDistributionBuilder();
+  configureFn(builder, stack);
+  const result = builder.build(stack, "TestDistribution");
+  return { result, template: Template.fromStack(stack) };
+}
+
+function withOrigin(builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) {
+  const bucket = new Bucket(stack, "TestBucket");
+  builder
+    .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+    .accessLogging(false)
+    .recommendedAlarms(false);
+}
+
+describe("function alarms on default behavior", () => {
+  it("creates execution/validation/throttles alarms by default", () => {
+    const { result, template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    expect(result.alarms.defaultBehaviorViewerRequestExecutionErrors).toBeDefined();
+    expect(result.alarms.defaultBehaviorViewerRequestValidationErrors).toBeDefined();
+    expect(result.alarms.defaultBehaviorViewerRequestThrottles).toBeDefined();
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 3);
+  });
+
+  it("creates execution-errors alarm with the correct shape", () => {
+    const { template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FunctionExecutionErrors",
+      Namespace: "AWS/CloudFront",
+      Threshold: 0,
+      ComparisonOperator: "GreaterThanThreshold",
+      Statistic: "Sum",
+      Period: 60,
+      TreatMissingData: "notBreaching",
+    });
+  });
+
+  it("includes FunctionName and Region=Global dimensions", () => {
+    const { template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FunctionExecutionErrors",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({ Name: "FunctionName" }),
+        Match.objectLike({ Name: "Region", Value: "Global" }),
+      ]),
+    });
+  });
+
+  it("scopes alarm descriptions to the default behavior and event type", () => {
+    const { template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FunctionExecutionErrors",
+      AlarmDescription: Match.stringLikeRegexp(
+        "default behavior \\(viewer-request\\).*Threshold: > 0",
+      ),
+    });
+  });
+});
+
+describe("function alarms on additional behaviors", () => {
+  it("scopes alarm keys to the path pattern and event type", () => {
+    const { result } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.behavior("/api/*", {
+        origin: new HttpOrigin("api.example.com"),
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    expect(result.alarms.behaviorApiSlashStarViewerRequestExecutionErrors).toBeDefined();
+    expect(result.alarms.behaviorApiSlashStarViewerRequestValidationErrors).toBeDefined();
+    expect(result.alarms.behaviorApiSlashStarViewerRequestThrottles).toBeDefined();
+    expect(result.alarms.defaultBehaviorViewerRequestExecutionErrors).toBeUndefined();
+  });
+
+  it("includes the path pattern in alarm descriptions", () => {
+    const { template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.behavior("/api/*", {
+        origin: new HttpOrigin("api.example.com"),
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FunctionExecutionErrors",
+      AlarmDescription: Match.stringLikeRegexp('behavior "/api/\\*" \\(viewer-request\\)'),
+    });
+  });
+
+  it("emits independent alarms for the same event type across different behaviors", () => {
+    const { result, template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      }).behavior("/api/*", {
+        origin: new HttpOrigin("api.example.com"),
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    // Two CfFunctions × 3 alarms each = 6 function alarms (distribution alarms disabled).
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 6);
+    expect(result.alarms.defaultBehaviorViewerRequestExecutionErrors).toBeDefined();
+    expect(result.alarms.behaviorApiSlashStarViewerRequestExecutionErrors).toBeDefined();
+  });
+});
+
+describe("customization", () => {
+  it("allows per-function threshold overrides", () => {
+    const { template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+            recommendedAlarms: { throttles: { threshold: 5 } },
+          },
+        ],
+      });
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FunctionThrottles",
+      Threshold: 5,
+    });
+  });
+
+  it("allows per-function treatMissingData overrides", () => {
+    const { template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+            recommendedAlarms: {
+              validationErrors: { treatMissingData: TreatMissingData.BREACHING },
+            },
+          },
+        ],
+      });
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FunctionValidationErrors",
+      TreatMissingData: "breaching",
+    });
+  });
+});
+
+describe("disabling", () => {
+  it("disables all three alarms for a function when recommendedAlarms is false", () => {
+    const { result, template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+            recommendedAlarms: false,
+          },
+        ],
+      });
+    });
+
+    expect(result.alarms.defaultBehaviorViewerRequestExecutionErrors).toBeUndefined();
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
+  it("disables all three alarms when enabled: false", () => {
+    const { result, template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+            recommendedAlarms: { enabled: false },
+          },
+        ],
+      });
+    });
+
+    expect(result.alarms).toEqual({});
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
+  it("disables a single alarm while keeping the others", () => {
+    const { result, template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+            recommendedAlarms: { executionErrors: false },
+          },
+        ],
+      });
+    });
+
+    expect(result.alarms.defaultBehaviorViewerRequestExecutionErrors).toBeUndefined();
+    expect(result.alarms.defaultBehaviorViewerRequestValidationErrors).toBeDefined();
+    expect(result.alarms.defaultBehaviorViewerRequestThrottles).toBeDefined();
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+  });
+});
+
+describe("region signposting", () => {
+  function buildInRegion(
+    region: string | undefined,
+    configureFn: (b: ReturnType<typeof createDistributionBuilder>, stack: Stack) => void,
+  ) {
+    const app = new App();
+    const stack =
+      region === undefined
+        ? new Stack(app, "TestStack")
+        : new Stack(app, "TestStack", { env: { region, account: "123456789012" } });
+    const builder = createDistributionBuilder();
+    configureFn(builder, stack);
+    builder.build(stack, "TestDistribution");
+    return stack;
+  }
+
+  it("emits no warning when the stack is in us-east-1", () => {
+    const stack = buildInRegion("us-east-1", (b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    const warnings = Annotations.fromStack(stack).findWarning(
+      "*",
+      Match.stringLikeRegexp("CloudFront metrics are emitted"),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("emits a synth-time warning when the stack is outside us-east-1 and alarms are created", () => {
+    const stack = buildInRegion("us-west-2", (b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    const warnings = Annotations.fromStack(stack).findWarning(
+      "*",
+      Match.stringLikeRegexp('deployed in "us-west-2"'),
+    );
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  it("emits no warning when no alarms are created, regardless of region", () => {
+    const stack = buildInRegion("us-west-2", (b, stack) => {
+      const bucket = new Bucket(stack, "TestBucket");
+      b.origin(S3BucketOrigin.withOriginAccessControl(bucket))
+        .accessLogging(false)
+        .recommendedAlarms(false);
+    });
+
+    const warnings = Annotations.fromStack(stack).findWarning(
+      "*",
+      Match.stringLikeRegexp("CloudFront metrics are emitted"),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("emits no warning when the stack region is an unresolved token (env-agnostic)", () => {
+    const stack = buildInRegion(undefined, (b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    const warnings = Annotations.fromStack(stack).findWarning(
+      "*",
+      Match.stringLikeRegexp("CloudFront metrics are emitted"),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+});
+
+describe("interactions with other alarm sources", () => {
+  it("emits custom addAlarm() alarms alongside function alarms without key collisions", () => {
+    const { result, template } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      }).addAlarm("custom4xx", (a) =>
+        a
+          .metric(
+            () =>
+              new Metric({
+                namespace: "AWS/CloudFront",
+                metricName: "4xxErrorRate",
+                statistic: "Average",
+              }),
+          )
+          .threshold(5)
+          .greaterThan(),
+      );
+    });
+
+    // 3 function alarms + 1 custom alarm (distribution alarms disabled via recommendedAlarms(false))
+    expect(result.alarms.defaultBehaviorViewerRequestExecutionErrors).toBeDefined();
+    expect(result.alarms.defaultBehaviorViewerRequestValidationErrors).toBeDefined();
+    expect(result.alarms.defaultBehaviorViewerRequestThrottles).toBeDefined();
+    expect(result.alarms.custom4xx).toBeDefined();
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+  });
+
+  it("emits distinct alarm keys for path patterns that would otherwise collide on slug", () => {
+    const { result } = buildResult((b, stack) => {
+      withOrigin(b, stack);
+      b.behavior("/api/*", {
+        origin: new HttpOrigin("api.example.com"),
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      }).behavior("/api*", {
+        origin: new HttpOrigin("api-legacy.example.com"),
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+          },
+        ],
+      });
+    });
+
+    // `/api/*` → ApiSlashStar, `/api*` → ApiStar — the two patterns must not
+    // produce the same slug, otherwise createAlarms would throw on duplicate keys.
+    expect(result.alarms.behaviorApiSlashStarViewerRequestExecutionErrors).toBeDefined();
+    expect(result.alarms.behaviorApiStarViewerRequestExecutionErrors).toBeDefined();
+  });
+});

--- a/packages/cloudfront/test/behavior-functions.test.ts
+++ b/packages/cloudfront/test/behavior-functions.test.ts
@@ -404,6 +404,43 @@ describe("additional path-pattern behaviors", () => {
     ).toThrow(/behavior for path pattern "\/api\/\*" is already defined/);
   });
 
+  it("throws when two path patterns produce the same alarm/construct slug", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const builder = createDistributionBuilder()
+      .origin(withBucketOrigin(stack))
+      .accessLogging(false)
+      .recommendedAlarms(false)
+      .behavior("/*.html", { origin: new HttpOrigin("pages.example.com") });
+
+    // `/*.html` and `*.html` both slug to "StarHtml"; the collision must be
+    // surfaced at registration time, not deferred to createAlarms.
+    expect(() =>
+      builder.behavior("*.html", { origin: new HttpOrigin("pages-2.example.com") }),
+    ).toThrow(/produces the same alarm\/construct slug \("StarHtml"\)/);
+  });
+
+  it("applies an explicit functionName when provided", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+              functionName: "example-redirect-fn",
+            },
+          ],
+        });
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Function", {
+      Name: "example-redirect-fn",
+    });
+  });
+
   it("throws when two functions on the same additional behavior share an eventType", () => {
     expect(() =>
       synthTemplate((b, stack) => {

--- a/packages/cloudfront/test/behavior-functions.test.ts
+++ b/packages/cloudfront/test/behavior-functions.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { S3BucketOrigin, HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import {
+  CachePolicy,
+  FunctionCode,
+  FunctionEventType,
+  FunctionRuntime,
+  ImportSource,
+  KeyValueStore,
+} from "aws-cdk-lib/aws-cloudfront";
+import { ref } from "@composurecdk/core";
+import { type BucketBuilderResult } from "@composurecdk/s3";
+import { createDistributionBuilder } from "../src/distribution-builder.js";
+
+const INLINE_CODE = `
+  async function handler(event) {
+    return event.request;
+  }
+`;
+
+function withBucketOrigin(stack: Stack) {
+  const bucket = new Bucket(stack, "TestBucket");
+  return S3BucketOrigin.withOriginAccessControl(bucket);
+}
+
+function synthTemplate(
+  configureFn: (builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) => void,
+) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createDistributionBuilder();
+  configureFn(builder, stack);
+  const result = builder.build(stack, "TestDistribution");
+  return { result, template: Template.fromStack(stack) };
+}
+
+describe("default behavior inline functions", () => {
+  it("creates a CloudFront Function for an inline function on the default behavior", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    template.resourceCountIs("AWS::CloudFront::Function", 1);
+  });
+
+  it("wires the function into the default behavior's FunctionAssociations", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          FunctionAssociations: Match.arrayWith([
+            Match.objectLike({
+              EventType: "viewer-request",
+              FunctionARN: Match.anyValue(),
+            }),
+          ]),
+        }),
+      }),
+    });
+  });
+
+  it("returns the CfFunction in the build result under the behavior+event key", () => {
+    const { result } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    expect(result.functions.defaultBehaviorViewerRequest).toBeDefined();
+  });
+
+  it("defaults the runtime to cloudfront-js-2.0", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Function", {
+      FunctionConfig: Match.objectLike({
+        Runtime: "cloudfront-js-2.0",
+      }),
+    });
+  });
+
+  it("honours a user-provided runtime", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+              runtime: FunctionRuntime.JS_1_0,
+            },
+          ],
+        });
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Function", {
+      FunctionConfig: Match.objectLike({
+        Runtime: "cloudfront-js-1.0",
+      }),
+    });
+  });
+
+  it("applies a provided comment to the Function", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+              comment: "URI rewrite",
+            },
+          ],
+        });
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Function", {
+      FunctionConfig: Match.objectLike({ Comment: "URI rewrite" }),
+    });
+  });
+
+  it("associates a KeyValueStore with the Function", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const kvs = new KeyValueStore(stack, "Kvs", {
+      source: ImportSource.fromInline(JSON.stringify({ data: [{ key: "a", value: "b" }] })),
+    });
+
+    createDistributionBuilder()
+      .origin(withBucketOrigin(stack))
+      .accessLogging(false)
+      .recommendedAlarms(false)
+      .defaultBehavior({
+        functions: [
+          {
+            eventType: FunctionEventType.VIEWER_REQUEST,
+            code: FunctionCode.fromInline(INLINE_CODE),
+            keyValueStore: kvs,
+          },
+        ],
+      })
+      .build(stack, "TestDistribution");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::CloudFront::Function", {
+      FunctionConfig: Match.objectLike({
+        KeyValueStoreAssociations: Match.arrayWith([
+          Match.objectLike({ KeyValueStoreARN: Match.anyValue() }),
+        ]),
+      }),
+    });
+  });
+
+  it("supports functions on both viewer-request and viewer-response", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+            {
+              eventType: FunctionEventType.VIEWER_RESPONSE,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    template.resourceCountIs("AWS::CloudFront::Function", 2);
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          FunctionAssociations: Match.arrayWith([
+            Match.objectLike({ EventType: "viewer-request" }),
+            Match.objectLike({ EventType: "viewer-response" }),
+          ]),
+        }),
+      }),
+    });
+  });
+
+  it("throws when two functions share the same eventType on the default behavior", () => {
+    expect(() =>
+      synthTemplate((b, stack) => {
+        b.origin(withBucketOrigin(stack))
+          .accessLogging(false)
+          .recommendedAlarms(false)
+          .defaultBehavior({
+            functions: [
+              {
+                eventType: FunctionEventType.VIEWER_REQUEST,
+                code: FunctionCode.fromInline(INLINE_CODE),
+              },
+              {
+                eventType: FunctionEventType.VIEWER_REQUEST,
+                code: FunctionCode.fromInline(INLINE_CODE),
+              },
+            ],
+          });
+      }),
+    ).toThrow(/default behavior has multiple functions for eventType "viewer-request"/);
+  });
+
+  it("creates no function resources when functions is omitted or empty", () => {
+    const { result, template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .defaultBehavior({ functions: [] });
+    });
+
+    template.resourceCountIs("AWS::CloudFront::Function", 0);
+    expect(Object.keys(result.functions)).toHaveLength(0);
+  });
+
+  it("emits no FunctionAssociations on the default behavior when functions is omitted", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack)).accessLogging(false).recommendedAlarms(false);
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          FunctionAssociations: Match.absent(),
+        }),
+      }),
+    });
+  });
+
+  it("throws when keyValueStore is used with a non-JS_2_0 runtime", () => {
+    expect(() =>
+      synthTemplate((b, stack) => {
+        const kvs = new KeyValueStore(stack, "Kvs", {
+          source: ImportSource.fromInline(JSON.stringify({ data: [{ key: "a", value: "b" }] })),
+        });
+        b.origin(withBucketOrigin(stack))
+          .accessLogging(false)
+          .recommendedAlarms(false)
+          .defaultBehavior({
+            functions: [
+              {
+                eventType: FunctionEventType.VIEWER_REQUEST,
+                code: FunctionCode.fromInline(INLINE_CODE),
+                runtime: FunctionRuntime.JS_1_0,
+                keyValueStore: kvs,
+              },
+            ],
+          });
+      }),
+    ).toThrow(/keyValueStore, which requires FunctionRuntime.JS_2_0/);
+  });
+});
+
+describe("additional path-pattern behaviors", () => {
+  it("creates an additional cache behavior with its own origin", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .behavior("/api/*", {
+          origin: new HttpOrigin("api.example.com"),
+          cachePolicy: CachePolicy.CACHING_DISABLED,
+        });
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: Match.objectLike({
+        CacheBehaviors: Match.arrayWith([
+          Match.objectLike({
+            PathPattern: "/api/*",
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("creates an inline function on an additional behavior", () => {
+    const { result, template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .behavior("/api/*", {
+          origin: new HttpOrigin("api.example.com"),
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    template.resourceCountIs("AWS::CloudFront::Function", 1);
+    expect(result.functions.behaviorApiSlashStarViewerRequest).toBeDefined();
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: Match.objectLike({
+        CacheBehaviors: Match.arrayWith([
+          Match.objectLike({
+            PathPattern: "/api/*",
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({ EventType: "viewer-request" }),
+            ]),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("supports multiple additional behaviors with independent functions", () => {
+    const { result, template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogging(false)
+        .recommendedAlarms(false)
+        .behavior("/api/*", {
+          origin: new HttpOrigin("api.example.com"),
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        })
+        .behavior("*.html", {
+          origin: new HttpOrigin("pages.example.com"),
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_RESPONSE,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    template.resourceCountIs("AWS::CloudFront::Function", 2);
+    expect(result.functions.behaviorApiSlashStarViewerRequest).toBeDefined();
+    expect(result.functions.behaviorStarHtmlViewerResponse).toBeDefined();
+  });
+
+  it("throws when the same path pattern is added twice", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const builder = createDistributionBuilder()
+      .origin(withBucketOrigin(stack))
+      .accessLogging(false)
+      .recommendedAlarms(false)
+      .behavior("/api/*", { origin: new HttpOrigin("api.example.com") });
+
+    expect(() =>
+      builder.behavior("/api/*", { origin: new HttpOrigin("api-2.example.com") }),
+    ).toThrow(/behavior for path pattern "\/api\/\*" is already defined/);
+  });
+
+  it("throws when two functions on the same additional behavior share an eventType", () => {
+    expect(() =>
+      synthTemplate((b, stack) => {
+        b.origin(withBucketOrigin(stack))
+          .accessLogging(false)
+          .recommendedAlarms(false)
+          .behavior("/api/*", {
+            origin: new HttpOrigin("api.example.com"),
+            functions: [
+              {
+                eventType: FunctionEventType.VIEWER_REQUEST,
+                code: FunctionCode.fromInline(INLINE_CODE),
+              },
+              {
+                eventType: FunctionEventType.VIEWER_REQUEST,
+                code: FunctionCode.fromInline(INLINE_CODE),
+              },
+            ],
+          });
+      }),
+    ).toThrow(/behavior "\/api\/\*" has multiple functions for eventType "viewer-request"/);
+  });
+
+  it("resolves a Resolvable origin on an additional behavior from compose context", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const apiBucket = new Bucket(stack, "ApiBucket");
+
+    const result = createDistributionBuilder()
+      .origin(withBucketOrigin(stack))
+      .accessLogging(false)
+      .recommendedAlarms(false)
+      .behavior("/api/*", {
+        origin: ref<BucketBuilderResult>("api").map((r) =>
+          S3BucketOrigin.withOriginAccessControl(r.bucket),
+        ),
+      })
+      .build(stack, "TestDistribution", {
+        api: { bucket: apiBucket },
+      });
+
+    expect(result.distribution).toBeDefined();
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: Match.objectLike({
+        CacheBehaviors: Match.arrayWith([Match.objectLike({ PathPattern: "/api/*" })]),
+      }),
+    });
+  });
+
+  it("creates no CacheBehaviors when no additional behaviors are added", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack)).accessLogging(false).recommendedAlarms(false);
+    });
+
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: Match.objectLike({
+        CacheBehaviors: Match.absent(),
+      }),
+    });
+  });
+});

--- a/packages/examples/src/static-website/app.ts
+++ b/packages/examples/src/static-website/app.ts
@@ -1,7 +1,8 @@
 import { App, Duration } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import { Source } from "aws-cdk-lib/aws-s3-deployment";
-import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin, S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { CachePolicy, FunctionCode, FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
 import { compose, ref } from "@composurecdk/core";
 import { createTopicBuilder } from "@composurecdk/sns";
 import { createStackBuilder, outputs } from "@composurecdk/cloudformation";
@@ -22,6 +23,11 @@ import {
  * - S3 bucket configured for private access (no public website hosting)
  * - CloudFront distribution with Origin Access Control (OAC) for secure S3 access
  * - Cross-component reference using {@link ref} to wire the bucket as a CloudFront origin
+ * - An inline CloudFront Function on the default behavior (viewer-response
+ *   header injection) and a path-pattern behavior (`/api/*` → HTTP origin)
+ *   with its own viewer-request function. Both functions get path-scoped
+ *   recommended alarms (FunctionExecutionErrors / ValidationErrors / Throttles)
+ *   emitted automatically by the builder.
  * - Automatic content deployment with CloudFront cache invalidation
  * - Custom error responses for 403/404 handling
  * - Cost-optimised defaults (PriceClass 100, HTTP→HTTPS redirect)
@@ -60,6 +66,49 @@ export function createStaticWebsiteApp(app = new App()) {
         .origin(
           ref("site", (r: BucketBuilderResult) => S3BucketOrigin.withOriginAccessControl(r.bucket)),
         )
+        // Inline CloudFront Function on the default behavior: add a
+        // permissive-but-informative `x-served-by` response header on every
+        // response from the origin. The builder creates the Function construct,
+        // wires it into FunctionAssociations, and emits
+        // FunctionExecutionErrors/ValidationErrors/Throttles alarms keyed by
+        // `defaultBehaviorViewerResponse*`.
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_RESPONSE,
+              code: FunctionCode.fromInline(`
+                function handler(event) {
+                  var response = event.response;
+                  response.headers["x-served-by"] = { value: "composurecdk-example" };
+                  return response;
+                }
+              `),
+              comment: "Add x-served-by header",
+            },
+          ],
+        })
+        // Path-pattern behavior: `/api/*` routes to a separate HTTP origin with
+        // caching disabled. Its own viewer-request function strips any inbound
+        // `authorization` header before the request reaches the origin.
+        // Alarms for this function are keyed by `behaviorApiSlashStar*`, so
+        // they page independently of the default behavior's function.
+        .behavior("/api/*", {
+          origin: new HttpOrigin("api.example.com"),
+          cachePolicy: CachePolicy.CACHING_DISABLED,
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(`
+                function handler(event) {
+                  var request = event.request;
+                  delete request.headers["authorization"];
+                  return request;
+                }
+              `),
+              comment: "Strip Authorization header before forwarding to API origin",
+            },
+          ],
+        })
         .errorResponses([
           {
             httpStatus: 403,

--- a/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
@@ -424,6 +424,154 @@ exports[`static-website-app > stack > matches the expected synthesised template 
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "StaticWebsitecdnBehaviorApiSlashStarViewerRequestExecutionErrorsAlarmE949C7D3": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "StaticWebsitealertsBD655E35",
+          },
+        ],
+        "AlarmDescription": "CloudFront Function on behavior "/api/*" (viewer-request) is raising execution errors. Threshold: > 0 errors in 1 minute.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "ComposureCDK-StarViewerRequestFnFB835158",
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "Region",
+            "Value": "Global",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FunctionExecutionErrors",
+        "Namespace": "AWS/CloudFront",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "StaticWebsitecdnBehaviorApiSlashStarViewerRequestFnC65BFFAF": {
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "
+                function handler(event) {
+                  var request = event.request;
+                  delete request.headers["authorization"];
+                  return request;
+                }
+              ",
+        "FunctionConfig": {
+          "Comment": "Strip Authorization header before forwarding to API origin",
+          "Runtime": "cloudfront-js-2.0",
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::Region",
+              },
+              "ComposureCDK-StarViewerRequestFnFB835158",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Function",
+    },
+    "StaticWebsitecdnBehaviorApiSlashStarViewerRequestThrottlesAlarmBB314E05": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "StaticWebsitealertsBD655E35",
+          },
+        ],
+        "AlarmDescription": "CloudFront Function on behavior "/api/*" (viewer-request) is being throttled — likely exceeding its 1ms compute budget. Threshold: > 0 throttles in 1 minute.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "ComposureCDK-StarViewerRequestFnFB835158",
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "Region",
+            "Value": "Global",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FunctionThrottles",
+        "Namespace": "AWS/CloudFront",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "StaticWebsitecdnBehaviorApiSlashStarViewerRequestValidationErrorsAlarm26A0559D": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "StaticWebsitealertsBD655E35",
+          },
+        ],
+        "AlarmDescription": "CloudFront Function on behavior "/api/*" (viewer-request) is producing validation errors. Threshold: > 0 errors in 1 minute.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "ComposureCDK-StarViewerRequestFnFB835158",
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "Region",
+            "Value": "Global",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FunctionValidationErrors",
+        "Namespace": "AWS/CloudFront",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "StaticWebsitecdnDDCEC06E": {
       "DependsOn": [
         "StaticWebsitecdnAccessLogsPolicy6BB3093C",
@@ -431,6 +579,26 @@ exports[`static-website-app > stack > matches the expected synthesised template 
       ],
       "Properties": {
         "DistributionConfig": {
+          "CacheBehaviors": [
+            {
+              "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "StaticWebsitecdnBehaviorApiSlashStarViewerRequestFnC65BFFAF",
+                      "FunctionARN",
+                    ],
+                  },
+                },
+              ],
+              "PathPattern": "/api/*",
+              "TargetOriginId": "ComposureCDKStaticWebsiteStackStaticWebsitecdnOrigin2388BF2F9",
+              "ViewerProtocolPolicy": "allow-all",
+            },
+          ],
           "Comment": "Example static website",
           "CustomErrorResponses": [
             {
@@ -449,6 +617,17 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           "DefaultCacheBehavior": {
             "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
             "Compress": true,
+            "FunctionAssociations": [
+              {
+                "EventType": "viewer-response",
+                "FunctionARN": {
+                  "Fn::GetAtt": [
+                    "StaticWebsitecdnDefaultBehaviorViewerResponseFn0F6C5DA4",
+                    "FunctionARN",
+                  ],
+                },
+              },
+            ],
             "ResponseHeadersPolicyId": "67f7725c-6f97-4210-82d7-5512b31e9d03",
             "TargetOriginId": "ComposureCDKStaticWebsiteStackStaticWebsitecdnOrigin168F4EAEC",
             "ViewerProtocolPolicy": "redirect-to-https",
@@ -484,11 +663,169 @@ exports[`static-website-app > stack > matches the expected synthesised template 
                 "OriginAccessIdentity": "",
               },
             },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only",
+                "OriginSSLProtocols": [
+                  "TLSv1.2",
+                ],
+              },
+              "DomainName": "api.example.com",
+              "Id": "ComposureCDKStaticWebsiteStackStaticWebsitecdnOrigin2388BF2F9",
+            },
           ],
           "PriceClass": "PriceClass_100",
         },
       },
       "Type": "AWS::CloudFront::Distribution",
+    },
+    "StaticWebsitecdnDefaultBehaviorViewerResponseExecutionErrorsAlarm0ABFC962": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "StaticWebsitealertsBD655E35",
+          },
+        ],
+        "AlarmDescription": "CloudFront Function on default behavior (viewer-response) is raising execution errors. Threshold: > 0 errors in 1 minute.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "ComposureCDK-StaViewerResponseFn21894680",
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "Region",
+            "Value": "Global",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FunctionExecutionErrors",
+        "Namespace": "AWS/CloudFront",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "StaticWebsitecdnDefaultBehaviorViewerResponseFn0F6C5DA4": {
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "
+                function handler(event) {
+                  var response = event.response;
+                  response.headers["x-served-by"] = { value: "composurecdk-example" };
+                  return response;
+                }
+              ",
+        "FunctionConfig": {
+          "Comment": "Add x-served-by header",
+          "Runtime": "cloudfront-js-2.0",
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::Region",
+              },
+              "ComposureCDK-StaViewerResponseFn21894680",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Function",
+    },
+    "StaticWebsitecdnDefaultBehaviorViewerResponseThrottlesAlarmBE826DA3": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "StaticWebsitealertsBD655E35",
+          },
+        ],
+        "AlarmDescription": "CloudFront Function on default behavior (viewer-response) is being throttled — likely exceeding its 1ms compute budget. Threshold: > 0 throttles in 1 minute.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "ComposureCDK-StaViewerResponseFn21894680",
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "Region",
+            "Value": "Global",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FunctionThrottles",
+        "Namespace": "AWS/CloudFront",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "StaticWebsitecdnDefaultBehaviorViewerResponseValidationErrorsAlarmD4E6BE39": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "StaticWebsitealertsBD655E35",
+          },
+        ],
+        "AlarmDescription": "CloudFront Function on default behavior (viewer-response) is producing validation errors. Threshold: > 0 errors in 1 minute.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "ComposureCDK-StaViewerResponseFn21894680",
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "Region",
+            "Value": "Global",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FunctionValidationErrors",
+        "Namespace": "AWS/CloudFront",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "StaticWebsitecdnErrorRateAlarmEDAC30D6": {
       "Properties": {

--- a/packages/examples/test/static-website-app.test.ts
+++ b/packages/examples/test/static-website-app.test.ts
@@ -148,6 +148,36 @@ describe("static-website-app", () => {
       });
     });
 
+    it("creates a viewer-response function on the default behavior", () => {
+      const template = synthTemplate();
+      template.resourceCountIs("AWS::CloudFront::Function", 2);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({ EventType: "viewer-response" }),
+            ]),
+          }),
+        }),
+      });
+    });
+
+    it("creates an additional /api/* behavior with its own viewer-request function", () => {
+      const template = synthTemplate();
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: "/api/*",
+              FunctionAssociations: Match.arrayWith([
+                Match.objectLike({ EventType: "viewer-request" }),
+              ]),
+            }),
+          ]),
+        }),
+      });
+    });
+
     it("configures custom error responses for 403 and 404", () => {
       const template = synthTemplate();
       template.hasResourceProperties("AWS::CloudFront::Distribution", {


### PR DESCRIPTION
## Summary
- Add `behavior(pathPattern, config)` on `DistributionBuilder` for path-pattern cache behaviors (with `Resolvable` origin support for cross-component wiring).
- Support declaring inline CloudFront Functions per behavior via `functions: InlineFunctionDefinition[]`. The builder owns the `CfFunction` constructs so it can emit path-scoped alarms (`FunctionExecutionErrors`, `FunctionValidationErrors`, `FunctionThrottles`) keyed by behavior scope + event type.
- Warn at synth time if any recommended alarm is created outside `us-east-1`, since CloudFront metrics are only emitted there.

Closes #32

## Test plan
- [ ] `npx nx test cloudfront` passes
- [ ] `npm run lint` and `npm run format:check` pass
- [ ] Review new tests: `behavior-functions.test.ts`, `behavior-function-alarms.test.ts`
- [ ] Spot-check that `resolveBehaviors` enforces: at most one function per event type per behavior, and `keyValueStore` implies `FunctionRuntime.JS_2_0`