### PR TITLE
feat: builder-level .tag() / .tags() via decorator wrapper + tags() afterBuild

### DIFF
--- a/docs/adr/0006-decorator-builder-pattern.md
+++ b/docs/adr/0006-decorator-builder-pattern.md
@@ -1,0 +1,78 @@
+# ADR 0006: Decorator pattern for cross-cutting builder features
+
+- **Status:** Accepted
+- **Date:** 2026-05-07
+
+## Context
+
+`@composurecdk/core` exports `Builder<Props, T>(constructor)` and the `IBuilder<Props, T>` mapped type — a deliberately minimal, CDK-agnostic builder primitive. Every builder package in the library uses it directly. [ADR-0005](0005-builder-copy.md) added `.copy()` to that primitive for variant authoring and strategy hand-off; any cross-cutting extension must compose with it.
+
+Some features apply to **every** builder rather than to one resource type — tagging is the first; structured logging hooks, dry-run modes, and removal-policy defaults are plausible follow-ups. Three implementation paths surfaced when designing the tagging surface (issue #66):
+
+1. **Per-builder methods.** Each builder class declares its own `.tag()` / `.tags()` and applies them in `build()`. ~10 lines × ~30 builders, with drift risk on every change.
+2. **Modify `core.Builder()`** to special-case the cross-cutting method names. Eliminates duplication but couples `core` to `aws-cdk-lib` and grows with each new feature.
+3. **A decorator factory wrapping `Builder()`.** A new factory in a CDK-aware package returns a Proxy that intercepts the cross-cutting methods and delegates everything else to the inner core proxy.
+
+## Decision
+
+**Cross-cutting builder features are added via decorator factories that wrap `Builder()`. Each library builder factory opts in by calling the decorator instead of bare `Builder()`. `core` stays minimal.**
+
+Shape:
+
+- **Naming.** A decorator is `<feature>Builder<Props, T>(constructor)` (e.g. `taggedBuilder`) with a paired type alias `I<Feature>Builder<Props, T>`. Both live in the package most natural for the feature — `@composurecdk/cloudformation` for CDK-aware features.
+- **Type.** `I<Feature>Builder<Props, T>` re-derives `IBuilder<Props, T>`'s mapped pieces but rewrites every chainable return position to `I<Feature>Builder<Props, T>`, so the decorator's added methods stay reachable after any chained call.
+- **Runtime.** The decorator returns an outer Proxy wrapping the inner `Builder()` Proxy. The outer intercepts the feature's method names, wraps `build()` to apply the feature, intercepts `.copy()` to clone the decorator's own state and re-wrap the inner copy, and re-wraps any other inner-returning methods so the chain returns the outer Proxy.
+- **Opt-in.** Each builder factory chooses bare `Builder()` or a decorator. ESLint can enforce a default for library code (see [ADR-0001 lint precedent](0001-builder-type-emission.md)).
+
+For `taggedBuilder`'s implementation specifics, see the [Tagging section of `extensions.md`](../extensions.md#tagging).
+
+## Composing with `.copy()`
+
+[ADR-0005](0005-builder-copy.md) introduces `.copy()` on `IBuilder`. A decorator must intercept it explicitly: without an interception, `outer.copy()` would surface the bare inner Proxy returned by core, silently dropping both the decorator's added methods and any build-time hooks the decorator installs.
+
+The interception pattern is:
+
+1. Call `inner.copy()` to obtain a new inner Proxy with cloned `props` (and any class-implemented `[COPY_STATE]` state).
+2. Clone the decorator's own per-instance state (e.g. the tag accumulator) so the copy and the original mutate independently.
+3. Re-wrap the new inner with a fresh outer Proxy, returning a same-shaped tagged builder.
+
+Class-level `[COPY_STATE]` from core handles state stored on the wrapped class. Decorator-level state (state stored in the decorator's closure) is invisible to the class and must be cloned by the decorator's own `.copy()` interception.
+
+## Stacking decorators
+
+The runtime stacks cleanly: a second decorator wraps `taggedBuilder(C)` the same way `taggedBuilder` wraps `Builder(C)`. The proxy chain forwards unintercepted access through to the next layer.
+
+The type system does not. TypeScript imposes three constraints that together prevent decorators from sharing the mapped-type computation:
+
+- `this`-types are only legal in classes and interfaces, not in type aliases — so `tag(...): this` is not expressible on `ITaggedBuilder`.
+- Interfaces cannot `extend` mapped types — so a stacked decorator cannot inherit `ITaggedBuilder`'s mapped pieces.
+- Type aliases cannot self-reference through a generic helper — so a `ChainableShape<P, T, Self>` extracted helper, with each decorator pinning `Self` to itself, fails as circular.
+
+The practical consequence: **each decorator that wants chainability declares its own complete mapped-type alias**, with its own name in every chainable return position. A stacked decorator does not extend or intersect the inner decorator's type — it restates the chainable shape and lists every method from every decorator it includes.
+
+```ts
+// ITaggedBuilder<P, T> — chainable returns are ITaggedBuilder
+// IBarBuilder<P, T>    — chainable returns are IBarBuilder, has .bar()
+// IFooBuilder<P, T>    — chainable returns are IFooBuilder, lists .tag/.tags/.bar/.foo
+```
+
+Cost per decorator: two mapped-type blocks (~6 lines) plus an explicit list of every method any included decorator contributes. The cost grows linearly with included methods, not with stack depth — but it does grow.
+
+This shape is workable for a small number of decorators. If the library accumulates more than a handful, the replication will justify either codegen or a different approach (e.g. a class-based builder primitive that supports `this`-types). That rethink is out of scope for this ADR; it is a known future cost, not a present problem.
+
+## Consequences
+
+- `@composurecdk/core` stays minimal. `Builder()` and `IBuilder<Props, T>` remain free of CDK dependencies.
+- Cross-cutting features ship in CDK-aware packages and are consumed by every builder package as a peer dependency. Existing dependency direction (builder packages → CDK-aware packages → `core`) is preserved.
+- Adding a new cross-cutting feature is a single-package change plus a one-line factory swap per builder. No per-builder method boilerplate.
+- A lint rule can guarantee library builders pick up the decorator by default. Custom builders authored outside the library can use bare `Builder()` directly.
+- Decorators must explicitly intercept `.copy()` to preserve their wrapping and clone their own per-instance state — a forgotten interception silently drops the decorator's surface from the copy.
+- Stacking multiple decorators is supported but not free: each new decorator restates the chainable mapped pieces and lists every method it includes. Acceptable up to a handful; revisit beyond.
+- Each builder package gains a peer dependency on the package hosting the decorator (`@composurecdk/cloudformation` for `taggedBuilder`). A dedicated `@composurecdk/builder` package was considered but rejected for now — the only decorator today is tightly coupled to `Tags.of` from `aws-cdk-lib`, which `cloudformation` already depends on. Revisit if decorators land in additional domain packages.
+
+## Alternatives considered
+
+- **Modify `core.Builder()` to special-case cross-cutting method names.** Rejected: couples `core` to `aws-cdk-lib` and grows the proxy with feature-specific code.
+- **Per-builder `.tag()` / `.tags()` methods on each class.** Rejected: ~300 lines of duplicated mechanics with drift risk on every change.
+- **A mixin or base class.** Rejected: the library uses interfaces, not inheritance ([architecture.md](../architecture.md)). A base class would force builders to extend a framework class.
+- **Aspect-based application without a builder-level surface.** Rejected for tagging: authors need a place to write the tag declaration that sits next to the resource it targets. Aspects remain the right tool for system-wide concerns; `tags({ system: {...} })` covers that case via an `afterBuild` hook.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0003: Nested `compose()` — propagate parent context into inner components](0003-nested-compose-context-propagation.md)
 - [ADR-0004: Split-alarm builder pattern for AWS services with fixed-region metrics](0004-split-alarm-builder-for-fixed-region-metrics.md)
 - [ADR-0005: `.copy()` on Builder for variant authoring and strategy hand-off](0005-builder-copy.md)
+- [ADR-0006: Decorator pattern for cross-cutting builder features](0006-decorator-builder-pattern.md)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -43,7 +43,7 @@ Multiple `.afterBuild()` calls can be chained. Hooks run in registration order:
 ```ts
 compose({ site, cdn }, { site: [], cdn: ["site"] })
   .afterBuild(outputs({ ... }))
-  .afterBuild(tagging({ ... }))
+  .afterBuild(tags({ ... }))
   .build(stack, "MySystem");
 ```
 
@@ -93,6 +93,61 @@ compose({ ... }, { ... })
 
 Hooks that reference component results can use `Ref` and `resolve` from `@composurecdk/core` to resolve values lazily, just as builders do.
 
+## Tagging
+
+Tagging spans both the builder API and the system extension surface. Two layers cover different use cases:
+
+### Layer 1 — `.tag()` / `.tags()` on every builder
+
+Every builder factory the library ships exposes `.tag(key, value)` and `.tags({...})` directly on the builder — provided the wrapped CFN resource supports tags. Tags accumulate during configuration and apply to every construct exposed in the build result. The walker descends through plain-object literals (so wrappers like `Record<string, { construct, metadata }>` are unwrapped naturally) and stops at construct boundaries, leaving CDK's tag aspect to propagate to each construct's subtree.
+
+```ts
+createInstanceBuilder()
+  .vpc(vpc)
+  .role(agentRole)
+  .tag("Project", "claude-rig") // selector tag for an IAM kill-switch
+  .tags({ Owner: "platform", Environment: "prod" });
+```
+
+Use builder-level tagging for **selector tags** that drive IAM resource-tag conditions, EventBridge filters, kill-switches, and cost-allocation tags scoped to a specific resource type. The tag is set at create-time on every resource the builder produces, which is what those downstream consumers require.
+
+Keys and values are validated synchronously when `.tag()` / `.tags()` is called. The validator rejects empty keys, the reserved `aws:` prefix (case-insensitive), keys longer than 128 characters, values longer than 256 characters, and characters outside the AWS-documented tag character set.
+
+Duplicate `.tag(k, ...)` calls last-wins and emit a Node process warning with name `ComposureCDKTagOverride` so the override is visible at the call site. If layered configuration intentionally overrides earlier tags (e.g. a base builder factory plus per-environment refinements), suppress the noise with either:
+
+- `node --disable-warning=ComposureCDKTagOverride …` on Node 21.3+ to silence them globally, or
+- a `process.on("warning", w => { if (w.name !== "ComposureCDKTagOverride") /* … */ })` listener for finer control.
+
+### Layer 2 — `tags()` afterBuild hook for cross-cutting tags
+
+For ownership, environment, and cost-allocation tags that should reach every component of a composed system, use the `tags()` hook:
+
+```ts
+import { compose } from "@composurecdk/core";
+import { tags } from "@composurecdk/cloudformation";
+
+compose(
+  { agent: createInstanceBuilder(), bucket: createBucketBuilder() },
+  { agent: [], bucket: [] },
+)
+  .afterBuild(
+    tags({
+      system: { Owner: "platform", Environment: "prod" },
+      byComponent: { agent: { Project: "claude-rig" } },
+    }),
+  )
+  .build(stack, "MySystem");
+```
+
+- **`system`** — applied to the top-level scope. CDK's tag aspect propagates each tag to every taggable descendant.
+- **`byComponent`** — applied to a specific component's scope. Under `.withStacks()` or `.withStackStrategy()` this is the per-component stack; otherwise it's the top-level scope. Component keys are statically checked against the composed system's component keys.
+
+### Precedence
+
+Builder-level tags win on key collision because they target a closer scope. CDK's tag priority resolves this automatically — there is no special configuration to enable it. Use Layer 2 for blanket cost/ownership dimensions and Layer 1 for the specific resource type a downstream consumer cares about.
+
+See [ADR-0006](./adr/0006-decorator-builder-pattern.md) for the architectural decision behind the wrapper that powers builder-level tagging.
+
 ## Built-in hooks
 
 ### `outputs()` — `@composurecdk/cloudformation`
@@ -128,3 +183,7 @@ Each output definition accepts:
 - **`description`** — Optional description for the CloudFormation output.
 - **`exportName`** — Optional export name for cross-stack references.
 - **`scope`** — Optional Stack to attach the output to. Either an `IConstruct` (a direct Stack reference, typical with `.withStacks()`) or a component key string typed against the composed system (typical with `.withStackStrategy()`, where stacks are created dynamically). When omitted, the output falls back to the hook's `scope` — the top-level scope given to `build()`. See [Per-Output Stack Routing](./stack-management.md#per-output-stack-routing).
+
+### `tags()` — `@composurecdk/cloudformation`
+
+Applies cross-cutting tags to a composed system. See the [Tagging](#tagging) section above for the full API and the trade-off between Layer 1 (`.tag()` on individual builders) and Layer 2 (`tags()` here).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -113,10 +113,10 @@ Use builder-level tagging for **selector tags** that drive IAM resource-tag cond
 
 Keys and values are validated synchronously when `.tag()` / `.tags()` is called. The validator rejects empty keys, the reserved `aws:` prefix (case-insensitive), keys longer than 128 characters, values longer than 256 characters, and characters outside the AWS-documented tag character set.
 
-Duplicate `.tag(k, ...)` calls last-wins and emit a Node process warning with name `ComposureCDKTagOverride` so the override is visible at the call site. If layered configuration intentionally overrides earlier tags (e.g. a base builder factory plus per-environment refinements), suppress the noise with either:
+Duplicate `.tag(k, ...)` calls last-wins and emit a Node process warning with name `ComposureCDKTagOverride` so the override is visible at the call site. The name is also exported as `TAG_OVERRIDE_WARNING_NAME` for callers that want to filter without a string literal. If layered configuration intentionally overrides earlier tags (e.g. a base builder factory plus per-environment refinements), suppress the noise with either:
 
 - `node --disable-warning=ComposureCDKTagOverride …` on Node 21.3+ to silence them globally, or
-- a `process.on("warning", w => { if (w.name !== "ComposureCDKTagOverride") /* … */ })` listener for finer control.
+- a `process.on("warning", w => { if (w.name !== TAG_OVERRIDE_WARNING_NAME) /* … */ })` listener for finer control.
 
 ### Layer 2 — `tags()` afterBuild hook for cross-cutting tags
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,61 @@ import eslint from "@eslint/js";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
+import eslintComments from "@eslint-community/eslint-plugin-eslint-comments";
+
+/**
+ * Flags uses of `Builder()` or `IBuilder<…>` imported from `@composurecdk/core`
+ * in library builder files. Library builders should opt into the shared tagging
+ * surface via `taggedBuilder` / `ITaggedBuilder` from `@composurecdk/cloudformation`.
+ */
+const taggedSuffix =
+  "If the wrapped CFN resource has no Tags property (Route53 records, IAM ManagedPolicy, " +
+  "SNS Subscription, AWS Budgets), disable this rule on the offending line with a directive " +
+  "naming the resource: `// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::… has no Tags property`.";
+
+const builderTaggingRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Library builders must use `taggedBuilder` / `ITaggedBuilder` from `@composurecdk/cloudformation` " +
+        "unless the wrapped CFN resource has no Tags property.",
+    },
+    schema: [],
+    messages: {
+      restrictedCall:
+        "Use `taggedBuilder` from `@composurecdk/cloudformation` instead of `Builder` from `@composurecdk/core`. " +
+        taggedSuffix,
+      restrictedType:
+        "Use `ITaggedBuilder` from `@composurecdk/cloudformation` instead of `IBuilder` from `@composurecdk/core`. " +
+        taggedSuffix,
+    },
+  },
+  create(ctx) {
+    const localBuilderNames = new Set();
+    const localIBuilderNames = new Set();
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== "@composurecdk/core") return;
+        for (const spec of node.specifiers) {
+          if (spec.type !== "ImportSpecifier") continue;
+          if (spec.imported.name === "Builder") localBuilderNames.add(spec.local.name);
+          if (spec.imported.name === "IBuilder") localIBuilderNames.add(spec.local.name);
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.type === "Identifier" && localBuilderNames.has(node.callee.name)) {
+          ctx.report({ node: node.callee, messageId: "restrictedCall" });
+        }
+      },
+      TSTypeReference(node) {
+        if (node.typeName.type === "Identifier" && localIBuilderNames.has(node.typeName.name)) {
+          ctx.report({ node: node.typeName, messageId: "restrictedType" });
+        }
+      },
+    };
+  },
+};
 
 /**
  * Flags Lifecycle-implementing classes whose `build` method does not accept a
@@ -85,11 +140,13 @@ export default defineConfig(
       composurecdk: {
         rules: {
           "lifecycle-build-context-required": lifecycleContextParamRule,
+          "builder-must-be-tagged": builderTaggingRule,
         },
       },
     },
     rules: {
       "composurecdk/lifecycle-build-context-required": "error",
+      "composurecdk/builder-must-be-tagged": "error",
       "no-restricted-syntax": [
         "error",
         {
@@ -108,6 +165,25 @@ export default defineConfig(
             "Parameter properties cannot be ECMAScript private. Declare the field with `readonly #field` and assign it in the constructor body.",
         },
       ],
+    },
+  },
+  {
+    // The tagged-builder wrapper IS the implementation of the tagged-builder
+    // surface — by definition it must reach for `Builder` / `IBuilder` from
+    // `@composurecdk/core`. Disable the rule at the file level rather than
+    // peppering disable comments through the body.
+    files: ["packages/cloudformation/src/tagged-builder.ts"],
+    rules: {
+      "composurecdk/builder-must-be-tagged": "off",
+    },
+  },
+  {
+    files: ["packages/*/src/**/*.ts", "packages/*/test/**/*.ts"],
+    plugins: {
+      "@eslint-community/eslint-comments": eslintComments,
+    },
+    rules: {
+      "@eslint-community/eslint-comments/require-description": ["error", { ignore: [] }],
     },
   },
   eslintConfigPrettier,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
         "@eslint/js": "^10.0.1",
         "@nx/js": "22.7.1",
         "eslint": "^10.3.0",
