### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 0.6.0 (2026-05-07)
+
+### 🚀 Features
+
+- ⚠️ **budgets:** encode service constraints in NotifySubscribers + Email ([#75](https://github.com/laazyj/composureCDK/pull/75))
+- ⚠️ **cloudformation:** consume Lifecycle<StackBuilderResult> in singleStack/groupedStacks; drop toScopeFactory ([#78](https://github.com/laazyj/composureCDK/issues/78))
+- **core:** add .copy() to Builder via COPY_STATE hook ([cfc9d02](https://github.com/laazyj/composureCDK/commit/cfc9d02))
+
+### 🩹 Fixes
+
+- **release-tag:** allow GitHub squash-merge `(#NN)` suffix ([#73](https://github.com/laazyj/composureCDK/pull/73), [#72](https://github.com/laazyj/composureCDK/issues/72))
+
+### ⚠️ Breaking Changes
+
+- **cloudformation:** consume Lifecycle<StackBuilderResult> in singleStack/groupedStacks; drop toScopeFactory ([#78](https://github.com/laazyj/composureCDK/issues/78))
+  singleStack and groupedStacks in
+  @composurecdk/cloudformation now take a Lifecycle<StackBuilderResult>
+  instead of a ScopeFactory. StackBuilder.toScopeFactory() is removed.
+  Pre-1.0; release-please will pick up the major bump on the
+  cloudformation package.
+- **budgets:** encode service constraints in NotifySubscribers + Email ([#75](https://github.com/laazyj/composureCDK/pull/75))
+  `notifyOnActual`, `notifyOnForecasted`,
+  `withRecommendedThresholds`, and `NotificationEntry.subscribers` now
+  take a `NotifySubscribers` object instead of variadic
+  `BudgetSubscriber` arguments. Email addresses must be constructed via
+  `email("addr@host")`. The `BudgetSubscriber` type is removed.
+  Migration:
+  before: .notifyOnActual(100, alertTopic, "ops@example.com")
+  after: .notifyOnActual(100, { sns: alertTopic, emails: [email("ops@example.com")] })
+
+### ❤️ Thank You
+
+- Jason Duffett
+
 ## 0.5.1 (2026-05-02)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -7728,7 +7728,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7738,15 +7738,15 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7756,16 +7756,16 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
-        "@composurecdk/logs": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/logs": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7775,15 +7775,15 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7793,14 +7793,14 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/core": "^0.5.0",
+        "@composurecdk/core": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7810,16 +7810,16 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
-        "@composurecdk/s3": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/s3": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7835,7 +7835,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -7851,7 +7851,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -7861,16 +7861,16 @@
         "vitest": "^4.1.2"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
-        "@composurecdk/logs": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/logs": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.250.0",
@@ -7883,21 +7883,21 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/apigateway": "^0.5.0",
-        "@composurecdk/cloudformation": "^0.5.0",
-        "@composurecdk/cloudfront": "^0.5.0",
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
-        "@composurecdk/ec2": "^0.5.0",
-        "@composurecdk/lambda": "^0.5.0",
-        "@composurecdk/route53": "^0.5.0",
-        "@composurecdk/s3": "^0.5.0",
-        "@composurecdk/sns": "^0.5.0"
+        "@composurecdk/apigateway": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.6.0",
+        "@composurecdk/cloudfront": "^0.6.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/ec2": "^0.6.0",
+        "@composurecdk/lambda": "^0.6.0",
+        "@composurecdk/route53": "^0.6.0",
+        "@composurecdk/s3": "^0.6.0",
+        "@composurecdk/sns": "^0.6.0"
       }
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7907,14 +7907,14 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/core": "^0.5.0",
+        "@composurecdk/core": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7924,16 +7924,16 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
-        "@composurecdk/logs": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/logs": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7943,14 +7943,14 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/core": "^0.5.0",
+        "@composurecdk/core": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7960,15 +7960,15 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7978,16 +7978,16 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
-        "@composurecdk/logs": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/logs": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7997,8 +7997,8 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.5.0",
-        "@composurecdk/core": "^0.5.0",
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
-    "@composurecdk/logs": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/logs": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/core": "^0.5.0",
+    "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
-    "@composurecdk/s3": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/s3": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
-    "@composurecdk/logs": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/logs": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {
@@ -22,16 +22,16 @@
     "constructs": "^10.6.0"
   },
   "peerDependencies": {
-    "@composurecdk/apigateway": "^0.5.0",
-    "@composurecdk/cloudformation": "^0.5.0",
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/cloudfront": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
-    "@composurecdk/ec2": "^0.5.0",
-    "@composurecdk/lambda": "^0.5.0",
-    "@composurecdk/route53": "^0.5.0",
-    "@composurecdk/s3": "^0.5.0",
-    "@composurecdk/sns": "^0.5.0"
+    "@composurecdk/apigateway": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.6.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/cloudfront": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/ec2": "^0.6.0",
+    "@composurecdk/lambda": "^0.6.0",
+    "@composurecdk/route53": "^0.6.0",
+    "@composurecdk/s3": "^0.6.0",
+    "@composurecdk/sns": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/core": "^0.5.0",
+    "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
-    "@composurecdk/logs": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/logs": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/core": "^0.5.0",
+    "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -39,8 +39,8 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
-    "@composurecdk/logs": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/logs": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.5.0",
-    "@composurecdk/core": "^0.5.0",
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },


### PR DESCRIPTION
Release **v0.6.0**.

Generated by `release-prepare` workflow run [#25493058476](https://github.com/laazyj/composureCDK/actions/runs/25493058476).

## Merge checklist

- [x] CI is green
- [x] Changelog reads correctly
- [x] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.6.0`, which triggers `release.yml` (deploy-test → npm publish).