### PR TITLE
feat(budgets)!: encode service constraints in NotifySubscribers + Email

### DIFF
--- a/packages/budgets/README.md
+++ b/packages/budgets/README.md
@@ -7,12 +7,12 @@ This package provides a fluent builder for `AWS::Budgets::Budget` with well-arch
 ## Budget Builder
 
 ```ts
-import { createBudgetBuilder } from "@composurecdk/budgets";
+import { createBudgetBuilder, email } from "@composurecdk/budgets";
 
 const budget = createBudgetBuilder()
   .budgetName("AgentBudget")
-  .limit({ amount: 50, unit: "GBP" })
-  .notifyOnActual(100, "ops@example.com")
+  .limit({ amount: 50 })
+  .notifyOnActual(100, { emails: [email("ops@example.com")] })
   .build(stack, "AgentBudget");
 ```
 
@@ -31,33 +31,42 @@ Every field on [CfnBudget.BudgetDataProperty](https://docs.aws.amazon.com/cdk/ap
 
 ### Notifications
 
-Percentage-threshold helpers cover the common case; `addNotification` accepts the raw shape when you need absolute-value thresholds or a different comparison operator.
+Each notification takes a `NotifySubscribers` object with **at most one** `sns` topic and a list of validated `emails` — AWS Budgets caps every notification at 1 SNS subscriber plus up to 10 EMAIL subscribers. The shape encodes that constraint in the type system: passing two SNS topics is unrepresentable.
 
 ```ts
+import { email } from "@composurecdk/budgets";
+
 createBudgetBuilder()
   .limit({ amount: 100 })
-  .notifyOnActual(80, "ops@example.com") // 80% ACTUAL → email
-  .notifyOnForecasted(
-    100,
-    ref("alerts", (r) => r.topic),
-  ) // 100% FORECASTED → SNS topic
+  .notifyOnActual(80, { emails: [email("ops@example.com")] }) // 80% ACTUAL → email
+  .notifyOnForecasted(100, { sns: ref("alerts", (r) => r.topic) }) // 100% FORECASTED → SNS topic
+  .notifyOnActual(100, {
+    sns: killSwitchTopic,
+    emails: [email("oncall@example.com")],
+  }) // hard breach → automation + human
   .addNotification({
     notificationType: "ACTUAL",
     threshold: 120,
     thresholdType: "ABSOLUTE_VALUE",
-    subscribers: ["oncall@example.com"],
+    subscribers: { emails: [email("oncall@example.com")] },
   });
 ```
 
-Subscribers may be email strings, `ITopic` instances, or `Resolvable<ITopic>` references to topics owned by sibling components.
+Email addresses must be constructed via `email(string)`, which validates and brands the value — bare strings are rejected at compile time. The `sns` slot accepts an `ITopic` instance or a `Resolvable<ITopic>` reference to a topic owned by a sibling component.
 
 ### Recommended Thresholds
 
 ```ts
-createBudgetBuilder().limit({ amount: 50 }).withRecommendedThresholds("ops@example.com");
+createBudgetBuilder()
+  .limit({ amount: 50 })
+  .withRecommendedThresholds({ emails: [email("ops@example.com")] });
 ```
 
 Applies the AWS Cost Optimization pillar defaults: `ACTUAL` at 80% and `FORECASTED` at 100%.
+
+### Currency
+
+`limit({ amount, unit })` validates `unit` against the AWS-Budgets-supported ISO 4217 set (`DEFAULT_BUDGET_CURRENCIES`). Typos like `"ZZZ"` throw at synth instead of mid-deploy. Because the synth context cannot see an account's billing currency, anything other than `"USD"` also emits a non-fatal warning (`@composurecdk/budgets:limit-currency`) — verify the configured unit matches your billing currency before deploying.
 
 ## Defaults
 

--- a/packages/budgets/src/budget-alarms.ts
+++ b/packages/budgets/src/budget-alarms.ts
@@ -2,6 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import { ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import type { BudgetAlarmConfig } from "./alarm-config.js";
+import { assertValidBudgetCurrency } from "./currency.js";
 
 const BILLING_METRIC_PERIOD = Duration.hours(6);
 
@@ -31,6 +32,7 @@ export function resolveBudgetAlarmDefinitions(
 
   const cfg = config.estimatedCharges;
   const currency = cfg.currency ?? "USD";
+  assertValidBudgetCurrency(currency, `EstimatedChargesAlarmConfig: currency`);
 
   return [
     {

--- a/packages/budgets/src/budget-builder.ts
+++ b/packages/budgets/src/budget-builder.ts
@@ -6,15 +6,18 @@ import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { BudgetAlarmConfig } from "./alarm-config.js";
 import { buildBudgetAlarms } from "./budget-alarm-builder.js";
+import { assertValidBudgetCurrency, warnIfNonUsdCurrency } from "./currency.js";
 import { BUDGET_DEFAULTS } from "./defaults.js";
 import {
-  type BudgetSubscriber,
   type NotificationEntry,
   type NotificationType,
+  type NotifySubscribers,
   resolveSubscribers,
   toCfnNotificationWithSubscribers,
 } from "./notifications.js";
 import { createBudgetsTopicPolicies } from "./topic-policy.js";
+
+const MAX_EMAILS_PER_NOTIFICATION = 10;
 
 /**
  * Spend limit for a cost or usage budget.
@@ -25,6 +28,12 @@ export interface BudgetLimit {
   /**
    * Currency or usage unit. Defaults to
    * {@link BUDGET_DEFAULTS.limitUnit} when omitted.
+   *
+   * For `COST` budgets, must be a recognised AWS Budgets currency
+   * (validated at synth — see {@link DEFAULT_BUDGET_CURRENCIES}). The
+   * builder also emits a non-fatal warning when this is anything other
+   * than `"USD"`, since the account's billing currency isn't visible
+   * at synth and a mismatch is rejected at deploy time.
    */
   unit?: string;
 }
@@ -121,9 +130,12 @@ export interface BudgetBuilderResult {
  * ```ts
  * createBudgetBuilder()
  *   .budgetName("AgentBudget")
- *   .limit({ amount: 50, unit: "GBP" })
- *   .notifyOnActual(100, ref("alerts", r => r.topic))
- *   .withRecommendedThresholds()
+ *   .limit({ amount: 50 })
+ *   .notifyOnActual(100, {
+ *     emails: [email("ops@example.com")],
+ *     sns: ref("alerts", r => r.topic),
+ *   })
+ *   .withRecommendedThresholds({ emails: [email("ops@example.com")] })
  *   .build(stack, "AgentBudget");
  * ```
  */
@@ -140,10 +152,11 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
    *
    * @param thresholdPercent - Percentage of the budget limit (e.g. `80`).
    *   For absolute-value thresholds, use {@link addNotification} directly.
-   * @param subscribers - One or more email addresses / SNS topics (or
-   *   {@link Resolvable} refs to topics).
+   * @param subscribers - Up to one SNS topic plus up to ten validated
+   *   email addresses. AWS Budgets caps each notification at 1 SNS + up
+   *   to 10 EMAIL subscribers.
    */
-  notifyOnActual(thresholdPercent: number, ...subscribers: BudgetSubscriber[]): this {
+  notifyOnActual(thresholdPercent: number, subscribers: NotifySubscribers): this {
     return this.#addPercentageNotification("ACTUAL", thresholdPercent, subscribers);
   }
 
@@ -153,8 +166,10 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
    *
    * @param thresholdPercent - Percentage of the budget limit (e.g. `100`).
    *   For absolute-value thresholds, use {@link addNotification} directly.
+   * @param subscribers - Up to one SNS topic plus up to ten validated
+   *   email addresses.
    */
-  notifyOnForecasted(thresholdPercent: number, ...subscribers: BudgetSubscriber[]): this {
+  notifyOnForecasted(thresholdPercent: number, subscribers: NotifySubscribers): this {
     return this.#addPercentageNotification("FORECASTED", thresholdPercent, subscribers);
   }
 
@@ -174,12 +189,12 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
    * - `FORECASTED` at 100% — trending-over-budget alert.
    *
    * Must be called with at least one subscriber; the same subscriber
-   * list is used for both thresholds.
+   * set is used for both thresholds.
    *
    * @see https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-best-practices.html
    */
-  withRecommendedThresholds(...subscribers: BudgetSubscriber[]): this {
-    if (subscribers.length === 0) {
+  withRecommendedThresholds(subscribers: NotifySubscribers): this {
+    if (!hasAnySubscriber(subscribers)) {
       throw new Error(
         `BudgetBuilder: withRecommendedThresholds(...) must be called with at least one subscriber.`,
       );
@@ -227,7 +242,13 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
       );
     }
 
-    const { notificationsWithSubscribers, snsTopics } = this.#buildNotifications(context);
+    const limitUnit = budgetProps.limit?.unit ?? BUDGET_DEFAULTS.limitUnit;
+    if (budgetType === "COST" && budgetProps.limit) {
+      assertValidBudgetCurrency(limitUnit, `BudgetBuilder "${id}": limit unit`);
+      warnIfNonUsdCurrency(scope, limitUnit, `BudgetBuilder "${id}": limit unit`);
+    }
+
+    const { notificationsWithSubscribers, snsTopics } = this.#buildNotifications(id, context);
 
     const budgetData: CfnBudget.BudgetDataProperty = {
       budgetName: budgetProps.budgetName,
@@ -237,7 +258,7 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
         ? {
             budgetLimit: {
               amount: budgetProps.limit.amount,
-              unit: budgetProps.limit.unit ?? BUDGET_DEFAULTS.limitUnit,
+              unit: limitUnit,
             },
           }
         : {}),
@@ -269,9 +290,9 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
   #addPercentageNotification(
     notificationType: NotificationType,
     thresholdPercent: number,
-    subscribers: BudgetSubscriber[],
+    subscribers: NotifySubscribers,
   ): this {
-    if (subscribers.length === 0) {
+    if (!hasAnySubscriber(subscribers)) {
       throw new Error(
         `BudgetBuilder: ${notificationType} notification at ${String(thresholdPercent)}% requires at least one subscriber.`,
       );
@@ -280,7 +301,10 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
     return this;
   }
 
-  #buildNotifications(context: Record<string, object>): {
+  #buildNotifications(
+    id: string,
+    context: Record<string, object>,
+  ): {
     notificationsWithSubscribers: CfnBudget.NotificationWithSubscribersProperty[];
     snsTopics: ITopic[];
   } {
@@ -288,6 +312,14 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
     const allSnsTopics: ITopic[] = [];
 
     for (const entry of this.#notifications) {
+      const emailCount = entry.subscribers.emails?.length ?? 0;
+      if (emailCount > MAX_EMAILS_PER_NOTIFICATION) {
+        throw new Error(
+          `BudgetBuilder "${id}": ${describeNotification(entry)} has ${String(emailCount)} email subscribers; ` +
+            `AWS Budgets allows at most ${String(MAX_EMAILS_PER_NOTIFICATION)} email subscribers per notification (plus up to 1 SNS topic).`,
+        );
+      }
+
       const resolved = resolveSubscribers(entry.subscribers, context);
       notificationsWithSubscribers.push(toCfnNotificationWithSubscribers(entry, resolved.cfn));
       allSnsTopics.push(...resolved.snsTopics);
@@ -295,6 +327,15 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
 
     return { notificationsWithSubscribers, snsTopics: allSnsTopics };
   }
+}
+
+function hasAnySubscriber(subscribers: NotifySubscribers): boolean {
+  return subscribers.sns !== undefined || (subscribers.emails?.length ?? 0) > 0;
+}
+
+function describeNotification(entry: NotificationEntry): string {
+  const unit = (entry.thresholdType ?? "PERCENTAGE") === "PERCENTAGE" ? "%" : "";
+  return `notification ${entry.notificationType} @ ${String(entry.threshold)}${unit}`;
 }
 
 /**

--- a/packages/budgets/src/currency.ts
+++ b/packages/budgets/src/currency.ts
@@ -1,0 +1,39 @@
+import { Annotations, Token } from "aws-cdk-lib";
+import type { IConstruct } from "constructs";
+import { DEFAULT_BUDGET_CURRENCIES } from "./defaults.js";
+
+/**
+ * Throws if `unit` is not in {@link DEFAULT_BUDGET_CURRENCIES}.
+ *
+ * `context` is woven into the message (e.g. `BudgetBuilder "X": limit
+ * unit ...`) so callers can blame the right field. Catches typos like
+ * `"USDD"` or `"ZZZ"` at synth instead of mid-deploy.
+ */
+export function assertValidBudgetCurrency(unit: string, context: string): void {
+  if (DEFAULT_BUDGET_CURRENCIES.includes(unit)) return;
+  throw new Error(
+    `${context}: "${unit}" is not a recognised AWS Budgets currency code. ` +
+      `Expected one of: ${DEFAULT_BUDGET_CURRENCIES.join(", ")}.`,
+  );
+}
+
+/**
+ * Annotates `scope` with a non-fatal warning when `unit` is anything
+ * other than `USD`. The synth context cannot see an account's billing
+ * currency, and AWS Budgets rejects `BudgetLimit.Unit` values that
+ * don't match it — so a non-USD configuration deserves a "make sure
+ * this matches your billing currency" nudge.
+ *
+ * Short-circuits on unresolved tokens so env-agnostic stacks aren't
+ * spammed.
+ */
+export function warnIfNonUsdCurrency(scope: IConstruct, unit: string, context: string): void {
+  if (Token.isUnresolved(unit)) return;
+  if (unit === "USD") return;
+  Annotations.of(scope).addWarningV2(
+    "@composurecdk/budgets:limit-currency",
+    `${context}: currency "${unit}" must match the account's billing currency or AWS Budgets ` +
+      `will reject the request at deploy time. Most accounts default to USD; verify yours and ` +
+      `suppress this warning if intentional.`,
+  );
+}

--- a/packages/budgets/src/defaults.ts
+++ b/packages/budgets/src/defaults.ts
@@ -43,3 +43,52 @@ export const BUDGET_DEFAULTS = {
     forecastedPercent: 100,
   },
 };
+
+/**
+ * ISO 4217 currency codes accepted by AWS Budgets for `COST` budgets'
+ * `BudgetLimit.Unit` and the `EstimatedCharges` alarm's `Currency`
+ * dimension. Sourced from the AWS Billing supported-currencies list.
+ *
+ * The synth context cannot see an account's billing currency, so the
+ * builder uses this set for shape validation only — a hard error on
+ * anything outside it (catches typos like `"ZZZ"`/`"USDD"`) — and emits
+ * a soft warning when the configured unit is anything other than `USD`,
+ * since most accounts default to USD billing.
+ *
+ * @see https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/manage-account-payment.html
+ */
+export const DEFAULT_BUDGET_CURRENCIES: readonly string[] = [
+  "AED",
+  "ARS",
+  "AUD",
+  "BRL",
+  "CAD",
+  "CHF",
+  "CLP",
+  "CNY",
+  "COP",
+  "CZK",
+  "DKK",
+  "EUR",
+  "GBP",
+  "HKD",
+  "IDR",
+  "ILS",
+  "INR",
+  "JPY",
+  "KRW",
+  "MXN",
+  "MYR",
+  "NOK",
+  "NZD",
+  "PLN",
+  "RUB",
+  "SAR",
+  "SEK",
+  "SGD",
+  "THB",
+  "TRY",
+  "TWD",
+  "USD",
+  "ZAR",
+];

--- a/packages/budgets/src/email.ts
+++ b/packages/budgets/src/email.ts
@@ -1,0 +1,43 @@
+declare const emailBrand: unique symbol;
+
+/**
+ * A validated email address suitable for use as a budget notification
+ * subscriber. Construct via {@link email}; the brand prevents bare
+ * strings from being passed where an `Email` is required, ensuring the
+ * value has been syntactically validated and length-checked against
+ * AWS Budgets' per-subscriber limit.
+ */
+export type Email = string & { readonly [emailBrand]: true };
+
+const MAX_LEN = 50;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validates and brands a string as an {@link Email}.
+ *
+ * The pattern intentionally errs on the side of acceptance — anything
+ * obviously not an email (whitespace, missing `@`, missing TLD) is
+ * rejected, but any address AWS Budgets will plausibly accept passes.
+ * The 50-char cap matches the Budgets API's documented per-subscriber
+ * limit.
+ *
+ * @throws If the input is empty, exceeds 50 characters, or doesn't
+ * contain `local@domain.tld`.
+ *
+ * @see https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_Subscriber.html
+ */
+export function email(input: string): Email {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    throw new Error("email cannot be empty");
+  }
+  if (trimmed.length > MAX_LEN) {
+    throw new Error(
+      `email exceeds ${String(MAX_LEN)} chars (AWS Budgets per-subscriber limit): "${trimmed}"`,
+    );
+  }
+  if (!EMAIL_REGEX.test(trimmed)) {
+    throw new Error(`invalid email address: "${trimmed}"`);
+  }
+  return trimmed as Email;
+}

--- a/packages/budgets/src/index.ts
+++ b/packages/budgets/src/index.ts
@@ -11,14 +11,15 @@ export {
   type BudgetAlarmBuilderProps,
   type BudgetAlarmBuilderResult,
 } from "./budget-alarm-builder.js";
-export { BUDGET_DEFAULTS } from "./defaults.js";
+export { BUDGET_DEFAULTS, DEFAULT_BUDGET_CURRENCIES } from "./defaults.js";
 export { type BudgetAlarmConfig, type EstimatedChargesAlarmConfig } from "./alarm-config.js";
 export { createBudgetsTopicPolicies } from "./topic-policy.js";
+export { email, type Email } from "./email.js";
 export {
   resolveSubscribers,
   toCfnNotificationWithSubscribers,
-  type BudgetSubscriber,
   type NotificationEntry,
   type NotificationType,
+  type NotifySubscribers,
   type ResolvedSubscribers,
 } from "./notifications.js";

--- a/packages/budgets/src/notifications.ts
+++ b/packages/budgets/src/notifications.ts
@@ -1,12 +1,38 @@
 import { CfnBudget } from "aws-cdk-lib/aws-budgets";
 import type { ITopic } from "aws-cdk-lib/aws-sns";
 import { resolve, type Resolvable } from "@composurecdk/core";
+import type { Email } from "./email.js";
 
 /**
- * A subscriber that receives budget notifications. Either an email
- * address (string) or an SNS topic (concrete or resolvable reference).
+ * Subscribers attached to a budget notification.
+ *
+ * AWS Budgets enforces an asymmetric per-notification subscriber rule
+ * that CloudFormation does not model:
+ *
+ * - up to 10 subscribers per notification
+ * - **at most one** with `SubscriptionType=SNS`
+ * - the remainder must be `EMAIL`
+ *
+ * This shape encodes that constraint in the type system: `sns` is
+ * singular, so passing two SNS topics is unrepresentable. The
+ * combined-count cap is enforced at synth time.
+ *
+ * @see https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_NotificationWithSubscribers.html
  */
-export type BudgetSubscriber = string | ITopic | Resolvable<ITopic>;
+export interface NotifySubscribers {
+  /**
+   * Optional SNS topic to publish notifications to. AWS Budgets allows
+   * at most one SNS subscriber per notification; route fan-out by
+   * adding additional subscriptions to this single topic.
+   */
+  sns?: ITopic | Resolvable<ITopic>;
+  /**
+   * Optional list of validated email addresses. Construct each value
+   * via {@link email}; bare strings are rejected at compile time. The
+   * combined `sns` + `emails` count must be ≤ 10.
+   */
+  emails?: Email[];
+}
 
 /**
  * Which side of spend a notification triggers on.
@@ -34,17 +60,15 @@ export interface NotificationEntry {
    * absolute amount when `thresholdType` is `ABSOLUTE_VALUE`.
    */
   threshold: number;
-  subscribers: BudgetSubscriber[];
+  subscribers: NotifySubscribers;
   comparisonOperator?: "GREATER_THAN" | "LESS_THAN" | "EQUAL_TO";
   thresholdType?: "PERCENTAGE" | "ABSOLUTE_VALUE";
 }
 
 /**
- * Resolved subscriber after any {@link Resolvable} has been resolved.
- *
- * `snsTopics` is surfaced separately so the builder can create
- * `AWS::SNS::TopicPolicy` entries granting `budgets.amazonaws.com`
- * permission to publish.
+ * Resolved subscribers in the CloudFormation shape required by
+ * `AWS::Budgets::Budget`, plus any SNS topic referenced (so the caller
+ * can create matching `AWS::SNS::TopicPolicy` grants).
  */
 export interface ResolvedSubscribers {
   cfn: CfnBudget.SubscriberProperty[];
@@ -52,26 +76,29 @@ export interface ResolvedSubscribers {
 }
 
 /**
- * Resolve a list of {@link BudgetSubscriber}s into the CloudFormation
- * shape required by `AWS::Budgets::Budget` and a flat list of any SNS
- * topics referenced (so the caller can create topic policies).
+ * Resolve a {@link NotifySubscribers} into the CloudFormation shape for
+ * `AWS::Budgets::Budget`'s `Subscribers` array, plus any SNS topic
+ * referenced so the caller can create a matching topic policy.
+ *
+ * The SNS subscriber (if any) is emitted first, followed by emails in
+ * declaration order — the order is not load-bearing, but stable output
+ * keeps test snapshots steady.
  */
 export function resolveSubscribers(
-  subscribers: BudgetSubscriber[],
+  subscribers: NotifySubscribers,
   context: Record<string, object>,
 ): ResolvedSubscribers {
   const cfn: CfnBudget.SubscriberProperty[] = [];
   const snsTopics: ITopic[] = [];
 
-  for (const subscriber of subscribers) {
-    if (typeof subscriber === "string") {
-      cfn.push({ address: subscriber, subscriptionType: "EMAIL" });
-      continue;
-    }
-
-    const topic = resolve(subscriber, context);
+  if (subscribers.sns !== undefined) {
+    const topic = resolve(subscribers.sns, context);
     cfn.push({ address: topic.topicArn, subscriptionType: "SNS" });
     snsTopics.push(topic);
+  }
+
+  for (const address of subscribers.emails ?? []) {
+    cfn.push({ address, subscriptionType: "EMAIL" });
   }
 
   return { cfn, snsTopics };

--- a/packages/budgets/test/budget-alarms.test.ts
+++ b/packages/budgets/test/budget-alarms.test.ts
@@ -101,6 +101,14 @@ describe("recommended alarms", () => {
       });
     });
 
+    it("rejects an unknown ISO 4217 currency", () => {
+      expect(() =>
+        buildResult((b) => {
+          b.recommendedAlarms({ estimatedCharges: { threshold: 25, currency: "ZZZ" } });
+        }),
+      ).toThrow(/not a recognised AWS Budgets currency/);
+    });
+
     it("honours custom evaluation/datapoints overrides", () => {
       const { template } = buildResult((b) => {
         b.recommendedAlarms({

--- a/packages/budgets/test/budget-builder.test.ts
+++ b/packages/budgets/test/budget-builder.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { ref } from "@composurecdk/core";
 import { createBudgetBuilder } from "../src/budget-builder.js";
+import { email } from "../src/email.js";
+import type { NotifySubscribers } from "../src/notifications.js";
 
 function newStack(): Stack {
   const app = new App();
@@ -90,13 +92,78 @@ describe("BudgetBuilder", () => {
     });
 
     it("throws when a percentage notification has no subscribers", () => {
-      expect(() => createBudgetBuilder().notifyOnActual(80)).toThrow(/at least one subscriber/);
+      expect(() => createBudgetBuilder().notifyOnActual(80, {})).toThrow(/at least one subscriber/);
     });
 
     it("throws when withRecommendedThresholds() is called with no subscribers", () => {
-      expect(() => createBudgetBuilder().withRecommendedThresholds()).toThrow(
+      expect(() => createBudgetBuilder().withRecommendedThresholds({})).toThrow(
         /at least one subscriber/,
       );
+    });
+
+    it("throws when a notification has more than 10 email subscribers", () => {
+      const stack = newStack();
+      const eleven = Array.from({ length: 11 }, (_, i) => email(`a${String(i)}@x.co`));
+
+      const builder = createBudgetBuilder()
+        .limit({ amount: 50 })
+        .notifyOnActual(80, { emails: eleven });
+
+      expect(() => builder.build(stack, "TooMany")).toThrow(/at most 10 email subscribers/);
+    });
+
+    it("permits 1 SNS + 10 EMAIL on a single notification (AWS-documented max)", () => {
+      const stack = newStack();
+      const topic = new Topic(stack, "AlertsTopic");
+      const ten = Array.from({ length: 10 }, (_, i) => email(`a${String(i)}@x.co`));
+
+      expect(() =>
+        createBudgetBuilder()
+          .limit({ amount: 50 })
+          .notifyOnActual(80, { sns: topic, emails: ten })
+          .build(stack, "MaxSubscribers"),
+      ).not.toThrow();
+    });
+  });
+
+  describe("currency validation", () => {
+    it("throws on an unknown ISO 4217 string", () => {
+      const stack = newStack();
+      expect(() =>
+        createBudgetBuilder().limit({ amount: 25, unit: "ZZZ" }).build(stack, "BadCcy"),
+      ).toThrow(/not a recognised AWS Budgets currency/);
+    });
+
+    it("emits a soft warning when the unit is not USD", () => {
+      const stack = newStack();
+      createBudgetBuilder().limit({ amount: 25, unit: "GBP" }).build(stack, "GbpBudget");
+
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("billing currency"),
+      );
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    it("emits no warning for USD", () => {
+      const stack = newStack();
+      createBudgetBuilder().limit({ amount: 25, unit: "USD" }).build(stack, "UsdBudget");
+
+      const warnings = Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("billing currency"),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("does not validate the unit for USAGE budgets (usage units, not currencies)", () => {
+      const stack = newStack();
+      expect(() =>
+        createBudgetBuilder()
+          .budgetType("USAGE")
+          .limit({ amount: 100, unit: "GB-Mo" })
+          .build(stack, "UsageBudget"),
+      ).not.toThrow();
     });
   });
 
@@ -105,7 +172,7 @@ describe("BudgetBuilder", () => {
       const stack = newStack();
       createBudgetBuilder()
         .limit({ amount: 50 })
-        .notifyOnActual(80, "ops@example.com")
+        .notifyOnActual(80, { emails: [email("ops@example.com")] })
         .build(stack, "EmailBudget");
 
       Template.fromStack(stack).hasResourceProperties("AWS::Budgets::Budget", {
@@ -127,7 +194,7 @@ describe("BudgetBuilder", () => {
       const stack = newStack();
       createBudgetBuilder()
         .limit({ amount: 50 })
-        .notifyOnForecasted(100, "ops@example.com")
+        .notifyOnForecasted(100, { emails: [email("ops@example.com")] })
         .build(stack, "ForecastedBudget");
 
       Template.fromStack(stack).hasResourceProperties("AWS::Budgets::Budget", {
@@ -141,6 +208,14 @@ describe("BudgetBuilder", () => {
         ]),
       });
     });
+
+    it("rejects bare strings at compile time (type-level guard)", () => {
+      // If this line ever stops being a type error, the branded-Email
+      // constraint has regressed and runtime is the only remaining net.
+      // @ts-expect-error — bare string is not assignable to Email.
+      const subscribers: NotifySubscribers = { emails: ["bare@example.com"] };
+      void subscribers;
+    });
   });
 
   describe("SNS subscribers", () => {
@@ -150,7 +225,7 @@ describe("BudgetBuilder", () => {
 
       createBudgetBuilder()
         .limit({ amount: 50 })
-        .notifyOnActual(100, topic)
+        .notifyOnActual(100, { sns: topic })
         .build(stack, "SnsBudget");
 
       const template = Template.fromStack(stack);
@@ -174,8 +249,8 @@ describe("BudgetBuilder", () => {
 
       const result = createBudgetBuilder()
         .limit({ amount: 50 })
-        .notifyOnActual(80, topic)
-        .notifyOnForecasted(100, topic)
+        .notifyOnActual(80, { sns: topic })
+        .notifyOnForecasted(100, { sns: topic })
         .build(stack, "DupSnsBudget");
 
       expect(Object.keys(result.topicPolicies)).toHaveLength(1);
@@ -188,7 +263,7 @@ describe("BudgetBuilder", () => {
 
       createBudgetBuilder()
         .limit({ amount: 50 })
-        .notifyOnActual(100, ref<{ topic: Topic }>("alerts").get("topic"))
+        .notifyOnActual(100, { sns: ref<{ topic: Topic }>("alerts").get("topic") })
         .build(stack, "RefSnsBudget", { alerts: { topic } });
 
       Template.fromStack(stack).hasResourceProperties("AWS::Budgets::Budget", {
@@ -199,6 +274,37 @@ describe("BudgetBuilder", () => {
         ]),
       });
     });
+
+    it("emits 1 SNS + N EMAIL subscribers on the same notification (the original bug's fix)", () => {
+      const stack = newStack();
+      const killSwitch = new Topic(stack, "KillSwitchTopic");
+
+      createBudgetBuilder()
+        .limit({ amount: 50 })
+        .notifyOnActual(100, {
+          sns: killSwitch,
+          emails: [email("alerts@example.com")],
+        })
+        .build(stack, "MixedBudget");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Budgets::Budget", {
+        NotificationsWithSubscribers: [
+          Match.objectLike({
+            Notification: Match.objectLike({
+              NotificationType: "ACTUAL",
+              Threshold: 100,
+            }),
+            Subscribers: Match.arrayWith([
+              Match.objectLike({ SubscriptionType: "SNS" }),
+              Match.objectLike({
+                Address: "alerts@example.com",
+                SubscriptionType: "EMAIL",
+              }),
+            ]),
+          }),
+        ],
+      });
+    });
   });
 
   describe("withRecommendedThresholds", () => {
@@ -206,7 +312,7 @@ describe("BudgetBuilder", () => {
       const stack = newStack();
       createBudgetBuilder()
         .limit({ amount: 50 })
-        .withRecommendedThresholds("ops@example.com")
+        .withRecommendedThresholds({ emails: [email("ops@example.com")] })
         .build(stack, "RecBudget");
 
       const template = Template.fromStack(stack);
@@ -231,7 +337,7 @@ describe("BudgetBuilder", () => {
     it("does not duplicate notifications when build() is called twice", () => {
       const builder = createBudgetBuilder()
         .limit({ amount: 50 })
-        .withRecommendedThresholds("ops@example.com");
+        .withRecommendedThresholds({ emails: [email("ops@example.com")] });
 
       const stackA = newStack();
       builder.build(stackA, "FirstBudget");
@@ -258,7 +364,7 @@ describe("BudgetBuilder", () => {
           threshold: 120,
           thresholdType: "ABSOLUTE_VALUE",
           comparisonOperator: "GREATER_THAN",
-          subscribers: ["oncall@example.com"],
+          subscribers: { emails: [email("oncall@example.com")] },
         })
         .build(stack, "RawBudget");
 

--- a/packages/budgets/test/email.test.ts
+++ b/packages/budgets/test/email.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { email } from "../src/email.js";
+
+describe("email()", () => {
+  it("brands a syntactically valid address", () => {
+    const value = email("ops@example.com");
+    expect(value).toBe("ops@example.com");
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(email("  ops@example.com  ")).toBe("ops@example.com");
+  });
+
+  it("rejects empty input", () => {
+    expect(() => email("")).toThrow(/empty/);
+    expect(() => email("   ")).toThrow(/empty/);
+  });
+
+  it("rejects addresses over 50 characters", () => {
+    const long = "a".repeat(46) + "@b.co"; // 51 chars
+    expect(() => email(long)).toThrow(/exceeds 50/);
+  });
+
+  it("rejects strings without an @", () => {
+    expect(() => email("not-an-email")).toThrow(/invalid email/);
+  });
+
+  it("rejects strings without a TLD", () => {
+    expect(() => email("ops@example")).toThrow(/invalid email/);
+  });
+
+  it("rejects whitespace inside the address", () => {
+    expect(() => email("ops @example.com")).toThrow(/invalid email/);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace variadic `BudgetSubscriber[]` with a structured `NotifySubscribers { sns?, emails? }` shape — passing two SNS topics is now unrepresentable in TypeScript.
- Add branded `Email` type with a validating `email()` factory so bare strings are rejected at compile time.
- Validate `BudgetLimit.unit` and `EstimatedChargesAlarmConfig.currency` against `DEFAULT_BUDGET_CURRENCIES` (hard error on unknown ISO 4217 strings, soft warning on non-USD).
- Cap email subscribers at 10 per notification at synth time (AWS allows 1 SNS + 10 EMAIL).

## Why

A user hit a 5-minute partial-stack rollback from this code:

```ts
.notifyOnActual(100, alertTopic, killSwitchTopic)  // two SNS topics
```

CloudFormation accepted the template; the Budgets service rejected the request mid-deploy with `Unable to create subscriber - one notification can only have 1 subscribers with type of SNS`. A prior bug had the same shape (`Unit: "GBP"` accepted by CFN, rejected at deploy by a USD-only billing account).

Both are "service rejects what CFN accepts" — the kind of constraint the builder should encode rather than punt to a slow round-trip. This change moves both into the type system / synth-time validation.

## Migration

```ts
// before
.notifyOnActual(100, alertTopic, "ops@example.com")
.withRecommendedThresholds("ops@example.com")

// after
import { email } from "@composurecdk/budgets";

.notifyOnActual(100, { sns: alertTopic, emails: [email("ops@example.com")] })
.withRecommendedThresholds({ emails: [email("ops@example.com")] })
```

The `BudgetSubscriber` type is removed from the public API. `NotificationEntry.subscribers` is retyped to `NotifySubscribers` so the escape hatch carries the same constraint.

## Test plan

- [x] `npx nx test budgets` — 67 tests pass (added: email factory, >10-email cap, 1+10 max-allowed, ZZZ rejection, GBP soft-warning, USD no-warning, USAGE skip, type-level bare-string rejection, 1 SNS + N EMAIL on a single notification mirroring the original bug)
- [x] `npx nx run-many -t build typecheck test` — green across 15 projects
- [x] `npm run lint` and `npm run format:check` — clean
- [ ] Verify the migrated call site for the user's original bug synthesises with 1 SNS + 1 EMAIL on the 100% notification (covered by the new "original bug's fix" test case)
- [ ] Confirm `unit: "ZZZ"` errors at synth and `unit: "GBP"` annotates with `@composurecdk/budgets:limit-currency`