@@ -1890,6 +1891,36 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.1.tgz",
+      "integrity": "sha512-Ql2nJFwA8wUGpILYGOQaT1glPsmvEwE0d+a+l7AALLzQvInqdbXJdx7aSu0DpUX9dB1wMVBMhm99/++S3MdEtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "ignore": "^7.0.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7978,6 +8009,7 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
+        "@composurecdk/cloudformation": "^0.6.0",
         "@composurecdk/cloudwatch": "^0.6.0",
         "@composurecdk/core": "^0.6.0",
         "@composurecdk/logs": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
     "*.{ts,tsx,js,jsx,json,md,yaml,yml}": "prettier --write"
   },
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
     "@eslint/js": "^10.0.1",
+    "@nx/js": "22.7.1",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
-    "@nx/js": "22.7.1",
     "nx": "22.7.1",
     "prettier": "^3.8.3",
     "typescript-eslint": "^8.58.2"

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",

--- a/packages/acm/src/certificate-builder.ts
+++ b/packages/acm/src/certificate-builder.ts
@@ -7,13 +7,8 @@ import {
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import type { IHostedZone } from "aws-cdk-lib/aws-route53";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { CertificateAlarmConfig } from "./alarm-config.js";
 import { createCertificateAlarms } from "./certificate-alarms.js";
@@ -124,7 +119,7 @@ export interface CertificateBuilderResult {
  *   .validationZone(zone);
  * ```
  */
-export type ICertificateBuilder = IBuilder<CertificateBuilderProps, CertificateBuilder>;
+export type ICertificateBuilder = ITaggedBuilder<CertificateBuilderProps, CertificateBuilder>;
 
 class CertificateBuilder implements Lifecycle<CertificateBuilderResult> {
   props: Partial<CertificateBuilderProps> = {};
@@ -218,5 +213,5 @@ class CertificateBuilder implements Lifecycle<CertificateBuilderResult> {
  * ```
  */
 export function createCertificateBuilder(): ICertificateBuilder {
-  return Builder<CertificateBuilderProps, CertificateBuilder>(CertificateBuilder);
+  return taggedBuilder<CertificateBuilderProps, CertificateBuilder>(CertificateBuilder);
 }

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "@composurecdk/logs": "^0.6.0",

--- a/packages/apigateway/src/rest-api-builder.ts
+++ b/packages/apigateway/src/rest-api-builder.ts
@@ -6,7 +6,8 @@ import {
   type RestApiProps,
 } from "aws-cdk-lib/aws-apigateway";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle, type Resolvable } from "@composurecdk/core";
+import { type Lifecycle, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { RestApiBuilderPropsBase, RestApiBuilderResultBase } from "./builder-common.js";
 import { REST_API_DEFAULTS } from "./defaults.js";
@@ -53,7 +54,7 @@ export type RestApiBuilderResult = RestApiBuilderResultBase<RestApi>;
  *   );
  * ```
  */
-export type IRestApiBuilder = IBuilder<RestApiBuilderProps, RestApiBuilder>;
+export type IRestApiBuilder = ITaggedBuilder<RestApiBuilderProps, RestApiBuilder>;
 
 class RestApiBuilder implements Lifecycle<RestApiBuilderResult> {
   props: Partial<RestApiBuilderProps> = {};
@@ -154,5 +155,5 @@ class RestApiBuilder implements Lifecycle<RestApiBuilderResult> {
  * ```
  */
 export function createRestApiBuilder(): IRestApiBuilder {
-  return Builder<RestApiBuilderProps, RestApiBuilder>(RestApiBuilder);
+  return taggedBuilder<RestApiBuilderProps, RestApiBuilder>(RestApiBuilder);
 }

--- a/packages/apigateway/src/spec-rest-api-builder.ts
+++ b/packages/apigateway/src/spec-rest-api-builder.ts
@@ -1,6 +1,7 @@
 import { type RestApiBase, SpecRestApi, type SpecRestApiProps } from "aws-cdk-lib/aws-apigateway";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { RestApiBuilderPropsBase, RestApiBuilderResultBase } from "./builder-common.js";
 import { SPEC_REST_API_DEFAULTS } from "./defaults.js";
@@ -42,7 +43,7 @@ export type SpecRestApiBuilderResult = RestApiBuilderResultBase<SpecRestApi>;
  *   .apiDefinition(ApiDefinition.fromAsset("openapi/petstore.yaml"));
  * ```
  */
-export type ISpecRestApiBuilder = IBuilder<SpecRestApiBuilderProps, SpecRestApiBuilder>;
+export type ISpecRestApiBuilder = ITaggedBuilder<SpecRestApiBuilderProps, SpecRestApiBuilder>;
 
 class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
   props: Partial<SpecRestApiBuilderProps> = {};
@@ -116,5 +117,5 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
  * ```
  */
 export function createSpecRestApiBuilder(): ISpecRestApiBuilder {
-  return Builder<SpecRestApiBuilderProps, SpecRestApiBuilder>(SpecRestApiBuilder);
+  return taggedBuilder<SpecRestApiBuilderProps, SpecRestApiBuilder>(SpecRestApiBuilder);
 }

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",

--- a/packages/budgets/src/budget-alarm-builder.ts
+++ b/packages/budgets/src/budget-alarm-builder.ts
@@ -2,13 +2,8 @@ import { type CfnBudget } from "aws-cdk-lib/aws-budgets";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Annotations, Stack, Token } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
 import type { BudgetAlarmConfig } from "./alarm-config.js";
