### PR TITLE
fix(release): move git config under version/changelog subcommands

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -46,7 +46,7 @@ Scopes are optional and do not affect the bump.
    npx nx release --dry-run
    ```
 
-   Prints the planned version, changelog, and per-package bumps. Safe any time. `nx.json` sets `release.git.commit/tag/push` to `false`, so a non-`--dry-run` local invocation modifies files but does not commit, tag, or push — `git restore` undoes it.
+   Prints the planned version, changelog, and per-package bumps. Safe any time. `nx.json` sets `commit/tag/push` to `false` under both `release.version.git` and `release.changelog.git`, so a non-`--dry-run` local invocation modifies files but does not commit, tag, or push — `git restore` undoes it.
 
 2. **Open the release PR.** Trigger **Actions → Release Prepare → Run workflow**:
    - Leave inputs blank for a normal conventional-commits-driven release.

--- a/nx.json
+++ b/nx.json
@@ -28,19 +28,23 @@
     "version": {
       "conventionalCommits": true,
       "fallbackCurrentVersionResolver": "disk",
-      "preVersionCommand": "npm run verify"
+      "preVersionCommand": "npm run verify",
+      "git": {
+        "commit": false,
+        "tag": false,
+        "push": false
+      }
     },
     "releaseTagPattern": "v{version}",
-    "git": {
-      "commit": false,
-      "tag": false,
-      "push": false,
-      "commitMessage": "chore(release): v{version}"
-    },
     "changelog": {
       "automaticFromRef": true,
       "projectChangelogs": false,
-      "workspaceChangelog": true
+      "workspaceChangelog": true,
+      "git": {
+        "commit": false,
+        "tag": false,
+        "push": false
+      }
     }
   },
   "analytics": false


### PR DESCRIPTION
## Summary

`nx release version` (used by `release-prepare.yml`) rejects the top-level `release.git` property and requires per-subcommand git config. Failing run from PR #70's first attempted use of the new flow: https://github.com/laazyj/composureCDK/actions/runs/25256293126/job/74056129916

```
NX  The "release.git" property in nx.json may not be used with the "nx release version"
    subcommand or programmatic API. Instead, configure git options for subcommands directly
    with "release.version.git" and "release.changelog.git".
```

## Fix

Move `commit/tag/push: false` under both `release.version.git` and `release.changelog.git` in `nx.json`. Drop the now-unused top-level `commitMessage` (the `release-prepare.yml` workflow constructs its own commit subject).

`docs/ci.md` updated to reference the new config path.

## Test plan

- [ ] CI passes.
- [ ] After merge, run **Actions → Release Prepare → Run workflow** and confirm `nx release version` proceeds past the config validation step.