### PR TITLE
ci(release): use OIDC trusted publishing without setup-node registry-url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -34,7 +37,6 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- v0.6.0 release failed at `nx-release-publish` with `Not Found - PUT https://registry.npmjs.org/@composurecdk%2fcore` ([failed run](https://github.com/laazyj/composureCDK/actions/runs/25493878159/job/74814233742)).
- Root cause: `actions/setup-node` with `registry-url` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc` and exports `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` as a placeholder. The current runner npm (11.11.0) sends that placeholder as the auth header on publish and the registry rejects it with a 404, never falling back to OIDC. v0.5.1 was published on an older runner npm that tolerated the bogus token.
- Drop `registry-url` so no auth line is written and npm CLI uses OIDC against the default `https://registry.npmjs.org/`. Trusted publisher config (configured per `docs/ci.md`) takes over.
- Make the `publish` job's `permissions` block explicit (`contents: read`, `id-token: write`) so OIDC token availability does not depend on workflow-level inheritance.

## Test plan

- [ ] PR merges to main green (CI runs format/typecheck/build/lint/test).
- [ ] Re-tag `v0.6.0` to the merged commit; `release.yml` runs deploy-test then publishes all 14 packages with OIDC + provenance.
- [ ] `npm view @composurecdk/core@0.6.0` returns the new version.