@@ -66,7 +61,7 @@ export interface BudgetAlarmBuilderResult {
  *
  * @see {@link createBudgetAlarmBuilder}
  */
-export type IBudgetAlarmBuilder = IBuilder<BudgetAlarmBuilderProps, BudgetAlarmBuilder>;
+export type IBudgetAlarmBuilder = ITaggedBuilder<BudgetAlarmBuilderProps, BudgetAlarmBuilder>;
 
 /**
  * The `AWS/Billing EstimatedCharges` metric is emitted in `us-east-1`
@@ -224,5 +219,5 @@ class BudgetAlarmBuilder implements Lifecycle<BudgetAlarmBuilderResult> {
  * budget from custom alarms via `.addAlarm()`.
  */
 export function createBudgetAlarmBuilder(): IBudgetAlarmBuilder {
-  return Builder<BudgetAlarmBuilderProps, BudgetAlarmBuilder>(BudgetAlarmBuilder);
+  return taggedBuilder<BudgetAlarmBuilderProps, BudgetAlarmBuilder>(BudgetAlarmBuilder);
 }

--- a/packages/budgets/src/budget-builder.ts
+++ b/packages/budgets/src/budget-builder.ts
@@ -139,6 +139,7 @@ export interface BudgetBuilderResult {
  *   .build(stack, "AgentBudget");
  * ```
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Budgets::Budget has no Tags property
 export type IBudgetBuilder = IBuilder<BudgetBuilderProps, BudgetBuilder>;
 
 class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
@@ -342,5 +343,6 @@ function describeNotification(entry: NotificationEntry): string {
  * Creates a new {@link IBudgetBuilder} for configuring an AWS Budget.
  */
 export function createBudgetBuilder(): IBudgetBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Budgets::Budget has no Tags property
   return Builder<BudgetBuilderProps, BudgetBuilder>(BudgetBuilder);
 }

--- a/packages/cloudformation/src/apply-builder-tags.ts
+++ b/packages/cloudformation/src/apply-builder-tags.ts
@@ -1,0 +1,67 @@
+import { Tags } from "aws-cdk-lib";
+import { Construct, type IConstruct } from "constructs";
+
+function isConstruct(value: unknown): value is IConstruct {
+  return value !== null && typeof value === "object" && Construct.isConstruct(value);
+}
+
+/**
+ * Applies every accumulated tag to every {@link IConstruct} reachable in a
+ * builder result.
+ *
+ * Recursively descends through plain-object literals, tagging every
+ * `IConstruct` it finds. Stops at:
+ *
+ * - **Constructs** — tagged via `Tags.of(...).add(...)`. The CDK Aspect
+ *   schedules tag application across the construct's subtree at
+ *   synth-prepare time, so the walker does not recurse into the construct's
+ *   internals.
+ * - **Class instances that aren't constructs** (e.g. `PolicyDocument`) —
+ *   skipped. Plain-object detection requires `Object.prototype` as the
+ *   prototype, so class instances are opaque to the walker.
+ * - **Arrays and primitives** — skipped.
+ *
+ * The contract this implements: every construct exposed in a builder's
+ * result type is a tag target. Wrapper shapes such as
+ * `Record<string, { construct: ..., metadata: ... }>` are unwrapped
+ * naturally — the walker descends through the plain-object value and tags
+ * the construct field. Authors do not need an opt-in marker; if a construct
+ * appears in the result, it is tagged.
+ */
+export function applyBuilderTags(result: object, tags: ReadonlyMap<string, string>): void {
+  if (tags.size === 0) return;
+  walkAndTag(result, tags);
+}
+
+function walkAndTag(value: unknown, tags: ReadonlyMap<string, string>): void {
+  if (isConstruct(value)) {
+    applyTagsToConstruct(value, tags);
+    return;
+  }
+  if (isPlainObject(value)) {
+    for (const inner of Object.values(value)) {
+      walkAndTag(inner, tags);
+    }
+  }
+}
+
+/**
+ * Applies every entry of `tags` to `target` via `Tags.of(target).add(...)`.
+ * Accepts any iterable of `[key, value]` pairs so callers can pass `Map`,
+ * `Object.entries(record)`, or other compatible sources without copying.
+ */
+export function applyTagsToConstruct(target: IConstruct, tags: Iterable<[string, string]>): void {
+  const t = Tags.of(target);
+  for (const [key, value] of tags) {
+    t.add(key, value);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  // Accept both `{...}` literals and `Object.create(null)` dictionaries — the
+  // latter is a common idiom for prototype-pollution-safe key/value maps and
+  // would otherwise be silently skipped here.
+  const proto = Object.getPrototypeOf(value) as object | null;
+  return proto === null || proto === Object.prototype;
+}

--- a/packages/cloudformation/src/index.ts
+++ b/packages/cloudformation/src/index.ts
@@ -5,3 +5,6 @@ export {
 } from "./stack-builder.js";
 export { singleStack, groupedStacks } from "./strategies.js";
 export { outputs, type OutputDefinition, type OutputDefinitions } from "./outputs.js";
+export { taggedBuilder, type ITaggedBuilder } from "./tagged-builder.js";
+export { applyBuilderTags } from "./apply-builder-tags.js";
+export { validateTag } from "./tag-validator.js";

--- a/packages/cloudformation/src/index.ts
+++ b/packages/cloudformation/src/index.ts
@@ -8,3 +8,4 @@ export { outputs, type OutputDefinition, type OutputDefinitions } from "./output
 export { taggedBuilder, type ITaggedBuilder } from "./tagged-builder.js";
 export { applyBuilderTags } from "./apply-builder-tags.js";
 export { validateTag } from "./tag-validator.js";
+export { tags, type TagDefinitions } from "./tags.js";

--- a/packages/cloudformation/src/index.ts
+++ b/packages/cloudformation/src/index.ts
@@ -5,7 +5,7 @@ export {
 } from "./stack-builder.js";
 export { singleStack, groupedStacks } from "./strategies.js";
 export { outputs, type OutputDefinition, type OutputDefinitions } from "./outputs.js";
-export { taggedBuilder, type ITaggedBuilder } from "./tagged-builder.js";
+export { taggedBuilder, type ITaggedBuilder, TAG_OVERRIDE_WARNING_NAME } from "./tagged-builder.js";
 export { applyBuilderTags } from "./apply-builder-tags.js";
 export { validateTag } from "./tag-validator.js";
 export { tags, type TagDefinitions } from "./tags.js";

--- a/packages/cloudformation/src/stack-builder.ts
+++ b/packages/cloudformation/src/stack-builder.ts
@@ -1,6 +1,7 @@
-import { Stack, type StackProps, Tags } from "aws-cdk-lib";
+import { Stack, type StackProps } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import { Builder, COPY_STATE, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "./tagged-builder.js";
 
 /**
  * The build output of a {@link IStackBuilder}. Contains the CDK Stack
@@ -24,45 +25,27 @@ export interface StackBuilderResult {
  * builder to a strategy that may be invoked after further configuration of
  * the original, pass `builder.copy()` to snapshot the current state.
  *
+ * Tags accumulated via {@link ITaggedBuilder.tag | .tag()} or
+ * {@link ITaggedBuilder.tags | .tags()} are applied to the resulting Stack.
+ * CloudFormation propagates stack-level tags to every resource the stack
+ * contains, so a single `.tag()` call on a stack reaches everything inside.
+ *
  * @example
  * ```ts
  * const { stack } = createStackBuilder()
  *   .description("Network infrastructure")
  *   .terminationProtection(true)
+ *   .tag("Owner", "platform")
  *   .build(app, "NetworkStack");
  * ```
  */
-export type IStackBuilder = IBuilder<StackProps, StackBuilder> & {
-  /**
-   * Adds a tag to the Stack. Tags are applied to the Stack and propagate
-   * to all resources within it.
-   *
-   * @param key - The tag key.
-   * @param value - The tag value.
-   * @returns The builder for chaining.
-   */
-  tag(key: string, value: string): IStackBuilder;
-};
+export type IStackBuilder = ITaggedBuilder<StackProps, StackBuilder>;
 
 class StackBuilder implements Lifecycle<StackBuilderResult> {
   props: Partial<StackProps> = {};
-  readonly #tags: [string, string][] = [];
-
-  tag(key: string, value: string): this {
-    this.#tags.push([key, value]);
-    return this;
-  }
-
-  [COPY_STATE](next: StackBuilder): void {
-    next.#tags.push(...this.#tags);
-  }
 
   build(scope: IConstruct, id: string): StackBuilderResult {
-    const stack = new Stack(scope, id, this.props);
-    this.#tags.forEach(([key, value]) => {
-      Tags.of(stack).add(key, value);
-    });
-    return { stack };
+    return { stack: new Stack(scope, id, this.props) };
   }
 }
 
@@ -71,9 +54,10 @@ class StackBuilder implements Lifecycle<StackBuilderResult> {
  *
  * This is the entry point for declarative stack configuration. The returned
  * builder exposes every {@link StackProps} property as a fluent setter/getter,
- * plus {@link IStackBuilder.tag | .tag()} for adding tags. It implements
- * {@link Lifecycle}, so it composes naturally and can be passed to
- * {@link singleStack} or {@link groupedStacks}.
+ * `.tag(key, value)` / `.tags({...})` for stack-level tagging, and `.copy()`
+ * for variant authoring. It implements {@link Lifecycle}, so it composes
+ * naturally and can be passed to {@link singleStack} or
+ * {@link groupedStacks}.
  *
  * @returns A fluent builder for a CloudFormation Stack.
  *
@@ -83,6 +67,7 @@ class StackBuilder implements Lifecycle<StackBuilderResult> {
  * const { stack } = createStackBuilder()
  *   .description("Service layer")
  *   .terminationProtection(true)
+ *   .tag("Owner", "platform")
  *   .build(app, "ServiceStack");
  *
  * // Hand a configured builder to a strategy. Use `.copy()` to snapshot
@@ -97,5 +82,5 @@ class StackBuilder implements Lifecycle<StackBuilderResult> {
  * ```
  */
 export function createStackBuilder(): IStackBuilder {
-  return Builder<StackProps, StackBuilder>(StackBuilder);
+  return taggedBuilder<StackProps, StackBuilder>(StackBuilder);
 }

--- a/packages/cloudformation/src/tag-validator.ts
+++ b/packages/cloudformation/src/tag-validator.ts
@@ -1,0 +1,71 @@
+/**
+ * AWS allows letters, digits, whitespace, and the symbols `_ . : / = + - @`
+ * in tag keys and values, with non-ASCII letters/digits permitted via
+ * Unicode classes. Empty values are permitted by AWS for `Value`, but
+ * empty `Key` is not. The character set is validated against this regex.
+ *
+ * `\p{Z}` matches the full Unicode separator class — slightly more
+ * permissive than AWS's documented "white space," but errors on the side
+ * of accepting input that the AWS API may yet reject at deploy time. The
+ * extra rejections happen later but are reported in the API response.
+ *
+ * @see https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+ */
+const TAG_CHAR_RE = /^[\p{L}\p{Z}\p{N}_.:/=+\-@]*$/u;
+
+const KEY_MAX = 128;
+const VALUE_MAX = 256;
+
+/**
+ * Validates a single tag key/value pair against AWS tag constraints.
+ *
+ * Throws synchronously at the call site so authors see the failure where the
+ * bad value was written, not at deploy time. Validates:
+ *
+ * - `key` is non-empty and at most {@link KEY_MAX} characters.
+ * - `key` does not start with the reserved `aws:` prefix (case-insensitive).
+ * - `value` is at most {@link VALUE_MAX} characters.
+ * - both `key` and `value` use only the AWS-permitted character set.
+ *
+ * The regex matches Unicode letters, digits, and whitespace plus the
+ * documented punctuation set, so non-ASCII tags are accepted as AWS
+ * supports them.
+ */
+export function validateTag(key: string, value: string): void {
+  if (key.length === 0) {
+    throw new Error("Tag key must be non-empty.");
+  }
+  if (key.length > KEY_MAX) {
+    throw new Error(`Tag key "${key}" exceeds ${String(KEY_MAX)}-character limit.`);
+  }
+  if (key.toLowerCase().startsWith("aws:")) {
+    throw new Error(
+      `Tag key "${key}" uses reserved "aws:" prefix; AWS rejects user tags with this prefix.`,
+    );
+  }
+  if (!TAG_CHAR_RE.test(key)) {
+    throw new Error(
+      `Tag key "${key}" contains characters outside the AWS tag character set ` +
+        "(letters, digits, whitespace, and `_ . : / = + - @`).",
+    );
+  }
+  if (value.length > VALUE_MAX) {
+    throw new Error(`Tag value for key "${key}" exceeds ${String(VALUE_MAX)}-character limit.`);
+  }
+  if (!TAG_CHAR_RE.test(value)) {
+    throw new Error(
+      `Tag value for key "${key}" contains characters outside the AWS tag character set ` +
+        "(letters, digits, whitespace, and `_ . : / = + - @`).",
+    );
+  }
+}
+
+/**
+ * Validates every entry of a record via {@link validateTag}, throwing on the
+ * first invalid pair so the failure surfaces at the configuring call site.
+ */
+export function validateTagRecord(values: Record<string, string>): void {
+  for (const [key, value] of Object.entries(values)) {
+    validateTag(key, value);
+  }
+}

--- a/packages/cloudformation/src/tagged-builder.ts
+++ b/packages/cloudformation/src/tagged-builder.ts
@@ -1,0 +1,182 @@
+import { Builder, type IBuilder } from "@composurecdk/core";
+import { applyBuilderTags } from "./apply-builder-tags.js";
+import { validateTag, validateTagRecord } from "./tag-validator.js";
+
+type Constructor<T> = new () => T;
+
+interface ObjectWithProps<Props extends object> {
+  props: Partial<Props>;
+}
+
+/**
+ * A fluent builder extended with tag-accumulating methods. Returned by
+ * {@link taggedBuilder}.
+ *
+ * Mirrors `IBuilder<Props, T>` from `@composurecdk/core` but rewrites every
+ * chainable return type to `ITaggedBuilder<Props, T>` so the augmenting
+ * `.tag()` / `.tags()` methods stay reachable after any prop setter or
+ * chainable method on `T`. {@link ITaggedBuilder.copy | `.copy()`} also
+ * returns a tagged builder so the chain survives variant authoring.
+ *
+ * Tags accumulated via {@link ITaggedBuilder.tag | .tag()} and
+ * {@link ITaggedBuilder.tags | .tags()} are applied to every construct in
+ * the build result — see {@link applyBuilderTags} for the exact walk.
+ *
+ * @typeParam Props - The configurable properties.
+ * @typeParam T - The target class the builder wraps.
+ */
+export type ITaggedBuilder<Props extends object, T> = {
+  [K in keyof Props]-?: ((arg: Props[K]) => ITaggedBuilder<Props, T>) & (() => Props[K]);
+} & {
+  [K in keyof T]: T[K] extends (...args: infer A) => T
+    ? (...args: A) => ITaggedBuilder<Props, T>
+    : T[K];
+} & {
+  /**
+   * Adds a single tag. Validates the key/value at call time and throws on
+   * AWS-rejected inputs (empty key, `aws:` prefix, oversize, disallowed
+   * characters).
+   *
+   * Repeated keys overwrite earlier values and emit a process warning so the
+   * override is visible at the call site.
+   *
+   * @param key - The tag key.
+   * @param value - The tag value.
+   * @returns The builder for chaining.
+   */
+  tag(key: string, value: string): ITaggedBuilder<Props, T>;
+
+  /**
+   * Adds many tags at once. Each entry is validated independently as if
+   * passed to {@link ITaggedBuilder.tag | .tag()}. Existing keys are
+   * overwritten with a process warning.
+   *
+   * @param values - A record of tag keys to values.
+   * @returns The builder for chaining.
+   */
+  tags(values: Record<string, string>): ITaggedBuilder<Props, T>;
+
+  /**
+   * Returns an independent tagged builder with the same configured props
+   * and a deep clone of the accumulated tags.
+   *
+   * Mirrors {@link IBuilder.copy} from `@composurecdk/core` but preserves
+   * the tagging surface. Mutations to the returned builder's tags do not
+   * affect the original, and vice versa.
+   */
+  copy(): ITaggedBuilder<Props, T>;
+};
+
+/**
+ * Wraps {@link Builder} to add the {@link ITaggedBuilder.tag | .tag()} and
+ * {@link ITaggedBuilder.tags | .tags()} accumulators and apply the
+ * collected tags to every construct in the build result.
+ *
+ * The wrapper maintains its own outer Proxy around the inner builder Proxy
+ * created by `@composurecdk/core`. The outer Proxy:
+ *
+ * 1. Intercepts `.tag(k, v)` and `.tags({...})` to validate inputs and
+ *    accumulate them in an insertion-ordered map. Repeated keys overwrite
+ *    earlier values and emit `process.emitWarning` so the override is
+ *    visible at the configuring call site.
+ * 2. Intercepts `build()` to call {@link applyBuilderTags} on the result
+ *    after the inner build completes.
+ * 3. Intercepts `copy()` so the returned builder is itself a tagged builder
+ *    with an independent clone of the accumulator. Without this, `.copy()`
+ *    on a tagged builder would surface the bare inner Proxy and silently
+ *    drop both the tag methods and the build-time walker.
+ * 4. Passes every other access through to the inner Proxy unchanged. Inner
+ *    methods that return the inner Proxy (chainable setters) are
+ *    re-wrapped so the chain returns the outer Proxy and the new tag
+ *    methods stay reachable.
+ *
+ * Each builder factory in the library opts in by calling `taggedBuilder()`
+ * instead of `Builder()`. Custom builders authored outside the library can
+ * use plain `Builder()` and forgo tagging.
+ *
+ * @typeParam Props - The configurable properties.
+ * @typeParam T - The target class the builder wraps.
+ *
+ * @example
+ * ```ts
+ * export function createBucketBuilder(): IBucketBuilder {
+ *   return taggedBuilder<BucketBuilderProps, BucketBuilder>(BucketBuilder);
+ * }
+ *
+ * createBucketBuilder()
+ *   .tag("Project", "claude-rig")
+ *   .tags({ Owner: "platform", Environment: "prod" })
+ *   .build(stack, "Bucket");
+ * ```
+ */
+export function taggedBuilder<Props extends object, T extends ObjectWithProps<Props>>(
+  constructor: Constructor<T>,
+): ITaggedBuilder<Props, T> {
+  const inner = Builder<Props, T>(constructor);
+  return wrapTagged<Props, T>(inner, new Map());
+}
+
+function wrapTagged<Props extends object, T extends ObjectWithProps<Props>>(
+  inner: IBuilder<Props, T>,
+  accumulator: Map<string, string>,
+): ITaggedBuilder<Props, T> {
+  const recordTag = (key: string, value: string): void => {
+    if (accumulator.has(key)) {
+      const previous = accumulator.get(key);
+      process.emitWarning(
+        `Tag "${key}" was already set to "${previous ?? ""}" and is being overwritten with "${value}". ` +
+          "Last write wins; remove the duplicate to silence this warning.",
+        { type: "ComposureCDKTagOverride" },
+      );
+    }
+    accumulator.set(key, value);
+  };
+
+  const buildFn = (...args: unknown[]): object => {
+    const target = inner as unknown as { build: (...a: unknown[]) => object };
+    const result = target.build(...args);
+    applyBuilderTags(result, accumulator);
+    return result;
+  };
+
+  const copyFn = (): ITaggedBuilder<Props, T> => {
+    const innerCopy = inner as unknown as { copy: () => IBuilder<Props, T> };
+    return wrapTagged<Props, T>(innerCopy.copy(), new Map(accumulator));
+  };
+
+  // Pre-bound interceptors close over `outer` so chained calls return the
+  // wrapper. They are referenced from the Proxy's `get` trap, which only
+  // reads them when a property is accessed (after this function returns).
+  const outer: ITaggedBuilder<Props, T> = new Proxy(inner, {
+    get(target, prop, receiver) {
+      if (prop === "tag") return tagFn;
+      if (prop === "tags") return tagsFn;
+      if (prop === "build") return buildFn;
+      if (prop === "copy") return copyFn;
+
+      const value = Reflect.get(target, prop, receiver) as unknown;
+      if (typeof value === "function") {
+        return (...args: unknown[]) => {
+          const ret = (value as (...a: unknown[]) => unknown).apply(target, args);
+          return ret === inner ? outer : ret;
+        };
+      }
+      return value;
+    },
+  }) as ITaggedBuilder<Props, T>;
+
+  const tagFn = (key: string, value: string): ITaggedBuilder<Props, T> => {
+    validateTag(key, value);
+    recordTag(key, value);
+    return outer;
+  };
+  const tagsFn = (values: Record<string, string>): ITaggedBuilder<Props, T> => {
+    validateTagRecord(values);
+    for (const [key, value] of Object.entries(values)) {
+      recordTag(key, value);
+    }
+    return outer;
+  };
+
+  return outer;
+}

--- a/packages/cloudformation/src/tagged-builder.ts
+++ b/packages/cloudformation/src/tagged-builder.ts
@@ -2,6 +2,16 @@ import { Builder, type IBuilder } from "@composurecdk/core";
 import { applyBuilderTags } from "./apply-builder-tags.js";
 import { validateTag, validateTagRecord } from "./tag-validator.js";
 
+/**
+ * The `name` attached to the `process.emitWarning` call when `.tag(k, v)` /
+ * `.tags({...})` overwrites an existing key. Exported so callers with
+ * layered configuration (a base builder plus per-environment refinements
+ * that intentionally override) can filter via
+ * `process.on("warning", w => { if (w.name !== TAG_OVERRIDE_WARNING_NAME) ... })`
+ * or the Node 21.3+ `--disable-warning=ComposureCDKTagOverride` CLI flag.
+ */
+export const TAG_OVERRIDE_WARNING_NAME = "ComposureCDKTagOverride";
+
 type Constructor<T> = new () => T;
 
 interface ObjectWithProps<Props extends object> {
@@ -126,7 +136,7 @@ function wrapTagged<Props extends object, T extends ObjectWithProps<Props>>(
       process.emitWarning(
         `Tag "${key}" was already set to "${previous ?? ""}" and is being overwritten with "${value}". ` +
           "Last write wins; remove the duplicate to silence this warning.",
-        { type: "ComposureCDKTagOverride" },
+        { type: TAG_OVERRIDE_WARNING_NAME },
       );
     }
     accumulator.set(key, value);
@@ -144,9 +154,11 @@ function wrapTagged<Props extends object, T extends ObjectWithProps<Props>>(
     return wrapTagged<Props, T>(innerCopy.copy(), new Map(accumulator));
   };
 
-  // Pre-bound interceptors close over `outer` so chained calls return the
-  // wrapper. They are referenced from the Proxy's `get` trap, which only
-  // reads them when a property is accessed (after this function returns).
+  // `tagFn` / `tagsFn` and `outer` form a cycle: the interceptors return
+  // `outer` for chaining, and `outer`'s `get` trap returns the interceptors.
+  // Resolved by Proxy laziness: the `get` trap closes over the names but
+  // does not read them until a property is accessed, by which point the
+  // `const`s below have initialised.
   const outer: ITaggedBuilder<Props, T> = new Proxy(inner, {
     get(target, prop, receiver) {
       if (prop === "tag") return tagFn;

--- a/packages/cloudformation/src/tags.ts
+++ b/packages/cloudformation/src/tags.ts
@@ -1,0 +1,127 @@
+import { type IConstruct } from "constructs";
+import { type AfterBuildHook } from "@composurecdk/core";
+import { applyTagsToConstruct } from "./apply-builder-tags.js";
+import { validateTagRecord } from "./tag-validator.js";
+
+/**
+ * Configures cross-cutting tag application against a composed system.
+ *
+ * - `system` tags reach every construct under the top-level scope passed
+ *   to `build(scope, id)` — useful for ownership, environment, and cost
+ *   allocation tags that should apply to every resource the system creates.
+ * - `byComponent` tags reach only the scope a named component was built
+ *   into. Under {@link ComposedSystem.withStacks} or
+ *   {@link ComposedSystem.withStackStrategy}, components may live in
+ *   different stacks — `byComponent` routes the tag to whichever scope
+ *   that component received.
+ *
+ * Component keys in `byComponent` are statically typed against the
+ * composed system's component keys, matching the pattern `outputs()` uses
+ * for its `scope` field, so a typo on a component name is a compile-time
+ * error.
+ *
+ * Builder-level tags applied via `.tag()` / `.tags()` always take
+ * precedence on key conflict because they target a closer scope; CDK's
+ * native tag priority resolves the collision automatically.
+ *
+ * @typeParam T - The composed system's build result type. Inferred from
+ * the surrounding `compose(...).afterBuild(tags(...))` chain.
+ */
+export interface TagDefinitions<T extends object = object> {
+  /**
+   * Tags applied to every construct under the top-level scope. Each
+   * key/value pair is validated against the AWS tag character set; invalid
+   * inputs throw at configuration time.
+   */
+  system?: Record<string, string>;
+
+  /**
+   * Tags applied only to constructs under a specific component's scope.
+   * Component keys are statically checked against the composed system's
+   * component keys. Each key/value pair is validated identically to
+   * `system`.
+   */
+  byComponent?: Partial<Record<keyof T & string, Record<string, string>>>;
+}
+
+/**
+ * Returns an {@link AfterBuildHook} that applies cross-cutting tags to a
+ * composed system. Modelled on {@link outputs} — both share the same
+ * `(scope, id, results, componentScopes)` shape and live alongside the
+ * other CloudFormation-flavoured composition helpers in this package.
+ *
+ * The hook walks the supplied {@link TagDefinitions} once per build:
+ *
+ * - `system` entries are applied to the top-level `scope` via
+ *   `Tags.of(scope).add(...)`. CDK's tag aspect propagates each tag
+ *   through the construct subtree to every taggable descendant.
+ * - `byComponent` entries are applied to `componentScopes[key]` —
+ *   each component's own scope, which under
+ *   {@link ComposedSystem.withStacks} or
+ *   {@link ComposedSystem.withStackStrategy} may be a per-component
+ *   stack rather than the top-level scope.
+ *
+ * Tag keys and values are validated synchronously inside the hook before
+ * any `Tags.of(...).add(...)` call. Invalid tags throw and surface at the
+ * `compose(...).afterBuild(tags({...}))` site rather than at deploy time.
+ *
+ * Builder-level tags (set via `.tag()` / `.tags()` on individual builders)
+ * land on closer-scoped constructs and therefore win on key collision —
+ * CDK's tag priority resolves the collision automatically. Use builder
+ * tags for selector tags that must match exactly one resource type;
+ * use this helper for system-wide concerns like ownership, environment,
+ * and cost-allocation dimensions.
+ *
+ * @param defs - System-wide and per-component tag definitions.
+ * @returns An `AfterBuildHook` to pass to {@link ComposedSystem.afterBuild}.
+ *
+ * @example
+ * ```ts
+ * import { compose } from "@composurecdk/core";
+ * import { tags } from "@composurecdk/cloudformation";
+ *
+ * compose(
+ *   { agent: createInstanceBuilder(), bucket: createBucketBuilder() },
+ *   { agent: [], bucket: [] },
+ * )
+ *   .afterBuild(
+ *     tags({
+ *       system: { Owner: "platform", Environment: "prod" },
+ *       byComponent: { agent: { Project: "claude-rig" } },
+ *     }),
+ *   )
+ *   .build(stack, "MySystem");
+ * ```
+ */
+export function tags<T extends object = object>(defs: TagDefinitions<T>): AfterBuildHook<T> {
+  // Validate eagerly so configuration errors surface at the call site.
+  if (defs.system) {
+    validateTagRecord(defs.system);
+  }
+  const byComponent = defs.byComponent as
+    | Record<string, Record<string, string> | undefined>
+    | undefined;
+  if (byComponent) {
+    for (const componentTags of Object.values(byComponent)) {
+      if (componentTags === undefined) continue;
+      validateTagRecord(componentTags);
+    }
+  }
+
+  return (scope, _id, _results, componentScopes) => {
+    if (defs.system) {
+      applyTagsToConstruct(scope, Object.entries(defs.system));
+    }
+    if (byComponent) {
+      const scopesByKey = componentScopes as Readonly<Record<string, IConstruct | undefined>>;
+      for (const [componentKey, componentTags] of Object.entries(byComponent)) {
+        if (componentTags === undefined) continue;
+        const target = scopesByKey[componentKey];
+        if (target === undefined) {
+          throw new Error(`tags(): byComponent entry "${componentKey}" is not a known component.`);
+        }
+        applyTagsToConstruct(target, Object.entries(componentTags));
+      }
+    }
+  };
+}

--- a/packages/cloudformation/test/apply-builder-tags.test.ts
+++ b/packages/cloudformation/test/apply-builder-tags.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { PolicyDocument, PolicyStatement, Effect } from "aws-cdk-lib/aws-iam";
+import { applyBuilderTags } from "../src/apply-builder-tags.js";
+
+interface CfnTagEntry {
+  Key: string;
+  Value: string;
+}
+
+interface CfnResourceWithTags {
+  Properties?: { Tags?: CfnTagEntry[] };
+}
+
+function tagsOnResource(resource: CfnResourceWithTags | undefined): CfnTagEntry[] {
+  return resource?.Properties?.Tags ?? [];
+}
+
+describe("applyBuilderTags", () => {
+  it("is a no-op when the tag map is empty", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const bucket = new Bucket(stack, "B");
+    applyBuilderTags({ bucket }, new Map());
+
+    const template = Template.fromStack(stack);
+    const buckets = template.findResources("AWS::S3::Bucket") as Record<
+      string,
+      CfnResourceWithTags
+    >;
+    expect(Object.values(buckets)[0]?.Properties?.Tags).toBeUndefined();
+  });
+
+  it("tags top-level IConstruct fields", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const bucket = new Bucket(stack, "B");
+    const topic = new Topic(stack, "T");
+
+    applyBuilderTags(
+      { bucket, topic },
+      new Map([
+        ["Owner", "platform"],
+        ["Project", "rig"],
+      ]),
+    );
+
+    const template = Template.fromStack(stack);
+    const buckets = template.findResources("AWS::S3::Bucket") as Record<
+      string,
+      CfnResourceWithTags
+    >;
+    const topics = template.findResources("AWS::SNS::Topic") as Record<string, CfnResourceWithTags>;
+    const expectedTags = [
+      { Key: "Owner", Value: "platform" },
+      { Key: "Project", Value: "rig" },
+    ];
+    expect(tagsOnResource(Object.values(buckets)[0])).toEqual(expect.arrayContaining(expectedTags));
+    expect(tagsOnResource(Object.values(topics)[0])).toEqual(expect.arrayContaining(expectedTags));
+  });
+
+  it("tags constructs nested one level inside Record-typed fields", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const result = {
+      primary: new Bucket(stack, "Primary"),
+      siblings: {
+        a: new Topic(stack, "A"),
+        b: new Topic(stack, "B"),
+      },
+    };
+
+    applyBuilderTags(result, new Map([["CostCenter", "1234"]]));
+
+    const template = Template.fromStack(stack);
+    const topics = template.findResources("AWS::SNS::Topic") as Record<string, CfnResourceWithTags>;
+    const tagged = Object.values(topics).filter((r) =>
+      tagsOnResource(r).some((t) => t.Key === "CostCenter" && t.Value === "1234"),
+    );
+    expect(tagged).toHaveLength(2);
+  });
+
+  it("recurses through wrapper objects to tag nested constructs", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const wrappedTopic = new Topic(stack, "Wrapped");
+    const directTopic = new Topic(stack, "Direct");
+
+    // The wrapper bundles a construct alongside metadata. The walker
+    // descends into plain-object literals, so both topics are tagged
+    // and the metadata fields are skipped (not constructs).
+    const result = {
+      direct: directTopic,
+      wrappers: {
+        only: { inner: wrappedTopic, label: "x" },
+      },
+    };
+
+    applyBuilderTags(result, new Map([["Owner", "platform"]]));
+
+    const template = Template.fromStack(stack);
+    const topics = template.findResources("AWS::SNS::Topic") as Record<string, CfnResourceWithTags>;
+    const taggedNames = Object.entries(topics)
+      .filter(([, r]) => tagsOnResource(r).some((t) => t.Key === "Owner"))
+      .map(([key]) => key);
+    expect(taggedNames).toHaveLength(2);
+    expect(taggedNames.some((n) => n.includes("Direct"))).toBe(true);
+    expect(taggedNames.some((n) => n.includes("Wrapped"))).toBe(true);
+  });
+
+  it("skips CDK core objects that are not constructs (PolicyDocument)", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const bucket = new Bucket(stack, "B");
+    const inlinePolicy = new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:GetObject"],
+          resources: ["*"],
+        }),
+      ],
+    });
+
+    // Should not throw and should leave the PolicyDocument untouched.
+    expect(() => {
+      applyBuilderTags({ bucket, inlinePolicy }, new Map([["Owner", "platform"]]));
+    }).not.toThrow();
+
+    // The bucket received the tag; the document is unaffected (PolicyDocument
+    // exposes no public tag API — verifying via construct identity is enough).
+    const template = Template.fromStack(stack);
+    const buckets = template.findResources("AWS::S3::Bucket") as Record<
+      string,
+      CfnResourceWithTags
+    >;
+    expect(tagsOnResource(Object.values(buckets)[0])).toEqual(
+      expect.arrayContaining([{ Key: "Owner", Value: "platform" }]),
+    );
+  });
+
+  it("skips primitive-valued fields without enumerating them", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const bucket = new Bucket(stack, "B");
+    const result = {
+      bucket,
+      label: "literal",
+      count: 3,
+      flags: true,
+      empty: null,
+      missing: undefined,
+    };
+
+    expect(() => {
+      applyBuilderTags(result, new Map([["Owner", "platform"]]));
+    }).not.toThrow();
+
+    const template = Template.fromStack(stack);
+    const buckets = template.findResources("AWS::S3::Bucket") as Record<
+      string,
+      CfnResourceWithTags
+    >;
+    expect(tagsOnResource(Object.values(buckets)[0])).toEqual(
+      expect.arrayContaining([{ Key: "Owner", Value: "platform" }]),
+    );
+  });
+
+  it("descends into Object.create(null) dictionaries", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const a = new Topic(stack, "A");
+    const b = new Topic(stack, "B");
+
+    // Builder authors may use Object.create(null) for Record fields whose keys
+    // come from user input — the prototype is null, not Object.prototype.
+    const nullProtoMap = Object.create(null) as Record<string, Topic>;
+    nullProtoMap.first = a;
+    nullProtoMap.second = b;
+
+    applyBuilderTags({ alarms: nullProtoMap }, new Map([["Owner", "platform"]]));
+
+    const template = Template.fromStack(stack);
+    const topics = template.findResources("AWS::SNS::Topic") as Record<string, CfnResourceWithTags>;
+    const tagged = Object.values(topics).filter((r) =>
+      tagsOnResource(r).some((t) => t.Key === "Owner" && t.Value === "platform"),
+    );
+    expect(tagged).toHaveLength(2);
+  });
+});

