### PR TITLE
fix(release-tag): allow GitHub squash-merge `(#NN)` suffix

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           subject=$(printf '%s' "$SUBJECT" | head -n1)
           # SemVer: MAJOR.MINOR.PATCH with optional -prerelease and +build identifiers.
-          if [[ "$subject" =~ ^chore\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)[[:space:]]*$ ]]; then
+          # GitHub squash-merge appends ` (#NN)` to the commit subject — allow it.
+          if [[ "$subject" =~ ^chore\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)(\ \(#[0-9]+\))?[[:space:]]*$ ]]; then
             version="${BASH_REMATCH[1]}"
             echo "version=${version}" >> "$GITHUB_OUTPUT"
             echo "Detected release commit for v${version}"


### PR DESCRIPTION
## Summary

GitHub squash-merges append ` (#PR_NUMBER)` to the commit subject by default, so the v0.5.1 release commit (squash-merge of #72) landed on main as `chore(release): v0.5.1 (#72)`. The strict regex in release-tag.yml didn't allow that suffix and the workflow failed: https://github.com/laazyj/composureCDK/actions/runs/25256538512

## Fix

Broaden the regex to accept an optional ` (#NN)` group between the version and end-of-line. Verified locally against:

| Subject                                | Result               |
| -------------------------------------- | -------------------- |
| `chore(release): v0.5.1 (#72)`         | ✅ matches v0.5.1    |
| `chore(release): v0.5.1`               | ✅ matches v0.5.1    |
| `chore(release): v1.0.0-rc.1 (#100)`   | ✅ matches v1.0.0-rc.1 |
| `chore(release): v1.0.0+build.5`       | ✅ matches v1.0.0+build.5 |
| `feat: not a release`                  | ❌ correctly rejected |
| `chore(release): v0.5.1 extra trailing text` | ❌ correctly rejected |

## Recovering v0.5.1

The v0.5.1 release commit is already on main but never got tagged. **After this PR merges**, recovery is a manual tag push (the existing `push: tags` trigger on `release.yml` is the documented escape hatch):

```sh
git fetch origin main
git tag -a v0.5.1 874eded -m "Release v0.5.1"
git push origin v0.5.1
```

That fires `release.yml` (deploy-test → npm publish). The GitHub Release will not auto-create (that step lives in `release-tag.yml`); create it manually with `gh release create v0.5.1 --notes-file <path>` using the relevant section of `CHANGELOG.md`.

## Test plan

- [ ] CI passes.
- [ ] After merge, manual tag push for v0.5.1 succeeds and `release.yml` publishes.
- [ ] Next release flows end-to-end through release-prepare → PR → squash-merge → release-tag → release.yml without intervention.