### PR TITLE
feat(cloudfront)!: collapse access-log props into accessLogs config

### DIFF
--- a/packages/cloudfront/README.md
+++ b/packages/cloudfront/README.md
@@ -37,15 +37,15 @@ compose({ site: createBucketBuilder(), cdn }, { site: [], cdn: ["site"] }).build
 
 `createDistributionBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.
 
-| Property                                | Default             | Rationale                                                                |
-| --------------------------------------- | ------------------- | ------------------------------------------------------------------------ |
-| `accessLogging`                         | `true`              | Auto-creates an S3 logging bucket for access log audit trail.            |
-| `priceClass`                            | `PRICE_CLASS_100`   | North America and Europe edge locations — sufficient and cost-effective. |
-| `httpVersion`                           | `HTTP2_AND_3`       | Enables HTTP/2 and HTTP/3 (QUIC) for improved performance.               |
-| `defaultRootObject`                     | `"index.html"`      | Standard for static website hosting.                                     |
-| `minimumProtocolVersion`                | `TLS_V1_2_2021`     | Requires TLS 1.2+ to prevent older, less secure protocol negotiation.    |
-| `defaultBehavior.viewerProtocolPolicy`  | `REDIRECT_TO_HTTPS` | Ensures all viewer traffic is encrypted in transit.                      |
-| `defaultBehavior.responseHeadersPolicy` | `SECURITY_HEADERS`  | Applies managed security headers (HSTS, X-Content-Type-Options, etc.).   |
+| Property                                | Default               | Rationale                                                                                  |
+| --------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------ |
+| `accessLogs`                            | `{ prefix: "logs/" }` | Auto-creates an S3 logging bucket for the access log audit trail under the `logs/` prefix. |
+| `priceClass`                            | `PRICE_CLASS_100`     | North America and Europe edge locations — sufficient and cost-effective.                   |
+| `httpVersion`                           | `HTTP2_AND_3`         | Enables HTTP/2 and HTTP/3 (QUIC) for improved performance.                                 |
+| `defaultRootObject`                     | `"index.html"`        | Standard for static website hosting.                                                       |
+| `minimumProtocolVersion`                | `TLS_V1_2_2021`       | Requires TLS 1.2+ to prevent older, less secure protocol negotiation.                      |
+| `defaultBehavior.viewerProtocolPolicy`  | `REDIRECT_TO_HTTPS`   | Ensures all viewer traffic is encrypted in transit.                                        |
+| `defaultBehavior.responseHeadersPolicy` | `SECURITY_HEADERS`    | Applies managed security headers (HSTS, X-Content-Type-Options, etc.).                     |
 
 These defaults are guided by the [AWS Well-Architected Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-data-in-transit.html).
 
@@ -63,14 +63,14 @@ import { PriceClass, ViewerProtocolPolicy } from "aws-cdk-lib/aws-cloudfront";
 const cdn = createDistributionBuilder()
   .origin(myOrigin)
   .priceClass(PriceClass.PRICE_CLASS_ALL)
-  .accessLogging(false)
+  .accessLogs(false)
   .defaultBehavior({ viewerProtocolPolicy: ViewerProtocolPolicy.ALLOW_ALL })
   .build(stack, "CDN");
 ```
 
 ### Access logging
 
-By default, the builder creates an S3 logging bucket (using `@composurecdk/s3` with its secure defaults) and configures it as the distribution's log destination. The created bucket is returned in the build result:
+CloudFront standard access logging is configured through a single `.accessLogs(config)` setting. By default, the builder creates a dedicated logging bucket (using `@composurecdk/s3` with its secure defaults, plus `BUCKET_OWNER_PREFERRED` object ownership which CloudFront standard logging requires) and writes logs under `logs/`. The created bucket is returned in the build result:
 
 ```ts
 const result = createDistributionBuilder().origin(myOrigin).build(stack, "CDN");
@@ -79,7 +79,39 @@ result.distribution; // Distribution
 result.accessLogsBucket; // Bucket | undefined
 ```
 