--- a/packages/cloudformation/test/tag-validator.test.ts
+++ b/packages/cloudformation/test/tag-validator.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { validateTag } from "../src/tag-validator.js";
+
+describe("validateTag", () => {
+  it("accepts a simple ASCII key/value pair", () => {
+    expect(() => {
+      validateTag("Project", "claude-rig");
+    }).not.toThrow();
+  });
+
+  it("accepts an empty value", () => {
+    expect(() => {
+      validateTag("Owner", "");
+    }).not.toThrow();
+  });
+
+  it("accepts the documented punctuation set in keys and values", () => {
+    expect(() => {
+      validateTag("cost-center.team_id:1", "value=foo+bar/baz@qux");
+    }).not.toThrow();
+  });
+
+  it("accepts non-ASCII letters and digits", () => {
+    expect(() => {
+      validateTag("Équipe", "platforme");
+    }).not.toThrow();
+  });
+
+  it("rejects an empty key", () => {
+    expect(() => {
+      validateTag("", "value");
+    }).toThrow(/non-empty/);
+  });
+
+  it("rejects keys longer than 128 characters", () => {
+    const key = "a".repeat(129);
+    expect(() => {
+      validateTag(key, "value");
+    }).toThrow(/128-character limit/);
+  });
+
+  it("accepts keys exactly 128 characters long", () => {
+    const key = "a".repeat(128);
+    expect(() => {
+      validateTag(key, "value");
+    }).not.toThrow();
+  });
+
+  it("rejects values longer than 256 characters", () => {
+    const value = "v".repeat(257);
+    expect(() => {
+      validateTag("Owner", value);
+    }).toThrow(/256-character limit/);
+  });
+
+  it("accepts values exactly 256 characters long", () => {
+    const value = "v".repeat(256);
+    expect(() => {
+      validateTag("Owner", value);
+    }).not.toThrow();
+  });
+
+  it("rejects keys starting with the reserved aws: prefix", () => {
+    expect(() => {
+      validateTag("aws:cloudformation:stackName", "x");
+    }).toThrow(/reserved "aws:" prefix/);
+  });
+
+  it("rejects keys starting with AWS: case-insensitively", () => {
+    expect(() => {
+      validateTag("AWS:foo", "x");
+    }).toThrow(/reserved "aws:" prefix/);
+  });
+
+  it("rejects characters outside the AWS tag character set in keys", () => {
+    expect(() => {
+      validateTag("bad!key", "value");
+    }).toThrow(/character set/);
+  });
+
+  it("rejects characters outside the AWS tag character set in values", () => {
+    expect(() => {
+      validateTag("Owner", "bad!value");
+    }).toThrow(/character set/);
+  });
+});

