### PR TITLE
feat(route53): add health check builder with recommended alarm

### DIFF
--- a/docs/adr/0004-split-alarm-builder-for-fixed-region-metrics.md
+++ b/docs/adr/0004-split-alarm-builder-for-fixed-region-metrics.md
@@ -1,0 +1,130 @@
+# ADR 0004: Split-alarm builder pattern for AWS services with fixed-region metrics
+
+- **Status:** Accepted
+- **Date:** 2026-04-25
+
+## Context
+
+A small set of AWS services emit CloudWatch metrics in a single fixed region
+regardless of where the underlying resource is created. Today this affects:
+
+- **CloudFront distributions** — `AWS/CloudFront` is `us-east-1` only.
+- **Route 53 health checks** — `AWS/Route53` is `us-east-1` only.
+
+CloudWatch alarms are regional. An alarm in any non-`us-east-1` stack against
+these namespaces will never receive data. With
+`treatMissingData: BREACHING` (the AWS-recommended value for Route 53 health
+checks) the alarm sits in `ALARM` permanently — every deploy pages on-call.
+With `NOT_BREACHING` it sits in `INSUFFICIENT_DATA` permanently — the safety
+net silently never fires.
+
+Either failure mode breaks the project's secure-by-default stance: a builder
+that creates a recommended alarm "by default" must actually be capable of
+firing. PR [#58](https://github.com/laazyj/composureCDK/pull/58) introduced
+`createCloudFrontAlarmBuilder` to address this for CloudFront; issue
+[#45](https://github.com/laazyj/composureCDK/issues/45) hits the same problem
+for Route 53 health checks. Without a deliberate pattern, every future
+fixed-region-metric service would need to rediscover the same shape.
+
+## Decision
+
+For services whose metric region is independent of the resource's region,
+ship **two builders** plus a single shared alarm-assembly helper:
+
+1. A combined builder (e.g. `createHealthCheckBuilder`,
+   `createDistributionBuilder`) that materialises the resource and its
+   recommended alarms in the same scope. Suitable when the stack is already
+   in the metric's region (the simple "all-in-`us-east-1`" layout).
+2. A standalone alarm builder (e.g. `createHealthCheckAlarmBuilder`,
+   `createCloudFrontAlarmBuilder`) that accepts a `Resolvable<*BuilderResult>`
+   for the resource and creates alarms in its own scope. Pair with
+   `compose().withStacks()` to route the alarm builder into a `us-east-1`
+   stack while the resource lives elsewhere — typical for production
+   accounts with a dedicated `us-east-1` monitoring stack.
+3. A shared internal helper `build*Alarms(scope, id, target, options)`. Both
+   builders delegate to it — it is the **only** place alarm assembly lives.
+   This keeps the recommended-alarm config shape, defaults, and `addAlarm()`
+   extension surface in lock-step between the two paths.
+
+Both builders emit a synth-time annotation
+(`addWarningV2("@composurecdk/<package>:alarm-region", …)`) when alarms
+would be materialised outside the metric's region, with
+`Token.isUnresolved` suppression for env-agnostic stacks. The warning ID is
+stable per package so users can suppress it deliberately if needed.
+
+```ts
+// packages/<service>/src/<service>-alarm-builder.ts
+
+/** @internal */
+export function build<Service>Alarms(
+  scope: IConstruct,
+  id: string,
+  target: Pick<<Service>BuilderResult, "<resource>">,
+  options: { recommendedAlarms?: <Service>AlarmConfig | false; customAlarms?: AlarmDefinitionBuilder<I<Resource>>[] } = {},
+): Record<string, Alarm> {
+  const recommendedDefs = ...resolve<Service>AlarmDefinitions(target.<resource>, options.recommendedAlarms);
+  const customAlarmDefs = options.customAlarms?.map((b) => b.resolve(target.<resource>)) ?? [];
+  const allAlarmDefs = [...recommendedDefs, ...customAlarmDefs];
+  if (allAlarmDefs.length > 0) warnIfNotIn<Region>(scope);
+  return createAlarms(scope, id, allAlarmDefs);
+}
+```
+
+### When this pattern applies
+
+Use it whenever the metric's region is fixed and not derivable from the
+resource's region. Today: CloudFront, Route 53. Likely future candidates:
+`AWS/Billing`, `AWS/Usage`, `AWS/CertificateManagerPrivateCA` (some
+metrics).
+
+For services where metric region == resource region (ACM, API Gateway, S3,
+Lambda, …) the simple combined-builder pattern remains correct — there is
+no cross-region split to express, and no new ADR/builder is needed.
+
+### Why this over the alternatives
+
+**Option considered: combined builder only, document the pitfall.** Rejected
+because the failure mode (silently broken alarms) is precisely the kind of
+hidden footgun the project's secure-by-default stance exists to prevent. A
+README warning is read by users who already suspect a problem; the
+synth-time annotation reaches users who don't.
+
+**Option considered: a single builder that accepts an alternate alarm scope.**
+Rejected because it conflates two concerns into one fluent surface
+(`createHealthCheckBuilder().alarmScope(otherStack)`) and works around —
+rather than uses — the existing `Resolvable` / `compose().withStacks()`
+machinery. The split-builder shape composes naturally with
+`Ref<*BuilderResult>` and matches how every other multi-stack scenario in
+the project is expressed.
+
+**Option considered: extract a generic `createCrossRegionAlarmBuilder<T>`
+abstraction.** Rejected for now — two instances (CloudFront, Route 53) is
+not enough to factor a generic well, and the per-service alarm-definition
+logic is the load-bearing part anyway. Revisit if a third or fourth service
+joins the list.
+
+## Consequences
+
+- Affected packages publish two factories instead of one. Package READMEs
+  must teach both, and the cross-region `compose().withStacks()` worked
+  example (set `crossRegionReferences: true` on both stacks).
+- The shared helper guarantees the two builders cannot drift on
+  recommended-alarm shape, defaults, or `treatMissingData` semantics — any
+  change lands in one place. Tests verify both paths produce the same alarm
+  surface against the same input.
+- The synth warning is non-fatal. Users who genuinely want a no-data alarm
+  (e.g. for a placeholder during initial development) can ignore it; users
+  who hit it accidentally see the message in `cdk synth` output before they
+  wonder why nothing pages.
+- `addAlarm()` for custom alarms attaches to whichever builder the user
+  invokes it on. Users wanting custom alarms in the `us-east-1` stack call
+  it on the standalone builder; users staying in `us-east-1` everywhere
+  call it on the combined builder. Symmetric and intuitive.
+- The pattern does **not** apply retroactively to ACM or other services
+  whose metrics live in the resource's region — those keep their single
+  combined-builder shape unchanged.
+- A new fixed-region-metric service entering the project should follow this
+  pattern by mirroring `cloudfront-alarm-builder.ts` /
+  `health-check-alarm-builder.ts`. If a third or fourth service lands, that
+  is the trigger to revisit option (3) above and consider extracting a
+  generic abstraction.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,6 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 ## Index
 
 - [ADR-0001: Builder type emission — export `*BuilderProps`, use `#` private fields](0001-builder-type-emission.md)
+- [ADR-0002: Policies — cross-cutting helpers applied to a construct subtree](0002-policies.md)
+- [ADR-0003: Nested `compose()` — propagate parent context into inner components](0003-nested-compose-context-propagation.md)
+- [ADR-0004: Split-alarm builder pattern for AWS services with fixed-region metrics](0004-split-alarm-builder-for-fixed-region-metrics.md)

--- a/packages/route53/README.md
+++ b/packages/route53/README.md
@@ -92,9 +92,120 @@ The defaults are exported as `HOSTED_ZONE_DEFAULTS`, `A_RECORD_DEFAULTS`, `AAAA_
 
 [^alias]: AWS ignores TTL on alias records and CDK emits a warning when one is set, so `A`, `AAAA`, and `HTTPS` builders skip the default TTL whenever the target is an alias.
 
-## Recommended Alarms
+## Health Check Builder
 
-Route 53 health checks expose a `HealthCheckStatus` metric that [AWS recommends alarming on](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53). This package does not yet expose a `HealthCheckBuilder`; once it does, the recommended alarm will be enabled by default alongside the health check. Tracked in [#45](https://github.com/laazyj/composureCDK/issues/45).
+```ts
+import { HealthCheckType } from "aws-cdk-lib/aws-route53";
+import { createHealthCheckBuilder } from "@composurecdk/route53";
+
+createHealthCheckBuilder()
+  .type(HealthCheckType.HTTPS)
+  .fqdn("api.example.com")
+  .resourcePath("/health")
+  .build(stack, "ApiHealthCheck");
+```
+
+Every [HealthCheckProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_route53.HealthCheckProps.html) property is available as a fluent setter on the builder.
+
+### Health-check defaults
+
+| Property           | Default                | Rationale                                                                                                                                                                                |
+| ------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `failureThreshold` | `3`                    | AWS guidance — three consecutive failures avoids flapping from transient endpoint hiccups.                                                                                               |
+| `requestInterval`  | `Duration.seconds(30)` | Standard health check; matches the CDK default.                                                                                                                                          |
+| `measureLatency`   | `true`                 | Per-region latency visibility on the Health Checks console; aligns with the Well-Architected operational-excellence pillar. Set `.measureLatency(false)` to opt out (small cost saving). |
+
+Exported as `HEALTH_CHECK_DEFAULTS` for visibility and testing.
+
+### Recommended Alarms
+
+The builder creates the [AWS-recommended](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53) `HealthCheckStatus` alarm by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions, or use [`alarmActionsPolicy`](../cloudwatch/README.md#alarm-actions-policy) for stack-wide wiring.
+
+| Alarm               | Metric                                | Default threshold |
+| ------------------- | ------------------------------------- | ----------------- |
+| `healthCheckStatus` | HealthCheckStatus (Minimum, 1 minute) | `< 1`             |
+
+`treatMissingData` defaults to `breaching`: missing datapoints are treated as unhealthy, matching the AWS example. This guards against the metric stopping emission while downstream systems still depend on the health check.
+
+The defaults are exported as `HEALTH_CHECK_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { HEALTH_CHECK_ALARM_DEFAULTS } from "@composurecdk/route53";
+```
+
+#### Customising thresholds
+
+```ts
+createHealthCheckBuilder()
+  .type(HealthCheckType.HTTPS)
+  .fqdn("api.example.com")
+  .recommendedAlarms({ healthCheckStatus: { evaluationPeriods: 2 } });
+```
+
+#### Disabling alarms
+
+Disable the recommended alarm with `recommendedAlarms({ healthCheckStatus: false })`, or disable all recommended alarms with `recommendedAlarms(false)`. Custom alarms attached via `addAlarm` are unaffected by either form.
+
+#### Custom alarms
+
+```ts
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+
+createHealthCheckBuilder()
+  .type(HealthCheckType.HTTPS)
+  .fqdn("api.example.com")
+  .addAlarm("connectionTime", (a) =>
+    a
+      .metric(
+        (hc) =>
+          new Metric({
+            namespace: "AWS/Route53",
+            metricName: "ConnectionTime",
+            dimensionsMap: { HealthCheckId: hc.healthCheckId },
+            statistic: "Average",
+          }),
+      )
+      .threshold(2000)
+      .greaterThan(),
+  );
+```
+
+#### Applying alarm actions
+
+No alarm actions are configured by default. Wire SNS or other actions via `alarmActionsPolicy` (or an `afterBuild` hook) — for cross-region deployments, the policy applied to the `us-east-1` monitoring stack covers both recommended and custom alarms.
+
+### Cross-region: `AWS/Route53` metrics live in `us-east-1` only
+
+Route 53 publishes its CloudWatch metrics in `us-east-1` regardless of where the health check is created. CloudWatch alarms are regional, so an alarm in any other region will never receive data. The combined builder emits a synth-time warning (`@composurecdk/route53:alarm-region`) when used outside `us-east-1`, but the better approach is to route the alarm into a `us-east-1` stack via `createHealthCheckAlarmBuilder` and `compose().withStacks()`:
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { HealthCheckType } from "aws-cdk-lib/aws-route53";
+import {
+  createHealthCheckBuilder,
+  createHealthCheckAlarmBuilder,
+  type HealthCheckBuilderResult,
+} from "@composurecdk/route53";
+
+compose(
+  {
+    api: createHealthCheckBuilder()
+      .type(HealthCheckType.HTTPS)
+      .fqdn("api.example.com")
+      .recommendedAlarms(false), // suppress alarms in the api's own stack
+
+    apiAlarms: createHealthCheckAlarmBuilder().healthCheck(ref<HealthCheckBuilderResult>("api")),
+  },
+  { api: [], apiAlarms: ["api"] },
+)
+  .withStacks({
+    api: appStack, //         any region — Route 53 health checks are global
+    apiAlarms: monitoringStack, // us-east-1 — where AWS/Route53 metrics live
+  })
+  .build(app, "App");
+```
+
+Set `crossRegionReferences: true` on both stacks so CDK can export the `HealthCheckId` from the app stack and import it in the alarm stack. The same pattern is documented for CloudFront alarms ([#58](https://github.com/laazyj/composureCDK/pull/58)) and codified in [ADR-0004](../../docs/adr/0004-split-alarm-builder-for-fixed-region-metrics.md).
 
 ## Zone DSL
 

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -39,6 +39,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudwatch": "^0.4.0",
     "@composurecdk/core": "^0.4.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"

--- a/packages/route53/src/defaults.ts
+++ b/packages/route53/src/defaults.ts
@@ -11,6 +11,7 @@ import type { NsRecordBuilderProps } from "./ns-record-builder.js";
 import type { DsRecordBuilderProps } from "./ds-record-builder.js";
 import type { HttpsRecordBuilderProps } from "./https-record-builder.js";
 import type { SvcbRecordBuilderProps } from "./svcb-record-builder.js";
+import type { HealthCheckBuilderProps } from "./health-check-builder.js";
 
 /**
  * Secure, AWS-recommended defaults applied to every public hosted zone built
@@ -126,4 +127,23 @@ export const HTTPS_RECORD_DEFAULTS: Partial<HttpsRecordBuilderProps> = {
  */
 export const SVCB_RECORD_DEFAULTS: Partial<SvcbRecordBuilderProps> = {
   ttl: DEFAULT_RECORD_TTL,
+};
+
+/**
+ * Defaults for {@link createHealthCheckBuilder}. Overridable via the fluent API.
+ *
+ * `failureThreshold` and `requestInterval` match CDK's defaults but are set
+ * explicitly so the values are surfaced in the package's defaults table and
+ * can be reasoned about without consulting CDK source. `measureLatency` is
+ * defaulted ON to align with the AWS Well-Architected operational-excellence
+ * pillar (per-region latency visibility on the Route 53 Health Checks
+ * console). It carries a small additional cost — disable explicitly via
+ * `.measureLatency(false)` if cost is a concern.
+ *
+ * @see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html
+ */
+export const HEALTH_CHECK_DEFAULTS: Partial<HealthCheckBuilderProps> = {
+  failureThreshold: 3,
+  requestInterval: Duration.seconds(30),
+  measureLatency: true,
 };

--- a/packages/route53/src/health-check-alarm-builder.ts
+++ b/packages/route53/src/health-check-alarm-builder.ts
@@ -1,0 +1,221 @@
+import { type IHealthCheck } from "aws-cdk-lib/aws-route53";
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { Annotations, Stack, Token } from "aws-cdk-lib";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
+import type { HealthCheckAlarmConfig } from "./health-check-alarm-config.js";
+import { resolveHealthCheckAlarmDefinitions } from "./health-check-alarms.js";
+import type { HealthCheckBuilderResult } from "./health-check-builder.js";
+
+/**
+ * Configuration properties for {@link createHealthCheckAlarmBuilder}.
+ *
+ * The standalone alarm builder mirrors the alarm surface that
+ * {@link createHealthCheckBuilder} creates by default. It exists so that
+ * alarms can be created in a different stack from the health check itself —
+ * specifically a `us-east-1` stack, since Route 53 emits all health check
+ * metrics there regardless of the health check's stack region.
+ *
+ * @see ADR-0004 — Split-alarm builder pattern for fixed-region metrics
+ */
+export interface HealthCheckAlarmBuilderProps {
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * Mirrors {@link HealthCheckBuilderProps.recommendedAlarms}. Set to
+   * `false` to disable all recommended alarms. Custom alarms added via
+   * {@link IHealthCheckAlarmBuilder.addAlarm} are unaffected.
+   *
+   * No alarm actions are configured by default. Use `alarmActionsPolicy`
+   * (or an `afterBuild` hook) to wire SNS or other actions onto the
+   * resulting alarms.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53
+   */
+  recommendedAlarms?: HealthCheckAlarmConfig | false;
+}
+
+/**
+ * The build output of an {@link IHealthCheckAlarmBuilder}.
+ */
+export interface HealthCheckAlarmBuilderResult {
+  /**
+   * The CloudWatch alarms created by this builder, keyed by alarm name.
+   * Uses the same key scheme as {@link HealthCheckBuilderResult.alarms}.
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for Route 53 health-check CloudWatch alarms, decoupled
+ * from the health check itself. Use this when the health check lives in a
+ * stack outside `us-east-1` — route this component into a `us-east-1` stack
+ * via `compose().withStacks()` so the alarms land where Route 53 actually
+ * emits metrics.
+ *
+ * @see {@link createHealthCheckAlarmBuilder}
+ */
+export type IHealthCheckAlarmBuilder = IBuilder<
+  HealthCheckAlarmBuilderProps,
+  HealthCheckAlarmBuilder
+>;
+
+/**
+ * Route 53 health-check metrics are emitted in `us-east-1` only. CloudWatch
+ * alarms are regional, so alarms created in any other region will never
+ * receive data. Warn (don't error) when alarms are being created outside
+ * `us-east-1`, unless the region is an unresolved token (env-agnostic stack
+ * — user knows best).
+ */
+function warnIfNotUsEast1(scope: IConstruct): void {
+  const region = Stack.of(scope).region;
+  if (Token.isUnresolved(region)) return;
+  if (region === "us-east-1") return;
+  Annotations.of(scope).addWarningV2(
+    "@composurecdk/route53:alarm-region",
+    `Route 53 health-check metrics are emitted in us-east-1 only, but this stack is ` +
+      `deployed in "${region}". CloudWatch alarms created here will not fire. Deploy the ` +
+      `stack in us-east-1, or use createHealthCheckAlarmBuilder() routed to a ` +
+      `us-east-1 stack via compose().withStacks().`,
+  );
+}
+
+/**
+ * Shared alarm-assembly used by both {@link createHealthCheckBuilder} (in its
+ * own stack) and {@link createHealthCheckAlarmBuilder} (typically in a
+ * separate `us-east-1` stack). Materialises the recommended health-check
+ * alarm and any user-supplied custom alarms, emits the region warning if the
+ * resulting scope is not in `us-east-1`, and creates the alarm constructs.
+ *
+ * @internal
+ */
+export function buildHealthCheckAlarms(
+  scope: IConstruct,
+  id: string,
+  target: Pick<HealthCheckBuilderResult, "healthCheck">,
+  options: {
+    recommendedAlarms?: HealthCheckAlarmConfig | false;
+    customAlarms?: AlarmDefinitionBuilder<IHealthCheck>[];
+  } = {},
+): Record<string, Alarm> {
+  const recommended = options.recommendedAlarms;
+  const recommendedDefs: AlarmDefinition[] =
+    recommended === false || recommended?.enabled === false
+      ? []
+      : resolveHealthCheckAlarmDefinitions(target.healthCheck, recommended);
+
+  const customAlarmDefs = options.customAlarms?.map((b) => b.resolve(target.healthCheck)) ?? [];
+  const allAlarmDefs = [...recommendedDefs, ...customAlarmDefs];
+
+  if (allAlarmDefs.length > 0) {
+    warnIfNotUsEast1(scope);
+  }
+
+  return createAlarms(scope, id, allAlarmDefs);
+}
+
+class HealthCheckAlarmBuilder implements Lifecycle<HealthCheckAlarmBuilderResult> {
+  props: Partial<HealthCheckAlarmBuilderProps> = {};
+  #healthCheck?: Resolvable<HealthCheckBuilderResult>;
+  readonly #customAlarms: AlarmDefinitionBuilder<IHealthCheck>[] = [];
+
+  /**
+   * Sets the health check to alarm on. Pass the result of
+   * {@link createHealthCheckBuilder} (or a {@link Ref} to it). The builder
+   * reads the health check from the result.
+   *
+   * Pair with `compose().withStacks()` to route this component into a
+   * `us-east-1` stack while the health check itself lives elsewhere — set
+   * `crossRegionReferences: true` on both stacks so CDK can wire the
+   * `HealthCheckId` reference automatically.
+   */
+  healthCheck(healthCheck: Resolvable<HealthCheckBuilderResult>): this {
+    this.#healthCheck = healthCheck;
+    return this;
+  }
+
+  /**
+   * Adds a custom alarm against the health check. The configure callback
+   * receives a fresh {@link AlarmDefinitionBuilder} pre-set with the alarm's
+   * key; configure metric, threshold, comparison and any other options.
+   *
+   * The created alarm is materialised in this builder's stack — useful for
+   * cross-region setups where you want all health-check alarms to live with
+   * the recommended ones.
+   */
+  addAlarm(
+    key: string,
+    configure: (
+      alarm: AlarmDefinitionBuilder<IHealthCheck>,
+    ) => AlarmDefinitionBuilder<IHealthCheck>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IHealthCheck>(key)));
+    return this;
+  }
+
+  build(
+    scope: IConstruct,
+    id: string,
+    context?: Record<string, object>,
+  ): HealthCheckAlarmBuilderResult {
+    if (!this.#healthCheck) {
+      throw new Error(
+        `HealthCheckAlarmBuilder "${id}" requires a health check. ` +
+          `Call .healthCheck() with a HealthCheckBuilderResult or a Ref to one.`,
+      );
+    }
+    const target = resolve(this.#healthCheck, context ?? {});
+    return {
+      alarms: buildHealthCheckAlarms(scope, id, target, {
+        recommendedAlarms: this.props.recommendedAlarms,
+        customAlarms: this.#customAlarms,
+      }),
+    };
+  }
+}
+
+/**
+ * Creates a new {@link IHealthCheckAlarmBuilder} for materialising Route 53
+ * health-check alarms in a stack separate from the health check itself.
+ *
+ * The recommended use is multi-region deployments: the health check lives in
+ * the application's stack (in any region — Route 53 health checks are
+ * global), and the alarms must live in a `us-east-1` stack so they can read
+ * the metrics Route 53 emits there.
+ *
+ * @example
+ * ```ts
+ * compose(
+ *   {
+ *     api: createHealthCheckBuilder()
+ *       .type(HealthCheckType.HTTPS)
+ *       .fqdn("api.example.com")
+ *       .recommendedAlarms(false),                  // suppress alarms in the api's own stack
+ *
+ *     apiAlarms: createHealthCheckAlarmBuilder()
+ *       .healthCheck(ref<HealthCheckBuilderResult>("api"))
+ *       .recommendedAlarms({ healthCheckStatus: { evaluationPeriods: 2 } }),
+ *   },
+ *   { api: [], apiAlarms: ["api"] },
+ * )
+ *   .withStacks({
+ *     api:       appStack,         // any region — health checks are global
+ *     apiAlarms: monitoringStack,  // us-east-1 — where AWS/Route53 metrics live
+ *   })
+ *   .build(app, "App");
+ * ```
+ *
+ * Set `crossRegionReferences: true` on both stacks so CDK can export the
+ * `HealthCheckId` from the app stack and import it in the alarm stack.
+ */
+export function createHealthCheckAlarmBuilder(): IHealthCheckAlarmBuilder {
+  return Builder<HealthCheckAlarmBuilderProps, HealthCheckAlarmBuilder>(HealthCheckAlarmBuilder);
+}

--- a/packages/route53/src/health-check-alarm-config.ts
+++ b/packages/route53/src/health-check-alarm-config.ts
@@ -1,0 +1,40 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for a Route 53 health check.
+ * The single recommended alarm — `healthCheckStatus` — is enabled by default
+ * with the AWS-recommended threshold. Set it to `false` to disable, or
+ * provide an {@link AlarmConfig} to tune the threshold or evaluation window.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53
+ */
+export interface HealthCheckAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the health check is reporting unhealthy.
+   *
+   * Metric: `AWS/Route53 HealthCheckStatus`, statistic Minimum, period
+   * 1 minute, dimension `HealthCheckId`. Minimum is the AWS-recommended
+   * statistic — it surfaces "at least one Route 53 checker sees it down"
+   * during the period.
+   *
+   * Default threshold: `< 1` for one consecutive 1-minute period.
+   * Default `treatMissingData: breaching` — missing data is treated as
+   * unhealthy, matching the AWS example.
+   *
+   * Note: `AWS/Route53` metrics are emitted only in `us-east-1`. Alarms
+   * created against this metric in any other region will never receive
+   * data. The builder emits a synth-time warning when this happens; for
+   * stacks outside `us-east-1`, route the alarm into a `us-east-1` stack
+   * via `createHealthCheckAlarmBuilder()` and `compose().withStacks()`.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53
+   */
+  healthCheckStatus?: AlarmConfig | false;
+}

--- a/packages/route53/src/health-check-alarm-defaults.ts
+++ b/packages/route53/src/health-check-alarm-defaults.ts
@@ -1,0 +1,33 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+interface HealthCheckAlarmDefaults {
+  enabled: true;
+  healthCheckStatus: Required<AlarmConfig>;
+}
+
+/**
+ * AWS-recommended default alarm configuration for Route 53 health checks.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53
+ */
+export const HEALTH_CHECK_ALARM_DEFAULTS: HealthCheckAlarmDefaults = {
+  enabled: true,
+
+  /**
+   * Alarm when `HealthCheckStatus < 1` for one consecutive 1-minute period.
+   * The metric is 0 (unhealthy) or 1 (healthy) per Route 53 checker, so the
+   * `Minimum` statistic surfaces "at least one checker reports unhealthy."
+   *
+   * `treatMissingData: breaching` matches AWS's recommendation — missing
+   * datapoints are treated as unhealthy. This guards against situations
+   * where the metric stops emitting (e.g. health check deletion) while the
+   * downstream system still depends on it.
+   */
+  healthCheckStatus: {
+    threshold: 1,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.BREACHING,
+  },
+};

--- a/packages/route53/src/health-check-alarms.ts
+++ b/packages/route53/src/health-check-alarms.ts
@@ -1,0 +1,53 @@
+import { Duration } from "aws-cdk-lib";
+import { ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import type { IHealthCheck } from "aws-cdk-lib/aws-route53";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { HealthCheckAlarmConfig } from "./health-check-alarm-config.js";
+import { HEALTH_CHECK_ALARM_DEFAULTS } from "./health-check-alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.minutes(1);
+
+/**
+ * Resolves the recommended alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s for a Route 53 health check.
+ *
+ * Period and statistic are fixed at the AWS-recommended values
+ * (1 minute, Minimum) and not exposed as configuration knobs — they are
+ * load-bearing for the recommended semantics ("the worst checker reading
+ * per minute"). Threshold, evaluation periods, datapoints, and missing-data
+ * behaviour remain user-configurable via {@link HealthCheckAlarmConfig}.
+ */
+export function resolveHealthCheckAlarmDefinitions(
+  healthCheck: IHealthCheck,
+  config: HealthCheckAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.healthCheckStatus !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.healthCheckStatus,
+      HEALTH_CHECK_ALARM_DEFAULTS.healthCheckStatus,
+    );
+    definitions.push({
+      key: "healthCheckStatus",
+      metric: new Metric({
+        namespace: "AWS/Route53",
+        metricName: "HealthCheckStatus",
+        dimensionsMap: { HealthCheckId: healthCheck.healthCheckId },
+        statistic: Stats.MINIMUM,
+        period: METRIC_PERIOD,
+      }),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `Route 53 health check is reporting unhealthy. Threshold: HealthCheckStatus < ${String(cfg.threshold)} (Minimum, 1 minute).`,
+    });
+  }
+
+  return definitions;
+}

--- a/packages/route53/src/health-check-builder.ts
+++ b/packages/route53/src/health-check-builder.ts
@@ -1,0 +1,145 @@
+import { HealthCheck, type HealthCheckProps, type IHealthCheck } from "aws-cdk-lib/aws-route53";
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { type IConstruct } from "constructs";
+import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { HealthCheckAlarmConfig } from "./health-check-alarm-config.js";
+import { buildHealthCheckAlarms } from "./health-check-alarm-builder.js";
+import { HEALTH_CHECK_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the Route 53 health-check builder.
+ *
+ * Extends the CDK {@link HealthCheckProps} with builder-specific options for
+ * AWS-recommended CloudWatch alarms.
+ */
+export interface HealthCheckBuilderProps extends HealthCheckProps {
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates a recommended `healthCheckStatus`
+   * alarm matching AWS guidance (`HealthCheckStatus < 1` for one minute,
+   * `treatMissingData: breaching`). The alarm can be customised or
+   * disabled. Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification methods
+   * are user-specific. Access alarms from the build result or use an
+   * `afterBuild` hook (or `alarmActionsPolicy`) to apply actions.
+   *
+   * Note: `AWS/Route53` metrics are emitted only in `us-east-1`. If this
+   * builder is used outside `us-east-1`, the synthesised alarm will never
+   * receive data — the builder emits a synth-time warning. For non-`us-east-1`
+   * stacks, suppress this builder's alarms with `recommendedAlarms: false`
+   * and create alarms in a `us-east-1` stack via
+   * {@link createHealthCheckAlarmBuilder}.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53
+   */
+  recommendedAlarms?: HealthCheckAlarmConfig | false;
+}
+
+/**
+ * The build output of an {@link IHealthCheckBuilder}.
+ */
+export interface HealthCheckBuilderResult {
+  /** The Route 53 health check construct created by the builder. */
+  healthCheck: HealthCheck;
+
+  /**
+   * CloudWatch alarms created for the health check, keyed by alarm name.
+   *
+   * Includes both AWS-recommended alarms and any custom alarms added via
+   * {@link IHealthCheckBuilder.addAlarm}. Access individual alarms by key
+   * (e.g. `result.alarms.healthCheckStatus`).
+   *
+   * No alarm actions are configured — apply them via the result or an
+   * `afterBuild` hook.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Route53
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for configuring and creating a Route 53 health check.
+ *
+ * Each configuration property from the CDK {@link HealthCheckProps} is
+ * exposed as an overloaded method: call with a value to set it (returns the
+ * builder for chaining), or call with no arguments to read the current value.
+ *
+ * The builder also creates the AWS-recommended `healthCheckStatus`
+ * CloudWatch alarm by default. Alarms can be customised or disabled via the
+ * `recommendedAlarms` property.
+ *
+ * @example
+ * ```ts
+ * const hc = createHealthCheckBuilder()
+ *   .type(HealthCheckType.HTTPS)
+ *   .fqdn("api.example.com")
+ *   .resourcePath("/health");
+ * ```
+ */
+export type IHealthCheckBuilder = IBuilder<HealthCheckBuilderProps, HealthCheckBuilder>;
+
+class HealthCheckBuilder implements Lifecycle<HealthCheckBuilderResult> {
+  props: Partial<HealthCheckBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<IHealthCheck>[] = [];
+
+  addAlarm(
+    key: string,
+    configure: (
+      alarm: AlarmDefinitionBuilder<IHealthCheck>,
+    ) => AlarmDefinitionBuilder<IHealthCheck>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IHealthCheck>(key)));
+    return this;
+  }
+
+  build(scope: IConstruct, id: string): HealthCheckBuilderResult {
+    const { recommendedAlarms, ...rest } = this.props;
+
+    if (!rest.type) {
+      throw new Error(
+        `HealthCheckBuilder "${id}" requires a type. Call .type() with a HealthCheckType value.`,
+      );
+    }
+
+    const mergedProps = {
+      ...HEALTH_CHECK_DEFAULTS,
+      ...rest,
+    } as HealthCheckProps;
+
+    const healthCheck = new HealthCheck(scope, id, mergedProps);
+
+    const alarms = buildHealthCheckAlarms(
+      scope,
+      id,
+      { healthCheck },
+      {
+        recommendedAlarms,
+        customAlarms: this.#customAlarms,
+      },
+    );
+
+    return { healthCheck, alarms };
+  }
+}
+
+/**
+ * Creates a new {@link IHealthCheckBuilder} for configuring a Route 53
+ * health check.
+ *
+ * @returns A fluent builder for a Route 53 health check.
+ *
+ * @example
+ * ```ts
+ * const hc = createHealthCheckBuilder()
+ *   .type(HealthCheckType.HTTPS)
+ *   .fqdn("api.example.com");
+ *
+ * const result = hc.build(stack, "ApiHealthCheck");
+ * ```
+ */
+export function createHealthCheckBuilder(): IHealthCheckBuilder {
+  return Builder<HealthCheckBuilderProps, HealthCheckBuilder>(HealthCheckBuilder);
+}

--- a/packages/route53/src/index.ts
+++ b/packages/route53/src/index.ts
@@ -71,6 +71,20 @@ export {
   type ISvcbRecordBuilder,
 } from "./svcb-record-builder.js";
 export {
+  createHealthCheckBuilder,
+  type HealthCheckBuilderProps,
+  type HealthCheckBuilderResult,
+  type IHealthCheckBuilder,
+} from "./health-check-builder.js";
+export {
+  createHealthCheckAlarmBuilder,
+  type HealthCheckAlarmBuilderProps,
+  type HealthCheckAlarmBuilderResult,
+  type IHealthCheckAlarmBuilder,
+} from "./health-check-alarm-builder.js";
+export type { HealthCheckAlarmConfig } from "./health-check-alarm-config.js";
+export { HEALTH_CHECK_ALARM_DEFAULTS } from "./health-check-alarm-defaults.js";
+export {
   cloudfrontAliasTarget,
   apiGatewayAliasTarget,
   apiGatewayDomainAliasTarget,
@@ -88,4 +102,5 @@ export {
   DS_RECORD_DEFAULTS,
   HTTPS_RECORD_DEFAULTS,
   SVCB_RECORD_DEFAULTS,
+  HEALTH_CHECK_DEFAULTS,
 } from "./defaults.js";

--- a/packages/route53/test/health-check-alarm-builder.test.ts
+++ b/packages/route53/test/health-check-alarm-builder.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { HealthCheckType, type IHealthCheck } from "aws-cdk-lib/aws-route53";
+import { compose, ref } from "@composurecdk/core";
+import type { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import { createHealthCheckBuilder } from "../src/health-check-builder.js";
+import {
+  createHealthCheckAlarmBuilder,
+  type HealthCheckAlarmBuilderResult,
+} from "../src/health-check-alarm-builder.js";
+import type { HealthCheckBuilderResult } from "../src/health-check-builder.js";
+
+const ACCOUNT = "123456789012";
+const ENV_US_EAST_1 = { account: ACCOUNT, region: "us-east-1" };
+const ENV_EU_WEST_2 = { account: ACCOUNT, region: "eu-west-2" };
+
+function connectionTimeAlarm(a: AlarmDefinitionBuilder<IHealthCheck>) {
+  return a
+    .metric(
+      (hc) =>
+        new Metric({
+          namespace: "AWS/Route53",
+          metricName: "ConnectionTime",
+          dimensionsMap: { HealthCheckId: hc.healthCheckId },
+          statistic: "Average",
+        }),
+    )
+    .threshold(2000)
+    .greaterThan();
+}
+
+function buildHealthCheck() {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", { env: ENV_US_EAST_1 });
+  const result = createHealthCheckBuilder()
+    .type(HealthCheckType.HTTPS)
+    .fqdn("api.example.com")
+    .recommendedAlarms(false)
+    .build(stack, "ApiHealthCheck");
+  return { app, stack, result };
+}
+
+describe("createHealthCheckAlarmBuilder", () => {
+  describe("with a concrete HealthCheckBuilderResult", () => {
+    it("creates the recommended alarm in the alarm builder's scope", () => {
+      const { stack, result } = buildHealthCheck();
+      const alarmResult = createHealthCheckAlarmBuilder()
+        .healthCheck(result)
+        .build(stack, "Alarms");
+
+      expect(alarmResult.alarms.healthCheckStatus).toBeDefined();
+      Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("recommendedAlarms(false) suppresses the recommended alarm", () => {
+      const { stack, result } = buildHealthCheck();
+      const alarmResult = createHealthCheckAlarmBuilder()
+        .healthCheck(result)
+        .recommendedAlarms(false)
+        .build(stack, "Alarms");
+
+      expect(alarmResult.alarms).toEqual({});
+      Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("creates custom addAlarm even when recommendedAlarms is false", () => {
+      const { stack, result } = buildHealthCheck();
+      const alarmResult = createHealthCheckAlarmBuilder()
+        .healthCheck(result)
+        .recommendedAlarms(false)
+        .addAlarm("connectionTime", connectionTimeAlarm)
+        .build(stack, "Alarms");
+
+      expect(alarmResult.alarms.connectionTime).toBeDefined();
+      Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("creates custom addAlarm alongside recommended alarms", () => {
+      const { stack, result } = buildHealthCheck();
+      const alarmResult = createHealthCheckAlarmBuilder()
+        .healthCheck(result)
+        .addAlarm("connectionTime", connectionTimeAlarm)
+        .build(stack, "Alarms");
+
+      expect(alarmResult.alarms.connectionTime).toBeDefined();
+      expect(alarmResult.alarms.healthCheckStatus).toBeDefined();
+      Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+
+    it("throws when healthCheck() was never called", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", { env: ENV_US_EAST_1 });
+      const builder = createHealthCheckAlarmBuilder();
+      expect(() => builder.build(stack, "Alarms")).toThrow(/requires a health check/);
+    });
+  });
+
+  describe("region warning", () => {
+    function buildAlarmsInRegion(region: string | undefined): Stack {
+      const app = new App();
+      const hcStackProps =
+        region === undefined ? undefined : { env: ENV_EU_WEST_2, crossRegionReferences: true };
+      const hcStack = new Stack(app, "HcStack", hcStackProps);
+      const result = createHealthCheckBuilder()
+        .type(HealthCheckType.HTTPS)
+        .fqdn("api.example.com")
+        .recommendedAlarms(false)
+        .build(hcStack, "ApiHealthCheck");
+
+      const alarmStack =
+        region === undefined
+          ? new Stack(app, "AlarmStack")
+          : new Stack(app, "AlarmStack", {
+              env: { account: ACCOUNT, region },
+              crossRegionReferences: true,
+            });
+      createHealthCheckAlarmBuilder().healthCheck(result).build(alarmStack, "Alarms");
+      return alarmStack;
+    }
+
+    it("emits a warning when the alarm stack is outside us-east-1", () => {
+      const stack = buildAlarmsInRegion("us-west-2");
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp('deployed in "us-west-2"'),
+      );
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    it("emits no warning when the alarm stack is in us-east-1", () => {
+      const stack = buildAlarmsInRegion("us-east-1");
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("emits no warning when the alarm stack region is an unresolved token", () => {
+      const stack = buildAlarmsInRegion(undefined);
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe("with a Ref<HealthCheckBuilderResult> through compose", () => {
+    it("resolves the health check and creates the same alarm surface", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", { env: ENV_US_EAST_1 });
+
+      const system = compose(
+        {
+          api: createHealthCheckBuilder()
+            .type(HealthCheckType.HTTPS)
+            .fqdn("api.example.com")
+            .recommendedAlarms(false),
+
+          apiAlarms: createHealthCheckAlarmBuilder().healthCheck(
+            ref<HealthCheckBuilderResult>("api"),
+          ),
+        },
+        { api: [], apiAlarms: ["api"] },
+      );
+
+      const result = system.build(stack, "Test") as {
+        api: HealthCheckBuilderResult;
+        apiAlarms: HealthCheckAlarmBuilderResult;
+      };
+
+      expect(result.api.alarms).toEqual({});
+      expect(result.apiAlarms.alarms.healthCheckStatus).toBeDefined();
+
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::Route53::HealthCheck", 1);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("routes alarms into a separate stack when withStacks() points apiAlarms elsewhere", () => {
+      const app = new App();
+      const appStack = new Stack(app, "AppStack", {
+        env: ENV_EU_WEST_2,
+        crossRegionReferences: true,
+      });
+      const alarmStack = new Stack(app, "AlarmStack", {
+        env: ENV_US_EAST_1,
+        crossRegionReferences: true,
+      });
+
+      compose(
+        {
+          api: createHealthCheckBuilder()
+            .type(HealthCheckType.HTTPS)
+            .fqdn("api.example.com")
+            .recommendedAlarms(false),
+
+          apiAlarms: createHealthCheckAlarmBuilder().healthCheck(
+            ref<HealthCheckBuilderResult>("api"),
+          ),
+        },
+        { api: [], apiAlarms: ["api"] },
+      )
+        .withStacks({
+          api: appStack,
+          apiAlarms: alarmStack,
+        })
+        .build(app, "MultiRegion");
+
+      const appTemplate = Template.fromStack(appStack);
+      const alarmTemplate = Template.fromStack(alarmStack);
+
+      appTemplate.resourceCountIs("AWS::Route53::HealthCheck", 1);
+      appTemplate.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+
+      alarmTemplate.resourceCountIs("AWS::Route53::HealthCheck", 0);
+      alarmTemplate.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+
+      const warnings = Annotations.fromStack(alarmStack).findWarning(
+        "*",
+        Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/packages/route53/test/health-check-alarms.test.ts
+++ b/packages/route53/test/health-check-alarms.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { HealthCheckType, type IHealthCheck } from "aws-cdk-lib/aws-route53";
+import { createHealthCheckBuilder } from "../src/health-check-builder.js";
+
+const ENV_US_EAST_1 = { account: "123456789012", region: "us-east-1" };
+
+function buildResult(configureFn?: (builder: ReturnType<typeof createHealthCheckBuilder>) => void) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", { env: ENV_US_EAST_1 });
+  const builder = createHealthCheckBuilder().type(HealthCheckType.HTTPS).fqdn("api.example.com");
+  configureFn?.(builder);
+  const result = builder.build(stack, "ApiHealthCheck");
+  return { result, template: Template.fromStack(stack) };
+}
+
+describe("recommended alarms", () => {
+  describe("defaults", () => {
+    it("creates the healthCheckStatus alarm by default", () => {
+      const { result, template } = buildResult();
+
+      expect(result.alarms.healthCheckStatus).toBeDefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("creates healthCheckStatus with AWS-recommended threshold and metric shape", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "HealthCheckStatus",
+        Namespace: "AWS/Route53",
+        Threshold: 1,
+        ComparisonOperator: "LessThanThreshold",
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        TreatMissingData: "breaching",
+        Statistic: "Minimum",
+        Period: 60,
+        Dimensions: Match.arrayWith([Match.objectLike({ Name: "HealthCheckId" })]),
+      });
+    });
+
+    it("includes threshold and period in the alarm description", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "HealthCheckStatus",
+        AlarmDescription: Match.stringLikeRegexp("HealthCheckStatus < 1.*1 minute"),
+      });
+    });
+  });
+
+  describe("customisation", () => {
+    it("honours a custom threshold", () => {
+      const { template } = buildResult((b) => {
+        b.recommendedAlarms({ healthCheckStatus: { threshold: 0.5 } });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "HealthCheckStatus",
+        Threshold: 0.5,
+      });
+    });
+
+    it("honours a custom evaluation window", () => {
+      const { template } = buildResult((b) => {
+        b.recommendedAlarms({
+          healthCheckStatus: { evaluationPeriods: 3, datapointsToAlarm: 2 },
+        });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "HealthCheckStatus",
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 2,
+      });
+    });
+
+    it("preserves unspecified fields when threshold is overridden", () => {
+      const { template } = buildResult((b) => {
+        b.recommendedAlarms({ healthCheckStatus: { threshold: 0.5 } });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "HealthCheckStatus",
+        EvaluationPeriods: 1,
+        TreatMissingData: "breaching",
+      });
+    });
+
+    it("disables the healthCheckStatus alarm when set to false", () => {
+      const { result, template } = buildResult((b) => {
+        b.recommendedAlarms({ healthCheckStatus: false });
+      });
+
+      expect(result.alarms.healthCheckStatus).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all alarms when recommendedAlarms is false", () => {
+      const { result, template } = buildResult((b) => {
+        b.recommendedAlarms(false);
+      });
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all alarms when enabled is false", () => {
+      const { result, template } = buildResult((b) => {
+        b.recommendedAlarms({ enabled: false });
+      });
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("custom alarms", () => {
+    it("creates a custom alarm alongside the recommended alarm", () => {
+      const { result, template } = buildResult((b) => {
+        b.addAlarm("connectionTime", (alarm) =>
+          alarm
+            .metric(
+              (hc: IHealthCheck) =>
+                new Metric({
+                  namespace: "AWS/Route53",
+                  metricName: "ConnectionTime",
+                  dimensionsMap: { HealthCheckId: hc.healthCheckId },
+                  statistic: "Average",
+                  period: Duration.minutes(1),
+                }),
+            )
+            .threshold(2000)
+            .greaterThan()
+            .description("Health check connection time is high"),
+        );
+      });
+
+      expect(result.alarms.connectionTime).toBeDefined();
+      expect(result.alarms.healthCheckStatus).toBeDefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+
+    it("rejects a custom alarm that collides with a recommended alarm key", () => {
+      expect(() =>
+        buildResult((b) => {
+          b.addAlarm("healthCheckStatus", (alarm) =>
+            alarm
+              .metric(
+                (hc: IHealthCheck) =>
+                  new Metric({
+                    namespace: "AWS/Route53",
+                    metricName: "HealthCheckStatus",
+                    dimensionsMap: { HealthCheckId: hc.healthCheckId },
+                    statistic: "Minimum",
+                    period: Duration.minutes(1),
+                  }),
+              )
+              .threshold(1)
+              .lessThan(),
+          );
+        }),
+      ).toThrow(/Duplicate alarm key/);
+    });
+  });
+
+  describe("treatMissingData semantics", () => {
+    it("uses BREACHING by default so missing data flags the health check unhealthy", () => {
+      const { template } = buildResult();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "HealthCheckStatus",
+        TreatMissingData: "breaching",
+      });
+    });
+  });
+});

--- a/packages/route53/test/health-check-builder.test.ts
+++ b/packages/route53/test/health-check-builder.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { HealthCheckType } from "aws-cdk-lib/aws-route53";
+import { createHealthCheckBuilder } from "../src/health-check-builder.js";
+
+const ENV_US_EAST_1 = { account: "123456789012", region: "us-east-1" };
+
+function buildInUsEast1(
+  configureFn?: (builder: ReturnType<typeof createHealthCheckBuilder>) => void,
+) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", { env: ENV_US_EAST_1 });
+  const builder = createHealthCheckBuilder().type(HealthCheckType.HTTPS).fqdn("api.example.com");
+  configureFn?.(builder);
+  const result = builder.build(stack, "ApiHealthCheck");
+  return { app, stack, result, template: Template.fromStack(stack) };
+}
+
+describe("createHealthCheckBuilder", () => {
+  describe("defaults", () => {
+    it("creates a Route 53 health check with merged AWS-recommended defaults", () => {
+      const { result, template } = buildInUsEast1();
+
+      expect(result.healthCheck).toBeDefined();
+      template.hasResourceProperties("AWS::Route53::HealthCheck", {
+        HealthCheckConfig: Match.objectLike({
+          Type: "HTTPS",
+          FullyQualifiedDomainName: "api.example.com",
+          FailureThreshold: 3,
+          RequestInterval: 30,
+          MeasureLatency: true,
+        }),
+      });
+    });
+
+    it("requires a type", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", { env: ENV_US_EAST_1 });
+      const builder = createHealthCheckBuilder().fqdn("api.example.com");
+      expect(() => builder.build(stack, "ApiHealthCheck")).toThrow(/requires a type/);
+    });
+
+    it("user overrides take precedence over defaults", () => {
+      const { template } = buildInUsEast1((b) => {
+        b.failureThreshold(5).measureLatency(false);
+      });
+
+      template.hasResourceProperties("AWS::Route53::HealthCheck", {
+        HealthCheckConfig: Match.objectLike({
+          FailureThreshold: 5,
+          MeasureLatency: false,
+        }),
+      });
+    });
+  });
+
+  describe("region warning", () => {
+    function buildInRegion(
+      region: string | undefined,
+      configureFn?: (builder: ReturnType<typeof createHealthCheckBuilder>) => void,
+    ) {
+      const app = new App();
+      const stack =
+        region === undefined
+          ? new Stack(app, "TestStack")
+          : new Stack(app, "TestStack", { env: { account: "123456789012", region } });
+      const builder = createHealthCheckBuilder()
+        .type(HealthCheckType.HTTPS)
+        .fqdn("api.example.com");
+      configureFn?.(builder);
+      builder.build(stack, "ApiHealthCheck");
+      return stack;
+    }
+
+    it("emits a warning when the stack is outside us-east-1", () => {
+      const stack = buildInRegion("eu-west-1");
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp('deployed in "eu-west-1"'),
+      );
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    it("emits no warning when the stack is in us-east-1", () => {
+      const stack = buildInRegion("us-east-1");
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("emits no warning when the stack region is an unresolved token", () => {
+      const stack = buildInRegion(undefined);
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("emits no warning when recommendedAlarms is false and no custom alarms are added", () => {
+      const stack = buildInRegion("eu-west-1", (b) => b.recommendedAlarms(false));
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `createHealthCheckBuilder` to `@composurecdk/route53`, wrapping `aws-route53.HealthCheck` with AWS-recommended defaults (`failureThreshold: 3`, `requestInterval: 30s`, `measureLatency: true`) and the AWS-recommended `HealthCheckStatus` CloudWatch alarm by default (Minimum < 1 over 1 minute, `treatMissingData: breaching`).
- Adds `createHealthCheckAlarmBuilder` (standalone) so alarms can be created in a separate `us-east-1` stack while the health check itself lives anywhere — `AWS/Route53` metrics are emitted in `us-east-1` only. Mirrors the CloudFront standalone-alarm pattern from #58.
- Introduces [ADR-0004](docs/adr/0004-split-alarm-builder-for-fixed-region-metrics.md) codifying the split-alarm pattern for AWS services with fixed-region metrics, so future services follow a consistent shape.
- Both builders delegate to a shared internal `buildHealthCheckAlarms` helper that emits a synth-time warning (`@composurecdk/route53:alarm-region`) when the alarm scope is outside `us-east-1`, with `Token.isUnresolved` suppression for env-agnostic stacks.

## Test plan

- [x] `npx nx run @composurecdk/route53:test` — 95 tests pass (22 new across three test files)
- [x] `npx nx run-many --target=test --all` — all 13 packages green
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Combined builder: defaults table verifies `FailureThreshold: 3`, `RequestInterval: 30`, `MeasureLatency: true`; user overrides win
- [x] Recommended alarm: namespace `AWS/Route53`, metric `HealthCheckStatus`, statistic `Minimum`, period 60s, threshold `< 1`, `treatMissingData: breaching`
- [x] `recommendedAlarms: false` / `{ enabled: false }` / `{ healthCheckStatus: false }` all suppress the recommended alarm
- [x] `addAlarm()` for custom alarms works on both builders; key collision throws
- [x] Region warning fires outside `us-east-1`, suppressed in `us-east-1` and for env-agnostic stacks
- [x] `compose().withStacks()` cross-region: app stack in `eu-west-2`, alarm stack in `us-east-1` — alarms land in the alarm stack with no region warning

Closes #45