-To provide your own bucket instead, set `logBucket` — the auto-created logging bucket is skipped. To disable access logging entirely, set `.accessLogging(false)`.
+`.accessLogs(config)` accepts either `false` to disable access logging, or an object describing how to handle logs:
+
+```ts
+import { Duration } from "aws-cdk-lib";
+
+// Disable access logging entirely
+createDistributionBuilder().origin(myOrigin).accessLogs(false);
+
+// Auto-create a logging bucket with a custom prefix
+createDistributionBuilder().origin(myOrigin).accessLogs({ prefix: "cdn/" });
+
+// Include cookies in the logs
+createDistributionBuilder().origin(myOrigin).accessLogs({ includeCookies: true });
+
+// Auto-create and customize the logging sub-builder
+createDistributionBuilder()
+  .origin(myOrigin)
+  .accessLogs({
+    configure: (sub) => sub.lifecycleRules([{ id: "ShortLogs", expiration: Duration.days(180) }]),
+  });
+
+// Bring your own destination bucket
+createDistributionBuilder().origin(myOrigin).accessLogs({ destination: myBucket });
+
+// Bring your own destination with a prefix and cookies
+createDistributionBuilder()
+  .origin(myOrigin)
+  .accessLogs({ destination: myBucket, prefix: "cdn/", includeCookies: true });
+```
+
+`destination` and `configure` cannot be combined — the destination bucket is user-managed and is not built by this builder.
+
+The config object replaces the default wholesale rather than merging with it. For example, `.accessLogs({ includeCookies: true })` does **not** preserve the default `prefix: "logs/"` — restate any default you want to keep.
 
 ## Recommended Alarms
 