--- a/packages/cloudformation/test/tagged-builder.test.ts
+++ b/packages/cloudformation/test/tagged-builder.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { type IConstruct } from "constructs";
+import { type Lifecycle } from "@composurecdk/core";
+import { taggedBuilder } from "../src/tagged-builder.js";
+
+interface SyntheticProps {
+  enabled?: boolean;
+  count?: number;
+}
+
+interface SyntheticResult {
+  primary: Bucket;
+  secondary: Topic;
+  alarms: Record<string, Topic>;
+  notes: string;
+  document: { kind: "policy"; statements: number };
+}
+
+class SyntheticBuilder implements Lifecycle<SyntheticResult> {
+  props: Partial<SyntheticProps> = {};
+
+  build(scope: IConstruct, id: string): SyntheticResult {
+    const stack = scope as Stack;
+    return {
+      primary: new Bucket(stack, `${id}Primary`),
+      secondary: new Topic(stack, `${id}Secondary`),
+      alarms: {
+        first: new Topic(stack, `${id}AlarmOne`),
+        second: new Topic(stack, `${id}AlarmTwo`),
+      },
+      notes: "not a construct",
+      document: { kind: "policy", statements: 3 },
+    };
+  }
+}
+
+interface CfnTagEntry {
+  Key: string;
+  Value: string;
+}
+
+interface CfnResourceWithTags {
+  Properties?: { Tags?: CfnTagEntry[] };
+}
+
+function tagsOnResource(resource: CfnResourceWithTags): CfnTagEntry[] {
+  return resource.Properties?.Tags ?? [];
+}
+
+function freshStack(): Stack {
+  return new Stack(new App(), "TestStack");
+}
+
+describe("taggedBuilder", () => {
+  describe("type augmentation", () => {
+    it("returns an object with .tag() and .tags() methods that chain", () => {
+      const builder = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder);
+      const tagged = builder.tag("Owner", "platform");
+      expect(tagged).toBe(builder);
+      const both = builder.tags({ Environment: "prod", Project: "rig" });
+      expect(both).toBe(builder);
+    });
+
+    it("preserves the inner Builder's prop setters and chainability", () => {
+      const builder = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder);
+      const chained = builder.enabled(true).count(3).tag("k", "v");
+      expect(chained).toBe(builder);
+      expect(builder.enabled()).toBe(true);
+      expect(builder.count()).toBe(3);
+    });
+  });
+
+  describe("applies tags to result constructs", () => {
+    it("tags the primary construct and all sibling constructs", () => {
+      const stack = freshStack();
+      const result = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder)
+        .tag("Project", "claude-rig")
+        .tag("Owner", "platform")
+        .build(stack, "Synth");
+
+      const template = Template.fromStack(stack);
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      for (const resource of Object.values(buckets)) {
+        expect(tagsOnResource(resource)).toEqual(
+          expect.arrayContaining([
+            { Key: "Project", Value: "claude-rig" },
+            { Key: "Owner", Value: "platform" },
+          ]),
+        );
+      }
+      const topics = template.findResources("AWS::SNS::Topic") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      // primary bucket + secondary topic + 2 alarm topics → 3 topics tagged.
+      expect(Object.keys(topics)).toHaveLength(3);
+      for (const resource of Object.values(topics)) {
+        expect(tagsOnResource(resource)).toEqual(
+          expect.arrayContaining([
+            { Key: "Project", Value: "claude-rig" },
+            { Key: "Owner", Value: "platform" },
+          ]),
+        );
+      }
+      expect(result.notes).toBe("not a construct");
+    });
+
+    it("tags entries inside Record<string, IConstruct> result fields", () => {
+      const stack = freshStack();
+      taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder)
+        .tag("CostCenter", "1234")
+        .build(stack, "Synth");
+
+      const template = Template.fromStack(stack);
+      const topics = template.findResources("AWS::SNS::Topic") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      // Both alarm topics receive the tag in addition to the secondary topic.
+      const taggedTopics = Object.values(topics).filter((r) =>
+        tagsOnResource(r).some((t) => t.Key === "CostCenter" && t.Value === "1234"),
+      );
+      expect(taggedTopics).toHaveLength(3);
+    });
+
+    it("does nothing when no tags are accumulated", () => {
+      const stack = freshStack();
+      taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder).build(stack, "Synth");
+
+      const template = Template.fromStack(stack);
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      for (const resource of Object.values(buckets)) {
+        expect(resource.Properties?.Tags).toBeUndefined();
+      }
+    });
+
+    it("applies all tags supplied via .tags({...})", () => {
+      const stack = freshStack();
+      taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder)
+        .tags({ Owner: "platform", Environment: "prod" })
+        .build(stack, "Synth");
+
+      const template = Template.fromStack(stack);
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      for (const resource of Object.values(buckets)) {
+        expect(tagsOnResource(resource)).toEqual(
+          expect.arrayContaining([
+            { Key: "Owner", Value: "platform" },
+            { Key: "Environment", Value: "prod" },
+          ]),
+        );
+      }
+    });
+  });
+
+  describe("validation", () => {
+    it("throws synchronously at the call site for invalid keys", () => {
+      const builder = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder);
+      expect(() => builder.tag("aws:foo", "value")).toThrow(/aws:/);
+      expect(() => builder.tag("", "value")).toThrow(/non-empty/);
+    });
+
+    it("validates each entry in .tags() independently", () => {
+      const builder = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder);
+      expect(() => builder.tags({ Owner: "platform", "bad!key": "value" })).toThrow(
+        /character set/,
+      );
+    });
+  });
+
+  describe("duplicate keys", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("last-write wins and emits a process warning", () => {
+      const warnings: string[] = [];
+      vi.spyOn(process, "emitWarning").mockImplementation((warning: string | Error) => {
+        warnings.push(typeof warning === "string" ? warning : warning.message);
+      });
+
+      const stack = freshStack();
+      taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder)
+        .tag("Owner", "first")
+        .tag("Owner", "second")
+        .build(stack, "Synth");
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatch(/already set to "first"/);
+      expect(warnings[0]).toMatch(/overwritten with "second"/);
+
+      const template = Template.fromStack(stack);
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      const allTags = Object.values(buckets).flatMap(tagsOnResource);
+      expect(allTags).toEqual(expect.arrayContaining([{ Key: "Owner", Value: "second" }]));
+      expect(allTags.find((t) => t.Key === "Owner")?.Value).toBe("second");
+    });
+  });
+
+  describe(".copy()", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("returns a tagged builder so .tag() / .tags() / build() walker remain reachable", () => {
+      const original = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder).tag(
+        "Owner",
+        "platform",
+      );
+      const clone = original.copy();
+      // Type-level: .tag() must exist on clone. Runtime: chaining returns the clone.
+      const chained = clone.tag("Project", "rig");
+      expect(chained).toBe(clone);
+
+      const stack = freshStack();
+      clone.build(stack, "Synth");
+      const template = Template.fromStack(stack);
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      for (const resource of Object.values(buckets)) {
+        expect(tagsOnResource(resource)).toEqual(
+          expect.arrayContaining([
+            { Key: "Owner", Value: "platform" },
+            { Key: "Project", Value: "rig" },
+          ]),
+        );
+      }
+    });
+
+    it("clones the tag accumulator so later mutations to the original do not affect the copy", () => {
+      // Squelch the override warning the original emits when tagged after copy.
+      vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+      const original = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder).tag(
+        "Owner",
+        "platform",
+      );
+      const clone = original.copy();
+      original.tag("Owner", "later");
+
+      const stack = freshStack();
+      clone.build(stack, "Synth");
+      const template = Template.fromStack(stack);
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      const allTags = Object.values(buckets).flatMap(tagsOnResource);
+      expect(allTags.find((t) => t.Key === "Owner")?.Value).toBe("platform");
+    });
+
+    it("clones the tag accumulator so mutations to the copy do not affect the original", () => {
+      const original = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder).tag(
+        "Owner",
+        "platform",
+      );
+      const clone = original.copy();
+      clone.tag("Project", "rig");
+
+      const stack = freshStack();
+      original.build(stack, "Synth");
+      const template = Template.fromStack(stack);
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        CfnResourceWithTags
+      >;
+      const allTags = Object.values(buckets).flatMap(tagsOnResource);
+      expect(allTags.find((t) => t.Key === "Project")).toBeUndefined();
+    });
+
+    it("preserves props alongside tags", () => {
+      const original = taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder)
+        .enabled(true)
+        .count(7)
+        .tag("Owner", "platform");
+      const clone = original.copy();
+      expect(clone.enabled()).toBe(true);
+      expect(clone.count()).toBe(7);
+    });
+  });
+
+  describe("Tags.of equivalence", () => {
+    it("matches the behaviour of calling Tags.of(...).add(...) on each construct", () => {
+      const stackA = freshStack();
+      taggedBuilder<SyntheticProps, SyntheticBuilder>(SyntheticBuilder)
+        .tag("Owner", "platform")
+        .build(stackA, "Synth");
+
+      const stackB = freshStack();
+      const direct = new SyntheticBuilder().build(stackB, "Synth");
+      Tags.of(direct.primary).add("Owner", "platform");
+      Tags.of(direct.secondary).add("Owner", "platform");
+      Tags.of(direct.alarms.first).add("Owner", "platform");
+      Tags.of(direct.alarms.second).add("Owner", "platform");
+
+      const aTemplate = JSON.stringify(Template.fromStack(stackA).toJSON());
+      const bTemplate = JSON.stringify(Template.fromStack(stackB).toJSON());
+      expect(aTemplate).toBe(bTemplate);
+    });
+  });
+});

--- a/packages/cloudformation/test/tags.test.ts
+++ b/packages/cloudformation/test/tags.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { type IConstruct } from "constructs";
+import { compose, type Lifecycle } from "@composurecdk/core";
+import { tags } from "../src/tags.js";
+
+interface CfnTagEntry {
+  Key: string;
+  Value: string;
+}
+interface CfnResourceWithTags {
+  Properties?: { Tags?: CfnTagEntry[] };
+}
+
+function tagsOnResource(resource: CfnResourceWithTags | undefined): CfnTagEntry[] {
+  return resource?.Properties?.Tags ?? [];
+}
+
+function bucketComponent(): Lifecycle<{ bucket: Bucket }> {
+  return {
+    build: (scope: IConstruct, id: string) => ({
+      bucket: new Bucket(scope, id),
+    }),
+  };
+}
+
+function topicComponent(): Lifecycle<{ topic: Topic }> {
+  return {
+    build: (scope: IConstruct, id: string) => ({
+      topic: new Topic(scope, id),
+    }),
+  };
+}
+
+describe("tags() afterBuild helper", () => {
+  it("applies `system` tags to every construct under the top-level scope", () => {
+    const stack = new Stack(new App(), "TestStack");
+
+    compose(
+      { primary: bucketComponent(), notifier: topicComponent() },
+      { primary: [], notifier: [] },
+    )
+      .afterBuild(
+        tags({
+          system: { Owner: "platform", Environment: "prod" },
+        }),
+      )
+      .build(stack, "MySystem");
+
+    const template = Template.fromStack(stack);
+    const buckets = template.findResources("AWS::S3::Bucket") as Record<
+      string,
+      CfnResourceWithTags
+    >;
+    const topics = template.findResources("AWS::SNS::Topic") as Record<string, CfnResourceWithTags>;
+    const expectedTags = [
+      { Key: "Owner", Value: "platform" },
+      { Key: "Environment", Value: "prod" },
+    ];
+    expect(tagsOnResource(Object.values(buckets)[0])).toEqual(expect.arrayContaining(expectedTags));
+    expect(tagsOnResource(Object.values(topics)[0])).toEqual(expect.arrayContaining(expectedTags));
+  });
+
+  it("applies `byComponent` tags only to that component's scope", () => {
+    const stackA = new Stack(new App(), "StackA");
+    const parent = stackA.node.scope;
+    if (!parent) throw new Error("stackA has no scope");
+    const stackB = new Stack(parent, "StackB");
+
+    compose(
+      { primary: bucketComponent(), notifier: topicComponent() },
+      { primary: [], notifier: [] },
+    )
+      .withStacks({ primary: stackA, notifier: stackB })
+      .afterBuild(
+        tags({
+          byComponent: {
+            primary: { Tier: "data" },
+            notifier: { Tier: "messaging" },
+          },
+        }),
+      )
+      .build(stackA, "MySystem");
+
+    const tA = Template.fromStack(stackA);
+    const tB = Template.fromStack(stackB);
+    const bucketTags = tagsOnResource(
+      Object.values(tA.findResources("AWS::S3::Bucket") as Record<string, CfnResourceWithTags>)[0],
+    );
+    const topicTags = tagsOnResource(
+      Object.values(tB.findResources("AWS::SNS::Topic") as Record<string, CfnResourceWithTags>)[0],
+    );
+
+    expect(bucketTags).toEqual(expect.arrayContaining([{ Key: "Tier", Value: "data" }]));
+    expect(bucketTags).not.toEqual(expect.arrayContaining([{ Key: "Tier", Value: "messaging" }]));
+    expect(topicTags).toEqual(expect.arrayContaining([{ Key: "Tier", Value: "messaging" }]));
+    expect(topicTags).not.toEqual(expect.arrayContaining([{ Key: "Tier", Value: "data" }]));
+  });
+
+  it("validates tag keys at configuration time", () => {
+    expect(() => tags({ system: { "aws:reserved": "x" } })).toThrow(/aws:/);
+    expect(() => tags({ system: { "": "x" } })).toThrow(/non-empty/);
+    expect(() => tags({ byComponent: { foo: { "bad!key": "x" } } })).toThrow(/character set/);
+  });
+
+  it("throws when `byComponent` references an unknown component", () => {
+    const stack = new Stack(new App(), "TestStack");
+
+    expect(() => {
+      compose({ primary: bucketComponent() }, { primary: [] })
+        .afterBuild(
+          tags({
+            byComponent: {
+              // Force an unknown key past the type system to test runtime guard.
+              missing: { Owner: "x" },
+            } as unknown as { primary?: Record<string, string> },
+          }),
+        )
+        .build(stack, "MySystem");
+    }).toThrow(/not a known component/);
+  });
+
+  it("composes with builder-level tags so closer scope wins on key collision", () => {
+    const stack = new Stack(new App(), "TestStack");
+
+    // A builder-level tag takes precedence over a system-level tag with the
+    // same key because Tags.of() applies at a deeper scope. Simulate the
+    // wrapper applying a builder-level Owner tag directly — the wrapper
+    // itself calls Tags.of(bucket).add(...) for each accumulated tag.
+    const taggedBucketComponent: Lifecycle<{ bucket: Bucket }> = {
+      build: (scope: IConstruct, id: string) => {
+        const bucket = new Bucket(scope, id);
+        Tags.of(bucket).add("Owner", "builder");
+        return { bucket };
+      },
+    };
+
+    compose({ primary: taggedBucketComponent }, { primary: [] })
+      .afterBuild(tags({ system: { Owner: "system" } }))
+      .build(stack, "MySystem");
+
+    const template = Template.fromStack(stack);
+    const buckets = template.findResources("AWS::S3::Bucket") as Record<
+      string,
+      CfnResourceWithTags
+    >;
+    const ownerTags = tagsOnResource(Object.values(buckets)[0]).filter((t) => t.Key === "Owner");
+    expect(ownerTags).toEqual([{ Key: "Owner", Value: "builder" }]);
+  });
+});

--- a/packages/cloudformation/tsconfig.build.json
+++ b/packages/cloudformation/tsconfig.build.json
@@ -5,7 +5,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/cloudformation/tsconfig.json
+++ b/packages/cloudformation/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "@composurecdk/s3": "^0.6.0",

--- a/packages/cloudfront/src/cloudfront-alarm-builder.ts
+++ b/packages/cloudfront/src/cloudfront-alarm-builder.ts
@@ -2,13 +2,8 @@ import { type Distribution } from "aws-cdk-lib/aws-cloudfront";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Annotations, Stack, Token } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
 import type { DistributionAlarmConfig } from "./alarm-config.js";
@@ -66,7 +61,10 @@ export interface CloudFrontAlarmBuilderResult {
  *
  * @see {@link createCloudFrontAlarmBuilder}
  */
-export type ICloudFrontAlarmBuilder = IBuilder<CloudFrontAlarmBuilderProps, CloudFrontAlarmBuilder>;
+export type ICloudFrontAlarmBuilder = ITaggedBuilder<
+  CloudFrontAlarmBuilderProps,
+  CloudFrontAlarmBuilder
+>;
 
 /**
  * CloudFront metrics are emitted in `us-east-1` only. CloudWatch alarms are
@@ -228,5 +226,5 @@ class CloudFrontAlarmBuilder implements Lifecycle<CloudFrontAlarmBuilderResult> 
  * `DistributionId` from the site stack and import it in the alarm stack.
  */
 export function createCloudFrontAlarmBuilder(): ICloudFrontAlarmBuilder {
-  return Builder<CloudFrontAlarmBuilderProps, CloudFrontAlarmBuilder>(CloudFrontAlarmBuilder);
+  return taggedBuilder<CloudFrontAlarmBuilderProps, CloudFrontAlarmBuilder>(CloudFrontAlarmBuilder);
 }

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -15,13 +15,8 @@ import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type Bucket, type IBucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import {
   DEFAULT_ACCESS_LOG_BUCKET_LIFECYCLE_RULES,
@@ -346,7 +341,7 @@ export interface DistributionBuilderResult {
  *   });
  * ```
  */
-export type IDistributionBuilder = IBuilder<DistributionBuilderProps, DistributionBuilder>;
+export type IDistributionBuilder = ITaggedBuilder<DistributionBuilderProps, DistributionBuilder>;
 
 class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
   props: Partial<DistributionBuilderProps> = {};
@@ -516,7 +511,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
  * ```
  */
 export function createDistributionBuilder(): IDistributionBuilder {
-  return Builder<DistributionBuilderProps, DistributionBuilder>(DistributionBuilder);
+  return taggedBuilder<DistributionBuilderProps, DistributionBuilder>(DistributionBuilder);
 }
 
 function resolveAccessLogs(

--- a/packages/cloudfront/test/behavior-functions.test.ts
+++ b/packages/cloudfront/test/behavior-functions.test.ts
@@ -503,3 +503,50 @@ describe("additional path-pattern behaviors", () => {
     });
   });
 });
