### PR TITLE
fix(core): propagate parent context into nested compose

### DIFF
--- a/docs/adr/0003-nested-compose-context-propagation.md
+++ b/docs/adr/0003-nested-compose-context-propagation.md
@@ -1,0 +1,121 @@
+# ADR 0003: Nested `compose()` — propagate parent context into inner components
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+
+## Context
+
+`ComposedSystem` returned from `compose()` is itself a `Lifecycle`, so the docs
+advertise that "composition is recursive — systems can be nested without
+special handling." In practice that was only half true. Issue
+[#51](https://github.com/laazyj/composureCDK/issues/51) reported that `ref()`
+calls inside a nested `compose()` could not resolve against outer siblings, so
+the natural "compose subsystems, then compose the subsystems" pattern broke
+the moment any wiring crossed a subsystem boundary.
+
+Root cause (pre-change `packages/core/src/compose.ts`):
+
+```ts
+build(scope, id) {                 // <- ignored Lifecycle's context arg
+  return this.#buildWith(scope, id).results;
+}
+
+#buildWith(scope, id, stacks?) {
+  for (const key of alg.topsort(this.#graph)) {
+    const deps = (this.#dependencies[key] ?? []);
+    const context = Object.fromEntries(
+      deps.map((dep) => [dep, results[dep]])     // <- inner-only context
+    );
+    results[key] = this.#components[key].build(..., context);
+  }
+}
+```
+
+`Lifecycle.build(scope, id, context?)` passes a context to every component,
+but `ComposedLifecycle.build` dropped that argument — so when a parent
+compose built the nested system with `{ dns: {...} }` as context, nothing
+downstream ever saw it. `ConfiguredLifecycle.build` (the result of
+`.withStacks()` / `.afterBuild()`) had the same defect.
+
+The customer hit this while modelling DNS and Site as two subsystems
+wired together. The workaround was to flatten everything into one
+top-level `compose()` with per-component `withStacks` routing — which works
+but loses the encapsulation benefit of nesting.
+
+## Decision
+
+**Propagate parent context into every inner component's context during
+`#buildWith`, with inner dependency values shadowing on key collision.**
+
+Both `ComposedLifecycle.build` and `ConfiguredLifecycle.build` now honour the
+`Lifecycle.build(scope, id, context?)` contract, accept the parent context,
+and thread it through to each component:
+
+```ts
+const innerContext = Object.fromEntries(deps.map((dep) => [dep, results[dep]]));
+const context = { ...parentContext, ...innerContext };
+```
+
+After the change, the developer pattern is:
+
+```ts
+const dns = compose({ zone, records }, { zone: [], records: ["zone"] });
+const site = compose({ cert, bucket, cdn }, { cert: [], bucket: [], cdn: ["cert", "bucket"] });
+
+const app = compose(
+  { dns, site },
+  { dns: [], site: ["dns"] }, // outer edge orders dns before site
+);
+```
+
+Inside `site`'s components, `ref<DnsResult>("dns").get("zone")` resolves —
+`dns` is present in the parent context that now flows into each inner
+component. Chained `.get()` and `.map()` already work against whatever
+context the ref receives, so no changes are needed in `ref.ts`.
+
+### Why this over the alternatives
+
+**Option considered: explicit `imports` API.** `compose(components, deps, { imports: [...] })`
+would let us type-check cross-boundary wiring statically. Rejected because
+it doubles the compose API surface and is redundant — the outer
+`dependencies` map already expresses "site needs dns," and refs already
+capture "which key to read." An `imports` option would restate the same
+relationship at the inner boundary. Revisit only if a concrete type-safety
+gap emerges.
+
+**Option considered: document the limitation and keep isolation.** Rejected
+because the customer case shows the natural pattern is nested composition.
+Forcing flattening is a real ergonomics tax, and the docs already promise
+recursive composition — the code should match.
+
+## Consequences
+
+- A nested `ComposedSystem` is no longer isolated from its parent. Inner
+  refs to an outer sibling key now resolve instead of throwing. The
+  existing nested-compose test (a nested system with no cross-boundary
+  refs) still passes unchanged.
+- Cross-boundary refs are not expressed in the inner dependency graph.
+  The outer topsort orders things correctly (because the outer
+  `dependencies` map encodes "site needs dns"), but an inner ref to an
+  outer key is resolved at runtime against the received context, not
+  validated against the inner graph. This matches how refs already
+  behave — a missing key throws the same "cannot be resolved" error.
+- Key collision (inner dep and outer sibling both named `x`): inner
+  shadows. This is the intuitive rule and matches lexical scoping; a
+  future change could add a warning if collisions become a confusion
+  source in practice.
+- `.withStacks()` / `.withStackStrategy()` / `.afterBuild()` continue to
+  work both at the outermost level and on nested systems. The
+  `ConfiguredLifecycle.build` signature and its internal `buildFn` type
+  pick up an optional `parentContext` parameter.
+- Flat-compose + `withStacks` remains a perfectly valid style. The
+  customer's existing code is not affected. Nesting is now a choice, not
+  a trap.
+- A lint rule (`composurecdk/lifecycle-build-context-required` in
+  `eslint.config.mjs`) flags any `Lifecycle`-implementing class whose
+  `build` method omits the `context` parameter while the class body uses
+  `Resolvable<…>`. Such a builder accepts refs at configuration time but
+  has no way to resolve them at build time — the rule catches the
+  mismatch at lint time rather than as a runtime "cannot be resolved"
+  throw. Optionality of `context` is preserved for leaf builders that
+  don't use refs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ Cycle detection happens at composition time, not build time. This means structur
 
 ### The result is a Lifecycle
 
-`compose` returns a `Lifecycle`. This means a composed system can itself be used as a component in a larger system. Composition is recursive — systems can be nested without special handling.
+`compose` returns a `Lifecycle`. This means a composed system can itself be used as a component in a larger system. Composition is recursive — systems can be nested without special handling. When a composed system is nested, the parent context flows through: components inside the nested system can `ref("outerKey")` to reach siblings of the nested system, provided the outer `compose` declares the corresponding dependency. Inner dependency values shadow the parent context on key collision, matching lexical scoping ([ADR-0003](adr/0003-nested-compose-context-propagation.md)).
 
 ### Dependency declarations are exhaustive
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,51 @@ import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
 
+/**
+ * Flags Lifecycle-implementing classes whose `build` method does not accept a
+ * `context` parameter but whose class body uses `Resolvable<…>`. Such builders
+ * accept refs at configuration time but have no way to resolve them at build
+ * time — calls to `resolve(value, context)` would receive `undefined` and the
+ * ref would throw "cannot be resolved".
+ *
+ * The rule keys on `Resolvable` (a name unique to this codebase) to avoid the
+ * false positives that keying on `resolve(` would produce (Promise.resolve, etc.).
+ */
+const lifecycleContextParamRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Lifecycle.build() must accept context when the builder uses Resolvable<…>",
+    },
+    schema: [],
+    messages: {
+      missingContext:
+        "`build()` is missing the `context` parameter, but this class uses `Resolvable<…>`. " +
+        "Refs need context to resolve — add `context?: Record<string, object>` (or a typed dependency record) and pass it to `resolve(value, context)`.",
+    },
+  },
+  create(ctx) {
+    const sourceCode = ctx.sourceCode;
+    return {
+      ClassBody(node) {
+        const build = node.body.find(
+          (member) =>
+            member.type === "MethodDefinition" &&
+            member.key.type === "Identifier" &&
+            member.key.name === "build",
+        );
+        if (!build) return;
+        if (build.value.params.length >= 3) return;
+
+        const classText = sourceCode.getText(node);
+        if (/\bResolvable\s*</.test(classText)) {
+          ctx.report({ node: build, messageId: "missingContext" });
+        }
+      },
+    };
+  },
+};
+
 export default defineConfig(
   { ignores: ["**/dist/", "**/node_modules/", "**/cdk.out/"] },
   eslint.configs.recommended,
@@ -35,7 +80,15 @@ export default defineConfig(
   },
   {
     files: ["packages/*/src/**/*.ts"],
+    plugins: {
+      composurecdk: {
+        rules: {
+          "lifecycle-build-context-required": lifecycleContextParamRule,
+        },
+      },
+    },
     rules: {
+      "composurecdk/lifecycle-build-context-required": "error",
       "no-restricted-syntax": [
         "error",
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,7 @@ const lifecycleContextParamRule = {
             member.key.name === "build",
         );
         if (!build) return;
+        // Lifecycle.build(scope, id, context?) — 3rd param is context.
         if (build.value.params.length >= 3) return;
 
         const classText = sourceCode.getText(node);

--- a/packages/core/src/compose.ts
+++ b/packages/core/src/compose.ts
@@ -217,32 +217,39 @@ class ComposedLifecycle<
   }
 
   withStacks(stacks: { [K in keyof Components]?: IConstruct }): ConfiguredSystem<Components> {
-    return new ConfiguredLifecycle((scope, id) => this.#buildWith(scope, id, stacks));
+    return new ConfiguredLifecycle((scope, id, parentContext) =>
+      this.#buildWith(scope, id, stacks, parentContext),
+    );
   }
 
   withStackStrategy(strategy: StackStrategy): ConfiguredSystem<Components> {
-    return new ConfiguredLifecycle((scope, id) => {
+    return new ConfiguredLifecycle((scope, id, parentContext) => {
       const stacks = Object.fromEntries(
         Object.keys(this.#components).map((key) => [key, strategy.resolve(scope, id, key)]),
       ) as { [K in keyof Components]?: IConstruct };
-      return this.#buildWith(scope, id, stacks);
+      return this.#buildWith(scope, id, stacks, parentContext);
     });
   }
 
   afterBuild(hook: AfterBuildHook<BuildResult<Components>>): ConfiguredSystem<Components> {
-    return new ConfiguredLifecycle<Components>((scope, id) =>
-      this.#buildWith(scope, id),
+    return new ConfiguredLifecycle<Components>((scope, id, parentContext) =>
+      this.#buildWith(scope, id, undefined, parentContext),
     ).afterBuild(hook);
   }
 
-  build(scope: IConstruct, id: string): BuildResult<Components> {
-    return this.#buildWith(scope, id).results;
+  build(
+    scope: IConstruct,
+    id: string,
+    parentContext?: Record<string, object>,
+  ): BuildResult<Components> {
+    return this.#buildWith(scope, id, undefined, parentContext).results;
   }
 
   #buildWith(
     scope: IConstruct,
     id: string,
     stacks?: { [K in keyof Components]?: IConstruct },
+    parentContext?: Record<string, object>,
   ): BuildOutcome<Components> {
     const results: Record<string, object> = {};
     const componentScopes: Record<string, IConstruct> = {};
@@ -251,7 +258,11 @@ class ComposedLifecycle<
       const componentScope = stacks?.[key] ?? scope;
       componentScopes[key] = componentScope;
       const deps = (this.#dependencies[key] ?? []) as string[];
-      const context = Object.fromEntries(deps.map((dep) => [dep, results[dep]]));
+      // Merge parent context (outer siblings visible when this system is nested)
+      // with inner dependency outputs. Inner deps shadow on key collision —
+      // local bindings take precedence over the enclosing scope.
+      const innerContext = Object.fromEntries(deps.map((dep) => [dep, results[dep]]));
+      const context = { ...parentContext, ...innerContext };
       results[key] = this.#components[key].build(componentScope, `${id}/${key}`, context);
     }
 
@@ -277,9 +288,19 @@ class ConfiguredLifecycle<
   Components extends Record<string, Lifecycle>,
 > implements ConfiguredSystem<Components> {
   readonly #hooks: AfterBuildHook<BuildResult<Components>>[] = [];
-  readonly #buildFn: (scope: IConstruct, id: string) => BuildOutcome<Components>;
+  readonly #buildFn: (
+    scope: IConstruct,
+    id: string,
+    parentContext?: Record<string, object>,
+  ) => BuildOutcome<Components>;
 
-  constructor(buildFn: (scope: IConstruct, id: string) => BuildOutcome<Components>) {
+  constructor(
+    buildFn: (
+      scope: IConstruct,
+      id: string,
+      parentContext?: Record<string, object>,
+    ) => BuildOutcome<Components>,
+  ) {
     this.#buildFn = buildFn;
   }
 
@@ -288,8 +309,12 @@ class ConfiguredLifecycle<
     return this;
   }
 
-  build(scope: IConstruct, id: string): BuildResult<Components> {
-    const { results, componentScopes } = this.#buildFn(scope, id);
+  build(
+    scope: IConstruct,
+    id: string,
+    parentContext?: Record<string, object>,
+  ): BuildResult<Components> {
+    const { results, componentScopes } = this.#buildFn(scope, id, parentContext);
     for (const hook of this.#hooks) {
       hook(scope, id, results, componentScopes);
     }

--- a/packages/core/src/compose.ts
+++ b/packages/core/src/compose.ts
@@ -258,9 +258,7 @@ class ComposedLifecycle<
       const componentScope = stacks?.[key] ?? scope;
       componentScopes[key] = componentScope;
       const deps = (this.#dependencies[key] ?? []) as string[];
-      // Merge parent context (outer siblings visible when this system is nested)
-      // with inner dependency outputs. Inner deps shadow on key collision —
-      // local bindings take precedence over the enclosing scope.
+      // Inner deps shadow parent context on key collision.
       const innerContext = Object.fromEntries(deps.map((dep) => [dep, results[dep]]));
       const context = { ...parentContext, ...innerContext };
       results[key] = this.#components[key].build(componentScope, `${id}/${key}`, context);
@@ -278,6 +276,12 @@ interface BuildOutcome<Components extends Record<string, Lifecycle>> {
   readonly componentScopes: { readonly [K in keyof Components]: IConstruct };
 }
 
+type BuildFn<Components extends Record<string, Lifecycle>> = (
+  scope: IConstruct,
+  id: string,
+  parentContext?: Record<string, object>,
+) => BuildOutcome<Components>;
+
 /**
  * A configured lifecycle that accumulates post-build hooks and applies them
  * after the underlying build function completes. Returned by
@@ -288,19 +292,9 @@ class ConfiguredLifecycle<
   Components extends Record<string, Lifecycle>,
 > implements ConfiguredSystem<Components> {
   readonly #hooks: AfterBuildHook<BuildResult<Components>>[] = [];
-  readonly #buildFn: (
-    scope: IConstruct,
-    id: string,
-    parentContext?: Record<string, object>,
-  ) => BuildOutcome<Components>;
+  readonly #buildFn: BuildFn<Components>;
 
-  constructor(
-    buildFn: (
-      scope: IConstruct,
-      id: string,
-      parentContext?: Record<string, object>,
-    ) => BuildOutcome<Components>,
-  ) {
+  constructor(buildFn: BuildFn<Components>) {
     this.#buildFn = buildFn;
   }
 

--- a/packages/core/test/compose.test.ts
+++ b/packages/core/test/compose.test.ts
@@ -4,6 +4,7 @@ import { compose, type AfterBuildHook } from "../src/compose.js";
 import { groupedStacks } from "../src/stack-strategy.js";
 import { CyclicDependencyError } from "../src/cyclic-dependency-error.js";
 import { type Lifecycle } from "../src/lifecycle.js";
+import { ref, resolve, type Resolvable } from "../src/ref.js";
 
 function createScope(): Construct {
   return new Construct(undefined as never, "root");
@@ -493,6 +494,89 @@ describe("compose", () => {
         .build(createScope(), "test");
 
       expect(aBuild.mock.calls[0][0]).toBe(customScope);
+    });
+  });
+
+  describe("nested compose", () => {
+    it("propagates parent context into inner components so refs can reach outer siblings", () => {
+      const dns: Lifecycle<{ zone: { name: string } }> = {
+        build: () => ({ zone: { name: "example.com" } }),
+      };
+
+      // Inner component capable of resolving a Ref against its received context.
+      interface CertResult {
+        certFor: string;
+      }
+      const certComponent = (zoneRef: Resolvable<{ name: string }>): Lifecycle<CertResult> => ({
+        build: (_scope, _id, context) => {
+          const zone = resolve(zoneRef, context);
+          return { certFor: zone.name };
+        },
+      });
+
+      const site = compose(
+        {
+          cert: certComponent(ref<{ zone: { name: string } }>("dns").get("zone")),
+        },
+        { cert: [] },
+      );
+
+      const system = compose({ dns, site }, { dns: [], site: ["dns"] });
+      const result = system.build(createScope(), "app");
+
+      expect(result.site.cert).toEqual({ certFor: "example.com" });
+    });
+
+    it("inner dep shadows parent context on key collision", () => {
+      const outerFoo: Lifecycle<{ from: string }> = {
+        build: () => ({ from: "outer" }),
+      };
+      const innerFoo: Lifecycle<{ from: string }> = {
+        build: () => ({ from: "inner" }),
+      };
+      const reader = spyComponent({ read: true });
+
+      const inner = compose(
+        { foo: innerFoo, reader: reader.lifecycle },
+        { foo: [], reader: ["foo"] },
+      );
+
+      compose({ foo: outerFoo, sub: inner }, { foo: [], sub: ["foo"] }).build(createScope(), "app");
+
+      expect(reader.build.mock.calls[0][2]).toEqual({ foo: { from: "inner" } });
+    });
+
+    it("still throws when an inner ref cannot be resolved in either inner deps or parent context", () => {
+      const dangling: Lifecycle = {
+        build: (_scope, _id, context) => {
+          resolve(ref<{ x: number }>("missing"), context);
+          return {};
+        },
+      };
+
+      const inner = compose({ dangling }, { dangling: [] });
+      const system = compose({ a: stubComponent({ y: 1 }), sub: inner }, { a: [], sub: ["a"] });
+
+      expect(() => system.build(createScope(), "app")).toThrow(/"missing"/);
+    });
+
+    it("propagates parent context through a nested .withStacks()-configured system", () => {
+      const dns: Lifecycle<{ zone: { name: string } }> = {
+        build: () => ({ zone: { name: "example.com" } }),
+      };
+      const reader = spyComponent({ ok: true });
+      const siteStack = new Construct(undefined as never, "siteStack");
+
+      const site = compose({ reader: reader.lifecycle }, { reader: [] }).withStacks({
+        reader: siteStack,
+      });
+
+      compose({ dns, site }, { dns: [], site: ["dns"] }).build(createScope(), "app");
+
+      expect(reader.build.mock.calls[0][0]).toBe(siteStack);
+      expect(reader.build.mock.calls[0][2]).toEqual({
+        dns: { zone: { name: "example.com" } },
+      });
     });
   });
 

--- a/packages/core/test/compose.test.ts
+++ b/packages/core/test/compose.test.ts
@@ -499,11 +499,8 @@ describe("compose", () => {
 
   describe("nested compose", () => {
     it("propagates parent context into inner components so refs can reach outer siblings", () => {
-      const dns: Lifecycle<{ zone: { name: string } }> = {
-        build: () => ({ zone: { name: "example.com" } }),
-      };
+      const dns = stubComponent({ zone: { name: "example.com" } });
 
-      // Inner component capable of resolving a Ref against its received context.
       interface CertResult {
         certFor: string;
       }
@@ -528,12 +525,8 @@ describe("compose", () => {
     });
 
     it("inner dep shadows parent context on key collision", () => {
-      const outerFoo: Lifecycle<{ from: string }> = {
-        build: () => ({ from: "outer" }),
-      };
-      const innerFoo: Lifecycle<{ from: string }> = {
-        build: () => ({ from: "inner" }),
-      };
+      const outerFoo = stubComponent({ from: "outer" });
+      const innerFoo = stubComponent({ from: "inner" });
       const reader = spyComponent({ read: true });
 
       const inner = compose(
@@ -561,9 +554,7 @@ describe("compose", () => {
     });
 
     it("propagates parent context through a nested .withStacks()-configured system", () => {
-      const dns: Lifecycle<{ zone: { name: string } }> = {
-        build: () => ({ zone: { name: "example.com" } }),
-      };
+      const dns = stubComponent({ zone: { name: "example.com" } });
       const reader = spyComponent({ ok: true });
       const siteStack = new Construct(undefined as never, "siteStack");
 


### PR DESCRIPTION
## Summary

- `ComposedLifecycle.build` and `ConfiguredLifecycle.build` honour the `Lifecycle.build(scope, id, context?)` contract — they now accept and forward `parentContext` into `#buildWith`, which merges it into each component's context. Inner dependencies shadow on key collision (lexical scoping). Outer topsort still orders cross-subsystem builds via the existing `dependencies` map. `ref.ts` unchanged.
- New ESLint rule `composurecdk/lifecycle-build-context-required` flags `Lifecycle` classes whose `build()` omits the `context` parameter while the class body uses `Resolvable<…>`, catching the runtime "cannot be resolved" error at lint time. Zero violations on the existing codebase.
- ADR 0003 records the decision (and the rejected alternatives — explicit `imports` API, docs-only). `docs/architecture.md` gets a short paragraph in the "result is a Lifecycle" section.

## Test plan

- [x] `npx nx test core` — 82 tests pass (5 new in a `nested compose` describe block: outer-sibling resolution; inner shadows outer on key collision; missing key still throws; `.withStacks(...)`-configured nested system also propagates)
- [x] `npm run lint` — clean, including the new rule
- [x] `npm run format:check` — clean
- [x] Existing nested-compose test (no cross-boundary refs) still passes unchanged
- [ ] Smoke test against `jasonduffett.net`: rewrite `createSystem` to nest `dns` + `site` subsystems and confirm `cdk synth` produces the same logical template as the flat version

Closes #51