### PR TITLE
refactor(cloudformation)!: reshape stack strategies to consume builders; add .copy() on core Builder

### DIFF
--- a/docs/adr/0005-builder-copy.md
+++ b/docs/adr/0005-builder-copy.md
@@ -1,0 +1,52 @@
+# ADR 0005: `.copy()` on Builder for variant authoring and strategy hand-off
+
+- **Status:** Accepted
+- **Date:** 2026-05-07
+
+## Context
+
+Two recurring needs sit on top of the fluent builder pattern in `@composurecdk/core`:
+
+1. **Variant authoring.** Users want to derive multiple configured variants from a shared base — for example, a `StackBuilder` configured with common tags, then specialized per region. Today they have to re-state the base configuration at each call site or factor it into a helper that returns a fresh builder.
+
+2. **Strategy hand-off snapshot.** Stack strategies in `@composurecdk/cloudformation` (`singleStack`, `groupedStacks`) call `builder.build(scope, id)` lazily during compose-build. If the user mutates the builder between hand-off and the deferred build, those mutations leak into the strategy's stack. Issue #78 surfaced this footgun while reshaping the strategies to consume builders directly instead of `ScopeFactory`s.
+
+A previous proposal (issue #78 as originally written) resolved the second need with a `freeze()` primitive that returned an immutable snapshot. `freeze()` solves only the hand-off case, requires mutation-guard machinery on every setter, and forces a throw-vs-no-op decision for setters on a frozen builder.
+
+## Decision
+
+`core/Builder()` exposes `.copy(): IBuilder<Props, T>` as a built-in proxy property. The default implementation:
+
+1. Allocates a fresh instance via the captured constructor.
+2. Shallow-clones `props` (`{ ...target.props }`).
+3. Calls an optional `[COPY_STATE](target)` hook on the underlying class so it can copy non-`props` state (private fields, internal accumulators).
+4. Wraps the new instance in a fresh proxy via `Builder(constructor, instance)` and returns it.
+
+`COPY_STATE` is a `Symbol.for(...)` key. Symbols pass through the existing `typeof prop === "symbol"` branch in the proxy, so the hook is invisible to the fluent API and to IDE autocomplete.
+
+`Builder()` accepts an optional second parameter, `instance: T = new constructor()`, used by `.copy()` (and any future caller) to wrap a pre-built instance without re-running the constructor for default state.
+
+`.copy()` is added to the `IBuilder` mapped type so it is discoverable in TS autocomplete on every builder.
+
+### Decorator-builder protocol
+
+Decorators that wrap `Builder()` and hold state on an outer proxy (for example a tag accumulator) **must override `.copy()` in that outer proxy**: clone the decorator's own state, chain to the inner `.copy()`, and re-wrap. The `[COPY_STATE]` hook only reaches the inner instance; it cannot see decorator-layer state. The protocol is part of the public contract for any future decorator pattern in this library.
+
+### Shallow vs deep clone of `props`
+
+`props` is shallow-cloned. Top-level keys are independent between original and copy; nested CDK references (VPCs, IRoles, etc.) are shared by design — these are construct identities, not configuration data. This matches the existing single-spread merge pattern (`{ ...DEFAULTS, ...this.props }`) used throughout the library. Builders with internal lists/maps/sets that should be deep-cloned implement `[COPY_STATE]`.
+
+## Alternatives considered
+
+- **`.freeze()` returning an immutable snapshot** (the original proposal in #78). Rejected: solves only the strategy hand-off problem, not variant authoring. Requires mutation guards on every setter and a throw-vs-no-op decision. `.copy()` covers the same hand-off case via the inline `singleStack(builder.copy())` idiom and additionally unlocks variant authoring with strictly less machinery.
+- **`.copy()` per-builder rather than in core.** Each builder class implements its own `.copy()`. Rejected: every builder would need the same proxy-rewrap dance; consumers would face an inconsistent surface (some builders have `.copy()`, others don't); the public contract for variant authoring would not be discoverable in `IBuilder`.
+- **Deep-clone `props` (e.g., via `structuredClone`).** Rejected: CDK construct references in props (VPC, IRole, ISecurityGroup) are not cloneable and shouldn't be — they are identities. Shallow clone matches the existing merge pattern and keeps construct identity stable across copies.
+- **Named-method hook (`copyStateInto`) instead of a Symbol.** Rejected: a named method either pollutes the public surface (showing up on every builder's autocomplete) or requires special-casing in the proxy's `methods` set. The Symbol passes cleanly through `Reflect.get`.
+
+## Consequences
+
+- Every builder gets `.copy()` for free without per-class boilerplate.
+- Builders with non-`props` state (StackBuilder's `#tags`; future decorator accumulators) opt in via `[COPY_STATE]` or, for decorator layers, by overriding `.copy()` in their proxy. The protocol is part of the public builder contract going forward.
+- The strategy reshape in #78 documents `singleStack(builder.copy())` as the snapshot-handoff idiom. The library does not enforce it at runtime; passing a live builder is permitted and useful when no further mutation occurs.
+- Shallow-clone semantics are part of the API. Documented in [architecture.md](../architecture.md#copying-a-builder) and JSDoc on `IBuilder.copy`.
+- `Builder()` now accepts an optional `instance` parameter. This is implementation infrastructure for `.copy()`; library consumers should continue to call `Builder(constructor)` with one argument unless they have a specific reason to wrap a pre-built instance.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0002: Policies — cross-cutting helpers applied to a construct subtree](0002-policies.md)
 - [ADR-0003: Nested `compose()` — propagate parent context into inner components](0003-nested-compose-context-propagation.md)
 - [ADR-0004: Split-alarm builder pattern for AWS services with fixed-region metrics](0004-split-alarm-builder-for-fixed-region-metrics.md)
+- [ADR-0005: `.copy()` on Builder for variant authoring and strategy hand-off](0005-builder-copy.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,6 +174,25 @@ The class must have a `props: Partial<Props>` field (this is how the builder pro
 
 Builder authors: see [ADR-0001](adr/0001-builder-type-emission.md) for type-emission rules.
 
+### Copying a builder
+
+Every builder exposes `.copy()`, returning an independent builder with the same configured state. Mutations to either side do not affect the other. This unlocks two patterns:
+
+```typescript
+// Variant authoring: derive specialized builders from a shared base
+const baseStack = createStackBuilder().tag("project", "shared");
+
+const us = baseStack.copy().description("US region stack");
+const eu = baseStack.copy().description("EU region stack");
+
+// Strategy hand-off snapshot: pass an isolated builder to a strategy
+compose(...).withStackStrategy(singleStack(baseStack.copy())).build(app, "MySystem");
+```
+
+`.copy()` shallow-clones `props`. Top-level keys are independent; nested object references (CDK constructs, IRoles, IVpcs) are shared by design — these are construct identities, not configuration data.
+
+State stored outside `props` (private fields, internal accumulators) is invisible to the default `.copy()`. A class that holds such state implements a `[COPY_STATE]` hook to copy it onto the cloned instance. Decorators that wrap `Builder()` and hold their own state on an outer proxy must override `.copy()` in that proxy rather than rely on the hook. See [ADR-0005](adr/0005-builder-copy.md) for the full design rationale.
+
 ## Defaults
 
 Builders apply secure, AWS-recommended defaults to every resource they create. Each builder package exports a `defaults.ts` module containing a constant of type `Partial<Props>` — the set of properties that are applied unless the user explicitly overrides them.

--- a/docs/stack-management.md
+++ b/docs/stack-management.md
@@ -96,19 +96,30 @@ compose({ handler, api, table }, { handler: [], api: ["handler"], table: [] })
   .build(app, "MySystem");
 ```
 
-Both `singleStack` and `groupedStacks` from `@composurecdk/cloudformation` default to creating CDK Stacks. Pass a custom `ScopeFactory` to use `DeploymentStack` or other subclasses:
+Both `singleStack` and `groupedStacks` from `@composurecdk/cloudformation` default to creating a plain CDK Stack. Pass a configured `IStackBuilder` to apply `description`, `terminationProtection`, tags, etc. to every Stack the strategy creates:
 
 ```ts
-import { singleStack } from "@composurecdk/cloudformation";
-import { createStackBuilder } from "@composurecdk/cloudformation";
+import { singleStack, createStackBuilder } from "@composurecdk/cloudformation";
 
-const factory = createStackBuilder()
+const baseStack = createStackBuilder()
   .terminationProtection(true)
-  .tag("team", "platform")
-  .toScopeFactory();
+  .tag("team", "platform");
 
 compose({ ... }, { ... })
-  .withStackStrategy(singleStack(factory))
+  .withStackStrategy(singleStack(baseStack.copy()))
+  .build(app, "MySystem");
+```
+
+The strategy calls `builder.build(scope, id).stack` lazily. Pass `builder.copy()` (rather than the live builder) when the original may be mutated further — `.copy()` snapshots the current props and tags so later edits do not leak into the strategy's stack.
+
+For non-Stack scope types (`DeploymentStack`, custom subclasses), drop down to `@composurecdk/core`'s `singleStack` / `groupedStacks`, which accept a raw `ScopeFactory`:
+
+```ts
+import { singleStack } from "@composurecdk/core";
+import { DeploymentStack } from "my-cdk-extensions";
+
+compose({ ... }, { ... })
+  .withStackStrategy(singleStack((scope, id) => new DeploymentStack(scope, id)))
   .build(app, "MySystem");
 ```
 
@@ -180,6 +191,6 @@ When `scope` is omitted, the output falls back to the scope passed to `build()` 
 Stack management is split across two packages:
 
 - **`@composurecdk/core`** — `StackStrategy`, `ScopeFactory`, `singleStack(factory)`, `groupedStacks(classify, factory)`, and `.withStacks()` / `.withStackStrategy()` on `ComposedSystem`. Core depends only on `constructs`, not `aws-cdk-lib`.
-- **`@composurecdk/cloudformation`** — `createStackBuilder()`, plus convenience `singleStack(factory?)` and `groupedStacks(classify, factory?)` that default to creating CDK Stacks. This package depends on `aws-cdk-lib`.
+- **`@composurecdk/cloudformation`** — `createStackBuilder()`, plus convenience `singleStack(builder?)` and `groupedStacks(classify, builder?)` that accept a `Lifecycle<StackBuilderResult>` (typically an `IStackBuilder`) and default to a fresh `createStackBuilder()`. This package depends on `aws-cdk-lib`.
 
-If you use CDK `Stack` (the common case), import strategies from `@composurecdk/cloudformation` for the default factory. If you use a custom Stack subclass, import from `@composurecdk/core` and provide your own `ScopeFactory`.
+If you use CDK `Stack` (the common case), import strategies from `@composurecdk/cloudformation` and pass a configured `IStackBuilder` (with `.copy()` to snapshot when needed). If you use a custom Stack subclass, import from `@composurecdk/core` and provide your own `ScopeFactory`.

--- a/packages/cloudformation/README.md
+++ b/packages/cloudformation/README.md
@@ -28,24 +28,20 @@ const { stack } = createStackBuilder()
   .build(app, "ServiceStack");
 ```
 
-### Scope factory
+### Variants and snapshots with `.copy()`
 
-Convert a configured builder into a `ScopeFactory` for use with stack strategies:
+`.copy()` returns an independent builder with the same configured state. Use it to derive variants from a shared base, or to snapshot a builder before handing it to a stack strategy that may be invoked after further mutations:
 
 ```ts
-const factory = createStackBuilder()
-  .terminationProtection(true)
-  .tag("team", "platform")
-  .toScopeFactory();
+const baseStack = createStackBuilder().tag("team", "platform");
 
-compose({ ... }, { ... })
-  .withStackStrategy(singleStack(factory))
-  .build(app, "MySystem");
+const { stack: us } = baseStack.copy().description("US region").build(app, "UsStack");
+const { stack: eu } = baseStack.copy().description("EU region").build(app, "EuStack");
 ```
 
 ## Stack Strategies
 
-Convenience wrappers around `@composurecdk/core`'s strategy primitives that default to creating Stacks via `createStackBuilder`. Pass an optional `ScopeFactory` to customise the Stack configuration.
+Convenience wrappers around `@composurecdk/core`'s strategy primitives. Both accept a `Lifecycle<StackBuilderResult>` (typically an `IStackBuilder`) and default to a fresh `createStackBuilder()` per call.
 
 ### singleStack
 
@@ -59,6 +55,16 @@ compose({ handler, api }, { handler: [], api: ["handler"] })
   .build(app, "MySystem");
 ```
 
+Pass a configured builder to apply tags, description, etc. to the strategy's stack. Use `.copy()` to snapshot the configuration when the original may be mutated later:
+
+```ts
+const base = createStackBuilder().tag("team", "platform");
+
+compose({ ... }, { ... })
+  .withStackStrategy(singleStack(base.copy()))
+  .build(app, "MySystem");
+```
+
 ### groupedStacks
 
 Groups components into named Stacks by a classifier function:
@@ -69,6 +75,18 @@ import { groupedStacks } from "@composurecdk/cloudformation";
 compose({ handler, api, table }, { ... })
   .withStackStrategy(
     groupedStacks((key) => (key === "table" ? "persistence" : "service")),
+  )
+  .build(app, "MySystem");
+```
+
+The same builder is invoked once per group key with `${systemId}-${group}` as the id, so any tags configured on the supplied builder propagate to every stack the strategy creates. As with `singleStack`, pass `builder.copy()` to snapshot the configuration when the original may be mutated after hand-off:
+
+```ts
+const base = createStackBuilder().tag("team", "platform");
+
+compose({ ... }, { ... })
+  .withStackStrategy(
+    groupedStacks((key) => (key === "table" ? "persistence" : "service"), base.copy()),
   )
   .build(app, "MySystem");
 ```

--- a/packages/cloudformation/src/stack-builder.ts
+++ b/packages/cloudformation/src/stack-builder.ts
@@ -1,6 +1,6 @@
 import { Stack, type StackProps, Tags } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle, type ScopeFactory } from "@composurecdk/core";
+import { Builder, COPY_STATE, type IBuilder, type Lifecycle } from "@composurecdk/core";
 
 /**
  * The build output of a {@link IStackBuilder}. Contains the CDK Stack
@@ -18,14 +18,15 @@ export interface StackBuilderResult {
  * as an overloaded method: call with a value to set it (returns the builder
  * for chaining), or call with no arguments to read the current value.
  *
- * The builder implements {@link Lifecycle}, so it can be used directly as a
- * component in a {@link compose | composed system}. When built, it creates
- * a Stack with the configured properties and returns a
- * {@link StackBuilderResult}.
+ * The builder implements {@link Lifecycle}, so it can be used directly as
+ * a component in a {@link compose | composed system}, or handed to a stack
+ * strategy via {@link singleStack} / {@link groupedStacks}. When handing a
+ * builder to a strategy that may be invoked after further configuration of
+ * the original, pass `builder.copy()` to snapshot the current state.
  *
  * @example
  * ```ts
- * const stack = createStackBuilder()
+ * const { stack } = createStackBuilder()
  *   .description("Network infrastructure")
  *   .terminationProtection(true)
  *   .build(app, "NetworkStack");
@@ -41,26 +42,6 @@ export type IStackBuilder = IBuilder<StackProps, StackBuilder> & {
    * @returns The builder for chaining.
    */
   tag(key: string, value: string): IStackBuilder;
-
-  /**
-   * Returns a {@link ScopeFactory} that creates Stacks with the builder's
-   * configured properties. Use this to integrate with
-   * {@link singleStack} or {@link groupedStacks} strategies.
-   *
-   * @returns A factory function compatible with stack strategies.
-   *
-   * @example
-   * ```ts
-   * const factory = createStackBuilder()
-   *   .terminationProtection(true)
-   *   .toScopeFactory();
-   *
-   * compose({ ... }, { ... })
-   *   .withStackStrategy(singleStack(factory))
-   *   .build(app, "MySystem");
-   * ```
-   */
-  toScopeFactory(): ScopeFactory;
 };
 
 class StackBuilder implements Lifecycle<StackBuilderResult> {
@@ -72,16 +53,8 @@ class StackBuilder implements Lifecycle<StackBuilderResult> {
     return this;
   }
 
-  toScopeFactory(): ScopeFactory {
-    const props = { ...this.props };
-    const tags = [...this.#tags];
-    return (scope: IConstruct, id: string) => {
-      const stack = new Stack(scope, id, props);
-      tags.forEach(([key, value]) => {
-        Tags.of(stack).add(key, value);
-      });
-      return stack;
-    };
+  [COPY_STATE](next: StackBuilder): void {
+    next.#tags.push(...this.#tags);
   }
 
   build(scope: IConstruct, id: string): StackBuilderResult {
@@ -98,9 +71,9 @@ class StackBuilder implements Lifecycle<StackBuilderResult> {
  *
  * This is the entry point for declarative stack configuration. The returned
  * builder exposes every {@link StackProps} property as a fluent setter/getter,
- * plus {@link IStackBuilder.tag | .tag()} for adding tags and
- * {@link IStackBuilder.toScopeFactory | .toScopeFactory()} for integration
- * with stack strategies.
+ * plus {@link IStackBuilder.tag | .tag()} for adding tags. It implements
+ * {@link Lifecycle}, so it composes naturally and can be passed to
+ * {@link singleStack} or {@link groupedStacks}.
  *
  * @returns A fluent builder for a CloudFormation Stack.
  *
@@ -112,14 +85,14 @@ class StackBuilder implements Lifecycle<StackBuilderResult> {
  *   .terminationProtection(true)
  *   .build(app, "ServiceStack");
  *
- * // Use as a scope factory with strategies
- * const factory = createStackBuilder()
+ * // Hand a configured builder to a strategy. Use `.copy()` to snapshot
+ * // when the original may be mutated further.
+ * const base = createStackBuilder()
  *   .terminationProtection(true)
- *   .tag("team", "platform")
- *   .toScopeFactory();
+ *   .tag("team", "platform");
  *
  * compose({ ... }, { ... })
- *   .withStackStrategy(singleStack(factory))
+ *   .withStackStrategy(singleStack(base.copy()))
  *   .build(app, "MySystem");
  * ```
  */

--- a/packages/cloudformation/src/strategies.ts
+++ b/packages/cloudformation/src/strategies.ts
@@ -1,23 +1,26 @@
 import {
-  type ScopeFactory,
+  type Lifecycle,
   type StackStrategy,
   singleStack as coreSingleStack,
   groupedStacks as coreGroupedStacks,
 } from "@composurecdk/core";
-import { createStackBuilder } from "./stack-builder.js";
-
-function defaultFactory(): ScopeFactory {
-  return createStackBuilder().toScopeFactory();
-}
+import { createStackBuilder, type StackBuilderResult } from "./stack-builder.js";
 
 /**
  * Creates a strategy that places all components in a single Stack.
  *
- * The Stack is created lazily on the first call to `resolve` and reused for
- * all subsequent components.
+ * The Stack is created lazily on the first call to `resolve` and reused
+ * for all subsequent components. The supplied `builder` is invoked at that
+ * point as `builder.build(scope, id).stack`, so any tags applied via the
+ * builder's `.tag()` method land on the resulting Stack.
  *
- * @param factory - Optional factory for creating the Stack. Defaults to
- *   a plain CDK `Stack` via {@link createStackBuilder}.
+ * The builder's `build()` is called lazily. If the original may be mutated
+ * after this call, pass `builder.copy()` to snapshot the configuration.
+ *
+ * @param builder - Optional builder for configuring the Stack. Defaults to
+ *   a fresh {@link createStackBuilder} per call, producing a plain Stack
+ *   with no extra configuration. For non-Stack scope types, use
+ *   `singleStack` from `@composurecdk/core` directly with a `ScopeFactory`.
  * @returns A {@link StackStrategy} that groups all components into one Stack.
  *
  * @example
@@ -25,23 +28,37 @@ function defaultFactory(): ScopeFactory {
  * compose({ handler, api }, { handler: [], api: ["handler"] })
  *   .withStackStrategy(singleStack())
  *   .build(app, "MySystem");
+ *
+ * // With a configured builder:
+ * const base = createStackBuilder().tag("team", "platform");
+ * compose({ ... }, { ... })
+ *   .withStackStrategy(singleStack(base.copy()))
+ *   .build(app, "MySystem");
  * ```
  */
-export function singleStack(factory?: ScopeFactory): StackStrategy {
-  return coreSingleStack(factory ?? defaultFactory());
+export function singleStack(builder?: Lifecycle<StackBuilderResult>): StackStrategy {
+  const stackBuilder = builder ?? createStackBuilder();
+  return coreSingleStack((scope, id) => stackBuilder.build(scope, id).stack);
 }
 
 /**
  * Creates a strategy that groups components into named Stacks determined by
  * a classifier function.
  *
- * Components that return the same group key share a Stack. Stacks are created
- * lazily as new group keys are encountered.
+ * Components that return the same group key share a Stack. Stacks are
+ * created lazily as new group keys are encountered. The supplied `builder`
+ * is invoked once per group as `builder.build(scope, id).stack` with
+ * `id = ${systemId}-${group}`, so any configured tags propagate to every
+ * Stack the strategy creates.
+ *
+ * The builder's `build()` is called lazily. If the original may be mutated
+ * after this call, pass `builder.copy()` to snapshot the configuration.
  *
  * @param classify - A function that maps a component key to a group name.
- * @param factory - Optional factory for creating Stacks. Defaults to
- *   a plain CDK `Stack` via {@link createStackBuilder}. The factory receives
- *   `${systemId}-${group}` as the id.
+ * @param builder - Optional builder for configuring each Stack. Defaults to
+ *   a fresh {@link createStackBuilder} per call. For non-Stack scope types,
+ *   use `groupedStacks` from `@composurecdk/core` directly with a
+ *   `ScopeFactory`.
  * @returns A {@link StackStrategy} that groups components by classifier output.
  *
  * @example
@@ -49,11 +66,20 @@ export function singleStack(factory?: ScopeFactory): StackStrategy {
  * compose({ handler, api, table }, { ... })
  *   .withStackStrategy(groupedStacks(key => key === "table" ? "persistence" : "service"))
  *   .build(app, "MySystem");
+ *
+ * // With a configured builder, snapshotted via .copy():
+ * const base = createStackBuilder().tag("team", "platform");
+ * compose({ ... }, { ... })
+ *   .withStackStrategy(
+ *     groupedStacks(key => key === "table" ? "persistence" : "service", base.copy()),
+ *   )
+ *   .build(app, "MySystem");
  * ```
  */
 export function groupedStacks(
   classify: (componentKey: string) => string,
-  factory?: ScopeFactory,
+  builder?: Lifecycle<StackBuilderResult>,
 ): StackStrategy {
-  return coreGroupedStacks(classify, factory ?? defaultFactory());
+  const stackBuilder = builder ?? createStackBuilder();
+  return coreGroupedStacks(classify, (scope, id) => stackBuilder.build(scope, id).stack);
 }

--- a/packages/cloudformation/test/outputs.test.ts
+++ b/packages/cloudformation/test/outputs.test.ts
@@ -252,7 +252,7 @@ describe("outputs", () => {
         { data: stubComponent({ name: "t1" }), api: stubComponent({ route: "/" }) },
         { data: [], api: ["data"] },
       )
-        .withStackStrategy(groupedStacks(classify, (parent, id) => new Stack(parent, id)))
+        .withStackStrategy(groupedStacks(classify))
         .afterBuild(
           outputs({
             TableName: { value: "tbl", scope: "data" },

--- a/packages/cloudformation/test/stack-builder.test.ts
+++ b/packages/cloudformation/test/stack-builder.test.ts
@@ -63,43 +63,62 @@ describe("StackBuilder", () => {
     });
   });
 
-  describe("toScopeFactory", () => {
-    it("returns a factory that creates Stacks with configured props", () => {
-      const factory = createStackBuilder()
-        .description("Factory stack")
-        .terminationProtection(true)
-        .toScopeFactory();
+  describe("copy", () => {
+    it("returns an independent builder with the same configured props", () => {
+      const original = createStackBuilder()
+        .description("Original description")
+        .terminationProtection(true);
 
-      const app = new App();
-      const scope = factory(app, "FactoryStack");
+      const copy = original.copy();
 
-      expect(scope).toBeInstanceOf(Stack);
-      const stack = scope as Stack;
-      expect(stack.templateOptions.description).toBe("Factory stack");
-      expect(stack.terminationProtection).toBe(true);
+      expect(copy.description()).toBe("Original description");
+      expect(copy.terminationProtection()).toBe(true);
     });
 
-    it("returns a factory that applies tags", () => {
-      const factory = createStackBuilder().tag("team", "platform").toScopeFactory();
+    it("isolates props mutations between original and copy", () => {
+      const original = createStackBuilder().description("Original");
+      const copy = original.copy();
 
+      original.description("Mutated original");
+      copy.description("Mutated copy");
+
+      expect(original.description()).toBe("Mutated original");
+      expect(copy.description()).toBe("Mutated copy");
+    });
+
+    it("isolates tag mutations between original and copy", () => {
       const app = new App();
-      factory(app, "TaggedFactoryStack");
+      const original = createStackBuilder().tag("team", "platform");
+      const copy = original.copy();
+
+      original.tag("env", "prod");
+      copy.tag("env", "test");
+
+      const { stack: originalStack } = original.build(app, "OriginalStack");
+      const { stack: copyStack } = copy.build(app, "CopyStack");
 
       const assembly = app.synth();
-      const stackArtifact = assembly.getStackByName("TaggedFactoryStack");
-      expect(stackArtifact.tags).toEqual({ team: "platform" });
+      expect(assembly.getStackByName(originalStack.stackName).tags).toEqual({
+        team: "platform",
+        env: "prod",
+      });
+      expect(assembly.getStackByName(copyStack.stackName).tags).toEqual({
+        team: "platform",
+        env: "test",
+      });
     });
 
-    it("creates independent stacks on each call", () => {
-      const factory = createStackBuilder().description("Shared config").toScopeFactory();
-
+    it("preserves accumulated tags on the copy", () => {
       const app = new App();
-      const stack1 = factory(app, "Stack1");
-      const stack2 = factory(app, "Stack2");
+      const original = createStackBuilder().tag("team", "platform").tag("env", "prod");
 
-      expect(stack1).not.toBe(stack2);
-      expect(stack1).toBeInstanceOf(Stack);
-      expect(stack2).toBeInstanceOf(Stack);
+      const { stack } = original.copy().build(app, "CopiedTaggedStack");
+
+      const assembly = app.synth();
+      expect(assembly.getStackByName(stack.stackName).tags).toEqual({
+        team: "platform",
+        env: "prod",
+      });
     });
   });
 

--- a/packages/cloudformation/test/strategies.test.ts
+++ b/packages/cloudformation/test/strategies.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
-import { Construct } from "constructs";
+import type { Lifecycle } from "@composurecdk/core";
 import { singleStack, groupedStacks } from "../src/strategies.js";
+import { createStackBuilder, type StackBuilderResult } from "../src/stack-builder.js";
 
 describe("singleStack", () => {
   it("creates a CDK Stack by default", () => {
@@ -23,15 +24,64 @@ describe("singleStack", () => {
     expect(scopeA).toBe(scopeB);
   });
 
-  it("uses a custom factory when provided", () => {
-    const factory = vi.fn((scope: Construct, id: string) => new Construct(scope, id));
-    const strategy = singleStack(factory);
+  it("uses a configured builder when provided", () => {
+    const builder = createStackBuilder().description("Configured by test");
+    const strategy = singleStack(builder);
     const app = new App();
 
-    strategy.resolve(app, "sys", "a");
+    const stack = strategy.resolve(app, "sys", "a") as Stack;
 
-    expect(factory).toHaveBeenCalledOnce();
-    expect(factory).toHaveBeenCalledWith(app, "sys");
+    expect(stack.templateOptions.description).toBe("Configured by test");
+  });
+
+  it("applies tags from the supplied builder to the resulting Stack", () => {
+    const builder = createStackBuilder().tag("team", "platform");
+    const strategy = singleStack(builder);
+    const app = new App();
+
+    strategy.resolve(app, "TaggedSys", "a");
+
+    const assembly = app.synth();
+    expect(assembly.getStackByName("TaggedSys").tags).toEqual({ team: "platform" });
+  });
+
+  it("isolates default-builder state across separate strategy invocations", () => {
+    const strategyA = singleStack();
+    const strategyB = singleStack();
+
+    const appA = new App();
+    const appB = new App();
+
+    strategyA.resolve(appA, "SysA", "a");
+    strategyB.resolve(appB, "SysB", "b");
+
+    expect(appA.synth().getStackByName("SysA").tags).toEqual({});
+    expect(appB.synth().getStackByName("SysB").tags).toEqual({});
+  });
+
+  it("snapshots configuration when handed builder.copy()", () => {
+    const base = createStackBuilder().tag("team", "platform");
+    const strategy = singleStack(base.copy());
+
+    base.tag("env", "leaked");
+
+    const app = new App();
+    strategy.resolve(app, "SnapshotSys", "a");
+
+    const assembly = app.synth();
+    expect(assembly.getStackByName("SnapshotSys").tags).toEqual({ team: "platform" });
+  });
+
+  it("accepts any Lifecycle<StackBuilderResult>", () => {
+    const app = new App();
+    const stub: Lifecycle<StackBuilderResult> = {
+      build: (scope, id) => ({ stack: new Stack(scope, id, { description: "from stub" }) }),
+    };
+
+    const strategy = singleStack(stub);
+    const stack = strategy.resolve(app, "StubSys", "a") as Stack;
+
+    expect(stack.templateOptions.description).toBe("from stub");
   });
 });
 
@@ -60,15 +110,31 @@ describe("groupedStacks", () => {
     expect(handlerScope).toBe(apiScope);
   });
 
-  it("uses a custom factory when provided", () => {
-    const factory = vi.fn((scope: Construct, id: string) => new Construct(scope, id));
+  it("uses a configured builder when provided", () => {
+    const builder = createStackBuilder().tag("team", "platform");
     const classify = (key: string) => (key === "table" ? "persistence" : "service");
-    const strategy = groupedStacks(classify, factory);
+    const strategy = groupedStacks(classify, builder);
     const app = new App();
 
-    strategy.resolve(app, "sys", "handler");
-    strategy.resolve(app, "sys", "table");
+    strategy.resolve(app, "Sys", "handler");
+    strategy.resolve(app, "Sys", "table");
 
-    expect(factory).toHaveBeenCalledTimes(2);
+    const assembly = app.synth();
+    expect(assembly.getStackByName("Sys-service").tags).toEqual({ team: "platform" });
+    expect(assembly.getStackByName("Sys-persistence").tags).toEqual({ team: "platform" });
+  });
+
+  it("snapshots configuration when handed builder.copy()", () => {
+    const base = createStackBuilder().tag("team", "platform");
+    const classify = (key: string) => (key === "table" ? "persistence" : "service");
+    const strategy = groupedStacks(classify, base.copy());
+
+    base.tag("env", "leaked");
+
+    const app = new App();
+    strategy.resolve(app, "Sys", "handler");
+
+    const assembly = app.synth();
+    expect(assembly.getStackByName("Sys-service").tags).toEqual({ team: "platform" });
   });
 });

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -12,6 +12,32 @@ interface ObjectWithProps<Props extends object> {
 }
 
 /**
+ * Optional hook a builder class can implement to clone non-`props` state
+ * during {@link IBuilder.copy}.
+ *
+ * The default `.copy()` shallow-clones `props` and wraps a fresh instance.
+ * State stored outside `props` (private fields, internal accumulators) is
+ * invisible to that default. A class with such state defines a method
+ * keyed by this symbol to copy it onto the new instance.
+ *
+ * See ADR-0005 for the full protocol, including how decorator layers
+ * participate.
+ *
+ * @example
+ * ```ts
+ * class StackBuilder {
+ *   props: Partial<StackProps> = {};
+ *   readonly #tags: [string, string][] = [];
+ *
+ *   [COPY_STATE](target: StackBuilder): void {
+ *     target.#tags.push(...this.#tags);
+ *   }
+ * }
+ * ```
+ */
+export const COPY_STATE = Symbol.for("composurecdk.builder.copyState");
+
+/**
  * A fluent builder interface generated from a props type and a target class.
  *
  * For each key in `Props`, the builder exposes an overloaded method:
@@ -22,6 +48,9 @@ interface ObjectWithProps<Props extends object> {
  * replaced to return the builder. All other members of `T` pass through as-is,
  * allowing methods like `build()` to be called directly on the builder.
  *
+ * Every builder also exposes {@link IBuilder.copy | `.copy()`}, which returns
+ * an independent builder with the same configured state.
+ *
  * @typeParam Props - The configurable properties.
  * @typeParam T - The target class the builder wraps.
  */
@@ -29,12 +58,38 @@ export type IBuilder<Props extends object, T> = {
   [K in keyof Props]-?: ((arg: Props[K]) => IBuilder<Props, T>) & (() => Props[K]);
 } & {
   [K in keyof T]: T[K] extends (...args: infer A) => T ? (...args: A) => IBuilder<Props, T> : T[K];
+} & {
+  /**
+   * Returns an independent builder with the same configured props and any
+   * state that the underlying class copies via {@link COPY_STATE}.
+   *
+   * Mutations to the returned builder do not affect the original, and
+   * vice versa.
+   *
+   * `props` is shallow-cloned (`{ ...this.props }`). Top-level keys are
+   * independent; nested object references (CDK constructs, IRoles, IVpcs,
+   * etc.) are shared by design — they are construct identities, not
+   * configuration data. Builders with internal lists/maps/sets that should
+   * be deep-cloned implement {@link COPY_STATE}.
+   *
+   * Use cases:
+   * - **Variant authoring** — derive multiple builders from a shared base
+   *   (`const us = base.copy().region("us-east-1")`).
+   * - **Strategy hand-off snapshot** — pass an isolated builder to a stack
+   *   strategy (`singleStack(base.copy())`) so later mutations to the
+   *   original don't leak into the strategy's lazy `build()`.
+   *
+   * See ADR-0005 for the design rationale.
+   */
+  copy(): IBuilder<Props, T>;
 };
 
 /**
  * Creates a fluent builder wrapping an instance of `T`.
  *
  * The builder is backed by a {@link Proxy} that intercepts property access:
+ * - For `copy`: returns a function that produces an independent builder with
+ *   the same configured state (see {@link IBuilder.copy}).
  * - For keys in `Props`: returns a getter/setter function. When called with a
  *   value, it sets the prop and returns the builder. When called with no args,
  *   it returns the current value.
@@ -42,12 +97,15 @@ export type IBuilder<Props extends object, T> = {
  * - For all other members: delegates directly to the underlying instance.
  *
  * @param constructor - The class to instantiate and wrap.
- * @returns A fluent {@link IBuilder} wrapping a new instance of `T`.
+ * @param instance - Optional pre-existing instance to wrap. Defaults to
+ *   `new constructor()`. Used internally by {@link IBuilder.copy} to wrap a
+ *   freshly cloned instance without re-running the constructor for new state.
+ * @returns A fluent {@link IBuilder} wrapping `instance`.
  */
 export function Builder<Props extends object, T extends ObjectWithProps<Props>>(
   constructor: Constructor<T>,
+  instance: T = new constructor(),
 ): IBuilder<Props, T> {
-  const instance = new constructor();
   const methods = new Set(
     Object.getOwnPropertyNames(Object.getPrototypeOf(instance)).filter(
       (key) =>
@@ -59,6 +117,18 @@ export function Builder<Props extends object, T extends ObjectWithProps<Props>>(
     get(target: T, prop: string | symbol) {
       if (typeof prop === "symbol") {
         return Reflect.get(target, prop) as unknown;
+      }
+
+      if (prop === "copy") {
+        return () => {
+          const next = new constructor();
+          next.props = { ...target.props };
+          const hook = (target as unknown as Record<symbol, unknown>)[COPY_STATE];
+          if (typeof hook === "function") {
+            (hook as (next: T) => void).call(target, next);
+          }
+          return Builder<Props, T>(constructor, next);
+        };
       }
 
       // Props getter/setter

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { Builder, type IBuilder } from "./builder.js";
+export { Builder, COPY_STATE, type IBuilder } from "./builder.js";
 export { constructId, sanitizeConstructId } from "./construct-id.js";
 export {
   compose,

--- a/packages/core/test/builder.test.ts
+++ b/packages/core/test/builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { Builder, type IBuilder } from "../src/builder.js";
+import { Builder, COPY_STATE, type IBuilder } from "../src/builder.js";
 
 // -- Test fixtures --
 
@@ -229,6 +229,157 @@ describe("Builder", () => {
 
       expect(builder1.name()).toBe("Alice");
       expect(builder2.name()).toBe("Bob");
+    });
+  });
+
+  describe("copy", () => {
+    it("returns a chainable builder of the same shape", () => {
+      const builder = Builder<SimpleProps, SimpleTarget>(SimpleTarget).name("Alice").count(5);
+
+      const copy = builder.copy();
+
+      expect(copy.name()).toBe("Alice");
+      expect(copy.count()).toBe(5);
+      expect(copy.greet()).toBe("Hello, Alice");
+    });
+
+    it("preserves all configured props", () => {
+      const builder = Builder<PropsWithDefaults, TargetWithDefaults>(TargetWithDefaults)
+        .enabled(false)
+        .timeout(60);
+
+      const copy = builder.copy();
+
+      expect(copy.enabled()).toBe(false);
+      expect(copy.timeout()).toBe(60);
+    });
+
+    it("isolates the copy from later mutations to the original", () => {
+      const original = Builder<SimpleProps, SimpleTarget>(SimpleTarget).name("Alice").count(5);
+
+      const copy = original.copy();
+      original.name("Bob").count(99);
+
+      expect(copy.name()).toBe("Alice");
+      expect(copy.count()).toBe(5);
+    });
+
+    it("isolates the original from later mutations to the copy", () => {
+      const original = Builder<SimpleProps, SimpleTarget>(SimpleTarget).name("Alice").count(5);
+
+      const copy = original.copy();
+      copy.name("Bob").count(99);
+
+      expect(original.name()).toBe("Alice");
+      expect(original.count()).toBe(5);
+    });
+
+    it("shares nested object references (shallow clone)", () => {
+      interface NestedProps {
+        config: { key: string };
+      }
+      class NestedTarget {
+        props: Partial<NestedProps> = {};
+      }
+
+      const config = { key: "value" };
+      const builder = Builder<NestedProps, NestedTarget>(NestedTarget).config(config);
+
+      const copy = builder.copy();
+
+      expect(copy.config()).toBe(config);
+      expect(copy.config()).toBe(builder.config());
+    });
+
+    it("invokes [COPY_STATE] when defined on the underlying class", () => {
+      const hook = vi.fn();
+      class WithHook {
+        props: Partial<SimpleProps> = {};
+        [COPY_STATE](next: WithHook): void {
+          hook(next);
+        }
+      }
+
+      const builder = Builder<SimpleProps, WithHook>(WithHook).name("Alice");
+
+      builder.copy();
+
+      expect(hook).toHaveBeenCalledOnce();
+      const arg = hook.mock.calls[0]?.[0] as WithHook | undefined;
+      expect(arg).toBeInstanceOf(WithHook);
+      expect(arg?.props.name).toBe("Alice");
+    });
+
+    it("uses [COPY_STATE] to deep-clone class-private state", () => {
+      class WithAccumulator {
+        props: Partial<SimpleProps> = {};
+        readonly #items: string[] = [];
+
+        add(value: string): this {
+          this.#items.push(value);
+          return this;
+        }
+
+        items(): readonly string[] {
+          return this.#items;
+        }
+
+        [COPY_STATE](next: WithAccumulator): void {
+          next.#items.push(...this.#items);
+        }
+      }
+
+      const original = Builder<SimpleProps, WithAccumulator>(WithAccumulator)
+        .name("Alice")
+        .add("first")
+        .add("second");
+
+      const copy = original.copy();
+      original.add("after-copy");
+      copy.add("on-copy-only");
+
+      expect(original.items()).toEqual(["first", "second", "after-copy"]);
+      expect(copy.items()).toEqual(["first", "second", "on-copy-only"]);
+    });
+
+    it("works on classes without a [COPY_STATE] hook", () => {
+      const builder = Builder<SimpleProps, SimpleTarget>(SimpleTarget).name("Alice");
+
+      expect(() => builder.copy()).not.toThrow();
+      expect(builder.copy().name()).toBe("Alice");
+    });
+
+    it("copies an unconfigured builder with no props set", () => {
+      const builder = Builder<SimpleProps, SimpleTarget>(SimpleTarget);
+
+      const copy = builder.copy();
+
+      expect(copy.name()).toBeUndefined();
+      expect(copy.count()).toBeUndefined();
+      copy.name("Alice");
+      expect(builder.name()).toBeUndefined();
+    });
+
+    it("supports repeated copying", () => {
+      const builder = Builder<SimpleProps, SimpleTarget>(SimpleTarget).name("Alice").count(5);
+
+      const a = builder.copy();
+      const b = a.copy().name("Bob");
+
+      expect(builder.name()).toBe("Alice");
+      expect(a.name()).toBe("Alice");
+      expect(b.name()).toBe("Bob");
+      expect(b.count()).toBe(5);
+    });
+
+    it("wraps a pre-instantiated instance when invoked directly", () => {
+      const instance = new SimpleTarget();
+      instance.props = { name: "Alice", count: 5 };
+
+      const builder = Builder<SimpleProps, SimpleTarget>(SimpleTarget, instance);
+
+      expect(builder.name()).toBe("Alice");
+      expect(builder.count()).toBe(5);
     });
   });
 });

--- a/packages/examples/src/multi-stack-app.ts
+++ b/packages/examples/src/multi-stack-app.ts
@@ -14,12 +14,17 @@ import { createFunctionBuilder, type FunctionBuilderResult } from "@composurecdk
  * - Routing components to different stacks via {@link ComposedSystem.withStacks}
  * - Cross-stack references resolved automatically by CDK
  * - Components without a stack mapping fall back to the default scope
+ * - `.copy()` for deriving stack variants from a shared base configuration
  */
 export function createMultiStackApp(app = new App()) {
-  const { stack: serviceStack } = createStackBuilder()
+  const baseStack = createStackBuilder().tag("project", "multi-stack-example");
+
+  const { stack: serviceStack } = baseStack
+    .copy()
     .description("Service resources for multi-stack example")
     .build(app, "ComposureCDK-MultiStackServiceStack");
-  const { stack: apiStack } = createStackBuilder()
+  const { stack: apiStack } = baseStack
+    .copy()
     .description("API resources for multi-stack example")
     .build(app, "ComposureCDK-MultiStackApiStack");
 

--- a/packages/examples/test/__snapshots__/multi-stack-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/multi-stack-app.test.ts.snap
@@ -43,6 +43,12 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
       "DeletionPolicy": "Retain",
       "Properties": {
         "RetentionInDays": 731,
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
@@ -86,6 +92,12 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
         "Namespace": "AWS/ApiGateway",
         "Period": 60,
         "Statistic": "Average",
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "Threshold": 0.05,
         "TreatMissingData": "notBreaching",
       },
@@ -120,11 +132,17 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
             ],
           },
         ],
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "MultiStackAppapiDeploymentA87644C906c5d79fb068938895d9e8be0a1d6e29": {
+    "MultiStackAppapiDeploymentA87644C95de9b18a41ec02ef96026c26a931afa1": {
       "DependsOn": [
         "MultiStackAppapiGET2EF1C40F",
       ],
@@ -154,7 +172,7 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
           "Format": "{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","user":"$context.identity.user","caller":"$context.identity.caller","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}",
         },
         "DeploymentId": {
-          "Ref": "MultiStackAppapiDeploymentA87644C906c5d79fb068938895d9e8be0a1d6e29",
+          "Ref": "MultiStackAppapiDeploymentA87644C95de9b18a41ec02ef96026c26a931afa1",
         },
         "MethodSettings": [
           {
@@ -168,6 +186,12 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
           "Ref": "MultiStackAppapiFB7EC5DD",
         },
         "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "TracingEnabled": true,
       },
       "Type": "AWS::ApiGateway::Stage",
@@ -176,6 +200,12 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
       "Properties": {
         "Description": "API in a separate stack from its handler",
         "Name": "MultiStackApi",
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
@@ -314,6 +344,12 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
         "MetricName": "Latency",
         "Namespace": "AWS/ApiGateway",
         "Period": 60,
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "Threshold": 2500,
         "TreatMissingData": "notBreaching",
       },
@@ -342,6 +378,12 @@ exports[`multi-stack-app > matches the expected api stack template 1`] = `
         "Namespace": "AWS/ApiGateway",
         "Period": 60,
         "Statistic": "Average",
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "Threshold": 0.05,
         "TreatMissingData": "notBreaching",
       },
@@ -426,6 +468,12 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
           ],
         },
         "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "Timeout": 30,
         "TracingConfig": {
           "Mode": "Active",
@@ -452,6 +500,12 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
         "MetricName": "Duration",
         "Namespace": "AWS/Lambda",
         "Period": 60,
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "Threshold": 27000,
         "TreatMissingData": "notBreaching",
       },
@@ -476,6 +530,12 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
         "Namespace": "AWS/Lambda",
         "Period": 60,
         "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "Threshold": 0,
         "TreatMissingData": "notBreaching",
       },
@@ -485,6 +545,12 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
       "DeletionPolicy": "Retain",
       "Properties": {
         "RetentionInDays": 731,
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
@@ -515,6 +581,12 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
               ],
             ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
           },
         ],
       },
@@ -563,6 +635,12 @@ exports[`multi-stack-app > matches the expected service stack template 1`] = `
         "Namespace": "AWS/Lambda",
         "Period": 60,
         "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "project",
+            "Value": "multi-stack-example",
+          },
+        ],
         "Threshold": 0,
         "TreatMissingData": "notBreaching",
       },


### PR DESCRIPTION
Closes #78.

## Summary

Two commits, single PR:

1. **`feat(core): add .copy() to Builder via COPY_STATE hook`** — `.copy()` on every fluent builder via `core/Builder()`, with a symbol-keyed `COPY_STATE` hook for builders that hold non-`props` state. ADR-0005 captures the design rationale.
2. **`feat(cloudformation)!: consume Lifecycle<StackBuilderResult> …`** — `singleStack`/`groupedStacks` now take a builder directly; `StackBuilder.toScopeFactory()` removed. `multi-stack-app` example refactored to demonstrate `.copy()`.

The original issue proposed `freeze()` for the strategy hand-off snapshot. We replaced it with the more general `.copy()`, which covers the same hand-off case via `singleStack(builder.copy())` **and** unlocks variant authoring (`base.copy().region("us-east-1")`). `.copy()` is strictly simpler — no mutation guards, no throw-vs-no-op decision. Full rationale in ADR-0005 (alternatives section) and on [issue #78](https://github.com/laazyj/composureCDK/issues/78#issuecomment-4396170624).

## What changed

### `@composurecdk/core` (non-breaking)

- `Builder()` proxy intercepts `.copy()` to produce an independent builder with a shallow-cloned `props`, then invokes an optional `[COPY_STATE](next)` hook for non-`props` state.
- `COPY_STATE` symbol exported. Symbol-keyed so it stays out of the fluent API and IDE autocomplete.
- `Builder()` accepts an optional second `instance: T` parameter, used internally by `.copy()` to wrap a cloned instance without re-running the constructor.
- `IBuilder` mapped type gains `copy(): IBuilder<Props, T>` for autocomplete discoverability.
- 11 new tests covering independence, prop preservation, shallow-share semantics, hook invocation, repeated copying, empty-builder copying, and direct pre-instantiated wrap.

### `@composurecdk/cloudformation` (breaking)

| Before | After |
|---|---|
| `singleStack(factory: ScopeFactory)` | `singleStack(builder?: Lifecycle<StackBuilderResult>)` |
| `groupedStacks(classify, factory: ScopeFactory)` | `groupedStacks(classify, builder?: Lifecycle<StackBuilderResult>)` |
| `builder.toScopeFactory()` | `builder` (pass directly) |
| Custom `Stack` subclass via raw factory | `singleStack` / `groupedStacks` from `@composurecdk/core` (keep `ScopeFactory`) |

- `StackBuilder` participates in the `.copy()` protocol via `[COPY_STATE]` cloning the private `#tags` accumulator.
- Strategy hand-off snapshot is now opt-in via `.copy()` rather than implicit (the previous `toScopeFactory()` snapshotted at call time).

### Docs

- New `docs/adr/0005-builder-copy.md` (Decision + alternatives + consequences).
- `docs/architecture.md` gains a "Copying a builder" subsection.
- `docs/stack-management.md` updated: drops the raw-`ScopeFactory` `DeploymentStack` snippet, points users at `@composurecdk/core` for non-Stack scope types.
- `packages/cloudformation/README.md` rewritten around the new builder-passthrough + `.copy()` idiom.

### Examples

- `packages/examples/src/multi-stack-app.ts` refactored to show `.copy()` for shared-base variant authoring (one base builder with a `project` tag, two copies with different descriptions).
- Its snapshot refreshed for the new tag (verified diff is *only* `Tags` block additions). All other example snapshots stayed byte-identical.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npx nx run-many -t test` — 15 projects green, including 11 new core builder tests, 4 new stack-builder copy tests, 6 new strategy tests
- [x] Existing example snapshots stay green without `--update` (only `multi-stack-app` refreshed intentionally)
- [x] Pre-commit simplify review on each phase + post-commit simplify review across the full PR; four nits folded back via fixup + autosquash

## Coordination with #77

The open PR #77 (tags work) was the original reason this reshape was needed. After this lands, #77 will rebase and:

- Drop the `getBuilderTags` / `BUILDER_TAGS` / `TaggedInstance` escape hatch entirely (no longer needed — strategies consume builders directly).
- Implement the decorator-protocol override of `.copy()` on its outer proxy (documented in ADR-0005).
- Renumber its ADR from 0005 to 0006.