### PR TITLE
docs: add showcase and package downloads badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,19 +62,30 @@ If two components depend on each other, that is an architectural problem to be s
 
 - **Infrastructure engineers** who want to standardise patterns, enforce best practices, and reduce configuration drift across an organisation. ComposureCDK's defaults and builder patterns provide a consistent foundation that teams can extend.
 
+## Who's using ComposureCDK
+
+See [docs/showcase.md](docs/showcase.md) for case studies of projects built with ComposureCDK, and for the badge snippet to add to your own README:
+
+[![Built with ComposureCDK](https://img.shields.io/badge/built%20with-ComposureCDK-0f0d0c?labelColor=b85416)](https://github.com/laazyj/composureCDK)
+
 ## Packages
 
-| Package                    | Description                                                 |
-| -------------------------- | ----------------------------------------------------------- |
-| `@composurecdk/core`       | System lifecycle, dependency resolution, component protocol |
-| `@composurecdk/s3`         | S3 bucket components with secure defaults                   |
-| `@composurecdk/lambda`     | Lambda function components                                  |
-| `@composurecdk/ecs`        | ECS service and task components                             |
-| `@composurecdk/iam`        | IAM role and policy components                              |
-| `@composurecdk/apigateway` | API Gateway components                                      |
-| `@composurecdk/ec2`        | EC2 and VPC components                                      |
-| `@composurecdk/acm`        | ACM certificate components with DNS validation              |
-| `@composurecdk/route53`    | Route 53 hosted zones, records, and alias target helpers    |
+| Package                                                                                      | Downloads                                                                                                   | Description                                                       |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [`@composurecdk/acm`](https://www.npmjs.com/package/@composurecdk/acm)                       | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/acm?labelColor=b85416&color=0f0d0c)            | ACM certificate components with DNS validation                    |
+| [`@composurecdk/apigateway`](https://www.npmjs.com/package/@composurecdk/apigateway)         | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/apigateway?labelColor=b85416&color=0f0d0c)     | API Gateway components                                            |
+| [`@composurecdk/budgets`](https://www.npmjs.com/package/@composurecdk/budgets)               | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/budgets?labelColor=b85416&color=0f0d0c)        | AWS Budgets components with automatic SNS topic policies          |
+| [`@composurecdk/cloudformation`](https://www.npmjs.com/package/@composurecdk/cloudformation) | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/cloudformation?labelColor=b85416&color=0f0d0c) | CloudFormation stack builders and assignment strategies           |
+| [`@composurecdk/cloudfront`](https://www.npmjs.com/package/@composurecdk/cloudfront)         | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/cloudfront?labelColor=b85416&color=0f0d0c)     | CloudFront distribution components with well-architected defaults |
+| [`@composurecdk/cloudwatch`](https://www.npmjs.com/package/@composurecdk/cloudwatch)         | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/cloudwatch?labelColor=b85416&color=0f0d0c)     | CloudWatch alarm primitives shared by resource packages           |
+| [`@composurecdk/core`](https://www.npmjs.com/package/@composurecdk/core)                     | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/core?labelColor=b85416&color=0f0d0c)           | System lifecycle, dependency resolution, component protocol       |
+| [`@composurecdk/ec2`](https://www.npmjs.com/package/@composurecdk/ec2)                       | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/ec2?labelColor=b85416&color=0f0d0c)            | EC2 and VPC components                                            |
+| [`@composurecdk/iam`](https://www.npmjs.com/package/@composurecdk/iam)                       | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/iam?labelColor=b85416&color=0f0d0c)            | IAM role and policy components                                    |
+| [`@composurecdk/lambda`](https://www.npmjs.com/package/@composurecdk/lambda)                 | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/lambda?labelColor=b85416&color=0f0d0c)         | Lambda function components                                        |
+| [`@composurecdk/logs`](https://www.npmjs.com/package/@composurecdk/logs)                     | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/logs?labelColor=b85416&color=0f0d0c)           | CloudWatch log group components with secure defaults              |
+| [`@composurecdk/route53`](https://www.npmjs.com/package/@composurecdk/route53)               | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/route53?labelColor=b85416&color=0f0d0c)        | Route 53 hosted zones, records, and alias target helpers          |
+| [`@composurecdk/s3`](https://www.npmjs.com/package/@composurecdk/s3)                         | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/s3?labelColor=b85416&color=0f0d0c)             | S3 bucket components with secure defaults                         |
+| [`@composurecdk/sns`](https://www.npmjs.com/package/@composurecdk/sns)                       | ![npm downloads](https://img.shields.io/npm/dm/@composurecdk/sns?labelColor=b85416&color=0f0d0c)            | SNS topic components with well-architected defaults               |
 
 ## License
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,0 +1,38 @@
+# Showcase
+
+Real-world projects built with ComposureCDK. The case studies here extend the smaller, pattern-focused stacks in [`packages/examples/`](../packages/examples/README.md) — they show what a complete system looks like once ComposureCDK's defaults, lifecycles, and builders are in production.
+
+## Add the badge
+
+If your project uses ComposureCDK, paste this into your README:
+
+```markdown
+[![Built with ComposureCDK](https://img.shields.io/badge/built%20with-ComposureCDK-0f0d0c?labelColor=b85416)](https://github.com/laazyj/composureCDK)
+```
+
+It renders as:
+
+[![Built with ComposureCDK](https://img.shields.io/badge/built%20with-ComposureCDK-0f0d0c?labelColor=b85416)](https://github.com/laazyj/composureCDK)
+
+## Case studies
+
+<!--
+Skeleton for new entries. Copy below the closing `-->`, fill in, and remove the comment.
+
+### [Project Name](https://github.com/your-org/your-repo)
+
+Two to four sentences describing the project — what it does, the AWS surface it runs on, and how it uses ComposureCDK. Mention which packages it leans on most (e.g. `@composurecdk/lambda` + `@composurecdk/apigateway`) and any pattern that's specific to this deployment.
+
+```ts
+// Optional: a representative excerpt (≤ ~15 lines) showing the project's
+// composureCDK use. Aim for a snippet that wouldn't fit as a generic example
+// — something that captures *this* project's shape.
+```
+
+-->
+
+_No projects listed yet. Open a PR to add yours._
+
+## Submitting your project
+
+Open a pull request adding an entry under **Case studies** above, or open an issue if you'd prefer the maintainer to write the entry up. Entries should link to a public repo or homepage so readers can verify the project exists.


### PR DESCRIPTION
## Summary

- New `docs/showcase.md` with a "Built with ComposureCDK" shields.io badge snippet (for adopter READMEs) and a case-study skeleton; linked from a new "Who's using ComposureCDK" section in the top-level README.
- Refreshed the README packages table: each name links to npmjs.com, new monthly-downloads badge column, rows alphabetised, six previously-missing packages added (cloudwatch, sns, cloudfront, logs, budgets, cloudformation), and the stale `@composurecdk/ecs` row removed.
- Badges use a two-tone palette (`#b85416` label, `#0f0d0c` message) — the orange is a darkened variant of jasonduffett.net's `--tech: #ff7a3d`, chosen so white text on the label clears WCAG AA contrast.

## Test plan

- [x] Render `README.md` on GitHub — confirm the "Who's using ComposureCDK" section sits between _Who Is This For?_ and _Packages_, the "Built with" badge renders with readable text on both sides, and every package row's npm link and download badge resolve.
- [ ] Render `docs/showcase.md` on GitHub — confirm the badge snippet preview renders, the case-study skeleton is HTML-commented (not visible in the rendered output), and the empty-state line appears.
- [ ] `npm run lint && npm run format:check` clean.