### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.5.1 (2026-05-02)
+
+### 🚀 Features
+
+- **ec2:** add InstanceBuilder and VpcBuilder with well-architected d… ([#48](https://github.com/laazyj/composureCDK/pull/48), [#33](https://github.com/laazyj/composureCDK/issues/33))
+
+### 🩹 Fixes
+
+- **release:** move git config under version/changelog subcommands ([#71](https://github.com/laazyj/composureCDK/pull/71))
+
+### ❤️ Thank You
+
+- Jason Duffett
+
 ## 0.5.0 (2026-04-30)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -7746,7 +7746,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7764,7 +7764,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7783,7 +7783,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7801,7 +7801,7 @@
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7818,7 +7818,7 @@
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7837,7 +7837,7 @@
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7853,7 +7853,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -7869,7 +7869,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -7888,7 +7888,7 @@
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.250.0",
@@ -7915,7 +7915,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7932,7 +7932,7 @@
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7951,7 +7951,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7968,7 +7968,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7986,7 +7986,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -8005,7 +8005,7 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.5.1**.

Generated by `release-prepare` workflow run [#25256446874](https://github.com/laazyj/composureCDK/actions/runs/25256446874).

## Merge checklist

- [ ] CI is green
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.5.1`, which triggers `release.yml` (deploy-test → npm publish).