+
+describe("builder-level tags reach inline CloudFront Functions", () => {
+  it("applies .tag()/.tags() to every CloudFront Function created by the builder", () => {
+    const { template } = synthTemplate((b, stack) => {
+      b.origin(withBucketOrigin(stack))
+        .accessLogs(false)
+        .recommendedAlarms(false)
+        .tag("Project", "claude-rig")
+        .tags({ Owner: "platform" })
+        .defaultBehavior({
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        })
+        .behavior("/api/*", {
+          origin: new HttpOrigin("api.example.com"),
+          functions: [
+            {
+              eventType: FunctionEventType.VIEWER_REQUEST,
+              code: FunctionCode.fromInline(INLINE_CODE),
+            },
+          ],
+        });
+    });
+
+    interface CfnTagEntry {
+      Key: string;
+      Value: string;
+    }
+    const fns = template.findResources("AWS::CloudFront::Function") as Record<
+      string,
+      { Properties?: { Tags?: CfnTagEntry[] } }
+    >;
+    expect(Object.keys(fns)).toHaveLength(2);
+    for (const fn of Object.values(fns)) {
+      expect(fn.Properties?.Tags).toEqual(
+        expect.arrayContaining([
+          { Key: "Project", Value: "claude-rig" },
+          { Key: "Owner", Value: "platform" },
+        ]),
+      );
+    }
+  });
+});

--- a/packages/core/src/construct-id.ts
+++ b/packages/core/src/construct-id.ts
@@ -11,7 +11,7 @@
  * in the monorepo applies the same constraints.
  */
 
-// eslint-disable-next-line no-control-regex
+// eslint-disable-next-line no-control-regex -- the regex must literally match control characters to strip them from construct IDs
 const UNSAFE = /[/\x00-\x1f\x7f]/g;
 
 /**

--- a/packages/core/test/builder.test.ts
+++ b/packages/core/test/builder.test.ts
@@ -16,7 +16,7 @@ class SimpleTarget {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- intentional empty Props for the builder-with-no-props test fixture
 interface EmptyProps {}
 
 class EmptyTarget {
@@ -199,7 +199,7 @@ describe("Builder", () => {
       > &
         Record<string, unknown>;
 
-      // eslint-disable-next-line @typescript-eslint/dot-notation
+      // eslint-disable-next-line @typescript-eslint/dot-notation -- bracket access exercises the proxy's `get` trap for an unknown key
       const accessor = builder["nonexistent"];
       expect(typeof accessor).toBe("function");
     });

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "@composurecdk/logs": "^0.6.0",

--- a/packages/ec2/src/instance-builder.ts
+++ b/packages/ec2/src/instance-builder.ts
@@ -8,13 +8,8 @@ import {
 } from "aws-cdk-lib/aws-ec2";
 import { type IRole } from "aws-cdk-lib/aws-iam";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { InstanceAlarmConfig } from "./instance-alarm-config.js";
 import { createInstanceAlarms } from "./instance-alarms.js";
@@ -149,7 +144,7 @@ export interface InstanceBuilderResult {
  *   .machineImage(MachineImage.latestAmazonLinux2023());
  * ```
  */