--- a/packages/cloudfront/src/defaults.ts
+++ b/packages/cloudfront/src/defaults.ts
@@ -19,12 +19,13 @@ import type { DistributionBuilderProps, InlineFunctionDefinition } from "./distr
  */
 export const DISTRIBUTION_DEFAULTS: Partial<DistributionBuilderProps> = {
   /**
-   * Automatically create an S3 logging bucket for CloudFront standard access logs.
-   * Access logging provides an audit trail of all viewer requests for security
-   * monitoring and troubleshooting.
+   * Auto-create a dedicated logging bucket and write CloudFront standard
+   * access logs to it under the `logs/` prefix. Access logging provides an
+   * audit trail of all viewer requests for security monitoring and
+   * troubleshooting.
    * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_detect_investigate_events_app_service_logging.html
    */
-  accessLogging: true,
+  accessLogs: { prefix: "logs/" },
 
   /**
    * Use the cheapest price class — edge locations in North America and Europe.

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -12,7 +12,7 @@ import {
 } from "aws-cdk-lib/aws-cloudfront";
 import { type ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
-import { type Bucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
+import { type Bucket, type IBucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
 import {
@@ -23,7 +23,7 @@ import {
   type Resolvable,
 } from "@composurecdk/core";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
-import { createBucketBuilder } from "@composurecdk/s3";
+import { createBucketBuilder, type IBucketBuilder } from "@composurecdk/s3";
 import type { DistributionAlarmConfig, FunctionAlarmConfig } from "./alarm-config.js";
 import { DISTRIBUTION_DEFAULTS } from "./defaults.js";
 import { resolveBehaviors } from "./resolve-behaviors.js";
@@ -157,6 +157,29 @@ export interface AdditionalBehaviorConfig extends Omit<
 }
 
 /**
+ * Configures how CloudFront standard access logs are handled. Pass `false`
+ * to disable logging; pass an object to wire a destination, prefix,
+ * include cookies, or customize the auto-created sub-builder.
+ *
+ * `configure` cannot be combined with `destination` — a user-managed
+ * destination is not built by this builder.
+ */
+export type AccessLogsConfig =
+  | false
+  | {
+      destination?: IBucket;
+      prefix?: string;
+      includeCookies?: boolean;
+      /**
+       * Customize the auto-created logging sub-builder. Receives a builder
+       * pre-seeded with `versioned: false`, `objectOwnership:
+       * BUCKET_OWNER_PREFERRED`, `removalPolicy: RETAIN`, and recursive
+       * S3 server access logging disabled.
+       */
+      configure?: (b: IBucketBuilder) => IBucketBuilder;
+    };
+
+/**
  * Configuration properties for the CloudFront distribution builder.
  *
  * Extends the CDK {@link DistributionProps} with additional builder-specific
@@ -165,29 +188,22 @@ export interface AdditionalBehaviorConfig extends Omit<
  * {@link IDistributionBuilder.behavior} method rather than the raw
  * `additionalBehaviors` record.
  *
- * The `enableLogging` CDK prop is replaced by {@link accessLogging}, which
- * auto-creates a logging bucket with secure defaults when enabled.
+ * The CDK `enableLogging`, `logBucket`, `logFilePrefix`, and
+ * `logIncludesCookies` props are replaced by {@link accessLogs}, which
+ * auto-creates a logging bucket with secure defaults by default.
  */
 export interface DistributionBuilderProps extends Omit<
   DistributionProps,
-  "defaultBehavior" | "additionalBehaviors" | "enableLogging" | "certificate"
+  | "defaultBehavior"
+  | "additionalBehaviors"
+  | "enableLogging"
+  | "logBucket"
+  | "logFilePrefix"
+  | "logIncludesCookies"
+  | "certificate"
 > {
-  /**
-   * Whether to automatically create an S3 bucket for CloudFront standard
-   * access logging.
-   *
-   * When `true`, the builder creates a logging bucket using
-   * {@link createBucketBuilder} (with its secure defaults) and configures it
-   * as the distribution's log destination. The created bucket is returned in
-   * the build result as `accessLogsBucket`.
-   *
-   * When `false`, no logging bucket is created. You can still provide your
-   * own bucket via `logBucket`.
-   *
-   * This setting is ignored when `logBucket` is provided — the user-supplied
-   * bucket takes precedence.
-   */
-  accessLogging?: boolean;
+  /** See {@link AccessLogsConfig}. Defaults to `{ prefix: "logs/" }`. */
+  accessLogs?: AccessLogsConfig;
 
   /**
    * The ACM certificate to associate with the distribution for HTTPS.
@@ -405,7 +421,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
     }
 
     const {
-      accessLogging,
+      accessLogs,
       certificate,
       defaultBehavior: userBehavior,
       recommendedAlarms: alarmConfig,
@@ -413,28 +429,13 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
     } = this.props;
     const resolvedCertificate = certificate ? resolve(certificate, context ?? {}) : undefined;
     const {
-      accessLogging: defaultAccessLogging,
+      accessLogs: defaultAccessLogs,
       defaultBehavior: defaultBehaviorDefaults,
       ...cdkDefaults
     } = DISTRIBUTION_DEFAULTS;
-    const autoAccessLog = (accessLogging ?? defaultAccessLogging) && !distProps.logBucket;
+    const cfg = accessLogs ?? defaultAccessLogs;
 
-    let accessLogsBucket: Bucket | undefined;
-    let accessLogProps = {};
-
-    if (autoAccessLog) {
-      accessLogsBucket = createBucketBuilder()
-        .serverAccessLogs(false)
-        .versioned(false)
-        // CloudFront standard logging writes via ACLs, which requires BucketOwnerPreferred.
-        .objectOwnership(ObjectOwnership.BUCKET_OWNER_PREFERRED)
-        .removalPolicy(RemovalPolicy.RETAIN)
-        .build(scope, `${id}AccessLogs`).bucket;
-      accessLogProps = {
-        enableLogging: true,
-        logBucket: accessLogsBucket,
-      };
-    }
+    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg);
 
     const behaviors = resolveBehaviors({
       scope,
@@ -512,4 +513,60 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
  */
 export function createDistributionBuilder(): IDistributionBuilder {
   return Builder<DistributionBuilderProps, DistributionBuilder>(DistributionBuilder);
+}
+
+function resolveAccessLogs(
+  scope: IConstruct,
+  id: string,
+  cfg: AccessLogsConfig | undefined,
+): {
+  accessLogsBucket?: Bucket;
+  accessLogProps: Partial<
+    Pick<DistributionProps, "enableLogging" | "logBucket" | "logFilePrefix" | "logIncludesCookies">
+  >;
+} {
+  if (cfg === false || cfg === undefined) {
+    return { accessLogProps: {} };
+  }
+
+  const extras = {
+    ...(cfg.prefix !== undefined ? { logFilePrefix: cfg.prefix } : {}),
+    ...(cfg.includeCookies !== undefined ? { logIncludesCookies: cfg.includeCookies } : {}),
+  };
+
+  if (cfg.destination !== undefined) {
+    if (cfg.configure !== undefined) {
+      throw new Error(
+        "accessLogs: 'configure' cannot be combined with 'destination' — " +
+          "the destination bucket is user-managed and not built by this builder.",
+      );
+    }
+    return {
+      accessLogProps: {
+        enableLogging: true,
+        logBucket: cfg.destination,
+        ...extras,
+      },
+    };
+  }
+
+  let subBuilder = createBucketBuilder()
+    .serverAccessLogs(false)
+    .versioned(false)
+    // CloudFront standard logging writes via ACLs, which requires BucketOwnerPreferred.
+    .objectOwnership(ObjectOwnership.BUCKET_OWNER_PREFERRED)
+    .removalPolicy(RemovalPolicy.RETAIN);
+  if (cfg.configure) {
+    subBuilder = cfg.configure(subBuilder);
+  }
+  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`).bucket;
+
+  return {
+    accessLogsBucket,
+    accessLogProps: {
+      enableLogging: true,
+      logBucket: accessLogsBucket,
+      ...extras,
+    },
+  };
 }

--- a/packages/cloudfront/src/index.ts
+++ b/packages/cloudfront/src/index.ts
@@ -1,5 +1,6 @@
 export {
   createDistributionBuilder,
+  type AccessLogsConfig,
   type DistributionBuilderProps,
   type DistributionBuilderResult,
   type IDistributionBuilder,

--- a/packages/cloudfront/test/behavior-function-alarms.test.ts
+++ b/packages/cloudfront/test/behavior-function-alarms.test.ts
@@ -28,7 +28,7 @@ function withOrigin(builder: ReturnType<typeof createDistributionBuilder>, stack
   const bucket = new Bucket(stack, "TestBucket");
   builder
     .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-    .accessLogging(false)
+    .accessLogs(false)
     // Suppress only the distribution-level alarms so each test can focus on
     // function alarms. Note: `.recommendedAlarms(false)` would also disable
     // function alarms (master switch), which isn't what these tests want.
@@ -354,7 +354,7 @@ describe("region signposting", () => {
     const stack = buildInRegion("us-west-2", (b, stack) => {
       const bucket = new Bucket(stack, "TestBucket");
       b.origin(S3BucketOrigin.withOriginAccessControl(bucket))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false);
     });
 

--- a/packages/cloudfront/test/behavior-functions.test.ts
+++ b/packages/cloudfront/test/behavior-functions.test.ts
@@ -41,7 +41,7 @@ describe("default behavior inline functions", () => {
   it("creates a CloudFront Function for an inline function on the default behavior", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -59,7 +59,7 @@ describe("default behavior inline functions", () => {
   it("wires the function into the default behavior's FunctionAssociations", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -88,7 +88,7 @@ describe("default behavior inline functions", () => {
   it("returns the CfFunction in the build result under the behavior+event key", () => {
     const { result } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -106,7 +106,7 @@ describe("default behavior inline functions", () => {
   it("defaults the runtime to cloudfront-js-2.0", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -128,7 +128,7 @@ describe("default behavior inline functions", () => {
   it("honours a user-provided runtime", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -151,7 +151,7 @@ describe("default behavior inline functions", () => {
   it("applies a provided comment to the Function", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -178,7 +178,7 @@ describe("default behavior inline functions", () => {
 
     createDistributionBuilder()
       .origin(withBucketOrigin(stack))
-      .accessLogging(false)
+      .accessLogs(false)
       .recommendedAlarms(false)
       .defaultBehavior({
         functions: [
@@ -204,7 +204,7 @@ describe("default behavior inline functions", () => {
   it("supports functions on both viewer-request and viewer-response", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -237,7 +237,7 @@ describe("default behavior inline functions", () => {
     expect(() =>
       synthTemplate((b, stack) => {
         b.origin(withBucketOrigin(stack))
-          .accessLogging(false)
+          .accessLogs(false)
           .recommendedAlarms(false)
           .defaultBehavior({
             functions: [
@@ -258,7 +258,7 @@ describe("default behavior inline functions", () => {
   it("creates no function resources when functions is omitted or empty", () => {
     const { result, template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({ functions: [] });
     });
@@ -269,7 +269,7 @@ describe("default behavior inline functions", () => {
 
   it("emits no FunctionAssociations on the default behavior when functions is omitted", () => {
     const { template } = synthTemplate((b, stack) => {
-      b.origin(withBucketOrigin(stack)).accessLogging(false).recommendedAlarms(false);
+      b.origin(withBucketOrigin(stack)).accessLogs(false).recommendedAlarms(false);
     });
 
     template.hasResourceProperties("AWS::CloudFront::Distribution", {
@@ -288,7 +288,7 @@ describe("default behavior inline functions", () => {
           source: ImportSource.fromInline(JSON.stringify({ data: [{ key: "a", value: "b" }] })),
         });
         b.origin(withBucketOrigin(stack))
-          .accessLogging(false)
+          .accessLogs(false)
           .recommendedAlarms(false)
           .defaultBehavior({
             functions: [
@@ -309,7 +309,7 @@ describe("additional path-pattern behaviors", () => {
   it("creates an additional cache behavior with its own origin", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .behavior("/api/*", {
           origin: new HttpOrigin("api.example.com"),
@@ -331,7 +331,7 @@ describe("additional path-pattern behaviors", () => {
   it("creates an inline function on an additional behavior", () => {
     const { result, template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .behavior("/api/*", {
           origin: new HttpOrigin("api.example.com"),
@@ -363,7 +363,7 @@ describe("additional path-pattern behaviors", () => {
   it("supports multiple additional behaviors with independent functions", () => {
     const { result, template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .behavior("/api/*", {
           origin: new HttpOrigin("api.example.com"),
@@ -395,7 +395,7 @@ describe("additional path-pattern behaviors", () => {
     const stack = new Stack(app, "TestStack");
     const builder = createDistributionBuilder()
       .origin(withBucketOrigin(stack))
-      .accessLogging(false)
+      .accessLogs(false)
       .recommendedAlarms(false)
       .behavior("/api/*", { origin: new HttpOrigin("api.example.com") });
 
@@ -409,7 +409,7 @@ describe("additional path-pattern behaviors", () => {
     const stack = new Stack(app, "TestStack");
     const builder = createDistributionBuilder()
       .origin(withBucketOrigin(stack))
-      .accessLogging(false)
+      .accessLogs(false)
       .recommendedAlarms(false)
       .behavior("/*.html", { origin: new HttpOrigin("pages.example.com") });
 
@@ -423,7 +423,7 @@ describe("additional path-pattern behaviors", () => {
   it("applies an explicit functionName when provided", () => {
     const { template } = synthTemplate((b, stack) => {
       b.origin(withBucketOrigin(stack))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [
@@ -445,7 +445,7 @@ describe("additional path-pattern behaviors", () => {
     expect(() =>
       synthTemplate((b, stack) => {
         b.origin(withBucketOrigin(stack))
-          .accessLogging(false)
+          .accessLogs(false)
           .recommendedAlarms(false)
           .behavior("/api/*", {
             origin: new HttpOrigin("api.example.com"),
@@ -471,7 +471,7 @@ describe("additional path-pattern behaviors", () => {
 
     const result = createDistributionBuilder()
       .origin(withBucketOrigin(stack))
-      .accessLogging(false)
+      .accessLogs(false)
       .recommendedAlarms(false)
       .behavior("/api/*", {
         origin: ref<BucketBuilderResult>("api").map((r) =>
@@ -493,7 +493,7 @@ describe("additional path-pattern behaviors", () => {
 
   it("creates no CacheBehaviors when no additional behaviors are added", () => {
     const { template } = synthTemplate((b, stack) => {
-      b.origin(withBucketOrigin(stack)).accessLogging(false).recommendedAlarms(false);
+      b.origin(withBucketOrigin(stack)).accessLogs(false).recommendedAlarms(false);
     });
 
     template.hasResourceProperties("AWS::CloudFront::Distribution", {

--- a/packages/cloudfront/test/cloudfront-alarm-builder.test.ts
+++ b/packages/cloudfront/test/cloudfront-alarm-builder.test.ts
@@ -33,7 +33,7 @@ function buildDistribution(
   const stack = new Stack(app, "TestStack");
   const builder = createDistributionBuilder().recommendedAlarms(false);
   const bucket = new Bucket(stack, "TestBucket");
-  builder.origin(S3BucketOrigin.withOriginAccessControl(bucket)).accessLogging(false);
+  builder.origin(S3BucketOrigin.withOriginAccessControl(bucket)).accessLogs(false);
   configureFn?.(builder);
   const result = builder.build(stack, "TestDistribution");
   return { app, stack, result };
@@ -175,7 +175,7 @@ describe("createCloudFrontAlarmBuilder", () => {
       const bucket = new Bucket(distStack, "TestBucket");
       const result = createDistributionBuilder()
         .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-        .accessLogging(false)
+        .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
           functions: [viewerRequestFn],
@@ -231,7 +231,7 @@ describe("createCloudFrontAlarmBuilder", () => {
         {
           cdn: createDistributionBuilder()
             .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-            .accessLogging(false)
+            .accessLogs(false)
             .recommendedAlarms(false)
             .defaultBehavior({
               functions: [viewerRequestFn],
@@ -280,7 +280,7 @@ describe("createCloudFrontAlarmBuilder", () => {
         {
           cdn: createDistributionBuilder()
             .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-            .accessLogging(false)
+            .accessLogs(false)
             .recommendedAlarms(false)
             .defaultBehavior({
               functions: [viewerRequestFn],
@@ -326,7 +326,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
       .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-      .accessLogging(false)
+      .accessLogs(false)
       .defaultBehavior({
         functions: [viewerRequestFn],
       })
@@ -344,7 +344,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
       .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-      .accessLogging(false)
+      .accessLogs(false)
       .recommendedAlarms(false)
       .defaultBehavior({
         functions: [viewerRequestFn],
@@ -361,7 +361,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
       .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-      .accessLogging(false)
+      .accessLogs(false)
       .recommendedAlarms(false)
       .addAlarm("custom4xx", (a) =>
         a
@@ -388,7 +388,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
       .origin(S3BucketOrigin.withOriginAccessControl(bucket))
-      .accessLogging(false)
+      .accessLogs(false)
       .recommendedAlarms(false)
       .defaultBehavior({
         functions: [viewerRequestFn],

--- a/packages/cloudfront/test/distribution-alarms.test.ts
+++ b/packages/cloudfront/test/distribution-alarms.test.ts
@@ -20,7 +20,7 @@ function buildResult(
 
 function withOrigin(builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) {
   const bucket = new Bucket(stack, "TestBucket");
-  builder.origin(S3BucketOrigin.withOriginAccessControl(bucket)).accessLogging(false);
+  builder.origin(S3BucketOrigin.withOriginAccessControl(bucket)).accessLogs(false);
 }
 
 describe("recommended alarms", () => {

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -33,7 +33,7 @@ describe("DistributionBuilder", () => {
       const bucket = new Bucket(stack, "TestBucket");
       const origin = S3BucketOrigin.withOriginAccessControl(bucket);
 
-      const builder = createDistributionBuilder().origin(origin).accessLogging(false);
+      const builder = createDistributionBuilder().origin(origin).accessLogs(false);
       const result = builder.build(stack, "TestDistribution");
 
       expect(result).toBeDefined();
@@ -227,13 +227,13 @@ describe("DistributionBuilder", () => {
 
       const result = createDistributionBuilder()
         .origin(origin)
-        .accessLogging(false)
+        .accessLogs(false)
         .build(stack, "TestDistribution");
 
       expect(result.accessLogsBucket).toBeUndefined();
     });
 
-    it("skips auto-created logging bucket when logBucket is provided", () => {
+    it("skips auto-created logging bucket when destination is provided", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
@@ -242,10 +242,91 @@ describe("DistributionBuilder", () => {
 
       const result = createDistributionBuilder()
         .origin(origin)
-        .logBucket(logBucket)
+        .accessLogs({ destination: logBucket })
         .build(stack, "TestDistribution");
 
       expect(result.accessLogsBucket).toBeUndefined();
+    });
+
+    it("uses the default 'logs/' prefix on the log bucket", () => {
+      const template = synthTemplate((b, stack) => b.origin(withBucketOrigin(stack)));
+
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Logging: Match.objectLike({ Prefix: "logs/" }),
+        }),
+      });
+    });
+
+    it("applies a custom prefix on the auto-created log bucket", () => {
+      const template = synthTemplate((b, stack) =>
+        b.origin(withBucketOrigin(stack)).accessLogs({ prefix: "cdn/" }),
+      );
+
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Logging: Match.objectLike({ Prefix: "cdn/" }),
+        }),
+      });
+    });
+
+    it("applies a custom prefix on a user-provided destination", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const bucket = new Bucket(stack, "TestBucket");
+      const logBucket = new Bucket(stack, "LogBucket");
+      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+
+      createDistributionBuilder()
+        .origin(origin)
+        .accessLogs({ destination: logBucket, prefix: "cdn/" })
+        .build(stack, "TestDistribution");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Logging: Match.objectLike({ Prefix: "cdn/" }),
+        }),
+      });
+    });
+
+    it("forwards includeCookies to logIncludesCookies", () => {
+      const template = synthTemplate((b, stack) =>
+        b.origin(withBucketOrigin(stack)).accessLogs({ includeCookies: true }),
+      );
+
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: Match.objectLike({
+          Logging: Match.objectLike({ IncludeCookies: true }),
+        }),
+      });
+    });
+
+    it("applies a configure callback to the auto-created log bucket", () => {
+      const template = synthTemplate((b, stack) =>
+        b
+          .origin(withBucketOrigin(stack))
+          .accessLogs({ configure: (lb) => lb.bucketName("my-cdn-logs") }),
+      );
+
+      template.hasResourceProperties("AWS::S3::Bucket", {
+        BucketName: "my-cdn-logs",
+      });
+    });
+
+    it("throws when destination and configure are combined", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const bucket = new Bucket(stack, "TestBucket");
+      const logBucket = new Bucket(stack, "LogBucket");
+      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+
+      expect(() =>
+        createDistributionBuilder()
+          .origin(origin)
+          .accessLogs({ destination: logBucket, configure: (lb) => lb })
+          .build(stack, "TestDistribution"),
+      ).toThrow(/configure.*cannot be combined with.*destination/);
     });
 
     it("allows the user to override price class", () => {
@@ -311,7 +392,7 @@ describe("DistributionBuilder", () => {
             S3BucketOrigin.withOriginAccessControl(r.bucket),
           ),
         )
-        .accessLogging(false);
+        .accessLogs(false);
 
       const result = builder.build(stack, "TestDistribution", {
         site: { bucket },
@@ -343,7 +424,7 @@ describe("DistributionBuilder", () => {
         .origin(withBucketOrigin(stack))
         .certificate(ref<{ certificate: typeof cert }>("tls").map((r) => r.certificate))
         .domainNames(["example.com"])
-        .accessLogging(false);
+        .accessLogs(false);
 
       const result = builder.build(stack, "TestDistribution", {
         tls: { certificate: cert },
@@ -374,7 +455,7 @@ describe("DistributionBuilder", () => {
         .origin(withBucketOrigin(stack))
         .certificate(cert)
         .domainNames(["example.com"])
-        .accessLogging(false);
+        .accessLogs(false);
 
       const result = builder.build(stack, "TestDistribution");
 
@@ -397,7 +478,7 @@ describe("DistributionBuilder", () => {
       const bucket = new Bucket(stack, "TestBucket");
       const origin = S3BucketOrigin.withOriginAccessControl(bucket);
 
-      const builder = createDistributionBuilder().origin(origin).accessLogging(true);
+      const builder = createDistributionBuilder().origin(origin);
       builder.build(stack, "TestDistribution");
 
       const template = Template.fromStack(stack);
@@ -430,7 +511,7 @@ describe("DistributionBuilder", () => {
       const bucket = new Bucket(stack, "TestBucket");
       const origin = S3BucketOrigin.withOriginAccessControl(bucket);
 
-      const builder = createDistributionBuilder().origin(origin).accessLogging(false);
+      const builder = createDistributionBuilder().origin(origin).accessLogs(false);
       builder.build(stack, "TestDistribution");
 
       const template = Template.fromStack(stack);

--- a/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
@@ -670,6 +670,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
                 "RegionalDomainName",
               ],
             },
+            "Prefix": "logs/",
           },
           "Origins": [
             {


### PR DESCRIPTION
## Summary

- Replaces `accessLogging?: boolean` and the `logBucket` / `logFilePrefix` / `logIncludesCookies` CDK pass-throughs with a single discriminated `.accessLogs(config)` method on `DistributionBuilder`.
- Hides `enableLogging`, `logBucket`, `logFilePrefix`, and `logIncludesCookies` from `DistributionBuilderProps` via `Omit`, mirroring the pattern S3's `BucketBuilder` adopted in 7d01550.
- Adds a `{ configure }` variant that lets users customize the auto-created log bucket sub-builder (lifecycle rules, encryption, removal policy) without falling back to `afterBuild` escape hatches.

## Config shape

```ts
type AccessLogsConfig =
  | false
  | {
      destination?: IBucket;
      prefix?: string;
      includeCookies?: boolean;
      configure?: (b: IBucketBuilder) => IBucketBuilder;
    };
```

`destination` and `configure` cannot be combined — the destination bucket is user-managed and is not built by this builder.

The auto-created log bucket retains the CloudFront-specific `BUCKET_OWNER_PREFERRED` ownership seed and `RemovalPolicy.RETAIN`, which the user's `configure` callback can build on top of. The `distribution.node.addDependency(accessLogsBucket)` ordering is preserved for auto-created buckets only.

## Migration (BREAKING CHANGE)

```
.accessLogging(true)              -> (remove; default)
.accessLogging(false)             -> .accessLogs(false)
.logBucket(b)                     -> .accessLogs({ destination: b })
.logBucket(b).logFilePrefix("x/") -> .accessLogs({ destination: b, prefix: "x/" })
.logFilePrefix("x/")              -> .accessLogs({ prefix: "x/" })
.logIncludesCookies(true)         -> .accessLogs({ includeCookies: true })
```

The default `accessLogs: { prefix: "logs/" }` keeps the audit-trail behaviour unchanged for callers who never set the prop.

## Test plan

- [x] `npx nx run cloudfront:test` — 102 tests pass; new tests cover each variant (`{ prefix }`, `{ destination, prefix }`, `{ includeCookies }`, `{ configure }`, the destination + configure validation throw)
- [x] `npx nx run s3:test` — unchanged
- [x] `npx nx run cloudfront:build` — typecheck passes; the `Omit` change surfaces any callers still reaching for the removed fields
- [x] `npm run lint && npm run format:check`
- [ ] Spot-check synth: `createDistributionBuilder().origin(o).accessLogs({ configure: b => b.lifecycleRules([...]) }).build(stack, "CDN")` renders the auto-created log bucket with the user's lifecycle rules