### PR TITLE
feat(cloudwatch): explicit, readable alarm names with override seam

### DIFF
--- a/packages/acm/src/alarm-defaults.ts
+++ b/packages/acm/src/alarm-defaults.ts
@@ -1,9 +1,9 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "@composurecdk/cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
 
 interface CertificateAlarmDefaults {
   enabled: true;
-  daysToExpiry: Required<AlarmConfig>;
+  daysToExpiry: AlarmConfigDefaults;
 }
 
 /**

--- a/packages/acm/src/certificate-alarms.ts
+++ b/packages/acm/src/certificate-alarms.ts
@@ -25,6 +25,7 @@ export function resolveCertificateAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.daysToExpiry, CERTIFICATE_ALARM_DEFAULTS.daysToExpiry);
     definitions.push({
       key: "daysToExpiry",
+      alarmName: cfg.alarmName,
       metric: certificate.metricDaysToExpiry({ period: METRIC_PERIOD }),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,

--- a/packages/apigateway/src/alarm-defaults.ts
+++ b/packages/apigateway/src/alarm-defaults.ts
@@ -1,11 +1,11 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "@composurecdk/cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
 
 interface RestApiAlarmDefaults {
   enabled: true;
-  clientError: Required<AlarmConfig>;
-  serverError: Required<AlarmConfig>;
-  latency: Required<AlarmConfig>;
+  clientError: AlarmConfigDefaults;
+  serverError: AlarmConfigDefaults;
+  latency: AlarmConfigDefaults;
 }
 
 /**

--- a/packages/apigateway/src/rest-api-alarms.ts
+++ b/packages/apigateway/src/rest-api-alarms.ts
@@ -43,6 +43,7 @@ export function resolveRestApiAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.clientError, REST_API_ALARM_DEFAULTS.clientError);
     definitions.push({
       key: "clientError",
+      alarmName: cfg.alarmName,
       metric: apiMetric(api, "4XXError", Stats.AVERAGE),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -57,6 +58,7 @@ export function resolveRestApiAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.serverError, REST_API_ALARM_DEFAULTS.serverError);
     definitions.push({
       key: "serverError",
+      alarmName: cfg.alarmName,
       metric: apiMetric(api, "5XXError", Stats.AVERAGE),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -71,6 +73,7 @@ export function resolveRestApiAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.latency, REST_API_ALARM_DEFAULTS.latency);
     definitions.push({
       key: "latency",
+      alarmName: cfg.alarmName,
       metric: apiMetric(api, "Latency", Stats.percentile(90)),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,

--- a/packages/cloudfront/src/alarm-defaults.ts
+++ b/packages/cloudfront/src/alarm-defaults.ts
@@ -1,17 +1,17 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "@composurecdk/cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
 
 interface DistributionAlarmDefaults {
   enabled: true;
-  errorRate: Required<AlarmConfig>;
-  originLatency: Required<AlarmConfig>;
+  errorRate: AlarmConfigDefaults;
+  originLatency: AlarmConfigDefaults;
 }
 
 interface FunctionAlarmDefaults {
   enabled: true;
-  executionErrors: Required<AlarmConfig>;
-  validationErrors: Required<AlarmConfig>;
-  throttles: Required<AlarmConfig>;
+  executionErrors: AlarmConfigDefaults;
+  validationErrors: AlarmConfigDefaults;
+  throttles: AlarmConfigDefaults;
 }
 
 /**

--- a/packages/cloudfront/src/behavior-function-alarms.ts
+++ b/packages/cloudfront/src/behavior-function-alarms.ts
@@ -121,6 +121,7 @@ export function resolveBehaviorFunctionAlarmDefinitions(
     );
     definitions.push({
       key: `${keyPrefix}ExecutionErrors`,
+      alarmName: cfg.alarmName,
       metric: functionMetric(fn, "FunctionExecutionErrors"),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -138,6 +139,7 @@ export function resolveBehaviorFunctionAlarmDefinitions(
     );
     definitions.push({
       key: `${keyPrefix}ValidationErrors`,
+      alarmName: cfg.alarmName,
       metric: functionMetric(fn, "FunctionValidationErrors"),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -152,6 +154,7 @@ export function resolveBehaviorFunctionAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.throttles, FUNCTION_ALARM_DEFAULTS.throttles);
     definitions.push({
       key: `${keyPrefix}Throttles`,
+      alarmName: cfg.alarmName,
       metric: functionMetric(fn, "FunctionThrottles"),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,

--- a/packages/cloudfront/src/distribution-alarms.ts
+++ b/packages/cloudfront/src/distribution-alarms.ts
@@ -46,6 +46,7 @@ export function resolveDistributionAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.errorRate, DISTRIBUTION_ALARM_DEFAULTS.errorRate);
     definitions.push({
       key: "errorRate",
+      alarmName: cfg.alarmName,
       metric: distributionMetric(distribution, "5xxErrorRate", Stats.AVERAGE),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -63,6 +64,7 @@ export function resolveDistributionAlarmDefinitions(
     );
     definitions.push({
       key: "originLatency",
+      alarmName: cfg.alarmName,
       metric: distributionMetric(distribution, "OriginLatency", Stats.percentile(90)),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,

--- a/packages/cloudwatch/README.md
+++ b/packages/cloudwatch/README.md
@@ -59,6 +59,57 @@ const alarms = createAlarms(scope, "MyFunction", definitions);
 
 Construct IDs follow the pattern `${id}${Capitalize(key)}Alarm` (e.g., `MyFunctionErrorsAlarm`).
 
+### Alarm names
+
+Each alarm receives an explicit, hierarchical name of the form `${stackName}/${kebab(id)}/${kebab(key)}` (e.g. `payments-prod/checkout-fn/errors`) instead of CloudFormation's hash-suffixed default. Slashes render hierarchy in the console; segments are kebab-cased so names scan cleanly in dashboards, oncall pages, and email subjects, where word separation matters more than in code.
+
+Per-alarm overrides go through [`alarmName()`][alarm-name-src] — a validating constructor for the branded [`AlarmName`][alarm-name-src] type — and cross-cutting decoration through [alarmNamePolicy](#alarmnamepolicy). The default fallback lives in [`defaultAlarmName`][default-alarm-name-src].
+
+[alarm-name-src]: ./src/alarm-name.ts
+[default-alarm-name-src]: ./src/default-alarm-name.ts
+
+## alarmNamePolicy
+
+A [Policy](../../docs/adr/0002-policies.md) that decorates CloudWatch alarm names across an entire scope. Mirrors the shape of `alarmActionsPolicy` — install it once on an `App` or `Stack` and it applies to every alarm the subtree produces, including alarms created later by builders or nested composed systems.
+
+```ts
+import { alarmNamePolicy } from "@composurecdk/cloudwatch";
+
+alarmNamePolicy(app, {
+  defaults: { prefix: "prod" },
+  rules: [
+    { match: /Errors$/, suffix: "critical" },
+    { match: "throttles", suffix: "warning" },
+    { match: (ctx) => ctx.path.includes("payments"), prefix: "payments" },
+  ],
+});
+```
+
+For each alarm the policy reads the existing name (from `defaultAlarmName` or a per-alarm override), applies `defaults.prefix` / `defaults.suffix`, then layers each matching rule in declaration order. The result is validated via `alarmName()` and written back to the CFN resource.
+
+Rules support `prefix`, `suffix`, and `transform`. `transform` produces a new name from scratch and wins over `prefix`/`suffix` on the same rule. `replaceDefaults: true` on a matched rule suppresses the `defaults` decoration for that alarm.
+
+```ts
+alarmNamePolicy(app, {
+  defaults: { prefix: "prod" },
+  rules: [
+    { match: "team-x", prefix: "team-x", replaceDefaults: true },
+    {
+      match: /payments/,
+      transform: (ctx) => alarmName(`payments/${ctx.id}`),
+    },
+  ],
+});
+```
+
+Matchers use the same shape as `alarmActionsPolicy`: substring (tested against both `id` and `path`), `RegExp` (tested against `path`), or a predicate receiving the full match context. `singleOnly` / `compositeOnly` scope rules to one alarm kind.
+
+The separator between `prefix` / current-name / `suffix` segments defaults to `-`; pass `separator` to override.
+
+### Limitation: L1 reads only
+
+The policy reads `cfn.alarmName` and writes the decorated value back. If a name is set as an unresolved CDK token that doesn't resolve to a string at synth time, the alarm is skipped and the original name is left in place. In practice every alarm produced by ComposureCDK builders (and aws-cdk-lib's L2 `Alarm`) sets a resolvable string, so this is rare.
+
 ## alarmActionsPolicy
 
 A [Policy](../../docs/adr/0002-policies.md) that routes CloudWatch alarm actions (e.g. SNS notifications) to every `Alarm` and `CompositeAlarm` in a construct subtree. Install it once on an `App` or `Stack` and it applies to every alarm the subtree produces — including alarms created later by builders or nested composed systems.

--- a/packages/cloudwatch/src/alarm-config.ts
+++ b/packages/cloudwatch/src/alarm-config.ts
@@ -1,4 +1,5 @@
 import type { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmName } from "./alarm-name.js";
 
 /**
  * Configuration for a single recommended CloudWatch alarm.
@@ -6,6 +7,15 @@ import type { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
  * fields to tune thresholds without replacing the entire alarm.
  */
 export interface AlarmConfig {
+  /**
+   * Explicit CloudWatch alarm name. When omitted, the library derives a
+   * readable default from the stack name, builder id, and alarm key.
+   *
+   * Construct via the {@link alarmName} helper to opt into the same
+   * validation the library applies to its own auto-generated names.
+   */
+  alarmName?: AlarmName;
+
   /** Alarm threshold. Default varies per alarm type. */
   threshold?: number;
 
@@ -18,3 +28,9 @@ export interface AlarmConfig {
   /** How to treat missing data points. @default TreatMissingData.NOT_BREACHING */
   treatMissingData?: TreatMissingData;
 }
+
+/**
+ * Type for per-package `*_ALARM_DEFAULTS` constants. Defaults set every
+ * tunable field but never `alarmName` — names are derived per-instance.
+ */
+export type AlarmConfigDefaults = Required<Omit<AlarmConfig, "alarmName">>;

--- a/packages/cloudwatch/src/alarm-definition-builder.ts
+++ b/packages/cloudwatch/src/alarm-definition-builder.ts
@@ -1,5 +1,6 @@
 import { ComparisonOperator, type Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import type { AlarmDefinition } from "./alarm-definition.js";
+import type { AlarmName } from "./alarm-name.js";
 
 /**
  * Fluent builder for constructing deferred {@link AlarmDefinition}s.
@@ -12,6 +13,7 @@ import type { AlarmDefinition } from "./alarm-definition.js";
  */
 export class AlarmDefinitionBuilder<TConstruct> {
   readonly #key: string;
+  #alarmName?: AlarmName;
   #metricFactory?: (construct: TConstruct) => Metric;
   #threshold = 0;
   #comparisonOperator = ComparisonOperator.GREATER_THAN_THRESHOLD;
@@ -26,6 +28,16 @@ export class AlarmDefinitionBuilder<TConstruct> {
 
   metric(factory: (construct: TConstruct) => Metric): this {
     this.#metricFactory = factory;
+    return this;
+  }
+
+  /**
+   * Sets an explicit CloudWatch alarm name. When unset, {@link createAlarms}
+   * derives a default from the stack name, builder id, and alarm key. Use
+   * the {@link alarmName} helper to construct branded values.
+   */
+  alarmName(name: AlarmName): this {
+    this.#alarmName = name;
     return this;
   }
 
@@ -89,6 +101,7 @@ export class AlarmDefinitionBuilder<TConstruct> {
 
     const definition: AlarmDefinition = {
       key: this.#key,
+      alarmName: this.#alarmName,
       metric: this.#metricFactory(construct),
       threshold: this.#threshold,
       comparisonOperator: this.#comparisonOperator,

--- a/packages/cloudwatch/src/alarm-definition.ts
+++ b/packages/cloudwatch/src/alarm-definition.ts
@@ -1,11 +1,16 @@
 import type { ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmName } from "./alarm-name.js";
 
 /**
  * A fully-resolved alarm descriptor. All fields are required —
  * this is the canonical form consumed by {@link createAlarms}.
+ *
+ * `alarmName` is the only optional field: when omitted, {@link createAlarms}
+ * derives a default via `defaultAlarmName(scope, id, key)`.
  */
 export interface AlarmDefinition {
   key: string;
+  alarmName?: AlarmName;
   metric: Metric;
   threshold: number;
   comparisonOperator: ComparisonOperator;

--- a/packages/cloudwatch/src/alarm-name.ts
+++ b/packages/cloudwatch/src/alarm-name.ts
@@ -48,9 +48,6 @@ export function joinAlarmName(segments: readonly string[], sep = "/"): AlarmName
 /**
  * Lower-cases and hyphenates a string: splits camelCase / PascalCase /
  * snake_case / dotted boundaries into hyphen-separated lowercase words.
- *
- * Exported so consumers can compose names with the same convention used
- * by {@link defaultAlarmName}.
  */
 export function kebab(input: string): string {
   return input

--- a/packages/cloudwatch/src/alarm-name.ts
+++ b/packages/cloudwatch/src/alarm-name.ts
@@ -1,0 +1,63 @@
+declare const alarmNameBrand: unique symbol;
+
+/**
+ * A validated CloudWatch alarm name. Construct via {@link alarmName} or
+ * {@link joinAlarmName}; the brand prevents bare strings from being passed
+ * where an `AlarmName` is required.
+ */
+export type AlarmName = string & { readonly [alarmNameBrand]: true };
+
+const VALID_CHARS = /^[A-Za-z0-9\-_./#:()+ =@]+$/;
+const MAX_LEN = 255;
+
+/**
+ * Validates and brands a string as an {@link AlarmName}. The string is used
+ * verbatim — no sanitisation — so what the caller writes is exactly what
+ * appears in CloudWatch.
+ *
+ * @throws If the input is empty, exceeds 255 chars, or contains characters
+ * outside CloudWatch's allowed set: `[A-Za-z0-9-_./#:()+ =@]`.
+ */
+export function alarmName(input: string): AlarmName {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    throw new Error("alarm name cannot be empty");
+  }
+  if (trimmed.length > MAX_LEN) {
+    throw new Error(`alarm name exceeds ${String(MAX_LEN)} chars: "${trimmed}"`);
+  }
+  if (!VALID_CHARS.test(trimmed)) {
+    throw new Error(
+      `alarm name contains invalid characters (allowed: A-Z a-z 0-9 - _ . / # : ( ) + = @ space): "${trimmed}"`,
+    );
+  }
+  return trimmed as AlarmName;
+}
+
+/**
+ * Builds an {@link AlarmName} by kebab-casing each segment and joining with
+ * `sep`. Empty segments after kebab-casing are dropped, so callers can pass
+ * e.g. `Stack.of(scope).stackName` without worrying about token-resolution
+ * artefacts.
+ */
+export function joinAlarmName(segments: readonly string[], sep = "/"): AlarmName {
+  const parts = segments.map(kebab).filter((s) => s.length > 0);
+  return alarmName(parts.join(sep));
+}
+
+/**
+ * Lower-cases and hyphenates a string: splits camelCase / PascalCase /
+ * snake_case / dotted boundaries into hyphen-separated lowercase words.
+ *
+ * Exported so consumers can compose names with the same convention used
+ * by {@link defaultAlarmName}.
+ */
+export function kebab(input: string): string {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .replace(/[_\s.]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}

--- a/packages/cloudwatch/src/create-alarms.ts
+++ b/packages/cloudwatch/src/create-alarms.ts
@@ -1,6 +1,7 @@
 import { Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import type { IConstruct } from "constructs";
 import type { AlarmDefinition } from "./alarm-definition.js";
+import { defaultAlarmName } from "./default-alarm-name.js";
 
 function capitalize(s: string): string {
   return s[0].toUpperCase() + s.slice(1);
@@ -9,10 +10,13 @@ function capitalize(s: string): string {
 /**
  * Creates CDK {@link Alarm} constructs from fully-resolved {@link AlarmDefinition}s.
  *
- * Validates that all definition keys are unique before creating alarms.
+ * Validates that all definition keys are unique before creating alarms. Each
+ * alarm's `AlarmName` is taken verbatim from `def.alarmName` when supplied;
+ * otherwise it is derived from the scope, `id`, and `def.key` via
+ * {@link defaultAlarmName}.
  *
  * @param scope - CDK construct scope.
- * @param id - Base identifier; each alarm ID is `${id}${Capitalize(key)}Alarm`.
+ * @param id - Base identifier; each alarm's construct id is `${id}${Capitalize(key)}Alarm`.
  * @param definitions - Fully-resolved alarm definitions.
  * @returns A record mapping each definition's key to its created Alarm.
  * @throws If duplicate keys are found in the definitions.
@@ -32,6 +36,7 @@ export function createAlarms(
       );
     }
     alarms[def.key] = def.metric.createAlarm(scope, `${id}${capitalize(def.key)}Alarm`, {
+      alarmName: def.alarmName ?? defaultAlarmName(scope, id, def.key),
       threshold: def.threshold,
       evaluationPeriods: def.evaluationPeriods,
       datapointsToAlarm: def.datapointsToAlarm,

--- a/packages/cloudwatch/src/default-alarm-name.ts
+++ b/packages/cloudwatch/src/default-alarm-name.ts
@@ -1,0 +1,18 @@
+import { Stack } from "aws-cdk-lib";
+import type { IConstruct } from "constructs";
+import { type AlarmName, joinAlarmName } from "./alarm-name.js";
+
+/**
+ * Builds a human-readable, stack-scoped {@link AlarmName} from the alarm's
+ * scope, base id, and key.
+ *
+ * Format: `${stackName}/${kebab(id)}/${kebab(key)}`. Slashes are valid in
+ * CloudWatch alarm names and render hierarchy clearly in the console.
+ *
+ * Used by {@link createAlarms} as the fallback whenever an explicit
+ * `alarmName` is not supplied on the {@link AlarmDefinition}.
+ */
+export function defaultAlarmName(scope: IConstruct, id: string, key: string): AlarmName {
+  const stackName = Stack.of(scope).stackName;
+  return joinAlarmName([stackName, id, key]);
+}

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -1,10 +1,19 @@
-export type { AlarmConfig } from "./alarm-config.js";
+export type { AlarmConfig, AlarmConfigDefaults } from "./alarm-config.js";
 export type { AlarmDefinition } from "./alarm-definition.js";
 export { AlarmDefinitionBuilder } from "./alarm-definition-builder.js";
+export { type AlarmName, alarmName, joinAlarmName, kebab } from "./alarm-name.js";
+export { defaultAlarmName } from "./default-alarm-name.js";
 export { createAlarms } from "./create-alarms.js";
 export { resolveAlarmConfig, type ResolvedAlarmConfig } from "./resolve-alarm-config.js";
 export { alarmActionsPolicy } from "./policies/alarm-actions-policy.js";
 export type {
   AlarmActionsPolicyConfig,
   AlarmMatchContext,
+  AlarmMatcher,
 } from "./policies/alarm-actions-policy.js";
+export {
+  alarmNamePolicy,
+  type AlarmNamePolicyConfig,
+  type AlarmNameRule,
+  type AlarmNameTransformContext,
+} from "./policies/alarm-name-policy.js";

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -1,7 +1,7 @@
 export type { AlarmConfig, AlarmConfigDefaults } from "./alarm-config.js";
 export type { AlarmDefinition } from "./alarm-definition.js";
 export { AlarmDefinitionBuilder } from "./alarm-definition-builder.js";
-export { type AlarmName, alarmName, joinAlarmName } from "./alarm-name.js";
+export { type AlarmName, alarmName } from "./alarm-name.js";
 export { defaultAlarmName } from "./default-alarm-name.js";
 export { createAlarms } from "./create-alarms.js";
 export { resolveAlarmConfig, type ResolvedAlarmConfig } from "./resolve-alarm-config.js";

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -1,7 +1,7 @@
 export type { AlarmConfig, AlarmConfigDefaults } from "./alarm-config.js";
 export type { AlarmDefinition } from "./alarm-definition.js";
 export { AlarmDefinitionBuilder } from "./alarm-definition-builder.js";
-export { type AlarmName, alarmName, joinAlarmName, kebab } from "./alarm-name.js";
+export { type AlarmName, alarmName, joinAlarmName } from "./alarm-name.js";
 export { defaultAlarmName } from "./default-alarm-name.js";
 export { createAlarms } from "./create-alarms.js";
 export { resolveAlarmConfig, type ResolvedAlarmConfig } from "./resolve-alarm-config.js";

--- a/packages/cloudwatch/src/policies/alarm-actions-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-actions-policy.ts
@@ -6,29 +6,10 @@ import {
   type IAlarmAction,
 } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
+import { type AlarmRuleScope, ruleMatches } from "./policy-matcher.js";
+import type { AlarmMatchContext } from "./policy-matcher.js";
 
-/**
- * Selects which alarms a rule applies to.
- *
- * - `string` — substring match against the alarm's `id` OR `path`.
- * - `RegExp` — tested against `path`.
- * - predicate — receives the full {@link AlarmMatchContext}.
- */
-export type AlarmMatcher = string | RegExp | ((ctx: AlarmMatchContext) => boolean);
-
-/**
- * Context passed to matcher predicates and derived for every visited alarm.
- *
- * `id` and `path` come from the L2 alarm when one is present, otherwise from
- * the L1 `CfnAlarm` / `CfnCompositeAlarm`.
- */
-export interface AlarmMatchContext {
-  readonly alarm: IAlarm | undefined;
-  readonly cfn: CfnAlarm | CfnCompositeAlarm;
-  readonly id: string;
-  readonly path: string;
-  readonly isComposite: boolean;
-}
+export type { AlarmMatchContext, AlarmMatcher } from "./policy-matcher.js";
 
 /** A set of actions, one array per alarm state. All arrays are optional. */
 export interface AlarmActionSet {
@@ -38,15 +19,9 @@ export interface AlarmActionSet {
 }
 
 /** A rule: a matcher (or matchers) plus an action set, with optional scoping flags. */
-export interface AlarmActionRule extends AlarmActionSet {
-  /** Matcher(s). A rule matches when **any** supplied matcher matches. */
-  match: AlarmMatcher | AlarmMatcher[];
+export interface AlarmActionRule extends AlarmActionSet, AlarmRuleScope {
   /** When this rule matches, suppress `defaults` for the alarm. */
   replaceDefaults?: boolean;
-  /** Apply only to single (non-composite) alarms. */
-  singleOnly?: boolean;
-  /** Apply only to composite alarms. */
-  compositeOnly?: boolean;
 }
 
 /** Configuration for {@link alarmActionsPolicy}. */
@@ -84,19 +59,6 @@ function isAlreadyConfigured(cfn: CfnAlarm | CfnCompositeAlarm): boolean {
   if (resolved === undefined || resolved === null) return false;
   if (Array.isArray(resolved)) return resolved.length > 0;
   return true;
-}
-
-function matchesOne(matcher: AlarmMatcher, ctx: AlarmMatchContext): boolean {
-  if (typeof matcher === "function") return matcher(ctx);
-  if (matcher instanceof RegExp) return matcher.test(ctx.path);
-  return ctx.id.includes(matcher) || ctx.path.includes(matcher);
-}
-
-function ruleMatches(rule: AlarmActionRule, ctx: AlarmMatchContext): boolean {
-  if (rule.singleOnly === true && ctx.isComposite) return false;
-  if (rule.compositeOnly === true && !ctx.isComposite) return false;
-  const matchers = Array.isArray(rule.match) ? rule.match : [rule.match];
-  return matchers.some((m) => matchesOne(m, ctx));
 }
 
 function dedupe<T>(items: readonly T[]): T[] {

--- a/packages/cloudwatch/src/policies/alarm-name-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-name-policy.ts
@@ -1,0 +1,169 @@
+import { Aspects, Stack } from "aws-cdk-lib";
+import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { type IConstruct } from "constructs";
+import { type AlarmName, alarmName as brandAlarmName } from "../alarm-name.js";
+import type { AlarmMatchContext, AlarmMatcher } from "./alarm-actions-policy.js";
+
+/** Context passed to {@link AlarmNameRule.transform}. */
+export interface AlarmNameTransformContext extends AlarmMatchContext {
+  /**
+   * The alarm name as it stands at the moment this rule's transform runs:
+   * the original alarm name plus any prefix/suffix decorations contributed
+   * by `defaults` and earlier matched rules.
+   */
+  readonly currentName: string;
+}
+
+/**
+ * A rule for {@link alarmNamePolicy}. A rule matches when **any** supplied
+ * matcher matches.
+ *
+ * - `prefix` / `suffix` decorate the current name.
+ * - `transform` produces a new name from scratch and wins over `prefix`/`suffix`
+ *   when both are set on the same rule.
+ * - Multiple matched rules layer in declaration order.
+ */
+export interface AlarmNameRule {
+  /** Matcher(s). A rule matches when **any** supplied matcher matches. */
+  match: AlarmMatcher | AlarmMatcher[];
+  /** Prepended to the current name with the configured separator. */
+  prefix?: string;
+  /** Appended to the current name with the configured separator. */
+  suffix?: string;
+  /** Full transform — wins over `prefix`/`suffix` on the same rule. */
+  transform?: (ctx: AlarmNameTransformContext) => AlarmName;
+  /** When `true`, this rule's `prefix`/`suffix` replace `defaults` rather than layering on top. */
+  replaceDefaults?: boolean;
+  /** Apply only to single (non-composite) alarms. */
+  singleOnly?: boolean;
+  /** Apply only to composite alarms. */
+  compositeOnly?: boolean;
+}
+
+/** Configuration for {@link alarmNamePolicy}. */
+export interface AlarmNamePolicyConfig {
+  /** Decorations applied to every alarm unless a matching rule sets `replaceDefaults: true`. */
+  defaults?: Pick<AlarmNameRule, "prefix" | "suffix">;
+  /** Ordered list of rules. All matching rules contribute. */
+  rules?: AlarmNameRule[];
+  /**
+   * Separator between prefix / current-name / suffix segments.
+   * @default "-"
+   */
+  separator?: string;
+}
+
+function matchesOne(matcher: AlarmMatcher, ctx: AlarmMatchContext): boolean {
+  if (typeof matcher === "function") return matcher(ctx);
+  if (matcher instanceof RegExp) return matcher.test(ctx.path);
+  return ctx.id.includes(matcher) || ctx.path.includes(matcher);
+}
+
+function ruleMatches(rule: AlarmNameRule, ctx: AlarmMatchContext): boolean {
+  if (rule.singleOnly === true && ctx.isComposite) return false;
+  if (rule.compositeOnly === true && !ctx.isComposite) return false;
+  const matchers = Array.isArray(rule.match) ? rule.match : [rule.match];
+  return matchers.some((m) => matchesOne(m, ctx));
+}
+
+function decorate(
+  current: string,
+  prefix: string | undefined,
+  suffix: string | undefined,
+  sep: string,
+): string {
+  const parts: string[] = [];
+  if (prefix !== undefined && prefix.length > 0) parts.push(prefix);
+  parts.push(current);
+  if (suffix !== undefined && suffix.length > 0) parts.push(suffix);
+  return parts.join(sep);
+}
+
+function resolveAlarmName(cfn: CfnAlarm | CfnCompositeAlarm): string | undefined {
+  const value = cfn.alarmName;
+  if (value === undefined) return undefined;
+  const resolved: unknown = Stack.of(cfn).resolve(value);
+  return typeof resolved === "string" ? resolved : undefined;
+}
+
+/**
+ * Decorates CloudWatch alarm names across an entire scope.
+ *
+ * Installs a CDK
+ * {@link https://docs.aws.amazon.com/cdk/v2/guide/aspects.html | Aspect}
+ * that fires during the synth prepare phase. For every `AWS::CloudWatch::Alarm`
+ * (and `AWS::CloudWatch::CompositeAlarm`) found beneath `scope`:
+ *
+ * 1. The alarm's existing name is read (set by the library default or the
+ *    consumer's per-alarm override).
+ * 2. `defaults.prefix` / `defaults.suffix` decorate it, unless a matched
+ *    rule sets `replaceDefaults: true`.
+ * 3. Each matching rule contributes in declaration order — `transform`
+ *    replaces the current name; otherwise `prefix`/`suffix` decorate.
+ * 4. The final value is validated via {@link alarmName} and written back to
+ *    `cfn.alarmName`.
+ *
+ * Use cases: stage prefixing (`prod-…`), severity tagging (`…-critical`),
+ * team scoping. Composes with per-alarm `alarmName` overrides — those run
+ * first, the policy decorates the result.
+ *
+ * @example
+ * ```ts
+ * alarmNamePolicy(app, {
+ *   defaults: { prefix: "prod" },
+ *   rules: [
+ *     { match: /Errors$/, suffix: "critical" },
+ *     { match: "throttles", suffix: "warning" },
+ *   ],
+ * });
+ * ```
+ */
+export function alarmNamePolicy(scope: IConstruct, config: AlarmNamePolicyConfig): void {
+  const { defaults, rules = [], separator = "-" } = config;
+  const processed = new WeakSet<CfnAlarm | CfnCompositeAlarm>();
+
+  Aspects.of(scope).add({
+    visit(node: IConstruct): void {
+      const isAlarm = CfnAlarm.isCfnAlarm(node);
+      const isComposite = CfnCompositeAlarm.isCfnCompositeAlarm(node);
+      if (!isAlarm && !isComposite) return;
+      const cfn = node;
+      if (processed.has(cfn)) return;
+
+      const original = resolveAlarmName(cfn);
+      if (original === undefined) return;
+
+      const parent = cfn.node.scope;
+      const ctx: AlarmMatchContext = {
+        alarm: undefined,
+        cfn,
+        id: parent?.node.id ?? cfn.node.id,
+        path: parent?.node.path ?? cfn.node.path,
+        isComposite,
+      };
+
+      const matched = rules.filter((r) => ruleMatches(r, ctx));
+      const replaceDefaults = matched.some((r) => r.replaceDefaults === true);
+
+      let current = original;
+
+      if (defaults !== undefined && !replaceDefaults) {
+        current = decorate(current, defaults.prefix, defaults.suffix, separator);
+      }
+
+      for (const rule of matched) {
+        if (rule.transform !== undefined) {
+          current = rule.transform({ ...ctx, currentName: current });
+          continue;
+        }
+        current = decorate(current, rule.prefix, rule.suffix, separator);
+      }
+
+      if (current === original) return;
+
+      const validated: AlarmName = brandAlarmName(current);
+      cfn.alarmName = validated;
+      processed.add(cfn);
+    },
+  });
+}

--- a/packages/cloudwatch/src/policies/alarm-name-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-name-policy.ts
@@ -2,7 +2,7 @@ import { Aspects, Stack } from "aws-cdk-lib";
 import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
 import { type AlarmName, alarmName as brandAlarmName } from "../alarm-name.js";
-import type { AlarmMatchContext, AlarmMatcher } from "./alarm-actions-policy.js";
+import { type AlarmMatchContext, type AlarmRuleScope, ruleMatches } from "./policy-matcher.js";
 
 /** Context passed to {@link AlarmNameRule.transform}. */
 export interface AlarmNameTransformContext extends AlarmMatchContext {
@@ -23,9 +23,7 @@ export interface AlarmNameTransformContext extends AlarmMatchContext {
  *   when both are set on the same rule.
  * - Multiple matched rules layer in declaration order.
  */
-export interface AlarmNameRule {
-  /** Matcher(s). A rule matches when **any** supplied matcher matches. */
-  match: AlarmMatcher | AlarmMatcher[];
+export interface AlarmNameRule extends AlarmRuleScope {
   /** Prepended to the current name with the configured separator. */
   prefix?: string;
   /** Appended to the current name with the configured separator. */
@@ -34,10 +32,6 @@ export interface AlarmNameRule {
   transform?: (ctx: AlarmNameTransformContext) => AlarmName;
   /** When `true`, this rule's `prefix`/`suffix` replace `defaults` rather than layering on top. */
   replaceDefaults?: boolean;
-  /** Apply only to single (non-composite) alarms. */
-  singleOnly?: boolean;
-  /** Apply only to composite alarms. */
-  compositeOnly?: boolean;
 }
 
 /** Configuration for {@link alarmNamePolicy}. */
@@ -51,19 +45,6 @@ export interface AlarmNamePolicyConfig {
    * @default "-"
    */
   separator?: string;
-}
-
-function matchesOne(matcher: AlarmMatcher, ctx: AlarmMatchContext): boolean {
-  if (typeof matcher === "function") return matcher(ctx);
-  if (matcher instanceof RegExp) return matcher.test(ctx.path);
-  return ctx.id.includes(matcher) || ctx.path.includes(matcher);
-}
-
-function ruleMatches(rule: AlarmNameRule, ctx: AlarmMatchContext): boolean {
-  if (rule.singleOnly === true && ctx.isComposite) return false;
-  if (rule.compositeOnly === true && !ctx.isComposite) return false;
-  const matchers = Array.isArray(rule.match) ? rule.match : [rule.match];
-  return matchers.some((m) => matchesOne(m, ctx));
 }
 
 function decorate(

--- a/packages/cloudwatch/src/policies/policy-matcher.ts
+++ b/packages/cloudwatch/src/policies/policy-matcher.ts
@@ -1,0 +1,44 @@
+import type { CfnAlarm, CfnCompositeAlarm, IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+
+/**
+ * Selects which alarms a rule applies to.
+ *
+ * - `string` — substring match against the alarm's `id` OR `path`.
+ * - `RegExp` — tested against `path`.
+ * - predicate — receives the full {@link AlarmMatchContext}.
+ */
+export type AlarmMatcher = string | RegExp | ((ctx: AlarmMatchContext) => boolean);
+
+/**
+ * Context passed to matcher predicates and derived for every visited alarm.
+ *
+ * `id` and `path` come from the L2 alarm when one is present, otherwise from
+ * the L1 `CfnAlarm` / `CfnCompositeAlarm`.
+ */
+export interface AlarmMatchContext {
+  readonly alarm: IAlarm | undefined;
+  readonly cfn: CfnAlarm | CfnCompositeAlarm;
+  readonly id: string;
+  readonly path: string;
+  readonly isComposite: boolean;
+}
+
+/** Common scoping flags shared by every alarm-policy rule shape. */
+export interface AlarmRuleScope {
+  match: AlarmMatcher | AlarmMatcher[];
+  singleOnly?: boolean;
+  compositeOnly?: boolean;
+}
+
+export function matchesOne(matcher: AlarmMatcher, ctx: AlarmMatchContext): boolean {
+  if (typeof matcher === "function") return matcher(ctx);
+  if (matcher instanceof RegExp) return matcher.test(ctx.path);
+  return ctx.id.includes(matcher) || ctx.path.includes(matcher);
+}
+
+export function ruleMatches(rule: AlarmRuleScope, ctx: AlarmMatchContext): boolean {
+  if (rule.singleOnly === true && ctx.isComposite) return false;
+  if (rule.compositeOnly === true && !ctx.isComposite) return false;
+  const matchers = Array.isArray(rule.match) ? rule.match : [rule.match];
+  return matchers.some((m) => matchesOne(m, ctx));
+}

--- a/packages/cloudwatch/src/resolve-alarm-config.ts
+++ b/packages/cloudwatch/src/resolve-alarm-config.ts
@@ -1,12 +1,17 @@
 import type { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "./alarm-config.js";
+import type { AlarmConfig, AlarmConfigDefaults } from "./alarm-config.js";
+import type { AlarmName } from "./alarm-name.js";
 
 /**
- * A fully-resolved alarm configuration where every field is required.
- * Produced by {@link resolveAlarmConfig} after merging user overrides
- * onto defaults.
+ * A fully-resolved alarm configuration. Every numeric/enum field is required;
+ * `alarmName` is carried through verbatim from user config (or `undefined`
+ * when the consumer is happy with the library default).
+ *
+ * Produced by {@link resolveAlarmConfig} after merging user overrides onto
+ * defaults.
  */
 export interface ResolvedAlarmConfig {
+  alarmName?: AlarmName;
   threshold: number;
   evaluationPeriods: number;
   datapointsToAlarm: number;
@@ -15,13 +20,15 @@ export interface ResolvedAlarmConfig {
 
 /**
  * Resolves an absolute-threshold alarm config by layering user overrides
- * onto the defaults.
+ * onto the defaults. `alarmName` is propagated from user config only;
+ * defaults intentionally do not specify a name.
  */
 export function resolveAlarmConfig(
   userConfig: AlarmConfig | undefined,
-  defaults: Required<AlarmConfig>,
+  defaults: AlarmConfigDefaults,
 ): ResolvedAlarmConfig {
   return {
+    alarmName: userConfig?.alarmName,
     threshold: userConfig?.threshold ?? defaults.threshold,
     evaluationPeriods: userConfig?.evaluationPeriods ?? defaults.evaluationPeriods,
     datapointsToAlarm: userConfig?.datapointsToAlarm ?? defaults.datapointsToAlarm,

--- a/packages/cloudwatch/test/alarm-definition-builder.test.ts
+++ b/packages/cloudwatch/test/alarm-definition-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Duration } from "aws-cdk-lib";
 import { ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { AlarmDefinitionBuilder } from "../src/alarm-definition-builder.js";
+import { alarmName } from "../src/alarm-name.js";
 
 describe("AlarmDefinitionBuilder", () => {
   it("produces a correct definition with all fields set", () => {
@@ -101,6 +102,25 @@ describe("AlarmDefinitionBuilder", () => {
       .resolve("unused");
 
     expect(definition.description).toBe("Alert when count >= 42");
+  });
+
+  it("propagates alarmName when set", () => {
+    const metric = new Metric({ namespace: "Test", metricName: "Count" });
+    const definition = new AlarmDefinitionBuilder<string>("custom")
+      .metric(() => metric)
+      .alarmName(alarmName("payments-prod-errors"))
+      .resolve("unused");
+
+    expect(definition.alarmName).toBe("payments-prod-errors");
+  });
+
+  it("leaves alarmName undefined by default", () => {
+    const metric = new Metric({ namespace: "Test", metricName: "Count" });
+    const definition = new AlarmDefinitionBuilder<string>("noName")
+      .metric(() => metric)
+      .resolve("unused");
+
+    expect(definition.alarmName).toBeUndefined();
   });
 
   it("supports all comparison operators", () => {

--- a/packages/cloudwatch/test/alarm-name-policy.test.ts
+++ b/packages/cloudwatch/test/alarm-name-policy.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { Template } from "aws-cdk-lib/assertions";
+import { alarmName } from "../src/alarm-name.js";
+import { alarmNamePolicy } from "../src/policies/alarm-name-policy.js";
+
+function makeMetric(): Metric {
+  return new Metric({ namespace: "Test", metricName: "Count", period: Duration.minutes(1) });
+}
+
+function makeAlarm(scope: Stack, id: string, name?: string): Alarm {
+  return new Alarm(scope, id, {
+    alarmName: name ?? id,
+    metric: makeMetric(),
+    threshold: 1,
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  });
+}
+
+function alarmNamesByLogicalId(template: Template): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [logicalId, resource] of Object.entries(
+    template.findResources("AWS::CloudWatch::Alarm"),
+  )) {
+    const props = (resource as { Properties: { AlarmName?: string } }).Properties;
+    if (props.AlarmName !== undefined) out[logicalId] = props.AlarmName;
+  }
+  return out;
+}
+
+describe("alarmNamePolicy", () => {
+  it("applies defaults.prefix to every alarm name", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+    makeAlarm(stack, "Throttles", "stack/svc/throttles");
+
+    alarmNamePolicy(app, { defaults: { prefix: "prod" } });
+
+    const names = alarmNamesByLogicalId(Template.fromStack(stack));
+    for (const name of Object.values(names)) {
+      expect(name.startsWith("prod-")).toBe(true);
+    }
+  });
+
+  it("applies defaults.suffix", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+
+    alarmNamePolicy(app, { defaults: { suffix: "v1" } });
+
+    const names = alarmNamesByLogicalId(Template.fromStack(stack));
+    expect(Object.values(names)).toContain("stack/svc/errors-v1");
+  });
+
+  it("layers matching rule decoration on top of defaults", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+    makeAlarm(stack, "Throttles", "stack/svc/throttles");
+
+    alarmNamePolicy(app, {
+      defaults: { prefix: "prod" },
+      rules: [{ match: "Errors", suffix: "critical" }],
+    });
+
+    const names = alarmNamesByLogicalId(Template.fromStack(stack));
+    expect(Object.values(names)).toContain("prod-stack/svc/errors-critical");
+    expect(Object.values(names)).toContain("prod-stack/svc/throttles");
+  });
+
+  it("supports a custom separator", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+
+    alarmNamePolicy(app, { defaults: { prefix: "prod" }, separator: "_" });
+
+    const names = alarmNamesByLogicalId(Template.fromStack(stack));
+    expect(Object.values(names)).toContain("prod_stack/svc/errors");
+  });
+
+  it("transform replaces the current name and wins over prefix/suffix on the same rule", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+
+    alarmNamePolicy(app, {
+      defaults: { prefix: "prod" },
+      rules: [
+        {
+          match: "Errors",
+          prefix: "ignored",
+          suffix: "ignored",
+          transform: (ctx) => alarmName(`${ctx.currentName}-payments`),
+        },
+      ],
+    });
+
+    const names = alarmNamesByLogicalId(Template.fromStack(stack));
+    expect(Object.values(names)).toContain("prod-stack/svc/errors-payments");
+  });
+
+  it("replaceDefaults: true skips the default decoration for matched alarms", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+    makeAlarm(stack, "Throttles", "stack/svc/throttles");
+
+    alarmNamePolicy(app, {
+      defaults: { prefix: "prod" },
+      rules: [{ match: "Errors", prefix: "team-x", replaceDefaults: true }],
+    });
+
+    const names = alarmNamesByLogicalId(Template.fromStack(stack));
+    expect(Object.values(names)).toContain("team-x-stack/svc/errors");
+    expect(Object.values(names)).toContain("prod-stack/svc/throttles");
+  });
+
+  it("matches via regex against path", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "PaymentsErrors", "stack/svc/errors");
+    makeAlarm(stack, "OrdersErrors", "stack/svc/errors-orders");
+
+    alarmNamePolicy(app, {
+      rules: [{ match: /Payments/, suffix: "critical" }],
+    });
+
+    const names = alarmNamesByLogicalId(Template.fromStack(stack));
+    const paymentsName = Object.entries(names).find(([id]) => id.startsWith("PaymentsErrors"))?.[1];
+    const ordersName = Object.entries(names).find(([id]) => id.startsWith("OrdersErrors"))?.[1];
+    expect(paymentsName).toBe("stack/svc/errors-critical");
+    expect(ordersName).toBe("stack/svc/errors-orders");
+  });
+
+  it("ignores alarms with no AlarmName set", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new Alarm(stack, "NoName", {
+      metric: makeMetric(),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+    });
+
+    alarmNamePolicy(app, { defaults: { prefix: "prod" } });
+
+    // No throw, no name set.
+    const template = Template.fromStack(stack);
+    for (const resource of Object.values(template.findResources("AWS::CloudWatch::Alarm"))) {
+      const props = (resource as { Properties: { AlarmName?: string } }).Properties;
+      expect(props.AlarmName).toBeUndefined();
+    }
+  });
+
+  it("throws when the resulting name has invalid characters", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+
+    alarmNamePolicy(app, { defaults: { suffix: "bad!suffix" } });
+
+    expect(() => Template.fromStack(stack)).toThrow(/invalid characters/);
+  });
+});

--- a/packages/cloudwatch/test/alarm-name.test.ts
+++ b/packages/cloudwatch/test/alarm-name.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { alarmName, joinAlarmName, kebab } from "../src/alarm-name.js";
+
+describe("alarmName", () => {
+  it("returns the input verbatim when valid", () => {
+    expect(alarmName("payments-prod/lambda/errors")).toBe("payments-prod/lambda/errors");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(alarmName("  foo-bar  ")).toBe("foo-bar");
+  });
+
+  it("rejects empty input", () => {
+    expect(() => alarmName("")).toThrow(/empty/);
+    expect(() => alarmName("   ")).toThrow(/empty/);
+  });
+
+  it("rejects names longer than 255 chars", () => {
+    expect(() => alarmName("x".repeat(256))).toThrow(/255/);
+  });
+
+  it("accepts the full CloudWatch character set", () => {
+    expect(() => alarmName("abc-_./#:()+ =@123")).not.toThrow();
+  });
+
+  it("rejects characters outside CloudWatch's allowed set", () => {
+    expect(() => alarmName("oops!")).toThrow(/invalid characters/);
+    expect(() => alarmName("a&b")).toThrow(/invalid characters/);
+    expect(() => alarmName("a\nb")).toThrow(/invalid characters/);
+  });
+});
+
+describe("kebab", () => {
+  it.each([
+    ["camelCase", "camel-case"],
+    ["PascalCase", "pascal-case"],
+    ["snake_case", "snake-case"],
+    ["dotted.name", "dotted-name"],
+    ["space separated", "space-separated"],
+    ["numberOfNotificationsFailed", "number-of-notifications-failed"],
+    ["HTTPServer", "http-server"],
+    ["XMLParser", "xml-parser"],
+    ["already-kebab", "already-kebab"],
+    ["UPPER", "upper"],
+    ["ABCDef", "abc-def"],
+    ["", ""],
+    ["__leading_trailing__", "leading-trailing"],
+  ])("kebabs %p as %p", (input, expected) => {
+    expect(kebab(input)).toBe(expected);
+  });
+});
+
+describe("joinAlarmName", () => {
+  it("joins kebabed segments with the default '/' separator", () => {
+    expect(joinAlarmName(["MyStack", "siteAlerts", "numberOfNotificationsFailed"])).toBe(
+      "my-stack/site-alerts/number-of-notifications-failed",
+    );
+  });
+
+  it("supports a custom separator", () => {
+    expect(joinAlarmName(["MyStack", "siteAlerts", "errors"], "-")).toBe(
+      "my-stack-site-alerts-errors",
+    );
+  });
+
+  it("drops empty segments after kebabing", () => {
+    expect(joinAlarmName(["", "siteAlerts", "errors"])).toBe("site-alerts/errors");
+  });
+
+  it("validates the result", () => {
+    expect(() => joinAlarmName([])).toThrow(/empty/);
+  });
+});

--- a/packages/cloudwatch/test/create-alarms.test.ts
+++ b/packages/cloudwatch/test/create-alarms.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { Template } from "aws-cdk-lib/assertions";
+import { alarmName } from "../src/alarm-name.js";
 import { createAlarms } from "../src/create-alarms.js";
 import type { AlarmDefinition } from "../src/alarm-definition.js";
 
@@ -64,6 +65,25 @@ describe("createAlarms", () => {
     const alarms = template.findResources("AWS::CloudWatch::Alarm");
     const logicalIds = Object.keys(alarms);
     expect(logicalIds.some((id) => id.startsWith("MyFuncErrorsAlarm"))).toBe(true);
+  });
+
+  it("derives a default AlarmName from stack/id/key when none is supplied", () => {
+    const stack = new Stack(new App(), "MyServiceStack");
+    createAlarms(stack, "siteAlerts", [makeDefinition({ key: "errors" })]);
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "my-service-stack/site-alerts/errors",
+    });
+  });
+
+  it("uses an explicit alarmName verbatim when supplied on the definition", () => {
+    const stack = new Stack(new App(), "MyServiceStack");
+    createAlarms(stack, "siteAlerts", [
+      makeDefinition({ key: "errors", alarmName: alarmName("custom-name") }),
+    ]);
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "custom-name",
+    });
   });
 
   it("applies all definition properties to the alarm", () => {

--- a/packages/cloudwatch/test/default-alarm-name.test.ts
+++ b/packages/cloudwatch/test/default-alarm-name.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { defaultAlarmName } from "../src/default-alarm-name.js";
+
+describe("defaultAlarmName", () => {
+  it("produces stack/id/key with kebab-cased segments", () => {
+    const stack = new Stack(new App(), "MyServiceStack");
+    expect(defaultAlarmName(stack, "siteAlerts", "numberOfNotificationsFailed")).toBe(
+      "my-service-stack/site-alerts/number-of-notifications-failed",
+    );
+  });
+
+  it("uses Stack.of(scope), not the scope's id directly", () => {
+    const stack = new Stack(new App(), "OuterStack");
+    expect(defaultAlarmName(stack, "cdnAlarms", "errorRate")).toBe(
+      "outer-stack/cdn-alarms/error-rate",
+    );
+  });
+});

--- a/packages/cloudwatch/test/policy-matcher.test.ts
+++ b/packages/cloudwatch/test/policy-matcher.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import type { CfnAlarm, CfnCompositeAlarm, IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  type AlarmMatchContext,
+  type AlarmRuleScope,
+  matchesOne,
+  ruleMatches,
+} from "../src/policies/policy-matcher.js";
+
+function ctx(overrides: Partial<AlarmMatchContext> = {}): AlarmMatchContext {
+  return {
+    alarm: undefined as IAlarm | undefined,
+    cfn: {} as CfnAlarm | CfnCompositeAlarm,
+    id: "Errors",
+    path: "App/Stack/Service/Errors",
+    isComposite: false,
+    ...overrides,
+  };
+}
+
+describe("matchesOne", () => {
+  describe("string matcher", () => {
+    it("matches a substring of id", () => {
+      expect(matchesOne("Error", ctx({ id: "Errors", path: "unrelated" }))).toBe(true);
+    });
+
+    it("matches a substring of path", () => {
+      expect(matchesOne("Service", ctx({ id: "unrelated", path: "App/Service/Errors" }))).toBe(
+        true,
+      );
+    });
+
+    it("returns false when the substring appears in neither id nor path", () => {
+      expect(matchesOne("Throttles", ctx({ id: "Errors", path: "App/Stack/Errors" }))).toBe(false);
+    });
+
+    it("is case-sensitive", () => {
+      expect(matchesOne("errors", ctx({ id: "Errors", path: "App/Errors" }))).toBe(false);
+    });
+  });
+
+  describe("regex matcher", () => {
+    it("matches against path only, not id", () => {
+      expect(matchesOne(/Errors$/, ctx({ id: "Errors", path: "App/Service/foo" }))).toBe(false);
+      expect(matchesOne(/Errors$/, ctx({ id: "foo", path: "App/Service/Errors" }))).toBe(true);
+    });
+
+    it("supports flags", () => {
+      expect(matchesOne(/errors/i, ctx({ path: "App/Service/Errors" }))).toBe(true);
+    });
+  });
+
+  describe("predicate matcher", () => {
+    it("receives the full context and returns its result", () => {
+      const seen: AlarmMatchContext[] = [];
+      const result = matchesOne(
+        (c) => {
+          seen.push(c);
+          return c.isComposite;
+        },
+        ctx({ isComposite: true }),
+      );
+      expect(result).toBe(true);
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.isComposite).toBe(true);
+    });
+
+    it("returns false when predicate returns false", () => {
+      expect(matchesOne(() => false, ctx())).toBe(false);
+    });
+  });
+});
+
+describe("ruleMatches", () => {
+  it("returns true when a single matcher matches", () => {
+    const rule: AlarmRuleScope = { match: "Errors" };
+    expect(ruleMatches(rule, ctx({ id: "Errors" }))).toBe(true);
+  });
+
+  it("returns true when any matcher in an array matches (OR semantics)", () => {
+    const rule: AlarmRuleScope = { match: ["Throttles", /Errors$/] };
+    expect(ruleMatches(rule, ctx({ id: "foo", path: "App/Service/Errors" }))).toBe(true);
+  });
+
+  it("returns false when no matcher in an array matches", () => {
+    const rule: AlarmRuleScope = { match: ["Throttles", /Latency$/] };
+    expect(ruleMatches(rule, ctx({ id: "Errors", path: "App/Service/Errors" }))).toBe(false);
+  });
+
+  describe("singleOnly", () => {
+    it("excludes composite alarms when set", () => {
+      const rule: AlarmRuleScope = { match: "Errors", singleOnly: true };
+      expect(ruleMatches(rule, ctx({ id: "Errors", isComposite: true }))).toBe(false);
+      expect(ruleMatches(rule, ctx({ id: "Errors", isComposite: false }))).toBe(true);
+    });
+
+    it("has no effect when false or omitted", () => {
+      expect(ruleMatches({ match: "Errors", singleOnly: false }, ctx({ isComposite: true }))).toBe(
+        true,
+      );
+      expect(ruleMatches({ match: "Errors" }, ctx({ isComposite: true }))).toBe(true);
+    });
+  });
+
+  describe("compositeOnly", () => {
+    it("excludes single alarms when set", () => {
+      const rule: AlarmRuleScope = { match: "Errors", compositeOnly: true };
+      expect(ruleMatches(rule, ctx({ id: "Errors", isComposite: false }))).toBe(false);
+      expect(ruleMatches(rule, ctx({ id: "Errors", isComposite: true }))).toBe(true);
+    });
+
+    it("has no effect when false or omitted", () => {
+      expect(
+        ruleMatches({ match: "Errors", compositeOnly: false }, ctx({ isComposite: false })),
+      ).toBe(true);
+      expect(ruleMatches({ match: "Errors" }, ctx({ isComposite: false }))).toBe(true);
+    });
+  });
+
+  it("scope filters short-circuit before matchers run", () => {
+    let called = false;
+    const rule: AlarmRuleScope = {
+      match: () => {
+        called = true;
+        return true;
+      },
+      singleOnly: true,
+    };
+    ruleMatches(rule, ctx({ isComposite: true }));
+    expect(called).toBe(false);
+  });
+});

--- a/packages/examples/test/__snapshots__/dual-function-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/dual-function-app.test.ts.snap
@@ -24,6 +24,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "SNS topic is failing to deliver notifications. Threshold: > 0 failures in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/alerts/number-of-notifications-failed",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -55,6 +56,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "SNS topic failed to redrive a message to a subscription dead-letter queue; messages may be lost. Threshold: > 0 failed redrives in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/alerts/number-of-notifications-failed-to-redrive-to-dlq",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -86,6 +88,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "SNS topic messages are being filtered out due to invalid subscription filter policy attributes. Threshold: > 0 filtered messages in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/alerts/number-of-notifications-filtered-out-invalid-attributes",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -117,6 +120,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "SNS topic is redriving messages to a subscription dead-letter queue, indicating delivery failures. Threshold: > 0 redrives in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/alerts/number-of-notifications-redriven-to-dlq",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -209,6 +213,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "Lambda function p99 duration is approaching the configured timeout. Threshold: > 27000ms (90% of 30000ms timeout).",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/api/duration",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "Dimensions": [
@@ -237,6 +242,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "Lambda function is producing invocation errors. Threshold: > 0 errors in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/api/errors",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -265,6 +271,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "API receiving unusually high traffic. Threshold: >= 1000 invocations per minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/api/high-invocations",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -356,6 +363,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "Lambda function invocations are being throttled. Threshold: > 0 throttles in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/api/throttles",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -417,6 +425,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "Lambda function concurrent executions approaching reserved concurrency limit. Threshold: >= 40 (80% of 50 reserved).",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker/concurrent-executions",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "DatapointsToAlarm": 3,
         "Dimensions": [
@@ -445,6 +454,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "Lambda function p99 duration is approaching the configured timeout. Threshold: > 270000ms (90% of 300000ms timeout).",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker/duration",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "Dimensions": [
@@ -473,6 +483,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "Lambda function is producing invocation errors. Threshold: > 5 errors in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker/errors",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 2,
         "Dimensions": [
@@ -564,6 +575,7 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
           },
         ],
         "AlarmDescription": "Lambda function invocations are being throttled. Threshold: > 0 throttles in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker/throttles",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [

--- a/packages/examples/test/__snapshots__/mock-api-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/mock-api-app.test.ts.snap
@@ -73,6 +73,7 @@ exports[`mock-api-app > matches the expected synthesised template 1`] = `
     "MockApiAppapiClientErrorAlarmFE89E37D": {
       "Properties": {
         "AlarmDescription": "REST API client error rate is elevated. Threshold: > 5% of requests in 1 minute.",
+        "AlarmName": "composure-cdk-mock-api-stack/mock-api-app/api/client-error",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -224,6 +225,7 @@ exports[`mock-api-app > matches the expected synthesised template 1`] = `
     "MockApiAppapiLatencyAlarmBB38671F": {
       "Properties": {
         "AlarmDescription": "REST API p90 latency is elevated. Threshold: >= 2500ms in 1 minute.",
+        "AlarmName": "composure-cdk-mock-api-stack/mock-api-app/api/latency",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -251,6 +253,7 @@ exports[`mock-api-app > matches the expected synthesised template 1`] = `
     "MockApiAppapiServerErrorAlarm6503E5FE": {
       "Properties": {
         "AlarmDescription": "REST API server error rate is elevated. Threshold: > 2% of requests in 1 minute.",
+        "AlarmName": "composure-cdk-mock-api-stack/mock-api-app/api/server-error",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "Dimensions": [

--- a/packages/examples/test/__snapshots__/multi-stack-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/multi-stack-app.test.ts.snap
@@ -66,6 +66,7 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
     "MultiStackAppapiClientErrorAlarmEB102EFC": {
       "Properties": {
         "AlarmDescription": "REST API client error rate is elevated. Threshold: > 5% of requests in 1 minute.",
+        "AlarmName": "composure-cdk-multi-stack-api-stack/multi-stack-app/api/client-error",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -293,6 +294,7 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
     "MultiStackAppapiLatencyAlarm8D8FBA0C": {
       "Properties": {
         "AlarmDescription": "REST API p90 latency is elevated. Threshold: >= 2500ms in 1 minute.",
+        "AlarmName": "composure-cdk-multi-stack-api-stack/multi-stack-app/api/latency",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -320,6 +322,7 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
     "MultiStackAppapiServerErrorAlarm04133ED9": {
       "Properties": {
         "AlarmDescription": "REST API server error rate is elevated. Threshold: > 5% of requests in 1 minute.",
+        "AlarmName": "composure-cdk-multi-stack-api-stack/multi-stack-app/api/server-error",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "Dimensions": [
@@ -433,6 +436,7 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
     "MultiStackApphandlerDurationAlarm94B3212A": {
       "Properties": {
         "AlarmDescription": "Lambda function p99 duration is approaching the configured timeout. Threshold: > 27000ms (90% of 30000ms timeout).",
+        "AlarmName": "composure-cdk-multi-stack-service-stack/multi-stack-app/handler/duration",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "Dimensions": [
@@ -456,6 +460,7 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
     "MultiStackApphandlerErrorsAlarm7A72223A": {
       "Properties": {
         "AlarmDescription": "Lambda function is producing invocation errors. Threshold: > 0 errors in 1 minute.",
+        "AlarmName": "composure-cdk-multi-stack-service-stack/multi-stack-app/handler/errors",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -542,6 +547,7 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
     "MultiStackApphandlerThrottlesAlarm959649F7": {
       "Properties": {
         "AlarmDescription": "Lambda function invocations are being throttled. Threshold: > 0 throttles in 1 minute.",
+        "AlarmName": "composure-cdk-multi-stack-service-stack/multi-stack-app/handler/throttles",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [

--- a/packages/examples/test/__snapshots__/openapi-petstore-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/openapi-petstore-app.test.ts.snap
@@ -203,6 +203,7 @@ exports[`openapi-petstore-app > matches the expected synthesised template 1`] = 
     "OpenApiPetstoreAppapiClientErrorAlarm755B4262": {
       "Properties": {
         "AlarmDescription": "REST API client error rate is elevated. Threshold: > 5% of requests in 1 minute.",
+        "AlarmName": "composure-cdk-open-api-petstore-stack/open-api-petstore-app/api/client-error",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -308,6 +309,7 @@ exports[`openapi-petstore-app > matches the expected synthesised template 1`] = 
     "OpenApiPetstoreAppapiLatencyAlarm28B7B0BF": {
       "Properties": {
         "AlarmDescription": "REST API p90 latency is elevated. Threshold: >= 2500ms in 1 minute.",
+        "AlarmName": "composure-cdk-open-api-petstore-stack/open-api-petstore-app/api/latency",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -335,6 +337,7 @@ exports[`openapi-petstore-app > matches the expected synthesised template 1`] = 
     "OpenApiPetstoreAppapiServerErrorAlarm5B7B1B44": {
       "Properties": {
         "AlarmDescription": "REST API server error rate is elevated. Threshold: > 5% of requests in 1 minute.",
+        "AlarmName": "composure-cdk-open-api-petstore-stack/open-api-petstore-app/api/server-error",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "Dimensions": [

--- a/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
@@ -223,6 +223,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "SNS topic is failing to deliver notifications. Threshold: > 0 failures in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/alerts/number-of-notifications-failed",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -254,6 +255,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "SNS topic failed to redrive a message to a subscription dead-letter queue; messages may be lost. Threshold: > 0 failed redrives in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/alerts/number-of-notifications-failed-to-redrive-to-dlq",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -285,6 +287,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "SNS topic messages are being filtered out due to invalid subscription filter policy attributes. Threshold: > 0 filtered messages in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/alerts/number-of-notifications-filtered-out-invalid-attributes",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -316,6 +319,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "SNS topic is redriving messages to a subscription dead-letter queue, indicating delivery failures. Threshold: > 0 redrives in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/alerts/number-of-notifications-redriven-to-dlq",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -452,6 +456,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront Function on behavior "/api/*" (viewer-request) is raising execution errors. Threshold: > 0 errors in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/behavior-api-slash-star-viewer-request-execution-errors",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -520,6 +525,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront Function on behavior "/api/*" (viewer-request) is being throttled — likely exceeding its 1ms compute budget. Threshold: > 0 throttles in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/behavior-api-slash-star-viewer-request-throttles",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -560,6 +566,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront Function on behavior "/api/*" (viewer-request) is producing validation errors. Threshold: > 0 errors in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/behavior-api-slash-star-viewer-request-validation-errors",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -707,6 +714,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront Function on default behavior (viewer-response) is raising execution errors. Threshold: > 0 errors in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/default-behavior-viewer-response-execution-errors",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -775,6 +783,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront Function on default behavior (viewer-response) is being throttled — likely exceeding its 1ms compute budget. Threshold: > 0 throttles in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/default-behavior-viewer-response-throttles",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -815,6 +824,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront Function on default behavior (viewer-response) is producing validation errors. Threshold: > 0 errors in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/default-behavior-viewer-response-validation-errors",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -855,6 +865,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront distribution 5xx error rate is elevated. Threshold: > 2% in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/error-rate",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -902,6 +913,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "CloudFront origin latency is elevated. Threshold: > 5000ms p90 in 1 minute.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/cdn/origin-latency",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": [
@@ -1104,6 +1116,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "S3 bucket is returning client-side errors (filter: EntireBucket). Threshold: > 50 4xx errors in 5 minutes.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/site/client-errors:entire-bucket",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [
@@ -1227,6 +1240,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "AlarmDescription": "S3 bucket is returning server-side errors (filter: EntireBucket). Threshold: > 0 5xx errors in 5 minutes.",
+        "AlarmName": "composure-cdk-static-website-stack/static-website/site/server-errors:entire-bucket",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "Dimensions": [

--- a/packages/lambda/src/alarm-config.ts
+++ b/packages/lambda/src/alarm-config.ts
@@ -21,6 +21,12 @@ export type PercentageAlarmConfig = Omit<AlarmConfig, "threshold"> & {
 };
 
 /**
+ * Type for percentage-based defaults. Mirrors {@link AlarmConfigDefaults}:
+ * every tunable field is required, but `alarmName` is intentionally not.
+ */
+export type PercentageAlarmConfigDefaults = Required<Omit<PercentageAlarmConfig, "alarmName">>;
+
+/**
  * Controls which recommended alarms are created for a Lambda function.
  * All alarms are enabled by default with AWS-recommended thresholds.
  * Set individual alarms to `false` to disable them, or provide an

--- a/packages/lambda/src/alarm-defaults.ts
+++ b/packages/lambda/src/alarm-defaults.ts
@@ -1,13 +1,13 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "@composurecdk/cloudwatch";
-import type { PercentageAlarmConfig } from "./alarm-config.js";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+import type { PercentageAlarmConfigDefaults } from "./alarm-config.js";
 
 interface FunctionAlarmDefaults {
   enabled: true;
-  errors: Required<AlarmConfig>;
-  throttles: Required<AlarmConfig>;
-  duration: Required<PercentageAlarmConfig>;
-  concurrentExecutions: Required<PercentageAlarmConfig>;
+  errors: AlarmConfigDefaults;
+  throttles: AlarmConfigDefaults;
+  duration: PercentageAlarmConfigDefaults;
+  concurrentExecutions: PercentageAlarmConfigDefaults;
 }
 
 /**

--- a/packages/lambda/src/function-alarms.ts
+++ b/packages/lambda/src/function-alarms.ts
@@ -7,9 +7,13 @@ import {
 } from "aws-cdk-lib/aws-cloudwatch";
 import type { Function as LambdaFunction, FunctionProps } from "aws-cdk-lib/aws-lambda";
 import type { IConstruct } from "constructs";
-import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import type { AlarmDefinition, AlarmName } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
-import type { FunctionAlarmConfig, PercentageAlarmConfig } from "./alarm-config.js";
+import type {
+  FunctionAlarmConfig,
+  PercentageAlarmConfig,
+  PercentageAlarmConfigDefaults,
+} from "./alarm-config.js";
 import { FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
 
 const METRIC_PERIOD = Duration.minutes(1);
@@ -33,6 +37,7 @@ export function resolveFunctionAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.errors, FUNCTION_ALARM_DEFAULTS.errors);
     definitions.push({
       key: "errors",
+      alarmName: cfg.alarmName,
       metric: fn.metricErrors({ period: METRIC_PERIOD }),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -47,6 +52,7 @@ export function resolveFunctionAlarmDefinitions(
     const cfg = resolveAlarmConfig(config?.throttles, FUNCTION_ALARM_DEFAULTS.throttles);
     definitions.push({
       key: "throttles",
+      alarmName: cfg.alarmName,
       metric: fn.metricThrottles({ period: METRIC_PERIOD }),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -63,6 +69,7 @@ export function resolveFunctionAlarmDefinitions(
     const threshold = Math.round(timeoutMs * cfg.thresholdPercent);
     definitions.push({
       key: "duration",
+      alarmName: cfg.alarmName,
       metric: fn.metricDuration({ period: METRIC_PERIOD, statistic: Stats.percentile(99) }),
       threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -82,6 +89,7 @@ export function resolveFunctionAlarmDefinitions(
     const threshold = Math.round(reservedConcurrency * cfg.thresholdPercent);
     definitions.push({
       key: "concurrentExecutions",
+      alarmName: cfg.alarmName,
       metric: fn.metric("ConcurrentExecutions", {
         period: METRIC_PERIOD,
         statistic: Stats.MAXIMUM,
@@ -132,6 +140,7 @@ export function createFunctionAlarms(
 }
 
 interface ResolvedPercentageAlarmConfig {
+  alarmName?: AlarmName;
   thresholdPercent: number;
   evaluationPeriods: number;
   datapointsToAlarm: number;
@@ -144,7 +153,7 @@ interface ResolvedPercentageAlarmConfig {
  */
 function resolvePercentageAlarmConfig(
   userConfig: PercentageAlarmConfig | undefined,
-  defaults: Required<PercentageAlarmConfig>,
+  defaults: PercentageAlarmConfigDefaults,
 ): ResolvedPercentageAlarmConfig {
   const thresholdPercent = userConfig?.thresholdPercent ?? defaults.thresholdPercent;
 
@@ -155,6 +164,7 @@ function resolvePercentageAlarmConfig(
   }
 
   return {
+    alarmName: userConfig?.alarmName,
     thresholdPercent,
     evaluationPeriods: userConfig?.evaluationPeriods ?? defaults.evaluationPeriods,
     datapointsToAlarm: userConfig?.datapointsToAlarm ?? defaults.datapointsToAlarm,

--- a/packages/lambda/test/function-alarms.test.ts
+++ b/packages/lambda/test/function-alarms.test.ts
@@ -3,6 +3,7 @@ import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import { alarmName } from "@composurecdk/cloudwatch";
 import { createFunctionBuilder } from "../src/function-builder.js";
 
 function buildResult(configureFn: (builder: ReturnType<typeof createFunctionBuilder>) => void) {
@@ -155,6 +156,27 @@ describe("recommended alarms", () => {
         MetricName: "Throttles",
         EvaluationPeriods: 5,
         DatapointsToAlarm: 3,
+      });
+    });
+
+    it("allows overriding alarmName on a recommended alarm", () => {
+      const { template } = buildResult((b) => {
+        minimalFunction(b);
+        b.recommendedAlarms({ errors: { alarmName: alarmName("checkout-fn-errors") } });
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Errors",
+        AlarmName: "checkout-fn-errors",
+      });
+    });
+
+    it("derives a default AlarmName when not overridden", () => {
+      const { template } = buildResult(minimalFunction);
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Errors",
+        AlarmName: "test-stack/test-function/errors",
       });
     });
 
@@ -365,6 +387,22 @@ describe("addAlarm", () => {
     expect(result.alarms.lowInvocations).toBeDefined();
     // 2 recommended (errors, throttles) + 2 custom
     template.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+  });
+
+  it("propagates alarmName from .addAlarm to the rendered alarm", () => {
+    const { template } = buildResult((b) => {
+      minimalFunction(b);
+      b.addAlarm("invocations", (alarm) =>
+        alarm
+          .metric((fn) => fn.metricInvocations({ period: Duration.minutes(1) }))
+          .alarmName(alarmName("checkout-fn-invocations"))
+          .threshold(1),
+      );
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "checkout-fn-invocations",
+    });
   });
 
   it("throws on duplicate key with recommended alarm", () => {

--- a/packages/route53/src/health-check-alarm-defaults.ts
+++ b/packages/route53/src/health-check-alarm-defaults.ts
@@ -1,9 +1,9 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "@composurecdk/cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
 
 interface HealthCheckAlarmDefaults {
   enabled: true;
-  healthCheckStatus: Required<AlarmConfig>;
+  healthCheckStatus: AlarmConfigDefaults;
 }
 
 /**

--- a/packages/route53/src/health-check-alarms.ts
+++ b/packages/route53/src/health-check-alarms.ts
@@ -33,6 +33,7 @@ export function resolveHealthCheckAlarmDefinitions(
     );
     definitions.push({
       key: "healthCheckStatus",
+      alarmName: cfg.alarmName,
       metric: new Metric({
         namespace: "AWS/Route53",
         metricName: "HealthCheckStatus",

--- a/packages/s3/src/alarm-defaults.ts
+++ b/packages/s3/src/alarm-defaults.ts
@@ -1,10 +1,10 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "@composurecdk/cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
 
 interface BucketAlarmDefaults {
   enabled: true;
-  serverErrors: Required<AlarmConfig>;
-  clientErrors: Required<AlarmConfig>;
+  serverErrors: AlarmConfigDefaults;
+  clientErrors: AlarmConfigDefaults;
 }
 
 /**

--- a/packages/s3/src/bucket-alarms.ts
+++ b/packages/s3/src/bucket-alarms.ts
@@ -55,6 +55,7 @@ export function resolveBucketAlarmDefinitions(
       const cfg = resolveAlarmConfig(config?.serverErrors, BUCKET_ALARM_DEFAULTS.serverErrors);
       definitions.push({
         key: `serverErrors:${filterId}`,
+        alarmName: cfg.alarmName,
         metric: s3RequestMetric(bucket, filterId, "5xxErrors", Stats.SUM),
         threshold: cfg.threshold,
         comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -69,6 +70,7 @@ export function resolveBucketAlarmDefinitions(
       const cfg = resolveAlarmConfig(config?.clientErrors, BUCKET_ALARM_DEFAULTS.clientErrors);
       definitions.push({
         key: `clientErrors:${filterId}`,
+        alarmName: cfg.alarmName,
         metric: s3RequestMetric(bucket, filterId, "4xxErrors", Stats.SUM),
         threshold: cfg.threshold,
         comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,

--- a/packages/sns/src/topic-alarm-defaults.ts
+++ b/packages/sns/src/topic-alarm-defaults.ts
@@ -1,12 +1,12 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmConfig } from "@composurecdk/cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
 
 interface TopicAlarmDefaults {
   enabled: true;
-  numberOfNotificationsFailed: Required<AlarmConfig>;
-  numberOfNotificationsFilteredOutInvalidAttributes: Required<AlarmConfig>;
-  numberOfNotificationsRedrivenToDlq: Required<AlarmConfig>;
-  numberOfNotificationsFailedToRedriveToDlq: Required<AlarmConfig>;
+  numberOfNotificationsFailed: AlarmConfigDefaults;
+  numberOfNotificationsFilteredOutInvalidAttributes: AlarmConfigDefaults;
+  numberOfNotificationsRedrivenToDlq: AlarmConfigDefaults;
+  numberOfNotificationsFailedToRedriveToDlq: AlarmConfigDefaults;
 }
 
 /**

--- a/packages/sns/src/topic-alarms.ts
+++ b/packages/sns/src/topic-alarms.ts
@@ -29,6 +29,7 @@ export function resolveTopicAlarmDefinitions(
     );
     definitions.push({
       key: "numberOfNotificationsFailed",
+      alarmName: cfg.alarmName,
       metric: topic.metricNumberOfNotificationsFailed({ period: METRIC_PERIOD }),
       threshold: cfg.threshold,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -46,6 +47,7 @@ export function resolveTopicAlarmDefinitions(
     );
     definitions.push({
       key: "numberOfNotificationsFilteredOutInvalidAttributes",
+      alarmName: cfg.alarmName,
       metric: topic.metricNumberOfNotificationsFilteredOutInvalidAttributes({
         period: METRIC_PERIOD,
       }),
@@ -65,6 +67,7 @@ export function resolveTopicAlarmDefinitions(
     );
     definitions.push({
       key: "numberOfNotificationsRedrivenToDlq",
+      alarmName: cfg.alarmName,
       metric: topic.metric("NumberOfNotificationsRedrivenToDlq", {
         period: METRIC_PERIOD,
         statistic: "Sum",
@@ -85,6 +88,7 @@ export function resolveTopicAlarmDefinitions(
     );
     definitions.push({
       key: "numberOfNotificationsFailedToRedriveToDlq",
+      alarmName: cfg.alarmName,
       metric: topic.metric("NumberOfNotificationsFailedToRedriveToDlq", {
         period: METRIC_PERIOD,
         statistic: "Sum",


### PR DESCRIPTION
## Summary

Auto-generated alarms now ship with an explicit `AlarmName` derived from the stack name, builder id, and alarm key (kebab-cased, slash-joined). Operators see hierarchical names in the CloudWatch console instead of CFN-generated hash suffixes.

**Before:** `jasonduffettnetsiteAlertsNumberOfNotificationsFailedAlarmF37A3C89`
**After:** `jason-duffett-net-site-stack/site-alerts/number-of-notifications-failed`

## Override seams (layered, lowest precedence first)

1. **Library default** — `defaultAlarmName(scope, id, key)` from `${stackName}/${kebab(id)}/${kebab(key)}`.
2. **Per-alarm** — `recommendedAlarms: { errors: { alarmName: alarmName(\"checkout-fn-errors\") } }` and `addAlarm(...).alarmName(...)`. The `AlarmName` brand forces a one-line opt-in via the `alarmName()` helper, which validates charset (CloudWatch allows `[A-Za-z0-9-_./#:()+ =@]`) and length (<= 255).
3. **Cross-cutting policy** — `alarmNamePolicy(scope, { defaults, rules })` mirrors the existing `alarmActionsPolicy`. Supports `prefix` / `suffix` / `transform` decorations with substring, regex, and predicate matchers.

```ts
alarmNamePolicy(app, {
  defaults: { prefix: \"prod\" },
  rules: [
    { match: /Errors\$/, suffix: \"critical\" },
    { match: \"throttles\", suffix: \"warning\" },
    { match: ctx => ctx.path.includes(\"payments\"), prefix: \"payments\" },
  ],
});
```

## Threading

- `AlarmDefinition.alarmName?: AlarmName` and `AlarmConfig.alarmName?: AlarmName` carry the override through the existing `resolve* / createAlarms` pipeline (one-line propagation in each `*-alarms.ts`).
- New `AlarmConfigDefaults = Required<Omit<AlarmConfig, \"alarmName\">>` keeps per-package `*_ALARM_DEFAULTS` typing tight without forcing a name into defaults.
- `createAlarms` resolves `def.alarmName ?? defaultAlarmName(scope, id, def.key)`. Construct ids are unchanged, so `alarmActionsPolicy` matchers and existing logical ids stay stable.

## Test plan

- [x] New unit tests in `packages/cloudwatch/test/`:
  - `alarm-name.test.ts` — `alarmName()` validation, `kebab()` edge cases, `joinAlarmName()` separator + empty-segment handling.
  - `default-alarm-name.test.ts` — `${stackName}/${kebab(id)}/${kebab(key)}` formatting.
  - `alarm-name-policy.test.ts` — defaults, layering, transforms, separator, regex matching, `replaceDefaults`, no-name passthrough, invalid-char rejection.
  - `create-alarms.test.ts` — default-name fallback and explicit override.
  - `alarm-definition-builder.test.ts` — `.alarmName()` setter.
- [x] `packages/lambda/test/function-alarms.test.ts` — verifies recommendedAlarms override and addAlarm threading.
- [x] All 6 examples-package snapshots refreshed (`+38` lines, all `AlarmName` additions; no other CFN drift).
- [x] `npm run lint && npm run format:check` clean.
- [x] `npx nx run-many -t test` — 13 projects, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)