-export type IInstanceBuilder = IBuilder<InstanceBuilderProps, InstanceBuilder>;
+export type IInstanceBuilder = ITaggedBuilder<InstanceBuilderProps, InstanceBuilder>;
 
 class InstanceBuilder implements Lifecycle<InstanceBuilderResult> {
   props: Partial<InstanceBuilderProps> = {};
@@ -258,5 +253,5 @@ class InstanceBuilder implements Lifecycle<InstanceBuilderResult> {
  * ```
  */
 export function createInstanceBuilder(): IInstanceBuilder {
-  return Builder<InstanceBuilderProps, InstanceBuilder>(InstanceBuilder);
+  return taggedBuilder<InstanceBuilderProps, InstanceBuilder>(InstanceBuilder);
 }

--- a/packages/ec2/src/vpc-builder.ts
+++ b/packages/ec2/src/vpc-builder.ts
@@ -1,7 +1,8 @@
 import { FlowLogDestination, Vpc, type VpcProps } from "aws-cdk-lib/aws-ec2";
 import { type LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { createLogGroupBuilder, type ILogGroupBuilder } from "@composurecdk/logs";
 import { VPC_DEFAULTS } from "./vpc-defaults.js";
 
@@ -84,7 +85,7 @@ export interface VpcBuilderResult {
  * const network = createVpcBuilder().maxAzs(3).natGateways(3);
  * ```
  */
-export type IVpcBuilder = IBuilder<VpcBuilderProps, VpcBuilder>;
+export type IVpcBuilder = ITaggedBuilder<VpcBuilderProps, VpcBuilder>;
 
 const DEFAULT_FLOW_LOG_KEY = "DefaultFlowLog";
 
@@ -174,5 +175,5 @@ function resolveFlowLogs(
  * ```
  */
 export function createVpcBuilder(): IVpcBuilder {
-  return Builder<VpcBuilderProps, VpcBuilder>(VpcBuilder);
+  return taggedBuilder<VpcBuilderProps, VpcBuilder>(VpcBuilder);
 }

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -13,6 +13,7 @@ All example stacks use the `ComposureCDK-` name prefix. This convention enables 
 | [`ComposureCDK-OpenApiPetstoreStack`](src/openapi-petstore-app.ts)                                  | PetStore REST API defined by an inline OpenAPI 3.0 specification                                 |
 | [`ComposureCDK-DnsZoneStack`](src/dns-zone-app.ts)                                                  | Public Route 53 zone built with the BIND-style zone DSL, including a CloudFront `ALIAS` at `www` |
 | [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + EC2 instance with well-architected defaults, recommended alarms, and SNS alert wiring      |
+| [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`      |
 
 ## Prerequisites
 

--- a/packages/examples/bin/app.ts
+++ b/packages/examples/bin/app.ts
@@ -8,6 +8,7 @@ import { createMockApiApp } from "../src/mock-api-app.js";
 import { createMultiStackApp } from "../src/multi-stack-app.js";
 import { createOpenApiPetstoreApp } from "../src/openapi-petstore-app.js";
 import { createStaticWebsiteApp } from "../src/static-website/app.js";
+import { createTaggedSystemApp } from "../src/tagged-system-app.js";
 
 const app = new App();
 cleanDeskPolicy(app);
@@ -19,5 +20,6 @@ createMockApiApp(app);
 createMultiStackApp(app);
 createOpenApiPetstoreApp(app);
 createStaticWebsiteApp(app);
+createTaggedSystemApp(app);
 
 app.synth();

--- a/packages/examples/src/tagged-system-app.ts
+++ b/packages/examples/src/tagged-system-app.ts
@@ -1,0 +1,62 @@
+import { App, Stack } from "aws-cdk-lib";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  MachineImage,
+  type Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import { compose, ref } from "@composurecdk/core";
+import { tags } from "@composurecdk/cloudformation";
+import { createInstanceBuilder, createVpcBuilder, type VpcBuilderResult } from "@composurecdk/ec2";
+import { createBucketBuilder } from "@composurecdk/s3";
+
+/**
+ * A two-component system that demonstrates both layers of the tagging API.
+ *
+ * - **Layer 1** — `.tag(...)` on the EC2 instance applies a selector tag
+ *   `Project=claude-rig`. Downstream IAM kill-switches with a
+ *   `ec2:ResourceTag/Project = claude-rig` condition can target this
+ *   specific instance without affecting siblings (S3, VPC, alarms).
+ *
+ * - **Layer 2** — `tags({ system: {...} })` applies ownership and
+ *   environment tags across every taggable construct in the system,
+ *   including the auto-created flow-log LogGroup, alarms, and the bucket.
+ *   This covers cost allocation and operational ownership without
+ *   per-builder configuration.
+ *
+ * Builder-level tags win on key collision because they target a closer
+ * scope. Override `Owner: "platform"` on the instance via
+ * `.tag("Owner", "...")` and the instance's tag will take precedence over
+ * the system-wide value while siblings still get the system value.
+ */
+export function createTaggedSystemApp(app = new App()) {
+  const stack = new Stack(app, "ComposureCDK-TaggedSystemStack");
+
+  compose(
+    {
+      assets: createBucketBuilder().serverAccessLogs(false),
+
+      network: createVpcBuilder().maxAzs(2).natGateways(0),
+
+      agent: createInstanceBuilder()
+        .vpc(ref<VpcBuilderResult>("network").map((r): Vpc => r.vpc))
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .tag("Project", "claude-rig"),
+    },
+    { assets: [], network: [], agent: ["network"] },
+  )
+    .afterBuild(
+      tags({
+        system: {
+          Owner: "platform",
+          Environment: "prod",
+          CostCenter: "1234",
+        },
+      }),
+    )
+    .build(stack, "TaggedSystem");
+
+  return { stack };
+}

--- a/packages/examples/test/tagged-system-app.test.ts
+++ b/packages/examples/test/tagged-system-app.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { Template } from "aws-cdk-lib/assertions";
+import { createTaggedSystemApp } from "../src/tagged-system-app.js";
+
+interface CfnTagEntry {
+  Key: string;
+  Value: string;
+}
+interface CfnResourceWithTags {
+  Properties?: { Tags?: CfnTagEntry[] };
+}
+
+function tagsOnAll(template: Template, type: string): CfnTagEntry[][] {
+  const resources = template.findResources(type) as Record<string, CfnResourceWithTags>;
+  return Object.values(resources).map((r) => r.Properties?.Tags ?? []);
+}
+
+describe("tagged-system-app", () => {
+  const { stack } = createTaggedSystemApp();
+  const template = Template.fromStack(stack);
+
+  it("applies the selector tag only to the EC2 instance via .tag()", () => {
+    const instanceTags = tagsOnAll(template, "AWS::EC2::Instance");
+    expect(instanceTags).toHaveLength(1);
+    expect(instanceTags[0]).toEqual(
+      expect.arrayContaining([{ Key: "Project", Value: "claude-rig" }]),
+    );
+  });
+
+  it("does not apply the selector tag to siblings (bucket, VPC)", () => {
+    const bucketTags = tagsOnAll(template, "AWS::S3::Bucket").flat();
+    const vpcTags = tagsOnAll(template, "AWS::EC2::VPC").flat();
+    expect(bucketTags.find((t) => t.Key === "Project")).toBeUndefined();
+    expect(vpcTags.find((t) => t.Key === "Project")).toBeUndefined();
+  });
+
+  it("applies system-wide tags to every taggable construct", () => {
+    const expected = [
+      { Key: "Owner", Value: "platform" },
+      { Key: "Environment", Value: "prod" },
+      { Key: "CostCenter", Value: "1234" },
+    ];
+    const types = ["AWS::EC2::Instance", "AWS::S3::Bucket", "AWS::EC2::VPC", "AWS::Logs::LogGroup"];
+    for (const type of types) {
+      const allTags = tagsOnAll(template, type);
+      expect(allTags.length).toBeGreaterThan(0);
+      for (const tags of allTags) {
+        expect(tags).toEqual(expect.arrayContaining(expected));
+      }
+    }
+  });
+});

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"

--- a/packages/iam/src/managed-policy-builder.ts
+++ b/packages/iam/src/managed-policy-builder.ts
@@ -38,6 +38,7 @@ export interface ManagedPolicyBuilderResult {
  *   ]);
  * ```
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::IAM::ManagedPolicy has no Tags property
 export type IManagedPolicyBuilder = IBuilder<ManagedPolicyBuilderProps, ManagedPolicyBuilder>;
 
 class ManagedPolicyBuilder implements Lifecycle<ManagedPolicyBuilderResult> {
@@ -78,5 +79,6 @@ class ManagedPolicyBuilder implements Lifecycle<ManagedPolicyBuilderResult> {
  * @returns A fluent builder for a customer-managed policy.
  */
 export function createManagedPolicyBuilder(): IManagedPolicyBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::IAM::ManagedPolicy has no Tags property
   return Builder<ManagedPolicyBuilderProps, ManagedPolicyBuilder>(ManagedPolicyBuilder);
 }

--- a/packages/iam/src/role-builder.ts
+++ b/packages/iam/src/role-builder.ts
@@ -6,13 +6,8 @@ import {
   type RoleProps,
 } from "aws-cdk-lib/aws-iam";
 import type { IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { ROLE_DEFAULTS } from "./role-defaults.js";
 import { StatementBuilder } from "./statement-builder.js";
 
@@ -91,7 +86,7 @@ export interface RoleBuilderResult {
  *   ]);
  * ```
  */
-export type IRoleBuilder = IBuilder<RoleBuilderProps, RoleBuilder>;
+export type IRoleBuilder = ITaggedBuilder<RoleBuilderProps, RoleBuilder>;
 
 interface InlinePolicyEntry {
   name: string;
@@ -183,5 +178,5 @@ class RoleBuilder implements Lifecycle<RoleBuilderResult> {
  * ```
  */
 export function createRoleBuilder(): IRoleBuilder {
-  return Builder<RoleBuilderProps, RoleBuilder>(RoleBuilder);
+  return taggedBuilder<RoleBuilderProps, RoleBuilder>(RoleBuilder);
 }

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "@composurecdk/logs": "^0.6.0",

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -2,7 +2,8 @@ import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Function as LambdaFunction, type FunctionProps } from "aws-cdk-lib/aws-lambda";
 import type { LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import { createLogGroupBuilder } from "@composurecdk/logs";
 import type { FunctionAlarmConfig } from "./alarm-config.js";
@@ -106,7 +107,7 @@ export interface FunctionBuilderResult {
  *   .timeout(Duration.seconds(30));
  * ```
  */
-export type IFunctionBuilder = IBuilder<FunctionBuilderProps, FunctionBuilder>;
+export type IFunctionBuilder = ITaggedBuilder<FunctionBuilderProps, FunctionBuilder>;
 
 class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
   props: Partial<FunctionBuilderProps> = {};
@@ -182,5 +183,5 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
  * ```
  */
 export function createFunctionBuilder(): IFunctionBuilder {
-  return Builder<FunctionBuilderProps, FunctionBuilder>(FunctionBuilder);
+  return taggedBuilder<FunctionBuilderProps, FunctionBuilder>(FunctionBuilder);
 }

--- a/packages/lambda/test/function-builder.test.ts
+++ b/packages/lambda/test/function-builder.test.ts
@@ -348,4 +348,37 @@ describe("FunctionBuilder", () => {
       });
     });
   });
+
+  describe("tagging", () => {
+    it("applies builder tags to the function and the auto-created log group sibling", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      createFunctionBuilder()
+        .runtime(Runtime.NODEJS_22_X)
+        .handler("index.handler")
+        .code(Code.fromInline("exports.handler = async () => {}"))
+        .tag("Owner", "platform")
+        .tag("Project", "claude-rig")
+        .build(stack, "TestFunction");
+
+      const template = Template.fromStack(stack);
+      const fns = template.findResources("AWS::Lambda::Function") as Record<
+        string,
+        { Properties: { Tags?: { Key: string; Value: string }[] } }
+      >;
+      expect(Object.values(fns)[0]?.Properties.Tags).toEqual(
+        expect.arrayContaining([
+          { Key: "Owner", Value: "platform" },
+          { Key: "Project", Value: "claude-rig" },
+        ]),
+      );
+      const logGroups = template.findResources("AWS::Logs::LogGroup") as Record<
+        string,
+        { Properties: { Tags?: { Key: string; Value: string }[] } }
+      >;
+      expect(Object.values(logGroups)[0]?.Properties.Tags).toEqual(
+        expect.arrayContaining([{ Key: "Owner", Value: "platform" }]),
+      );
+    });
+  });
 });

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"

--- a/packages/logs/src/log-group-builder.ts
+++ b/packages/logs/src/log-group-builder.ts
@@ -1,6 +1,7 @@
 import { LogGroup, type LogGroupProps } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { LOG_GROUP_DEFAULTS } from "./defaults.js";
 
 export type LogGroupBuilderProps = LogGroupProps;
@@ -32,7 +33,7 @@ export interface LogGroupBuilderResult {
  *   .retention(RetentionDays.SIX_MONTHS);
  * ```
  */
-export type ILogGroupBuilder = IBuilder<LogGroupBuilderProps, LogGroupBuilder>;
+export type ILogGroupBuilder = ITaggedBuilder<LogGroupBuilderProps, LogGroupBuilder>;
 
 class LogGroupBuilder implements Lifecycle<LogGroupBuilderResult> {
   props: Partial<LogGroupBuilderProps> = {};
@@ -73,5 +74,5 @@ class LogGroupBuilder implements Lifecycle<LogGroupBuilderResult> {
  * ```
  */
 export function createLogGroupBuilder(): ILogGroupBuilder {
-  return Builder<LogGroupBuilderProps, LogGroupBuilder>(LogGroupBuilder);
+  return taggedBuilder<LogGroupBuilderProps, LogGroupBuilder>(LogGroupBuilder);
 }

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -39,6 +39,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",

--- a/packages/route53/src/a-record-builder.ts
+++ b/packages/route53/src/a-record-builder.ts
@@ -57,6 +57,7 @@ export interface ARecordBuilderResult {
  *   .target(cloudfrontAliasTarget(ref("cdn", (r: DistributionBuilderResult) => r.distribution)));
  * ```
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type IARecordBuilder = IBuilder<ARecordBuilderProps, ARecordBuilder>;
 
 class ARecordBuilder implements Lifecycle<ARecordBuilderResult> {
@@ -93,5 +94,6 @@ class ARecordBuilder implements Lifecycle<ARecordBuilderResult> {
  * @returns A fluent builder for a Route53 A record.
  */
 export function createARecordBuilder(): IARecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<ARecordBuilderProps, ARecordBuilder>(ARecordBuilder);
 }

--- a/packages/route53/src/aaaa-record-builder.ts
+++ b/packages/route53/src/aaaa-record-builder.ts
@@ -43,6 +43,7 @@ export interface AaaaRecordBuilderResult {
  * over both IPv4 and IPv6 — AWS alias targets support both families from a
  * single resource.
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type IAaaaRecordBuilder = IBuilder<AaaaRecordBuilderProps, AaaaRecordBuilder>;
 
 class AaaaRecordBuilder implements Lifecycle<AaaaRecordBuilderResult> {
@@ -82,5 +83,6 @@ class AaaaRecordBuilder implements Lifecycle<AaaaRecordBuilderResult> {
  * @returns A fluent builder for a Route53 AAAA record.
  */
 export function createAaaaRecordBuilder(): IAaaaRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<AaaaRecordBuilderProps, AaaaRecordBuilder>(AaaaRecordBuilder);
 }

--- a/packages/route53/src/caa-record-builder.ts
+++ b/packages/route53/src/caa-record-builder.ts
@@ -39,6 +39,7 @@ export interface CaaRecordBuilderResult {
  *
  * @see https://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type ICaaRecordBuilder = IBuilder<CaaRecordBuilderProps, CaaRecordBuilder>;
 
 class CaaRecordBuilder implements Lifecycle<CaaRecordBuilderResult> {
@@ -76,5 +77,6 @@ class CaaRecordBuilder implements Lifecycle<CaaRecordBuilderResult> {
  * @returns A fluent builder for a Route53 CAA record.
  */
 export function createCaaRecordBuilder(): ICaaRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<CaaRecordBuilderProps, CaaRecordBuilder>(CaaRecordBuilder);
 }

--- a/packages/route53/src/cname-record-builder.ts
+++ b/packages/route53/src/cname-record-builder.ts
@@ -36,6 +36,7 @@ export interface CnameRecordBuilderResult {
  * used at the apex. Use CNAME for non-AWS targets or for sub-domain
  * redirections where an alias is not available.
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type ICnameRecordBuilder = IBuilder<CnameRecordBuilderProps, CnameRecordBuilder>;
 
 class CnameRecordBuilder implements Lifecycle<CnameRecordBuilderResult> {
@@ -81,5 +82,6 @@ class CnameRecordBuilder implements Lifecycle<CnameRecordBuilderResult> {
  * @returns A fluent builder for a Route53 CNAME record.
  */
 export function createCnameRecordBuilder(): ICnameRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<CnameRecordBuilderProps, CnameRecordBuilder>(CnameRecordBuilder);
 }

--- a/packages/route53/src/ds-record-builder.ts
+++ b/packages/route53/src/ds-record-builder.ts
@@ -37,6 +37,7 @@ export interface DsRecordBuilderResult {
  *
  * @see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-chain-of-trust.html
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type IDsRecordBuilder = IBuilder<DsRecordBuilderProps, DsRecordBuilder>;
 
 class DsRecordBuilder implements Lifecycle<DsRecordBuilderResult> {
@@ -72,5 +73,6 @@ class DsRecordBuilder implements Lifecycle<DsRecordBuilderResult> {
  * @returns A fluent builder for a Route53 DS record.
  */
 export function createDsRecordBuilder(): IDsRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<DsRecordBuilderProps, DsRecordBuilder>(DsRecordBuilder);
 }

--- a/packages/route53/src/health-check-alarm-builder.ts
+++ b/packages/route53/src/health-check-alarm-builder.ts
@@ -2,13 +2,8 @@ import { type IHealthCheck } from "aws-cdk-lib/aws-route53";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Annotations, Stack, Token } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
 import type { HealthCheckAlarmConfig } from "./health-check-alarm-config.js";
@@ -63,7 +58,7 @@ export interface HealthCheckAlarmBuilderResult {
  *
  * @see {@link createHealthCheckAlarmBuilder}
  */
-export type IHealthCheckAlarmBuilder = IBuilder<
+export type IHealthCheckAlarmBuilder = ITaggedBuilder<
   HealthCheckAlarmBuilderProps,
   HealthCheckAlarmBuilder
 >;
@@ -217,5 +212,7 @@ class HealthCheckAlarmBuilder implements Lifecycle<HealthCheckAlarmBuilderResult
  * `HealthCheckId` from the app stack and import it in the alarm stack.
  */
 export function createHealthCheckAlarmBuilder(): IHealthCheckAlarmBuilder {
-  return Builder<HealthCheckAlarmBuilderProps, HealthCheckAlarmBuilder>(HealthCheckAlarmBuilder);
+  return taggedBuilder<HealthCheckAlarmBuilderProps, HealthCheckAlarmBuilder>(
+    HealthCheckAlarmBuilder,
+  );
 }

--- a/packages/route53/src/health-check-builder.ts
+++ b/packages/route53/src/health-check-builder.ts
@@ -1,7 +1,8 @@
 import { HealthCheck, type HealthCheckProps, type IHealthCheck } from "aws-cdk-lib/aws-route53";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { HealthCheckAlarmConfig } from "./health-check-alarm-config.js";
 import { buildHealthCheckAlarms } from "./health-check-alarm-builder.js";
@@ -79,7 +80,7 @@ export interface HealthCheckBuilderResult {
  *   .resourcePath("/health");
  * ```
  */
-export type IHealthCheckBuilder = IBuilder<HealthCheckBuilderProps, HealthCheckBuilder>;
+export type IHealthCheckBuilder = ITaggedBuilder<HealthCheckBuilderProps, HealthCheckBuilder>;
 
 class HealthCheckBuilder implements Lifecycle<HealthCheckBuilderResult> {
   props: Partial<HealthCheckBuilderProps> = {};
@@ -141,5 +142,5 @@ class HealthCheckBuilder implements Lifecycle<HealthCheckBuilderResult> {
  * ```
  */
 export function createHealthCheckBuilder(): IHealthCheckBuilder {
-  return Builder<HealthCheckBuilderProps, HealthCheckBuilder>(HealthCheckBuilder);
+  return taggedBuilder<HealthCheckBuilderProps, HealthCheckBuilder>(HealthCheckBuilder);
 }

--- a/packages/route53/src/hosted-zone-builder.ts
+++ b/packages/route53/src/hosted-zone-builder.ts
@@ -1,6 +1,7 @@
 import { PublicHostedZone, type PublicHostedZoneProps } from "aws-cdk-lib/aws-route53";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { HOSTED_ZONE_DEFAULTS } from "./defaults.js";
 
 /**
@@ -42,7 +43,7 @@ export interface HostedZoneBuilderResult {
  *   .comment("Primary customer-facing domain");
  * ```
  */
-export type IHostedZoneBuilder = IBuilder<HostedZoneBuilderProps, HostedZoneBuilder>;
+export type IHostedZoneBuilder = ITaggedBuilder<HostedZoneBuilderProps, HostedZoneBuilder>;
 
 class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
   props: Partial<HostedZoneBuilderProps> = {};
@@ -94,5 +95,5 @@ class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
  * ```
  */
 export function createHostedZoneBuilder(): IHostedZoneBuilder {
-  return Builder<HostedZoneBuilderProps, HostedZoneBuilder>(HostedZoneBuilder);
+  return taggedBuilder<HostedZoneBuilderProps, HostedZoneBuilder>(HostedZoneBuilder);
 }

--- a/packages/route53/src/https-record-builder.ts
+++ b/packages/route53/src/https-record-builder.ts
@@ -44,6 +44,7 @@ export interface HttpsRecordBuilderResult {
  * HTTP/3 upgrades. Specify exactly one of `values` (explicit parameter list)
  * or `target` (alias, typically a CloudFront distribution).
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type IHttpsRecordBuilder = IBuilder<HttpsRecordBuilderProps, HttpsRecordBuilder>;
 
 class HttpsRecordBuilder implements Lifecycle<HttpsRecordBuilderResult> {
@@ -91,5 +92,6 @@ class HttpsRecordBuilder implements Lifecycle<HttpsRecordBuilderResult> {
  * @returns A fluent builder for a Route53 HTTPS record.
  */
 export function createHttpsRecordBuilder(): IHttpsRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<HttpsRecordBuilderProps, HttpsRecordBuilder>(HttpsRecordBuilder);
 }

--- a/packages/route53/src/mx-record-builder.ts
+++ b/packages/route53/src/mx-record-builder.ts
@@ -35,6 +35,7 @@ export interface MxRecordBuilderResult {
  * Each value pairs a priority (lower wins) with a fully-qualified mail-server
  * host name. Pair with SPF/DKIM/DMARC TXT records for authenticated email.
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type IMxRecordBuilder = IBuilder<MxRecordBuilderProps, MxRecordBuilder>;
 
 class MxRecordBuilder implements Lifecycle<MxRecordBuilderResult> {
@@ -70,5 +71,6 @@ class MxRecordBuilder implements Lifecycle<MxRecordBuilderResult> {
  * @returns A fluent builder for a Route53 MX record.
  */
 export function createMxRecordBuilder(): IMxRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<MxRecordBuilderProps, MxRecordBuilder>(MxRecordBuilder);
 }

--- a/packages/route53/src/ns-record-builder.ts
+++ b/packages/route53/src/ns-record-builder.ts
@@ -35,6 +35,7 @@ export interface NsRecordBuilderResult {
  * (including another Route53 hosted zone). The apex NS record set is managed
  * by Route53 itself and should not be recreated here.
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type INsRecordBuilder = IBuilder<NsRecordBuilderProps, NsRecordBuilder>;
 
 class NsRecordBuilder implements Lifecycle<NsRecordBuilderResult> {
@@ -77,5 +78,6 @@ class NsRecordBuilder implements Lifecycle<NsRecordBuilderResult> {
  * @returns A fluent builder for a Route53 NS record.
  */
 export function createNsRecordBuilder(): INsRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<NsRecordBuilderProps, NsRecordBuilder>(NsRecordBuilder);
 }

--- a/packages/route53/src/srv-record-builder.ts
+++ b/packages/route53/src/srv-record-builder.ts
@@ -35,6 +35,7 @@ export interface SrvRecordBuilderResult {
  * the record name typically follows the `_service._proto` convention (e.g.
  * `_sip._tcp`). Lower priority wins; weight distributes load across peers.
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type ISrvRecordBuilder = IBuilder<SrvRecordBuilderProps, SrvRecordBuilder>;
 
 class SrvRecordBuilder implements Lifecycle<SrvRecordBuilderResult> {
@@ -72,5 +73,6 @@ class SrvRecordBuilder implements Lifecycle<SrvRecordBuilderResult> {
  * @returns A fluent builder for a Route53 SRV record.
  */
 export function createSrvRecordBuilder(): ISrvRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<SrvRecordBuilderProps, SrvRecordBuilder>(SrvRecordBuilder);
 }

--- a/packages/route53/src/svcb-record-builder.ts
+++ b/packages/route53/src/svcb-record-builder.ts
@@ -35,6 +35,7 @@ export interface SvcbRecordBuilderResult {
  * specifically, prefer {@link createHttpsRecordBuilder} — most clients only
  * consult HTTPS records for web traffic.
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type ISvcbRecordBuilder = IBuilder<SvcbRecordBuilderProps, SvcbRecordBuilder>;
 
 class SvcbRecordBuilder implements Lifecycle<SvcbRecordBuilderResult> {
@@ -73,5 +74,6 @@ class SvcbRecordBuilder implements Lifecycle<SvcbRecordBuilderResult> {
  * @returns A fluent builder for a Route53 SVCB record.
  */
 export function createSvcbRecordBuilder(): ISvcbRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<SvcbRecordBuilderProps, SvcbRecordBuilder>(SvcbRecordBuilder);
 }

--- a/packages/route53/src/txt-record-builder.ts
+++ b/packages/route53/src/txt-record-builder.ts
@@ -33,6 +33,7 @@ export interface TxtRecordBuilderResult {
  *
  * Commonly used for SPF, DKIM, DMARC, and domain-verification tokens.
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
 export type ITxtRecordBuilder = IBuilder<TxtRecordBuilderProps, TxtRecordBuilder>;
 
 class TxtRecordBuilder implements Lifecycle<TxtRecordBuilderResult> {
@@ -70,5 +71,6 @@ class TxtRecordBuilder implements Lifecycle<TxtRecordBuilderResult> {
  * @returns A fluent builder for a Route53 TXT record.
  */
 export function createTxtRecordBuilder(): ITxtRecordBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Route53::RecordSet has no Tags property
   return Builder<TxtRecordBuilderProps, TxtRecordBuilder>(TxtRecordBuilder);
 }

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "@composurecdk/logs": "^0.6.0",

--- a/packages/s3/src/bucket-builder.ts
+++ b/packages/s3/src/bucket-builder.ts
@@ -2,7 +2,8 @@ import { RemovalPolicy } from "aws-cdk-lib";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket, type BucketProps, type IBucket } from "aws-cdk-lib/aws-s3";
 import { type IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { BucketAlarmConfig } from "./alarm-config.js";
 import { createBucketAlarms } from "./bucket-alarms.js";
@@ -105,7 +106,7 @@ export interface BucketBuilderResult {
  *   .versioned(false);
  * ```
  */
-export type IBucketBuilder = IBuilder<BucketBuilderProps, BucketBuilder>;
+export type IBucketBuilder = ITaggedBuilder<BucketBuilderProps, BucketBuilder>;
 
 class BucketBuilder implements Lifecycle<BucketBuilderResult> {
   props: Partial<BucketBuilderProps> = {};
@@ -240,5 +241,5 @@ function autoDeleteProps(
  * ```
  */
 export function createBucketBuilder(): IBucketBuilder {
-  return Builder<BucketBuilderProps, BucketBuilder>(BucketBuilder);
+  return taggedBuilder<BucketBuilderProps, BucketBuilder>(BucketBuilder);
 }

--- a/packages/s3/src/bucket-deployment-builder.ts
+++ b/packages/s3/src/bucket-deployment-builder.ts
@@ -3,13 +3,8 @@ import { type IBucket } from "aws-cdk-lib/aws-s3";
 import { type IDistribution } from "aws-cdk-lib/aws-cloudfront";
 import type { LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { createLogGroupBuilder } from "@composurecdk/logs";
 import { effectiveDefaults } from "./bucket-deployment-defaults.js";
 import { type BucketDeploymentBuilderProps } from "./bucket-deployment-props.js";
@@ -58,7 +53,7 @@ export interface BucketDeploymentBuilderResult {
  *   .distributionPaths(["/*"]);
  * ```
  */
-export type IBucketDeploymentBuilder = IBuilder<
+export type IBucketDeploymentBuilder = ITaggedBuilder<
   BucketDeploymentBuilderProps,
   BucketDeploymentBuilder
 >;
@@ -184,5 +179,7 @@ class BucketDeploymentBuilder implements Lifecycle<BucketDeploymentBuilderResult
  * ```
  */
 export function createBucketDeploymentBuilder(): IBucketDeploymentBuilder {
-  return Builder<BucketDeploymentBuilderProps, BucketDeploymentBuilder>(BucketDeploymentBuilder);
+  return taggedBuilder<BucketDeploymentBuilderProps, BucketDeploymentBuilder>(
+    BucketDeploymentBuilder,
+  );
 }

--- a/packages/s3/test/bucket-builder.test.ts
+++ b/packages/s3/test/bucket-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { createBucketBuilder } from "../src/bucket-builder.js";
 
@@ -432,6 +433,105 @@ describe("BucketBuilder", () => {
       );
 
       template.resourceCountIs("Custom::S3AutoDeleteObjects", 0);
+    });
+  });
+
+  describe("tagging", () => {
+    it("applies builder tags to the primary bucket", () => {
+      const template = synthTemplate((b) =>
+        withoutLogging(b).tag("Project", "claude-rig").tag("Owner", "platform"),
+      );
+
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        { Properties: { Tags?: { Key: string; Value: string }[] } }
+      >;
+      const tags = Object.values(buckets)[0]?.Properties.Tags ?? [];
+      expect(tags).toEqual(
+        expect.arrayContaining([
+          { Key: "Project", Value: "claude-rig" },
+          { Key: "Owner", Value: "platform" },
+        ]),
+      );
+    });
+
+    it("does not crash when a sibling result field is undefined", () => {
+      const template = synthTemplate((b) => withoutLogging(b).tag("Project", "claude-rig"));
+
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        { Properties: { Tags?: { Key: string; Value: string }[] } }
+      >;
+      expect(Object.keys(buckets)).toHaveLength(1);
+      expect(Object.values(buckets)[0]?.Properties.Tags).toEqual(
+        expect.arrayContaining([{ Key: "Project", Value: "claude-rig" }]),
+      );
+    });
+
+    it("applies builder tags to the auto-created access logs bucket sibling", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      createBucketBuilder().tag("Project", "claude-rig").build(stack, "TestBucket");
+
+      const template = Template.fromStack(stack);
+      // Both buckets — the primary and the auto-created access-logs sibling — carry the tag.
+      const buckets = template.findResources("AWS::S3::Bucket");
+      expect(Object.keys(buckets)).toHaveLength(2);
+      for (const resource of Object.values(buckets) as {
+        Properties: { Tags?: { Key: string; Value: string }[] };
+      }[]) {
+        expect(resource.Properties.Tags).toEqual(
+          expect.arrayContaining([{ Key: "Project", Value: "claude-rig" }]),
+        );
+      }
+    });
+
+    it("applies builder tags to alarm constructs in the result", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      createBucketBuilder()
+        .serverAccessLogs(false)
+        .tag("Owner", "platform")
+        .addAlarm("requests", (alarm) =>
+          alarm.metric(
+            (bucket) =>
+              new Metric({
+                namespace: "AWS/S3",
+                metricName: "AllRequests",
+                dimensionsMap: { BucketName: bucket.bucketName },
+              }),
+          ),
+        )
+        .build(stack, "TestBucket");
+
+      const template = Template.fromStack(stack);
+      const alarms = template.findResources("AWS::CloudWatch::Alarm");
+      expect(Object.keys(alarms).length).toBeGreaterThan(0);
+      for (const resource of Object.values(alarms) as {
+        Properties: { Tags?: { Key: string; Value: string }[] };
+      }[]) {
+        expect(resource.Properties.Tags).toEqual(
+          expect.arrayContaining([{ Key: "Owner", Value: "platform" }]),
+        );
+      }
+    });
+
+    it("supports the .tags({...}) shorthand", () => {
+      const template = synthTemplate((b) =>
+        withoutLogging(b).tags({ Owner: "platform", Environment: "prod" }),
+      );
+
+      const buckets = template.findResources("AWS::S3::Bucket") as Record<
+        string,
+        { Properties: { Tags?: { Key: string; Value: string }[] } }
+      >;
+      const tags = Object.values(buckets)[0]?.Properties.Tags ?? [];
+      expect(tags).toEqual(
+        expect.arrayContaining([
+          { Key: "Owner", Value: "platform" },
+          { Key: "Environment", Value: "prod" },
+        ]),
+      );
     });
   });
 });

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.6.0",
     "@composurecdk/cloudwatch": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "aws-cdk-lib": "^2.0.0",

--- a/packages/sns/src/subscription-builder.ts
+++ b/packages/sns/src/subscription-builder.ts
@@ -78,6 +78,7 @@ export interface SubscriptionBuilderResult {
  *   .endpoint("ops@example.com");
  * ```
  */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::SNS::Subscription has no Tags property
 export type ISubscriptionBuilder = IBuilder<SubscriptionBuilderProps, SubscriptionBuilder>;
 
 class SubscriptionBuilder implements Lifecycle<SubscriptionBuilderResult> {
@@ -150,5 +151,6 @@ class SubscriptionBuilder implements Lifecycle<SubscriptionBuilderResult> {
  * ```
  */
 export function createSubscriptionBuilder(): ISubscriptionBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::SNS::Subscription has no Tags property
   return Builder<SubscriptionBuilderProps, SubscriptionBuilder>(SubscriptionBuilder);
 }

--- a/packages/sns/src/topic-builder.ts
+++ b/packages/sns/src/topic-builder.ts
@@ -7,13 +7,8 @@ import {
   type TopicProps,
 } from "aws-cdk-lib/aws-sns";
 import { type IConstruct } from "constructs";
-import {
-  Builder,
-  type IBuilder,
-  type Lifecycle,
-  resolve,
-  type Resolvable,
-} from "@composurecdk/core";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { TopicAlarmConfig } from "./topic-alarm-config.js";
 import { createTopicAlarms } from "./topic-alarms.js";
@@ -98,7 +93,7 @@ export interface TopicBuilderResult {
  *   .displayName("My Alert Topic");
  * ```
  */
-export type ITopicBuilder = IBuilder<TopicBuilderProps, TopicBuilder>;
+export type ITopicBuilder = ITaggedBuilder<TopicBuilderProps, TopicBuilder>;
 
 interface SubscriptionEntry {
   key: string;
@@ -198,5 +193,5 @@ class TopicBuilder implements Lifecycle<TopicBuilderResult> {
  * ```
  */
 export function createTopicBuilder(): ITopicBuilder {
-  return Builder<TopicBuilderProps, TopicBuilder>(TopicBuilder);
+  return taggedBuilder<TopicBuilderProps, TopicBuilder>(TopicBuilder);
 }


### PR DESCRIPTION
Closes #66. Supersedes #77 (rebased onto current `main` after `cd2cc65` landed; #77 can be closed).

## Why a new PR

`#77` was authored against `main` before `cd2cc65 feat(cloudformation)!: consume Lifecycle<StackBuilderResult> in singleStack/groupedStacks; drop toScopeFactory` landed. That commit removed `StackBuilder.toScopeFactory()` — which `#77`'s `getBuilderTags` escape-hatch existed to support — and reshaped the strategies to consume builders directly via `.build()`. Reauthored on top of current `main` rather than rebasing the original 12 commits, since `67afa42` (route StackBuilder through taggedBuilder) is fundamentally different content post-`cd2cc65`.

## What's different vs #77

- **Issue #6 dissolves.** `getBuilderTags` and the `BUILDER_TAGS` symbol are gone — no public escape hatch, no module-private accumulator on the wrapped instance. The accumulator lives only in the wrapper's closure.
- **`taggedBuilder` participates in `.copy()`** ([ADR-0005](docs/adr/0005-builder-copy.md)). The outer Proxy intercepts `copy`, calls `inner.copy()`, clones the accumulator, and re-wraps. Without this, `tagged.copy()` would surface the bare inner Proxy and silently drop both `.tag()` / `.tags()` and the build-time walker.
- **`StackBuilder` simplified.** No bespoke `#tags`, no `[COPY_STATE]` for tags, no `toScopeFactory` — just `taggedBuilder<StackProps, StackBuilder>(StackBuilder)` and a 3-line `build()`. Strategies on `main` consume `Lifecycle<StackBuilderResult>` directly, so the walker on `build()` is the single tagging path.
- **ADR renumbered to 0006** (`main` occupies 0005). Content adjusted: dropped the `getBuilderTags` escape-hatch wording, added a "Composing with `.copy()`" subsection that explains decorators must intercept `.copy()` and clone their own per-instance state.
- **Lint rule scoped by file.** `packages/cloudformation/src/tagged-builder.ts` is excluded from `composurecdk/builder-must-be-tagged` in the eslint config rather than carrying disable comments. Other builders keep the per-line disables for signposting.
- **`TAG_OVERRIDE_WARNING_NAME` exported** so callers filtering the override warning don't have to copy-paste the string from docs.

## Summary

Adds builder-level `.tag(key, value)` / `.tags({...})` to every builder in the library via a shared decorator wrapper, plus a complementary `tags()` afterBuild hook for system-wide cross-cutting tags.

The mechanism is a decorator factory `taggedBuilder<Props, T>(constructor)` that wraps `core.Builder()`. Every taggable builder factory in the library opts in by calling `taggedBuilder<>()` instead of bare `Builder<>()`. `@composurecdk/core` is unchanged — the decorator and its tag-application logic live in `@composurecdk/cloudformation` alongside `StackBuilder` and `outputs()`. A custom ESLint rule (`composurecdk/builder-must-be-tagged`) under `packages/*/src/**` enforces that future builders pick up the decorator by default.

The architectural decision being recorded is the **decorator-builder pattern itself** ([ADR-0006](docs/adr/0006-decorator-builder-pattern.md)), not the tagging feature — the pattern is the structural primitive for layering future cross-cutting features (telemetry, dry-run, etc.) onto every builder without modifying `core` or duplicating mechanics.

## Commits

1. **`feat(cloudformation): add taggedBuilder wrapper, tag validator, and result-walker`** — the decorator factory (with `.copy()` interception, `Object.create(null)` walker support, plain-object descent for wrapper shapes), `applyBuilderTags` walker, `validateTag` validator. Tests cover type augmentation, validation, override warnings, walker semantics, `.copy()` accumulator independence, and `Tags.of` equivalence.
2. **`feat(s3)!: wire BucketBuilder to taggedBuilder`** — first concrete migration. Chosen because BucketBuilder exercises every walker path: primary bucket, optional `accessLogsBucket` sibling, and `alarms: Record<string, Alarm>`.
3. **`feat(cloudformation)!: route StackBuilder through taggedBuilder, drop bespoke #tags`** — `StackBuilder` loses its bespoke `.tag()`, `#tags` array, `[COPY_STATE]` hook, and per-tag loop in `build()`. The walker handles tagging on the result; `taggedBuilder`'s `.copy()` interception handles tag isolation across copies.
4. **`feat!: roll taggedBuilder out across remaining builders + lint enforcement`** — mechanical migration of every other taggable builder (acm, apigateway, budgets/budget-alarm, cloudfront, ec2, iam/role, lambda, logs, route53/health-check + hosted-zone, sns/topic, s3/bucket-deployment). Non-taggable builders (Route53 records, sns/subscription, iam/managed-policy, budgets/budget) stay on bare `Builder()` with per-line `eslint-disable` directives naming the resource. Custom ESLint rule fires at the call/type site.
5. **`feat(cloudformation): add tags() afterBuild helper, ADR-0006, docs, example`** — Layer 2 hook (`tags({ system, byComponent })`), ADR-0006 documenting the decorator-builder pattern (including `.copy()` composition), `docs/extensions.md` Tagging section, and `packages/examples/src/tagged-system-app.ts`.
6. **`refactor(cloudformation): export TAG_OVERRIDE_WARNING_NAME, tighten Proxy cycle comment`** — simplify-pass cleanup from a code review.

## Behaviour summary

**Layer 1 — `.tag()` / `.tags()` on every taggable builder.** Tags accumulate during configuration (insertion-ordered map, last-wins on duplicate, with `process.emitWarning(name: "ComposureCDKTagOverride")` so overrides are visible). At `build()`, the walker recursively descends through plain-object literals (and `Object.create(null)` dictionaries) and tags every `IConstruct` it finds. Constructs are tag-application boundaries — CDK's tag aspect handles propagation across the construct's subtree. Class instances that aren't constructs (`PolicyDocument` etc.) are skipped.

**Layer 2 — `tags()` afterBuild hook.** `system` entries reach every taggable construct via `Tags.of(scope).add(...)` on the top-level scope. `byComponent` entries reach a specific component's scope (its per-component stack under `withStacks` / `withStackStrategy`). Component keys are statically typed against the composed system's keys.

**Validation.** Both layers validate keys/values eagerly: rejects empty keys, the reserved `aws:` prefix (case-insensitive), keys >128 chars, values >256 chars, and characters outside the AWS-documented tag character set.

**Precedence.** Builder-level tags win on key collision because they target a closer scope — CDK's tag priority resolves automatically.

**`.copy()` semantics.** Tagged builders preserve their decorator surface across `.copy()`, with a deep clone of the tag accumulator so original and copy mutate independently. See ADR-0006's "Composing with `.copy()`".

## Breaking changes

- Every migrated `IXxxBuilder` alias structurally extends `ITaggedBuilder<Props, T>` instead of `IBuilder<Props, T>`. Pure consumers that destructure or annotate against the old shape need to recompile.
- `StackBuilder.tag()`'s duplicate-key behaviour changes: previously appended silently (last-wins observable in CFN tags), now last-wins with `process.emitWarning`. Functionally compatible; previously-quiet duplicate calls now emit a warning.
- 14 builders wrapping non-taggable CFN resources (Route53 records ×11, `sns/subscription`, `iam/managed-policy`, `budgets/budget`) do **not** expose `.tag()` / `.tags()`. System-wide tagging on those resources still works via the `tags()` afterBuild hook (CDK's tag aspect propagates from the parent stack scope).
- Every builder package picks up `@composurecdk/cloudformation` as a peer dependency.

Pre-1.0; release-please will pick up the major bumps.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npx nx run-many -t build,typecheck,test` — 15 projects, all green
- [x] ESLint rule fires on `Builder()` calls and `IBuilder<…>` types imported from `@composurecdk/core` outside `tagged-builder.ts`
- [x] `packages/examples/src/tagged-system-app.ts` synthesises and the test asserts (a) the selector tag lands only on the EC2 instance, (b) system-wide tags reach the bucket, VPC, instance, and flow-log LogGroup
- [x] Existing snapshot tests for the other example apps still match (no incidental tag changes leaked into them)
- [x] Existing `StackBuilder` `.copy()` tests still pass against the new tagged path (tag isolation across copies)