### PR TITLE
feat(ec2): persistent EBS volume + attachment API

### DIFF
--- a/packages/ec2/README.md
+++ b/packages/ec2/README.md
@@ -120,6 +120,51 @@ const server = createInstanceBuilder()
   );
 ```
 
+### Attaching persistent volumes
+
+`attachVolume(key, volumeRef, opts)` mirrors the call shape of `addAlarm` and produces an `AWS::EC2::VolumeAttachment` for an externally-managed EBS volume. The volume reference accepts either a `Resolvable<VolumeBuilderResult>` (drop a `ref<VolumeBuilderResult>("data")` straight in) or a `Resolvable<IVolume>`.
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import {
+  createInstanceBuilder,
+  createVolumeBuilder,
+  createVpcBuilder,
+  type VolumeBuilderResult,
+  type VpcBuilderResult,
+} from "@composurecdk/ec2";
+import { Size } from "aws-cdk-lib";
+import { InstanceClass, InstanceSize, InstanceType, MachineImage } from "aws-cdk-lib/aws-ec2";
+
+compose(
+  {
+    network: createVpcBuilder().maxAzs(2).natGateways(0),
+
+    data: createVolumeBuilder()
+      .availabilityZone(ref<VpcBuilderResult>("network").map((r) => r.vpc.availabilityZones[0]))
+      .size(Size.gibibytes(50)),
+
+    agent: createInstanceBuilder()
+      .vpc(ref<VpcBuilderResult>("network").map((r) => r.vpc))
+      .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+      .machineImage(MachineImage.latestAmazonLinux2023())
+      .attachVolume("AgentData", ref<VolumeBuilderResult>("data"), { device: "/dev/sdf" }),
+  },
+  { network: [], data: ["network"], agent: ["network", "data"] },
+).build(stack, "AgentApp");
+```
+
+The result exposes the attachment under `result.agent.volumeAttachments.AgentData` and emits a per-attachment `volumeStalledIo` alarm under `result.agent.alarms["AgentData.volumeStalledIo"]`. When both AZs are concrete strings at synth, the builder asserts the instance and volume share an Availability Zone — synth-time failure beats boot-time failure.
+
+`VolumeStalledIOCheck` is published only for Nitro-instance attachments. On non-Nitro instances the alarm sits at `INSUFFICIENT_DATA`, which the `treatMissingData: NOT_BREACHING` default makes harmless. To disable the alarm per attachment:
+
+```ts
+.attachVolume("AgentData", ref<VolumeBuilderResult>("data"), {
+  device: "/dev/sdf",
+  recommendedAlarms: false,
+})
+```
+
 ## VPC Builder
 
 ```ts

--- a/packages/ec2/README.md
+++ b/packages/ec2/README.md
@@ -175,6 +175,82 @@ createVpcBuilder().flowLogs(false);
 
 For multiple flow logs against the same VPC, omit this config and create additional `FlowLog` constructs directly against the returned `vpc`.
 
+## Volume Builder
+
+```ts
+import { createVolumeBuilder } from "@composurecdk/ec2";
+import { Size } from "aws-cdk-lib";
+
+const data = createVolumeBuilder()
+  .availabilityZone("us-east-1a")
+  .size(Size.gibibytes(50))
+  .build(stack, "AgentData");
+```
+
+Every [VolumeProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.VolumeProps.html) property is available as a fluent setter on the builder, except `availabilityZone` which is set via the dedicated `.availabilityZone()` method (so it can be wired from a sibling `VpcBuilder` via `ref`) and `encryptionKey` which accepts a `Resolvable<IKey>` for cross-component KMS-key wiring.
+
+### Volume Defaults
+
+| Property        | Default                | Rationale                                                                                                 |
+| --------------- | ---------------------- | --------------------------------------------------------------------------------------------------------- |
+| `volumeType`    | `GP3`                  | Current-generation general-purpose SSD — cheaper and faster than GP2 at equivalent sizes.                 |
+| `encrypted`     | `true`                 | Encryption at rest with the account's default EBS KMS key. Pass `encryptionKey` for a CMK.                |
+| `autoEnableIo`  | `true`                 | Lets I/O resume on suspected inconsistency so the instance can come up unattended.                        |
+| `removalPolicy` | `RemovalPolicy.RETAIN` | A destroyed volume is unrecoverable; an orphaned volume is a $/month nuisance. Mirrors `BUCKET_DEFAULTS`. |
+
+Three properties intentionally have no default — they are application-specific and must be supplied explicitly:
+
+- `availabilityZone` (via the `.availabilityZone()` method)
+- `size`
+- `iops` / `throughput` (only when opting into a volume type that requires them)
+
+The defaults are exported as `VOLUME_DEFAULTS` for visibility and testing:
+
+```ts
+import { VOLUME_DEFAULTS } from "@composurecdk/ec2";
+```
+
+### Recommended Volume Alarms
+
+The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS) by default. No alarm actions are configured — wire actions via `alarmActionsPolicy` from `@composurecdk/cloudwatch`.
+
+| Alarm          | Metric                        | Default threshold    | Created when                                    |
+| -------------- | ----------------------------- | -------------------- | ----------------------------------------------- |
+| `burstBalance` | BurstBalance (Average, 5 min) | < 20% over 3 × 5 min | `volumeType` is burstable (`gp2`, `st1`, `sc1`) |
+
+The defaults are exported as `VOLUME_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { VOLUME_ALARM_DEFAULTS } from "@composurecdk/ec2";
+```
+
+`VolumeQueueLength` and `VolumeIdleTime` are deferred — both need per-`volumeType`/per-workload tuning to be a defensible default. Wire them via `addAlarm` until first-class support lands:
+
+```ts
+import { Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import { Duration } from "aws-cdk-lib";
+
+const data = createVolumeBuilder()
+  .availabilityZone("us-east-1a")
+  .size(Size.gibibytes(50))
+  .addAlarm("volumeQueueLength", (alarm) =>
+    alarm
+      .metric(
+        (volume) =>
+          new Metric({
+            namespace: "AWS/EBS",
+            metricName: "VolumeQueueLength",
+            dimensionsMap: { VolumeId: volume.volumeId },
+            statistic: Stats.AVERAGE,
+            period: Duration.minutes(5),
+          }),
+      )
+      .threshold(10)
+      .greaterThan()
+      .description("EBS volume queue length is high"),
+  );
+```
+
 ## Composing EC2 + VPC
 
 Compose the builders into a single system — the instance is wired to the VPC via `ref`:

--- a/packages/ec2/src/index.ts
+++ b/packages/ec2/src/index.ts
@@ -7,6 +7,9 @@ export {
 export { INSTANCE_DEFAULTS } from "./instance-defaults.js";
 export { type InstanceAlarmConfig } from "./instance-alarm-config.js";
 export { INSTANCE_ALARM_DEFAULTS } from "./instance-alarm-defaults.js";
+export { type AttachVolumeOptions } from "./instance-volume-attachments.js";
+export { type VolumeAttachmentAlarmConfig } from "./instance-volume-attachment-config.js";
+export { VOLUME_ATTACHMENT_ALARM_DEFAULTS } from "./instance-volume-attachment-defaults.js";
 
 export {
   createVolumeBuilder,

--- a/packages/ec2/src/index.ts
+++ b/packages/ec2/src/index.ts
@@ -9,6 +9,16 @@ export { type InstanceAlarmConfig } from "./instance-alarm-config.js";
 export { INSTANCE_ALARM_DEFAULTS } from "./instance-alarm-defaults.js";
 
 export {
+  createVolumeBuilder,
+  type IVolumeBuilder,
+  type VolumeBuilderProps,
+  type VolumeBuilderResult,
+} from "./volume-builder.js";
+export { VOLUME_DEFAULTS } from "./volume-defaults.js";
+export { type VolumeAlarmConfig } from "./volume-alarm-config.js";
+export { VOLUME_ALARM_DEFAULTS } from "./volume-alarm-defaults.js";
+
+export {
   createVpcBuilder,
   type FlowLogsConfig,
   type IVpcBuilder,

--- a/packages/ec2/src/instance-builder.ts
+++ b/packages/ec2/src/instance-builder.ts
@@ -1,5 +1,6 @@
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import {
+  type CfnVolumeAttachment,
   Instance,
   type IKeyPair,
   type ISecurityGroup,
@@ -14,6 +15,12 @@ import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { InstanceAlarmConfig } from "./instance-alarm-config.js";
 import { createInstanceAlarms } from "./instance-alarms.js";
 import { INSTANCE_DEFAULTS } from "./instance-defaults.js";
+import {
+  type AttachVolumeOptions,
+  type AttachVolumeRef,
+  createVolumeAttachments,
+  type PendingVolumeAttachment,
+} from "./instance-volume-attachments.js";
 
 /**
  * Configuration properties for the EC2 instance builder.
@@ -100,9 +107,10 @@ export interface InstanceBuilderResult {
   /**
    * CloudWatch alarms created for the instance, keyed by alarm name.
    *
-   * Includes both AWS-recommended alarms and any custom alarms added
-   * via {@link IInstanceBuilder.addAlarm}. Access individual alarms by
-   * key (e.g., `result.alarms.cpuUtilization`).
+   * Includes AWS-recommended instance alarms, any custom alarms added
+   * via {@link IInstanceBuilder.addAlarm}, and per-attachment alarms
+   * added by {@link IInstanceBuilder.attachVolume} (keyed
+   * `${attachmentKey}.${alarmKey}`, e.g. `AgentData.volumeStalledIo`).
    *
    * No alarm actions are configured — apply them via the result or an
    * `afterBuild` hook.
@@ -110,6 +118,15 @@ export interface InstanceBuilderResult {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EC2
    */
   alarms: Record<string, Alarm>;
+
+  /**
+   * `AWS::EC2::VolumeAttachment` constructs created via
+   * {@link IInstanceBuilder.attachVolume}, keyed by the attachment key
+   * supplied in that call.
+   *
+   * Empty when no volumes were attached.
+   */
+  volumeAttachments: Record<string, CfnVolumeAttachment>;
 }
 
 /**
@@ -149,6 +166,7 @@ export type IInstanceBuilder = ITaggedBuilder<InstanceBuilderProps, InstanceBuil
 class InstanceBuilder implements Lifecycle<InstanceBuilderResult> {
   props: Partial<InstanceBuilderProps> = {};
   readonly #customAlarms: AlarmDefinitionBuilder<Instance>[] = [];
+  readonly #volumeAttachments: PendingVolumeAttachment[] = [];
   #vpc?: Resolvable<IVpc>;
 
   /**
@@ -183,6 +201,38 @@ class InstanceBuilder implements Lifecycle<InstanceBuilderResult> {
     return this;
   }
 
+  /**
+   * Attaches an externally-managed EBS volume to the instance via an
+   * `AWS::EC2::VolumeAttachment` resource, mirroring the call shape of
+   * {@link addAlarm}.
+   *
+   * The `volumeRef` accepts either a `Resolvable<VolumeBuilderResult>`
+   * (drop a `ref<VolumeBuilderResult>("data")` straight in) or a
+   * `Resolvable<IVolume>` for an externally-managed volume — the builder
+   * unwraps either at build time.
+   *
+   * When both AZs are concrete at synth time, the builder asserts the
+   * instance and the volume are in the same Availability Zone — synth-
+   * time failure beats boot-time failure for AZ mismatches.
+   *
+   * Per-attachment AWS-recommended alarms (e.g. `volumeStalledIo`) are
+   * created by default and merged into the result's `alarms` record
+   * under prefixed keys (`${attachmentKey}.${alarmKey}`).
+   *
+   * @param key - Unique key for the attachment (used as the result-map
+   *   field name and as the construct id suffix).
+   * @param volumeRef - Resolvable to the volume to attach.
+   * @param options - Attachment options (`device`, `recommendedAlarms`).
+   * @returns This builder for chaining.
+   */
+  attachVolume(key: string, volumeRef: AttachVolumeRef, options: AttachVolumeOptions): this {
+    if (this.#volumeAttachments.some((a) => a.key === key)) {
+      throw new Error(`attachVolume: duplicate attachment key "${key}".`);
+    }
+    this.#volumeAttachments.push({ key, volumeRef, options });
+    return this;
+  }
+
   build(scope: IConstruct, id: string, context?: Record<string, object>): InstanceBuilderResult {
     const resolvedVpc = this.#vpc ? resolve(this.#vpc, context) : undefined;
 
@@ -211,7 +261,7 @@ class InstanceBuilder implements Lifecycle<InstanceBuilderResult> {
 
     const instance = new Instance(scope, id, mergedProps);
 
-    const alarms = createInstanceAlarms(
+    const instanceAlarms = createInstanceAlarms(
       scope,
       id,
       instance,
@@ -220,7 +270,20 @@ class InstanceBuilder implements Lifecycle<InstanceBuilderResult> {
       this.#customAlarms,
     );
 
-    return { instance, alarms };
+    const { attachments, alarms: attachmentAlarms } = createVolumeAttachments(
+      scope,
+      id,
+      instance,
+      mergedProps,
+      this.#volumeAttachments,
+      context,
+    );
+
+    return {
+      instance,
+      alarms: { ...instanceAlarms, ...attachmentAlarms },
+      volumeAttachments: attachments,
+    };
   }
 }
 

--- a/packages/ec2/src/instance-volume-attachment-config.ts
+++ b/packages/ec2/src/instance-volume-attachment-config.ts
@@ -1,0 +1,35 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for a per-attachment EBS
+ * volume on an EC2 instance.
+ *
+ * Default thresholds are sourced from the AWS-recommended CloudWatch
+ * alarm guide. Set the master switch or individual alarms to `false` to
+ * disable them, or provide an {@link AlarmConfig} to tune thresholds.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+ */
+export interface VolumeAttachmentAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all per-attachment alarms.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the per-attachment EBS volume status check reports a
+   * stalled I/O condition — typically a host or storage-subsystem issue
+   * for that specific attachment.
+   *
+   * Metric: `AWS/EBS VolumeStalledIOCheck`, statistic Maximum,
+   * period 1 minute. Default threshold: >= 1 over 10 consecutive minutes.
+   *
+   * The metric is published only for Nitro-instance attachments. On
+   * non-Nitro instances the alarm sits at `INSUFFICIENT_DATA`, which the
+   * `treatMissingData: NOT_BREACHING` default makes harmless.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+   */
+  volumeStalledIo?: AlarmConfig | false;
+}

--- a/packages/ec2/src/instance-volume-attachment-defaults.ts
+++ b/packages/ec2/src/instance-volume-attachment-defaults.ts
@@ -1,0 +1,31 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+
+interface VolumeAttachmentAlarmDefaults {
+  enabled: true;
+  volumeStalledIo: AlarmConfigDefaults;
+}
+
+/**
+ * AWS-recommended default alarm configuration for per-attachment EBS
+ * volumes.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+ */
+export const VOLUME_ATTACHMENT_ALARM_DEFAULTS: VolumeAttachmentAlarmDefaults = {
+  enabled: true,
+
+  /**
+   * The single AWS-recommended EBS alarm. Complements the existing
+   * `attachedEbsStatusCheckFailed` on the instance: the EC2-side metric
+   * pages on instance-level reachability, this one on per-volume health.
+   * The 10-of-10 evaluation window matches AWS guidance — EBS
+   * infrastructure usually self-heals within a few minutes.
+   */
+  volumeStalledIo: {
+    threshold: 1,
+    evaluationPeriods: 10,
+    datapointsToAlarm: 10,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};

--- a/packages/ec2/src/instance-volume-attachments.ts
+++ b/packages/ec2/src/instance-volume-attachments.ts
@@ -1,0 +1,203 @@
+import { Duration, Token } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  CfnVolumeAttachment,
+  type Instance,
+  type InstanceProps,
+  type IVolume,
+  type SelectedSubnets,
+} from "aws-cdk-lib/aws-ec2";
+import type { IConstruct } from "constructs";
+import { resolve, type Resolvable } from "@composurecdk/core";
+import { type AlarmDefinition, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { VolumeBuilderResult } from "./volume-builder.js";
+import type { VolumeAttachmentAlarmConfig } from "./instance-volume-attachment-config.js";
+import { VOLUME_ATTACHMENT_ALARM_DEFAULTS } from "./instance-volume-attachment-defaults.js";
+
+const STALLED_IO_PERIOD = Duration.minutes(1);
+const STALLED_IO_PERIOD_LABEL = `${String(STALLED_IO_PERIOD.toMinutes())} minute`;
+
+/**
+ * Reference to the volume to be attached. Either a sibling
+ * {@link VolumeBuilderResult} (the common composed-system case) or a
+ * concrete {@link IVolume} (for externally-managed volumes).
+ */
+export type AttachVolumeRef = Resolvable<VolumeBuilderResult> | Resolvable<IVolume>;
+
+/**
+ * Configuration for a single `attachVolume` call.
+ */
+export interface AttachVolumeOptions {
+  /**
+   * Linux device name to attach the volume as (e.g. `/dev/sdf`).
+   *
+   * The Linux kernel may rename this to `xvdf` etc. on the instance —
+   * resolve mounts via UUID rather than the device path.
+   *
+   * @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+   */
+  device: string;
+
+  /**
+   * Configuration for the per-attachment recommended alarms.
+   *
+   * @default - alarms enabled with the defaults in
+   *   {@link VOLUME_ATTACHMENT_ALARM_DEFAULTS}.
+   */
+  recommendedAlarms?: VolumeAttachmentAlarmConfig | false;
+}
+
+/**
+ * Internal config captured by {@link IInstanceBuilder.attachVolume} and
+ * forwarded to {@link createVolumeAttachments} at build time.
+ *
+ * @internal
+ */
+export interface PendingVolumeAttachment {
+  key: string;
+  volumeRef: AttachVolumeRef;
+  options: AttachVolumeOptions;
+}
+
+function resolveInstanceAz(instanceProps: InstanceProps): string | undefined {
+  if (instanceProps.availabilityZone && !Token.isUnresolved(instanceProps.availabilityZone)) {
+    return instanceProps.availabilityZone;
+  }
+
+  let selected: SelectedSubnets;
+  try {
+    selected = instanceProps.vpc.selectSubnets(instanceProps.vpcSubnets);
+  } catch {
+    // selectSubnets() throws for several unrelated reasons (no matching subnets,
+    // unresolved tokens, etc.). The validation is best-effort — if we can't
+    // resolve a concrete AZ, fall through and let CFN surface the real failure.
+    return undefined;
+  }
+
+  return selected.availabilityZones.find((az) => !Token.isUnresolved(az));
+}
+
+function unwrapVolume(resolved: VolumeBuilderResult | IVolume): IVolume {
+  if ("volumeId" in resolved) {
+    return resolved;
+  }
+  return resolved.volume;
+}
+
+function volumeAttachmentMetric(
+  volume: IVolume,
+  instance: Instance,
+  metricName: string,
+  statistic: string,
+  period: Duration,
+): Metric {
+  return new Metric({
+    namespace: "AWS/EBS",
+    metricName,
+    dimensionsMap: {
+      VolumeId: volume.volumeId,
+      InstanceId: instance.instanceId,
+    },
+    statistic,
+    period,
+  });
+}
+
+function resolveVolumeAttachmentAlarmDefinitions(
+  attachmentKey: string,
+  volume: IVolume,
+  instance: Instance,
+  config: VolumeAttachmentAlarmConfig | false | undefined,
+): AlarmDefinition[] {
+  if (config === false) return [];
+  const enabled = config?.enabled ?? VOLUME_ATTACHMENT_ALARM_DEFAULTS.enabled;
+  if (!enabled) return [];
+  if (config?.volumeStalledIo === false) return [];
+
+  const cfg = resolveAlarmConfig(
+    config?.volumeStalledIo,
+    VOLUME_ATTACHMENT_ALARM_DEFAULTS.volumeStalledIo,
+  );
+
+  return [
+    {
+      key: `${attachmentKey}.volumeStalledIo`,
+      alarmName: cfg.alarmName,
+      metric: volumeAttachmentMetric(
+        volume,
+        instance,
+        "VolumeStalledIOCheck",
+        Stats.MAXIMUM,
+        STALLED_IO_PERIOD,
+      ),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `EBS volume attachment "${attachmentKey}" is reporting a stalled I/O condition. ` +
+        `Threshold: >= ${String(cfg.threshold)} (max) over ${String(cfg.evaluationPeriods)} x ${STALLED_IO_PERIOD_LABEL}. ` +
+        `Note: VolumeStalledIOCheck is published only for Nitro-instance attachments.`,
+    },
+  ];
+}
+
+/**
+ * Creates a {@link CfnVolumeAttachment} for each pending attachment and
+ * (when configured) the per-attachment recommended alarms. Synth-time AZ
+ * alignment is validated when both the volume's AZ and the instance's
+ * effective AZ are concrete strings.
+ *
+ * @returns The created `CfnVolumeAttachment`s keyed by attachment key,
+ *   plus the per-attachment alarms keyed by `${attachmentKey}.${alarmKey}`
+ *   so they can be flat-merged into the instance's `alarms` record.
+ */
+export function createVolumeAttachments(
+  scope: IConstruct,
+  id: string,
+  instance: Instance,
+  instanceProps: InstanceProps,
+  attachments: PendingVolumeAttachment[],
+  context?: Record<string, object>,
+): { attachments: Record<string, CfnVolumeAttachment>; alarms: Record<string, Alarm> } {
+  const attachmentRecords: Record<string, CfnVolumeAttachment> = {};
+  const alarmDefinitions: AlarmDefinition[] = [];
+
+  // Resolve the instance AZ once — it is the same for every attachment.
+  const instanceAz = attachments.length > 0 ? resolveInstanceAz(instanceProps) : undefined;
+
+  for (const pending of attachments) {
+    const resolved = resolve(pending.volumeRef, context);
+    const volume = unwrapVolume(resolved);
+
+    if (instanceAz !== undefined && !Token.isUnresolved(volume.availabilityZone)) {
+      if (volume.availabilityZone !== instanceAz) {
+        throw new Error(
+          `attachVolume "${pending.key}": volume is in availability zone "${volume.availabilityZone}" ` +
+            `but the instance is in "${instanceAz}". ` +
+            `EBS volumes can only attach to instances in the same AZ.`,
+        );
+      }
+    }
+
+    const attachment = new CfnVolumeAttachment(scope, `${id}${pending.key}Attachment`, {
+      device: pending.options.device,
+      instanceId: instance.instanceId,
+      volumeId: volume.volumeId,
+    });
+    attachmentRecords[pending.key] = attachment;
+
+    alarmDefinitions.push(
+      ...resolveVolumeAttachmentAlarmDefinitions(
+        pending.key,
+        volume,
+        instance,
+        pending.options.recommendedAlarms,
+      ),
+    );
+  }
+
+  const alarms = alarmDefinitions.length > 0 ? createAlarms(scope, id, alarmDefinitions) : {};
+  return { attachments: attachmentRecords, alarms };
+}

--- a/packages/ec2/src/volume-alarm-config.ts
+++ b/packages/ec2/src/volume-alarm-config.ts
@@ -1,0 +1,36 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for an EBS volume.
+ * All applicable alarms are enabled by default with AWS-recommended
+ * thresholds. Set individual alarms to `false` to disable them, or
+ * provide an {@link AlarmConfig} to tune thresholds.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+ */
+export interface VolumeAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when a burstable volume's I/O credit balance falls low,
+   * indicating the volume is about to be throttled to baseline IOPS or
+   * throughput.
+   *
+   * Only created when the configured `volumeType` is one of the burstable
+   * types: `gp2` (IOPS credits), `st1` and `sc1` (throughput credits).
+   * For non-burstable types (`gp3`, `io1`, `io2`, `standard`) the metric
+   * is not emitted, so the alarm is skipped entirely.
+   *
+   * Metric: `AWS/EBS BurstBalance`, statistic Average, period 5 minutes.
+   * Default threshold: < 20% over 3 consecutive 5-minute windows.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+   * @see https://docs.aws.amazon.com/ebs/latest/userguide/general-purpose.html#gp2-volume-performance
+   */
+  burstBalance?: AlarmConfig | false;
+}

--- a/packages/ec2/src/volume-alarm-defaults.ts
+++ b/packages/ec2/src/volume-alarm-defaults.ts
@@ -1,0 +1,34 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+
+interface VolumeAlarmDefaults {
+  enabled: true;
+  burstBalance: AlarmConfigDefaults;
+}
+
+/**
+ * AWS-recommended default alarm configuration for EBS volumes.
+ *
+ * Thresholds are sourced from the CloudWatch Best Practice Recommended
+ * Alarms guide. Thresholds may reasonably be tuned per-workload; defaults
+ * bias toward catching obvious issues without excessive noise.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+ */
+export const VOLUME_ALARM_DEFAULTS: VolumeAlarmDefaults = {
+  enabled: true,
+
+  /**
+   * Burst credit balance is a percentage. Below 20% the volume is
+   * approaching throttling to baseline performance — early warning to
+   * upsize, switch to a non-burstable type (e.g. `gp3`), or investigate
+   * unexpectedly heavy I/O. The 3-of-3 evaluation at 5-minute granularity
+   * suppresses transient dips around backup windows.
+   */
+  burstBalance: {
+    threshold: 20,
+    evaluationPeriods: 3,
+    datapointsToAlarm: 3,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};

--- a/packages/ec2/src/volume-alarms.ts
+++ b/packages/ec2/src/volume-alarms.ts
@@ -1,0 +1,115 @@
+import { Duration } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import { EbsDeviceVolumeType, type IVolume, type Volume } from "aws-cdk-lib/aws-ec2";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { VolumeAlarmConfig } from "./volume-alarm-config.js";
+import { VOLUME_ALARM_DEFAULTS } from "./volume-alarm-defaults.js";
+
+/**
+ * BurstBalance is published at 5-minute granularity for burstable volume
+ * types. A shorter period yields missing data rather than higher resolution.
+ *
+ * @see https://docs.aws.amazon.com/ebs/latest/userguide/using_cloudwatch_ebs.html
+ */
+const BURST_METRIC_PERIOD = Duration.minutes(5);
+const BURST_METRIC_PERIOD_LABEL = `${String(BURST_METRIC_PERIOD.toMinutes())} minute`;
+
+/**
+ * EBS volume types that publish a `BurstBalance` metric. `gp2` accrues IOPS
+ * credits; `st1` and `sc1` accrue throughput credits. Other types
+ * (`gp3`, `io1`, `io2`, `standard`) have no burst credit model.
+ *
+ * @see https://docs.aws.amazon.com/ebs/latest/userguide/using_cloudwatch_ebs.html
+ */
+const BURSTABLE_VOLUME_TYPES: ReadonlySet<EbsDeviceVolumeType> = new Set([
+  EbsDeviceVolumeType.GP2,
+  EbsDeviceVolumeType.ST1,
+  EbsDeviceVolumeType.SC1,
+]);
+
+function isBurstableVolumeType(volumeType: EbsDeviceVolumeType | undefined): boolean {
+  return volumeType !== undefined && BURSTABLE_VOLUME_TYPES.has(volumeType);
+}
+
+function volumeMetric(
+  volume: IVolume,
+  metricName: string,
+  statistic: string,
+  period: Duration,
+): Metric {
+  return new Metric({
+    namespace: "AWS/EBS",
+    metricName,
+    dimensionsMap: { VolumeId: volume.volumeId },
+    statistic,
+    period,
+  });
+}
+
+/**
+ * Resolves the recommended alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s, applying contextual logic for the
+ * burstable-only credit alarm.
+ */
+export function resolveVolumeAlarmDefinitions(
+  volume: Volume,
+  config: VolumeAlarmConfig | undefined,
+  volumeType: EbsDeviceVolumeType | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.burstBalance !== false && isBurstableVolumeType(volumeType)) {
+    const cfg = resolveAlarmConfig(config?.burstBalance, VOLUME_ALARM_DEFAULTS.burstBalance);
+    definitions.push({
+      key: "burstBalance",
+      alarmName: cfg.alarmName,
+      metric: volumeMetric(volume, "BurstBalance", Stats.AVERAGE, BURST_METRIC_PERIOD),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `EBS burstable volume burst credit balance is low — baseline-IOPS throttling is imminent. Threshold: < ${String(cfg.threshold)}% (average) over ${String(cfg.evaluationPeriods)} x ${BURST_METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates AWS-recommended CloudWatch alarms for an EBS volume,
+ * merging recommended definitions with any custom alarm builders.
+ *
+ * @param scope - CDK construct scope for creating alarm constructs.
+ * @param id - Base identifier for alarm construct ids.
+ * @param volume - The EBS volume to create alarms for.
+ * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param volumeType - Resolved volume type, used to gate the contextual
+ *   burst-balance alarm.
+ * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @returns A record mapping alarm keys to their created Alarm constructs.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+ */
+export function createVolumeAlarms(
+  scope: IConstruct,
+  id: string,
+  volume: Volume,
+  config: VolumeAlarmConfig | false | undefined,
+  volumeType: EbsDeviceVolumeType | undefined,
+  customAlarms: AlarmDefinitionBuilder<Volume>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? VOLUME_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveVolumeAlarmDefinitions(volume, config, volumeType);
+  const custom = customAlarms.map((b) => b.resolve(volume));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/ec2/src/volume-builder.ts
+++ b/packages/ec2/src/volume-builder.ts
@@ -1,0 +1,227 @@
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { Volume, type VolumeProps } from "aws-cdk-lib/aws-ec2";
+import { type IKey } from "aws-cdk-lib/aws-kms";
+import { type IConstruct } from "constructs";
+import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { VolumeAlarmConfig } from "./volume-alarm-config.js";
+import { createVolumeAlarms } from "./volume-alarms.js";
+import { VOLUME_DEFAULTS } from "./volume-defaults.js";
+
+/**
+ * Configuration properties for the EBS volume builder.
+ *
+ * Extends the CDK {@link VolumeProps} but lifts the cross-component-wiring
+ * props to {@link Resolvable} so they can be supplied as either concrete
+ * values or {@link Ref}s to sibling components in a {@link compose}d system:
+ *
+ * - `availabilityZone` is supplied via the dedicated
+ *   {@link IVolumeBuilder.availabilityZone | .availabilityZone()} method
+ *   so it can be wired from a sibling `VpcBuilder`.
+ * - `encryptionKey` is exposed on the builder as a `Resolvable<IKey>`
+ *   setter so a sibling KMS key builder can supply a CMK.
+ *
+ * Other props (`size`, `volumeType`, `iops`, `throughput`, `enableMultiAttach`,
+ * `autoEnableIo`, `removalPolicy`, etc.) are passed through with their CDK
+ * types unchanged because they are almost always constructed inline rather
+ * than referenced from another component.
+ */
+export interface VolumeBuilderProps extends Omit<
+  VolumeProps,
+  "availabilityZone" | "encryptionKey"
+> {
+  /**
+   * Customer-managed KMS key (CMK) used to encrypt the volume.
+   *
+   * Accepts a concrete {@link IKey} or a {@link Ref} that resolves to one
+   * at build time (e.g. a sibling key builder in the same composed system).
+   *
+   * @default - the account's default EBS KMS key, applied because
+   *   `encrypted: true` is set in {@link VOLUME_DEFAULTS}.
+   *
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_protect_data_rest_encrypt.html
+   */
+  encryptionKey?: Resolvable<IKey>;
+
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates recommended alarms with sensible
+   * thresholds for every applicable metric. Individual alarms can be
+   * customized or disabled. Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification methods
+   * are user-specific. Access alarms from the build result or use an
+   * `afterBuild` hook to apply actions.
+   *
+   * Contextual alarms (`burstBalance`) are only created when the
+   * corresponding volume configuration is present — e.g., a burstable
+   * `gp2`/`st1`/`sc1` volume type.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+   */
+  recommendedAlarms?: VolumeAlarmConfig | false;
+}
+
+/**
+ * The build output of a {@link IVolumeBuilder}. Contains the CDK constructs
+ * created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface VolumeBuilderResult {
+  volume: Volume;
+
+  /**
+   * CloudWatch alarms created for the volume, keyed by alarm name.
+   *
+   * Includes both AWS-recommended alarms and any custom alarms added
+   * via {@link IVolumeBuilder.addAlarm}. Access individual alarms by
+   * key (e.g., `result.alarms.burstBalance`).
+   *
+   * No alarm actions are configured — apply them via the result or an
+   * `afterBuild` hook.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EBS
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS EBS volume.
+ *
+ * Each configuration property from the CDK {@link VolumeProps} is exposed
+ * as an overloaded method: call with a value to set it (returns the builder
+ * for chaining), or call with no arguments to read the current value.
+ *
+ * The `availabilityZone` is set via the dedicated
+ * {@link IVolumeBuilder.availabilityZone | .availabilityZone()} method that
+ * accepts a {@link Resolvable} value for cross-component wiring (e.g., to
+ * a sibling {@link IVpcBuilder}). The `encryptionKey` setter likewise
+ * accepts a {@link Resolvable} value so a sibling KMS-key builder's output
+ * can be supplied via {@link ref}.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates
+ * an EBS volume with the configured properties and returns a
+ * {@link VolumeBuilderResult}.
+ *
+ * AWS-recommended CloudWatch alarms are created by default. Alarms can be
+ * customized or disabled via the `recommendedAlarms` property. Custom
+ * alarms can be added via the {@link addAlarm} method.
+ *
+ * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.Volume.html
+ *
+ * @example
+ * ```ts
+ * const data = createVolumeBuilder()
+ *   .availabilityZone(ref<VpcBuilderResult>("network").map(r => r.vpc.availabilityZones[0]))
+ *   .size(Size.gibibytes(50));
+ * ```
+ */
+export type IVolumeBuilder = ITaggedBuilder<VolumeBuilderProps, VolumeBuilder>;
+
+class VolumeBuilder implements Lifecycle<VolumeBuilderResult> {
+  props: Partial<VolumeBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<Volume>[] = [];
+  #availabilityZone?: Resolvable<string>;
+
+  /**
+   * Sets the Availability Zone the volume will be created in.
+   *
+   * Accepts a concrete AZ string or a {@link Ref} that resolves to one at
+   * build time. This is how cross-component wiring works — e.g., to a
+   * sibling {@link IVpcBuilder} via
+   * `ref<VpcBuilderResult>("network").map(r => r.vpc.availabilityZones[0])`.
+   *
+   * @param availabilityZone - The AZ string or a Ref to one.
+   * @returns This builder for chaining.
+   */
+  availabilityZone(availabilityZone: Resolvable<string>): this {
+    this.#availabilityZone = availabilityZone;
+    return this;
+  }
+
+  /**
+   * Adds a custom CloudWatch alarm to be created alongside the recommended
+   * alarms. The provided callback receives an {@link AlarmDefinitionBuilder}
+   * scoped to the built {@link Volume}; configure it fluently and return it.
+   *
+   * @param key - A unique key for the alarm (used to generate the alarm id).
+   * @param configure - Callback that configures the alarm definition.
+   * @returns This builder for chaining.
+   */
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<Volume>) => AlarmDefinitionBuilder<Volume>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<Volume>(key)));
+    return this;
+  }
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): VolumeBuilderResult {
+    const resolvedAz = this.#availabilityZone
+      ? resolve(this.#availabilityZone, context)
+      : undefined;
+
+    if (resolvedAz === undefined) {
+      throw new Error(
+        `VolumeBuilder "${id}" requires an availability zone. ` +
+          `Call .availabilityZone() with a string or a Ref to one.`,
+      );
+    }
+
+    const { recommendedAlarms: alarmConfig, encryptionKey, ...volumeProps } = this.props;
+
+    const mergedProps = {
+      ...VOLUME_DEFAULTS,
+      ...volumeProps,
+      availabilityZone: resolvedAz,
+      ...(encryptionKey !== undefined ? { encryptionKey: resolve(encryptionKey, context) } : {}),
+    } as VolumeProps;
+
+    const volume = new Volume(scope, id, mergedProps);
+
+    const alarms = createVolumeAlarms(
+      scope,
+      id,
+      volume,
+      alarmConfig,
+      mergedProps.volumeType,
+      this.#customAlarms,
+    );
+
+    return { volume, alarms };
+  }
+}
+
+/**
+ * Creates a new {@link IVolumeBuilder} for configuring an AWS EBS volume.
+ *
+ * This is the entry point for defining an EBS volume component. The
+ * returned builder exposes every {@link VolumeBuilderProps} property as a
+ * fluent setter/getter, plus
+ * {@link IVolumeBuilder.availabilityZone | .availabilityZone()} for
+ * cross-component AZ wiring with Ref support. It implements
+ * {@link Lifecycle} for use with {@link compose}.
+ *
+ * @returns A fluent builder for an AWS EBS volume.
+ *
+ * @example
+ * ```ts
+ * const data = createVolumeBuilder()
+ *   .availabilityZone(ref<VpcBuilderResult>("network").map(r => r.vpc.availabilityZones[0]))
+ *   .size(Size.gibibytes(50));
+ *
+ * // Use standalone:
+ * const result = data.build(stack, "Data", { network });
+ *
+ * // Or compose into a system:
+ * const system = compose(
+ *   { network: createVpcBuilder(), data },
+ *   { network: [], data: ["network"] },
+ * );
+ * ```
+ */
+export function createVolumeBuilder(): IVolumeBuilder {
+  return taggedBuilder<VolumeBuilderProps, VolumeBuilder>(VolumeBuilder);
+}

--- a/packages/ec2/src/volume-defaults.ts
+++ b/packages/ec2/src/volume-defaults.ts
@@ -1,0 +1,50 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { EbsDeviceVolumeType, type VolumeProps } from "aws-cdk-lib/aws-ec2";
+
+/**
+ * Secure, AWS-recommended defaults applied to every EBS volume built with
+ * {@link createVolumeBuilder}. Each property can be individually overridden
+ * via the builder's fluent API.
+ *
+ * Three properties intentionally have no default — they are application-
+ * specific and must be supplied explicitly:
+ *   - `availabilityZone` (via the builder's `.availabilityZone()` method)
+ *   - `size`
+ *   - `iops` / `throughput` (only when opting into a volume type that
+ *     requires them, e.g. `io1`/`io2`)
+ */
+export const VOLUME_DEFAULTS: Partial<VolumeProps> = {
+  /**
+   * GP3 is the current-generation general-purpose SSD — cheaper and faster
+   * than GP2 at equivalent sizes, and matches the root-volume choice in
+   * {@link INSTANCE_DEFAULTS}.
+   * @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html
+   */
+  volumeType: EbsDeviceVolumeType.GP3,
+
+  /**
+   * Encrypt the volume at rest. Defaults to the account's default EBS KMS
+   * key; pass an `encryptionKey` to use a customer-managed key (CMK) for
+   * sensitive workloads per SEC08-BP02.
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_protect_data_rest_encrypt.html
+   * @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
+   */
+  encrypted: true,
+
+  /**
+   * When EBS detects inconsistent data on boot it disables I/O until the
+   * operator acknowledges. For a persistent data volume the safer default
+   * is to let I/O resume so the instance can come up unattended; override
+   * to `false` for workloads that prefer to block on potential corruption.
+   * @see https://docs.aws.amazon.com/ebs/latest/userguide/monitoring-volume-events.html
+   */
+  autoEnableIo: true,
+
+  /**
+   * Mirrors `BUCKET_DEFAULTS.removalPolicy`. A destroyed volume is
+   * unrecoverable; an orphaned volume is a $/month nuisance. Err on the
+   * side of retention — flip to `DESTROY` explicitly for ephemeral data.
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/rel_planning_for_recovery_back_up_data.html
+   */
+  removalPolicy: RemovalPolicy.RETAIN,
+};

--- a/packages/ec2/test/instance-attach-volume.test.ts
+++ b/packages/ec2/test/instance-attach-volume.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from "vitest";
+import { App, Lazy, Size, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  MachineImage,
+  Volume,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import { compose, ref } from "@composurecdk/core";
+import { createInstanceBuilder } from "../src/instance-builder.js";
+import { createVolumeBuilder, type VolumeBuilderResult } from "../src/volume-builder.js";
+import { createVpcBuilder, type VpcBuilderResult } from "../src/vpc-builder.js";
+
+describe("InstanceBuilder.attachVolume", () => {
+  describe("single attachment with VolumeBuilderResult ref", () => {
+    function buildAgent() {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = compose(
+        {
+          network: createVpcBuilder().maxAzs(2).natGateways(0),
+          data: createVolumeBuilder()
+            .availabilityZone(
+              ref<VpcBuilderResult>("network").map((r) => r.vpc.availabilityZones[0]),
+            )
+            .size(Size.gibibytes(20)),
+          agent: createInstanceBuilder()
+            .vpc(ref<VpcBuilderResult>("network").map((r) => r.vpc))
+            .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+            .machineImage(MachineImage.latestAmazonLinux2023())
+            .attachVolume("AgentData", ref<VolumeBuilderResult>("data"), {
+              device: "/dev/sdf",
+            }),
+        },
+        { network: [], data: ["network"], agent: ["network", "data"] },
+      ).build(stack, "AgentApp");
+      return { stack, result, template: Template.fromStack(stack) };
+    }
+
+    it("creates exactly one VolumeAttachment", () => {
+      const { template } = buildAgent();
+      template.resourceCountIs("AWS::EC2::VolumeAttachment", 1);
+    });
+
+    it("exposes the attachment in InstanceBuilderResult.volumeAttachments", () => {
+      const { result } = buildAgent();
+      expect(result.agent.volumeAttachments.AgentData).toBeDefined();
+    });
+
+    it("wires device, instanceId, and volumeId on the attachment", () => {
+      const { template } = buildAgent();
+      template.hasResourceProperties("AWS::EC2::VolumeAttachment", {
+        Device: "/dev/sdf",
+        InstanceId: Match.anyValue(),
+        VolumeId: Match.anyValue(),
+      });
+    });
+
+    it("creates the per-attachment volumeStalledIo alarm by default", () => {
+      const { result, template } = buildAgent();
+
+      expect(result.agent.alarms["AgentData.volumeStalledIo"]).toBeDefined();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Namespace: "AWS/EBS",
+        MetricName: "VolumeStalledIOCheck",
+        Statistic: "Maximum",
+        Period: 60,
+        Threshold: 1,
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        EvaluationPeriods: 10,
+        DatapointsToAlarm: 10,
+        TreatMissingData: "notBreaching",
+        Dimensions: Match.arrayEquals([
+          Match.objectLike({ Name: "InstanceId" }),
+          Match.objectLike({ Name: "VolumeId" }),
+        ]),
+      });
+    });
+  });
+
+  describe("Resolvable<IVolume> form", () => {
+    it("accepts a bare IVolume ref by unwrapping its volumeId", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+      const volume = new Volume(stack, "ExternalVolume", {
+        availabilityZone: vpc.availabilityZones[0],
+        size: Size.gibibytes(10),
+      });
+
+      createInstanceBuilder()
+        .vpc(vpc)
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .attachVolume(
+          "Bare",
+          ref<{ volume: Volume }>("ext").map((r) => r.volume),
+          {
+            device: "/dev/sdg",
+          },
+        )
+        .build(stack, "AgentInstance", { ext: { volume } });
+
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::EC2::VolumeAttachment", 1);
+    });
+  });
+
+  describe("multiple attachments", () => {
+    it("creates one attachment + alarm per call, namespaced by key", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = compose(
+        {
+          network: createVpcBuilder().maxAzs(2).natGateways(0),
+          data: createVolumeBuilder()
+            .availabilityZone(
+              ref<VpcBuilderResult>("network").map((r) => r.vpc.availabilityZones[0]),
+            )
+            .size(Size.gibibytes(20)),
+          logs: createVolumeBuilder()
+            .availabilityZone(
+              ref<VpcBuilderResult>("network").map((r) => r.vpc.availabilityZones[0]),
+            )
+            .size(Size.gibibytes(10)),
+          agent: createInstanceBuilder()
+            .vpc(ref<VpcBuilderResult>("network").map((r) => r.vpc))
+            .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+            .machineImage(MachineImage.latestAmazonLinux2023())
+            .attachVolume("AgentData", ref<VolumeBuilderResult>("data"), {
+              device: "/dev/sdf",
+            })
+            .attachVolume("AgentLogs", ref<VolumeBuilderResult>("logs"), {
+              device: "/dev/sdg",
+            }),
+        },
+        {
+          network: [],
+          data: ["network"],
+          logs: ["network"],
+          agent: ["network", "data", "logs"],
+        },
+      ).build(stack, "AgentApp");
+
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::EC2::VolumeAttachment", 2);
+      expect(result.agent.volumeAttachments.AgentData).toBeDefined();
+      expect(result.agent.volumeAttachments.AgentLogs).toBeDefined();
+      expect(result.agent.alarms["AgentData.volumeStalledIo"]).toBeDefined();
+      expect(result.agent.alarms["AgentLogs.volumeStalledIo"]).toBeDefined();
+    });
+
+    it("rejects duplicate attachment keys at configuration time", () => {
+      const builder = createInstanceBuilder()
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023());
+
+      builder.attachVolume("Same", ref<VolumeBuilderResult>("data"), { device: "/dev/sdf" });
+
+      expect(() =>
+        builder.attachVolume("Same", ref<VolumeBuilderResult>("data"), { device: "/dev/sdg" }),
+      ).toThrow(/duplicate attachment key/i);
+    });
+  });
+
+  describe("synth-time AZ validation", () => {
+    it("throws when the volume and instance AZs are concrete and mismatched", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", {
+        env: { account: "111111111111", region: "us-east-1" },
+      });
+      const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+
+      const volume = new Volume(stack, "ExternalVolume", {
+        availabilityZone: "us-east-1z",
+        size: Size.gibibytes(10),
+      });
+
+      const builder = createInstanceBuilder()
+        .vpc(vpc)
+        .availabilityZone("us-east-1a")
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .attachVolume(
+          "Mismatch",
+          ref<{ volume: Volume }>("ext").map((r) => r.volume),
+          {
+            device: "/dev/sdf",
+          },
+        );
+
+      expect(() => builder.build(stack, "Agent", { ext: { volume } })).toThrow(
+        /availability zone "us-east-1z".*"us-east-1a"/,
+      );
+    });
+
+    it("does not throw when both AZs match", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", {
+        env: { account: "111111111111", region: "us-east-1" },
+      });
+      const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+
+      const volume = new Volume(stack, "ExternalVolume", {
+        availabilityZone: "us-east-1a",
+        size: Size.gibibytes(10),
+      });
+
+      expect(() =>
+        createInstanceBuilder()
+          .vpc(vpc)
+          .availabilityZone("us-east-1a")
+          .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+          .machineImage(MachineImage.latestAmazonLinux2023())
+          .attachVolume(
+            "Match",
+            ref<{ volume: Volume }>("ext").map((r) => r.volume),
+            {
+              device: "/dev/sdf",
+            },
+          )
+          .build(stack, "Agent", { ext: { volume } }),
+      ).not.toThrow();
+    });
+
+    it("skips validation when the volume AZ is a CDK token", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", {
+        env: { account: "111111111111", region: "us-east-1" },
+      });
+      const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+
+      const tokenizedAz = Lazy.string({ produce: () => "us-east-1a" });
+      const volumeFromAttrs = Volume.fromVolumeAttributes(stack, "ImportedVolume", {
+        volumeId: "vol-deadbeef",
+        availabilityZone: tokenizedAz,
+      });
+
+      expect(() =>
+        createInstanceBuilder()
+          .vpc(vpc)
+          .availabilityZone("us-east-1z")
+          .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+          .machineImage(MachineImage.latestAmazonLinux2023())
+          .attachVolume("Tokenized", volumeFromAttrs, { device: "/dev/sdf" })
+          .build(stack, "Agent"),
+      ).not.toThrow();
+    });
+  });
+
+  describe("recommendedAlarms config on attachment", () => {
+    function buildAgent(opts: {
+      recommendedAlarms?: false | { volumeStalledIo?: false | { threshold?: number } };
+    }) {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+      const volume = new Volume(stack, "Vol", {
+        availabilityZone: vpc.availabilityZones[0],
+        size: Size.gibibytes(10),
+      });
+      const result = createInstanceBuilder()
+        .vpc(vpc)
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .attachVolume(
+          "Data",
+          ref<{ vol: Volume }>("ext").map((r) => r.vol),
+          {
+            device: "/dev/sdf",
+            ...opts,
+          },
+        )
+        .build(stack, "Agent", { ext: { vol: volume } });
+      return { result, template: Template.fromStack(stack) };
+    }
+
+    it("disables the alarm when recommendedAlarms is false", () => {
+      const { result } = buildAgent({ recommendedAlarms: false });
+      expect(result.alarms["Data.volumeStalledIo"]).toBeUndefined();
+    });
+
+    it("disables the alarm when volumeStalledIo is false", () => {
+      const { result } = buildAgent({ recommendedAlarms: { volumeStalledIo: false } });
+      expect(result.alarms["Data.volumeStalledIo"]).toBeUndefined();
+    });
+
+    it("allows tuning the threshold", () => {
+      const { template } = buildAgent({
+        recommendedAlarms: { volumeStalledIo: { threshold: 2 } },
+      });
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "VolumeStalledIOCheck",
+        Threshold: 2,
+      });
+    });
+  });
+
+  describe("default empty result", () => {
+    it("returns an empty volumeAttachments map when no attachments are configured", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+      const result = createInstanceBuilder()
+        .vpc(vpc)
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .build(stack, "Agent");
+
+      expect(result.volumeAttachments).toEqual({});
+    });
+
+    it("does not affect existing recommended-alarms shape when no attachments are configured", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+      createInstanceBuilder()
+        .vpc(vpc)
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .build(stack, "Agent");
+
+      const template = Template.fromStack(stack);
+      // 4 instance alarms (cpu + status + ebs + cpuCredit on T3) and zero volume-attachment alarms.
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+      template.resourceCountIs("AWS::EC2::VolumeAttachment", 0);
+    });
+  });
+});

--- a/packages/ec2/test/volume-alarms.test.ts
+++ b/packages/ec2/test/volume-alarms.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Size, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric, Stats, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { EbsDeviceVolumeType, type Volume } from "aws-cdk-lib/aws-ec2";
+import { createVolumeBuilder } from "../src/volume-builder.js";
+
+function buildVolume(
+  configureFn?: (b: ReturnType<typeof createVolumeBuilder>) => void,
+  volumeType: EbsDeviceVolumeType = EbsDeviceVolumeType.GP3,
+) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createVolumeBuilder()
+    .availabilityZone("us-east-1a")
+    .size(Size.gibibytes(50))
+    .volumeType(volumeType);
+  configureFn?.(builder);
+  const result = builder.build(stack, "TestVolume");
+  return { result, template: Template.fromStack(stack) };
+}
+
+describe("recommended volume alarms", () => {
+  describe("defaults", () => {
+    it("does NOT create burstBalance alarm for non-burstable gp3 volumes", () => {
+      const { result, template } = buildVolume();
+
+      expect(result.alarms.burstBalance).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("contextual burstBalance alarm", () => {
+    it("creates burstBalance alarm for gp2 (IOPS-credit) volumes", () => {
+      const { result, template } = buildVolume(undefined, EbsDeviceVolumeType.GP2);
+
+      expect(result.alarms.burstBalance).toBeDefined();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "BurstBalance",
+        Namespace: "AWS/EBS",
+        Threshold: 20,
+        ComparisonOperator: "LessThanThreshold",
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 3,
+        Statistic: "Average",
+        Period: 300,
+      });
+    });
+
+    it("creates burstBalance alarm for st1 (throughput-credit) volumes", () => {
+      const { result } = buildVolume((b) => b.size(Size.gibibytes(500)), EbsDeviceVolumeType.ST1);
+
+      expect(result.alarms.burstBalance).toBeDefined();
+    });
+
+    it("creates burstBalance alarm for sc1 (cold-credit) volumes", () => {
+      const { result } = buildVolume((b) => b.size(Size.gibibytes(500)), EbsDeviceVolumeType.SC1);
+
+      expect(result.alarms.burstBalance).toBeDefined();
+    });
+
+    it("does NOT create burstBalance alarm for io2 volumes", () => {
+      const { result, template } = buildVolume((b) => b.iops(3000), EbsDeviceVolumeType.IO2);
+
+      expect(result.alarms.burstBalance).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("includes threshold justification in the description", () => {
+      const { template } = buildVolume(undefined, EbsDeviceVolumeType.GP2);
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "BurstBalance",
+        AlarmDescription: Match.stringLikeRegexp("Threshold: < 20%"),
+      });
+    });
+  });
+
+  describe("customization", () => {
+    it("allows customizing burstBalance threshold on a burstable volume", () => {
+      const { template } = buildVolume(
+        (b) => b.recommendedAlarms({ burstBalance: { threshold: 10 } }),
+        EbsDeviceVolumeType.GP2,
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "BurstBalance",
+        Threshold: 10,
+      });
+    });
+
+    it("allows customizing treatMissingData", () => {
+      const { template } = buildVolume(
+        (b) =>
+          b.recommendedAlarms({
+            burstBalance: { treatMissingData: TreatMissingData.BREACHING },
+          }),
+        EbsDeviceVolumeType.GP2,
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "BurstBalance",
+        TreatMissingData: "breaching",
+      });
+    });
+  });
+
+  describe("disabling alarms", () => {
+    it("disables all alarms when recommendedAlarms is false", () => {
+      const { result, template } = buildVolume(
+        (b) => b.recommendedAlarms(false),
+        EbsDeviceVolumeType.GP2,
+      );
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all alarms when enabled is false", () => {
+      const { result, template } = buildVolume(
+        (b) => b.recommendedAlarms({ enabled: false }),
+        EbsDeviceVolumeType.GP2,
+      );
+
+      expect(result.alarms).toEqual({});
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables burstBalance explicitly on a burstable volume", () => {
+      const { result, template } = buildVolume(
+        (b) => b.recommendedAlarms({ burstBalance: false }),
+        EbsDeviceVolumeType.GP2,
+      );
+
+      expect(result.alarms.burstBalance).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("no default actions", () => {
+    it("creates alarms with no alarm actions", () => {
+      const { template } = buildVolume(undefined, EbsDeviceVolumeType.GP2);
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "BurstBalance",
+        AlarmActions: Match.absent(),
+      });
+    });
+  });
+});
+
+describe("volume addAlarm", () => {
+  it("creates a custom alarm alongside recommended alarms", () => {
+    const { result, template } = buildVolume(
+      (b) =>
+        b.addAlarm("volumeQueueLength", (alarm) =>
+          alarm
+            .metric(
+              (volume: Volume) =>
+                new Metric({
+                  namespace: "AWS/EBS",
+                  metricName: "VolumeQueueLength",
+                  dimensionsMap: { VolumeId: volume.volumeId },
+                  statistic: Stats.AVERAGE,
+                  period: Duration.minutes(5),
+                }),
+            )
+            .threshold(10)
+            .greaterThan()
+            .description("EBS volume queue length is high"),
+        ),
+      EbsDeviceVolumeType.GP2,
+    );
+
+    expect(result.alarms.burstBalance).toBeDefined();
+    expect(result.alarms.volumeQueueLength).toBeDefined();
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "VolumeQueueLength",
+      Threshold: 10,
+      AlarmDescription: "EBS volume queue length is high",
+    });
+  });
+});

--- a/packages/ec2/test/volume-builder.test.ts
+++ b/packages/ec2/test/volume-builder.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { App, RemovalPolicy, Size, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { EbsDeviceVolumeType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { ref } from "@composurecdk/core";
+import { createVolumeBuilder } from "../src/volume-builder.js";
+import { createVpcBuilder } from "../src/vpc-builder.js";
+
+function buildVolume(configureFn?: (b: ReturnType<typeof createVolumeBuilder>) => void) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createVolumeBuilder().availabilityZone("us-east-1a").size(Size.gibibytes(50));
+  configureFn?.(builder);
+  const result = builder.build(stack, "TestVolume");
+  return { stack, result, template: Template.fromStack(stack) };
+}
+
+describe("VolumeBuilder", () => {
+  describe("build", () => {
+    it("returns a VolumeBuilderResult with volume + alarms", () => {
+      const { result } = buildVolume();
+
+      expect(result.volume).toBeDefined();
+      expect(result.alarms).toBeDefined();
+    });
+
+    it("creates exactly one EBS volume", () => {
+      const { template } = buildVolume();
+
+      template.resourceCountIs("AWS::EC2::Volume", 1);
+    });
+
+    it("passes through size and availability zone", () => {
+      const { template } = buildVolume();
+
+      template.hasResourceProperties("AWS::EC2::Volume", {
+        Size: 50,
+        AvailabilityZone: "us-east-1a",
+      });
+    });
+
+    it("throws a clear error when availabilityZone is not provided", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const builder = createVolumeBuilder().size(Size.gibibytes(10));
+
+      expect(() => builder.build(stack, "TestVolume")).toThrow(/availability zone/i);
+    });
+
+    it("resolves a Ref-based availabilityZone from context", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const { vpc } = createVpcBuilder().build(stack, "Network");
+
+      const result = createVolumeBuilder()
+        .availabilityZone(ref<{ vpc: Vpc }>("network").map((r) => r.vpc.availabilityZones[0]))
+        .size(Size.gibibytes(20))
+        .build(stack, "TestVolume", { network: { vpc } });
+
+      expect(result.volume).toBeDefined();
+      const template = Template.fromStack(stack);
+      template.resourceCountIs("AWS::EC2::Volume", 1);
+    });
+
+    it("resolves a Ref-based encryptionKey from context", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const key = new Key(stack, "ProvidedKey");
+
+      createVolumeBuilder()
+        .availabilityZone("us-east-1a")
+        .size(Size.gibibytes(10))
+        .encryptionKey(ref<{ key: Key }>("kms").get("key"))
+        .build(stack, "TestVolume", { kms: { key } });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::EC2::Volume", {
+        Encrypted: true,
+        KmsKeyId: Match.anyValue(),
+      });
+    });
+  });
+
+  describe("secure defaults", () => {
+    it("defaults to GP3", () => {
+      const { template } = buildVolume();
+
+      template.hasResourceProperties("AWS::EC2::Volume", {
+        VolumeType: "gp3",
+      });
+    });
+
+    it("encrypts at rest with the account default KMS key", () => {
+      const { template } = buildVolume();
+
+      template.hasResourceProperties("AWS::EC2::Volume", {
+        Encrypted: true,
+        KmsKeyId: Match.absent(),
+      });
+    });
+
+    it("enables autoEnableIo so the instance can boot unattended", () => {
+      const { template } = buildVolume();
+
+      template.hasResourceProperties("AWS::EC2::Volume", {
+        AutoEnableIO: true,
+      });
+    });
+
+    it("retains the volume on stack deletion", () => {
+      const { template } = buildVolume();
+
+      template.hasResource("AWS::EC2::Volume", {
+        DeletionPolicy: "Retain",
+        UpdateReplacePolicy: "Retain",
+      });
+    });
+  });
+
+  describe("user overrides", () => {
+    it("allows flipping removalPolicy to DESTROY", () => {
+      const { template } = buildVolume((b) => {
+        b.removalPolicy(RemovalPolicy.DESTROY);
+      });
+
+      template.hasResource("AWS::EC2::Volume", {
+        DeletionPolicy: "Delete",
+        UpdateReplacePolicy: "Delete",
+      });
+    });
+
+    it("allows overriding the volumeType to gp2", () => {
+      const { template } = buildVolume((b) => {
+        b.volumeType(EbsDeviceVolumeType.GP2);
+      });
+
+      template.hasResourceProperties("AWS::EC2::Volume", {
+        VolumeType: "gp2",
+      });
+    });
+
+    it("allows opting into Multi-Attach", () => {
+      const { template } = buildVolume((b) => {
+        b.volumeType(EbsDeviceVolumeType.IO2).iops(3000).enableMultiAttach(true);
+      });
+
+      template.hasResourceProperties("AWS::EC2::Volume", {
+        MultiAttachEnabled: true,
+      });
+    });
+  });
+});

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -13,6 +13,7 @@ All example stacks use the `ComposureCDK-` name prefix. This convention enables 
 | [`ComposureCDK-OpenApiPetstoreStack`](src/openapi-petstore-app.ts)                                  | PetStore REST API defined by an inline OpenAPI 3.0 specification                                 |
 | [`ComposureCDK-DnsZoneStack`](src/dns-zone-app.ts)                                                  | Public Route 53 zone built with the BIND-style zone DSL, including a CloudFront `ALIAS` at `www` |
 | [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + EC2 instance with well-architected defaults, recommended alarms, and SNS alert wiring      |
+| [`ComposureCDK-AgentVolumeStack`](src/agent-volume-app.ts)                                          | VPC + EC2 instance with a persistent EBS data volume attached via `attachVolume` + alarm wiring  |
 | [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`      |
 
 ## Prerequisites

--- a/packages/examples/bin/app.ts
+++ b/packages/examples/bin/app.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { App } from "aws-cdk-lib";
 import { cleanDeskPolicy } from "../src/clean-desk-policy.js";
+import { createAgentVolumeApp } from "../src/agent-volume-app.js";
 import { createDnsZoneApp } from "../src/dns-zone-app.js";
 import { createDualFunctionApp } from "../src/dual-function-app.js";
 import { createEc2App } from "../src/ec2-app.js";
@@ -13,6 +14,7 @@ import { createTaggedSystemApp } from "../src/tagged-system-app.js";
 const app = new App();
 cleanDeskPolicy(app);
 
+createAgentVolumeApp(app);
 createDnsZoneApp(app);
 createDualFunctionApp(app);
 createEc2App(app);

--- a/packages/examples/src/agent-volume-app.ts
+++ b/packages/examples/src/agent-volume-app.ts
@@ -1,0 +1,78 @@
+import { App, Size, Stack } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  MachineImage,
+  type Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import { compose, ref } from "@composurecdk/core";
+import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
+import {
+  createInstanceBuilder,
+  createVolumeBuilder,
+  createVpcBuilder,
+  type VolumeBuilderResult,
+  type VpcBuilderResult,
+} from "@composurecdk/ec2";
+import { createTopicBuilder } from "@composurecdk/sns";
+
+/**
+ * A VPC + EC2 instance with a persistent EBS data volume attached at
+ * `/dev/sdf`, all composed into a single stack alongside an SNS alert
+ * topic.
+ *
+ * Demonstrates:
+ * - {@link createVolumeBuilder} with well-architected defaults (GP3,
+ *   encrypted at rest, `RemovalPolicy.RETAIN`).
+ * - Wiring the volume's AZ to a sibling `VpcBuilder` via
+ *   `ref<VpcBuilderResult>("network").map(...)`.
+ * - {@link createInstanceBuilder}'s `attachVolume` method producing a
+ *   first-class `AWS::EC2::VolumeAttachment` and a per-attachment
+ *   `volumeStalledIo` alarm.
+ * - Routing every alarm (instance + per-attachment) to a single SNS
+ *   topic via `alarmActionsPolicy` — no extra wiring needed for the
+ *   namespaced attachment alarm keys.
+ *
+ * NAT gateways are disabled to keep deploy/destroy fast and cheap.
+ */
+export function createAgentVolumeApp(app = new App()) {
+  const stack = new Stack(app, "ComposureCDK-AgentVolumeStack");
+
+  const { alerts } = compose(
+    {
+      alerts: createTopicBuilder().displayName("Agent Volume Alerts"),
+
+      network: createVpcBuilder().maxAzs(2).natGateways(0),
+
+      data: createVolumeBuilder()
+        .availabilityZone(
+          ref<VpcBuilderResult>("network").map(
+            (r: VpcBuilderResult): string => r.vpc.availabilityZones[0],
+          ),
+        )
+        .size(Size.gibibytes(20)),
+
+      agent: createInstanceBuilder()
+        .vpc(ref<VpcBuilderResult>("network").map((r: VpcBuilderResult): Vpc => r.vpc))
+        .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .attachVolume("AgentData", ref<VolumeBuilderResult>("data"), {
+          device: "/dev/sdf",
+        }),
+    },
+    {
+      alerts: [],
+      network: [],
+      data: ["network"],
+      agent: ["network", "data"],
+    },
+  ).build(stack, "AgentVolumeApp");
+
+  alarmActionsPolicy(stack, {
+    defaults: { alarmActions: [new SnsAction(alerts.topic)] },
+  });
+
+  return { stack };
+}

--- a/packages/examples/src/clean-desk-policy.ts
+++ b/packages/examples/src/clean-desk-policy.ts
@@ -2,6 +2,7 @@ import { Aspects, CfnDeletionPolicy, PropertyInjectors, RemovalPolicy, Stack } f
 import type { IAspect, IPropertyInjector } from "aws-cdk-lib";
 import { Bucket, CfnBucket, type BucketProps } from "aws-cdk-lib/aws-s3";
 import { LogGroup, type LogGroupProps } from "aws-cdk-lib/aws-logs";
+import { Volume, type VolumeProps } from "aws-cdk-lib/aws-ec2";
 import { RestApi, type RestApiProps } from "aws-cdk-lib/aws-apigateway";
 import {
   AwsCustomResource,
@@ -177,6 +178,7 @@ function resolveLogsBucketInStack(
  * Covered construct types:
  * - `aws-cdk-lib/aws-s3.Bucket`
  * - `aws-cdk-lib/aws-logs.LogGroup`
+ * - `aws-cdk-lib/aws-ec2.Volume`
  * - `aws-cdk-lib/aws-apigateway.RestApi` (Account + CloudWatch Role)
  *
  * If new stateful construct types are added to example stacks (e.g.
@@ -188,6 +190,7 @@ export function cleanDeskPolicy(scope: IConstruct): void {
   const injectors = PropertyInjectors.of(scope);
   injectors.add(new BucketRemovalPolicyInjector());
   injectors.add(new RemovalPolicyInjector<LogGroupProps>(LogGroup.PROPERTY_INJECTION_ID));
+  injectors.add(new RemovalPolicyInjector<VolumeProps>(Volume.PROPERTY_INJECTION_ID));
   injectors.add(new RestApiRemovalPolicyInjector());
 
   Aspects.of(scope).add(new DisableSourceLoggingOnDeleteAspect());

--- a/packages/examples/test/__snapshots__/agent-volume-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/agent-volume-app.test.ts.snap
@@ -1,0 +1,1034 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`agent-volume-app > matches the expected synthesised template 1`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "SsmParameterValueawsserviceamiamazonlinuxlatestal2023amikernel61x8664C96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+    },
+  },
+  "Resources": {
+    "AgentVolumeAppagentAgentDataAttachment": {
+      "Properties": {
+        "Device": "/dev/sdf",
+        "InstanceId": {
+          "Ref": "AgentVolumeAppagentC54F8099",
+        },
+        "VolumeId": {
+          "Ref": "AgentVolumeAppdataFC64D46A",
+        },
+      },
+      "Type": "AWS::EC2::VolumeAttachment",
+    },
+    "AgentVolumeAppagentAgentDatavolumeStalledIoAlarm3A095D1C": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "EBS volume attachment "AgentData" is reporting a stalled I/O condition. Threshold: >= 1 (max) over 10 x 1 minute. Note: VolumeStalledIOCheck is published only for Nitro-instance attachments.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/agent/agent-data-volume-stalled-io",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": [
+          {
+            "Name": "InstanceId",
+            "Value": {
+              "Ref": "AgentVolumeAppagentC54F8099",
+            },
+          },
+          {
+            "Name": "VolumeId",
+            "Value": {
+              "Ref": "AgentVolumeAppdataFC64D46A",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "VolumeStalledIOCheck",
+        "Namespace": "AWS/EBS",
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppagentAttachedEbsStatusCheckFailedAlarmE7F4220D": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "EC2 instance attached EBS volume(s) are unreachable or unable to complete I/O. Threshold: >= 1 failed checks (max) over 10 x 1 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/agent/attached-ebs-status-check-failed",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": [
+          {
+            "Name": "InstanceId",
+            "Value": {
+              "Ref": "AgentVolumeAppagentC54F8099",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "StatusCheckFailed_AttachedEBS",
+        "Namespace": "AWS/EC2",
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppagentC54F8099": {
+      "DependsOn": [
+        "AgentVolumeAppagentInstanceRoleCE2938BB",
+      ],
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "Encrypted": true,
+              "VolumeSize": 8,
+              "VolumeType": "gp3",
+            },
+          },
+        ],
+        "EbsOptimized": true,
+        "IamInstanceProfile": {
+          "Ref": "AgentVolumeAppagentInstanceProfile4E2FF6DC",
+        },
+        "ImageId": {
+          "Ref": "SsmParameterValueawsserviceamiamazonlinuxlatestal2023amikernel61x8664C96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
+        "InstanceType": "t3.micro",
+        "LaunchTemplate": {
+          "LaunchTemplateName": "AgentVolumeApp--agentLaunchTemplate",
+          "Version": {
+            "Fn::GetAtt": [
+              "AgentVolumeAppagentLaunchTemplate2029DE3B",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "Monitoring": true,
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "AgentVolumeAppagentInstanceSecurityGroup09EE35A3",
+              "GroupId",
+            ],
+          },
+        ],
+        "SubnetId": {
+          "Ref": "AgentVolumeAppnetworkIsolatedSubnet1SubnetEE7F71DC",
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--agent",
+          },
+        ],
+        "UserData": {
+          "Fn::Base64": "#!/bin/bash",
+        },
+      },
+      "Type": "AWS::EC2::Instance",
+    },
+    "AgentVolumeAppagentCpuCreditBalanceAlarm5BAF5650": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "EC2 burstable instance CPU credit balance is low — baseline throttling is imminent. Threshold: < 50 credits (minimum) over 3 x 5 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/agent/cpu-credit-balance",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": [
+          {
+            "Name": "InstanceId",
+            "Value": {
+              "Ref": "AgentVolumeAppagentC54F8099",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "CPUCreditBalance",
+        "Namespace": "AWS/EC2",
+        "Period": 300,
+        "Statistic": "Minimum",
+        "Threshold": 50,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppagentCpuUtilizationAlarm0911245B": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "EC2 instance CPU utilization is sustained at a high level. Threshold: > 80% average over 5 x 1 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/agent/cpu-utilization",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": [
+          {
+            "Name": "InstanceId",
+            "Value": {
+              "Ref": "AgentVolumeAppagentC54F8099",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/EC2",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppagentInstanceProfile4E2FF6DC": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "AgentVolumeAppagentInstanceRoleCE2938BB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "AgentVolumeAppagentInstanceRoleCE2938BB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--agent",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "AgentVolumeAppagentInstanceSecurityGroup09EE35A3": {
+      "Properties": {
+        "GroupDescription": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--agent/InstanceSecurityGroup",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--agent",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "AgentVolumeAppagentLaunchTemplate2029DE3B": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+        },
+        "LaunchTemplateName": "AgentVolumeApp--agentLaunchTemplate",
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "AgentVolumeAppagentStatusCheckFailedAlarmB8E9E14E": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "EC2 instance is failing its status checks. Threshold: > 0 failed checks over 2 x 1 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/agent/status-check-failed",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "Dimensions": [
+          {
+            "Name": "InstanceId",
+            "Value": {
+              "Ref": "AgentVolumeAppagentC54F8099",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "StatusCheckFailed",
+        "Namespace": "AWS/EC2",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppalerts0D02612E": {
+      "Properties": {
+        "DisplayName": "Agent Volume Alerts",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "AgentVolumeAppalertsNumberOfNotificationsFailedAlarm44FCA0DF": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "SNS topic is failing to deliver notifications. Threshold: > 0 failures in 1 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/alerts/number-of-notifications-failed",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "TopicName",
+            "Value": {
+              "Fn::GetAtt": [
+                "AgentVolumeAppalerts0D02612E",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFailed",
+        "Namespace": "AWS/SNS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppalertsNumberOfNotificationsFailedToRedriveToDlqAlarm91AA69A1": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "SNS topic failed to redrive a message to a subscription dead-letter queue; messages may be lost. Threshold: > 0 failed redrives in 1 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/alerts/number-of-notifications-failed-to-redrive-to-dlq",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "TopicName",
+            "Value": {
+              "Fn::GetAtt": [
+                "AgentVolumeAppalerts0D02612E",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFailedToRedriveToDlq",
+        "Namespace": "AWS/SNS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppalertsNumberOfNotificationsFilteredOutInvalidAttributesAlarm4D9BA4F6": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "SNS topic messages are being filtered out due to invalid subscription filter policy attributes. Threshold: > 0 filtered messages in 1 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/alerts/number-of-notifications-filtered-out-invalid-attributes",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "TopicName",
+            "Value": {
+              "Fn::GetAtt": [
+                "AgentVolumeAppalerts0D02612E",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFilteredOut-InvalidAttributes",
+        "Namespace": "AWS/SNS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppalertsNumberOfNotificationsRedrivenToDlqAlarmB5342705": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+        "AlarmDescription": "SNS topic is redriving messages to a subscription dead-letter queue, indicating delivery failures. Threshold: > 0 redrives in 1 minute.",
+        "AlarmName": "composure-cdk-agent-volume-stack/agent-volume-app/alerts/number-of-notifications-redriven-to-dlq",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "TopicName",
+            "Value": {
+              "Fn::GetAtt": [
+                "AgentVolumeAppalerts0D02612E",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsRedrivenToDlq",
+        "Namespace": "AWS/SNS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AgentVolumeAppalertsPolicyEC51ACBB": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sns:Publish",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": {
+                "Ref": "AgentVolumeAppalerts0D02612E",
+              },
+              "Sid": "AllowPublishThroughSSLOnly",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Topics": [
+          {
+            "Ref": "AgentVolumeAppalerts0D02612E",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::TopicPolicy",
+    },
+    "AgentVolumeAppdataFC64D46A": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AutoEnableIO": true,
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "Encrypted": true,
+        "MultiAttachEnabled": false,
+        "Size": 20,
+        "VolumeType": "gp3",
+      },
+      "Type": "AWS::EC2::Volume",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "AgentVolumeAppnetworkA421F964": {
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::VPC",
+    },
+    "AgentVolumeAppnetworkDefaultFlowLogCFEC3068": {
+      "Properties": {
+        "DeliverLogsPermissionArn": {
+          "Fn::GetAtt": [
+            "AgentVolumeAppnetworkDefaultFlowLogIAMRoleE912E37A",
+            "Arn",
+          ],
+        },
+        "LogDestinationType": "cloud-watch-logs",
+        "LogGroupName": {
+          "Ref": "AgentVolumeAppnetworkFlowLogsLogGroupB21FC068",
+        },
+        "ResourceId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+        "ResourceType": "VPC",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/DefaultFlowLog",
+          },
+        ],
+        "TrafficType": "ALL",
+      },
+      "Type": "AWS::EC2::FlowLog",
+    },
+    "AgentVolumeAppnetworkDefaultFlowLogIAMRoleDefaultPolicy468BE8B6": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "AgentVolumeAppnetworkFlowLogsLogGroupB21FC068",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AgentVolumeAppnetworkDefaultFlowLogIAMRoleDefaultPolicy468BE8B6",
+        "Roles": [
+          {
+            "Ref": "AgentVolumeAppnetworkDefaultFlowLogIAMRoleE912E37A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AgentVolumeAppnetworkDefaultFlowLogIAMRoleE912E37A": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "vpc-flow-logs.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/DefaultFlowLog",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "AgentVolumeAppnetworkFlowLogsLogGroupB21FC068": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "AgentVolumeAppnetworkIGW5CB8BDE2": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::InternetGateway",
+    },
+    "AgentVolumeAppnetworkIsolatedSubnet1RouteTableAssociation4910DB84": {
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AgentVolumeAppnetworkIsolatedSubnet1RouteTableBFEB9C15",
+        },
+        "SubnetId": {
+          "Ref": "AgentVolumeAppnetworkIsolatedSubnet1SubnetEE7F71DC",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "AgentVolumeAppnetworkIsolatedSubnet1RouteTableBFEB9C15": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/IsolatedSubnet1",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "AgentVolumeAppnetworkIsolatedSubnet1SubnetEE7F71DC": {
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.128.0/18",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Isolated",
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Isolated",
+          },
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/IsolatedSubnet1",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "AgentVolumeAppnetworkIsolatedSubnet2RouteTable65E75C10": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/IsolatedSubnet2",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "AgentVolumeAppnetworkIsolatedSubnet2RouteTableAssociationA9C7D882": {
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AgentVolumeAppnetworkIsolatedSubnet2RouteTable65E75C10",
+        },
+        "SubnetId": {
+          "Ref": "AgentVolumeAppnetworkIsolatedSubnet2Subnet9DCF5FD1",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "AgentVolumeAppnetworkIsolatedSubnet2Subnet9DCF5FD1": {
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            1,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.192.0/18",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Isolated",
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Isolated",
+          },
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/IsolatedSubnet2",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "AgentVolumeAppnetworkPublicSubnet1DefaultRouteEFE97BE9": {
+      "DependsOn": [
+        "AgentVolumeAppnetworkVPCGW3682EA26",
+      ],
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "AgentVolumeAppnetworkIGW5CB8BDE2",
+        },
+        "RouteTableId": {
+          "Ref": "AgentVolumeAppnetworkPublicSubnet1RouteTableF82EA861",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "AgentVolumeAppnetworkPublicSubnet1RouteTableAssociation04E3BEBB": {
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AgentVolumeAppnetworkPublicSubnet1RouteTableF82EA861",
+        },
+        "SubnetId": {
+          "Ref": "AgentVolumeAppnetworkPublicSubnet1SubnetE826CD3D",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "AgentVolumeAppnetworkPublicSubnet1RouteTableF82EA861": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/PublicSubnet1",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "AgentVolumeAppnetworkPublicSubnet1SubnetE826CD3D": {
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.0.0/18",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/PublicSubnet1",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "AgentVolumeAppnetworkPublicSubnet2DefaultRoute9B796CF4": {
+      "DependsOn": [
+        "AgentVolumeAppnetworkVPCGW3682EA26",
+      ],
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "AgentVolumeAppnetworkIGW5CB8BDE2",
+        },
+        "RouteTableId": {
+          "Ref": "AgentVolumeAppnetworkPublicSubnet2RouteTable48FCE736",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "AgentVolumeAppnetworkPublicSubnet2RouteTable48FCE736": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/PublicSubnet2",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "AgentVolumeAppnetworkPublicSubnet2RouteTableAssociation7A0D3A81": {
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AgentVolumeAppnetworkPublicSubnet2RouteTable48FCE736",
+        },
+        "SubnetId": {
+          "Ref": "AgentVolumeAppnetworkPublicSubnet2Subnet51BB99F4",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "AgentVolumeAppnetworkPublicSubnet2Subnet51BB99F4": {
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            1,
+            {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.64.0/18",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          {
+            "Key": "Name",
+            "Value": "ComposureCDK-AgentVolumeStack/AgentVolumeApp--network/PublicSubnet2",
+          },
+        ],
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "AgentVolumeAppnetworkRestrictDefaultSecurityGroupCustomResource3528DE01": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Account": {
+          "Ref": "AWS::AccountId",
+        },
+        "DefaultSecurityGroupId": {
+          "Fn::GetAtt": [
+            "AgentVolumeAppnetworkA421F964",
+            "DefaultSecurityGroup",
+          ],
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomVpcRestrictDefaultSGCustomResourceProviderHandlerDC833E5E",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::VpcRestrictDefaultSG",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "AgentVolumeAppnetworkVPCGW3682EA26": {
+      "Properties": {
+        "InternetGatewayId": {
+          "Ref": "AgentVolumeAppnetworkIGW5CB8BDE2",
+        },
+        "VpcId": {
+          "Ref": "AgentVolumeAppnetworkA421F964",
+        },
+      },
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+    },
+    "CustomVpcRestrictDefaultSGCustomResourceProviderHandlerDC833E5E": {
+      "DependsOn": [
+        "CustomVpcRestrictDefaultSGCustomResourceProviderRole26592FE0",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "7fa1e366ee8a9ded01fc355f704cff92bfd179574e6f9cfee800a3541df1b200.zip",
+        },
+        "Description": "Lambda function for removing all inbound/outbound rules from the VPC default security group",
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomVpcRestrictDefaultSGCustomResourceProviderRole26592FE0",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomVpcRestrictDefaultSGCustomResourceProviderRole26592FE0": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ec2:AuthorizeSecurityGroupIngress",
+                    "ec2:AuthorizeSecurityGroupEgress",
+                    "ec2:RevokeSecurityGroupIngress",
+                    "ec2:RevokeSecurityGroupEgress",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:",
+                          {
+                            "Ref": "AWS::Partition",
+                          },
+                          ":ec2:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":security-group/",
+                          {
+                            "Fn::GetAtt": [
+                              "AgentVolumeAppnetworkA421F964",
+                              "DefaultSecurityGroup",
+                            ],
+                          },
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "Inline",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/packages/examples/test/agent-volume-app.test.ts
+++ b/packages/examples/test/agent-volume-app.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { Template } from "aws-cdk-lib/assertions";
+import { createAgentVolumeApp } from "../src/agent-volume-app.js";
+
+describe("agent-volume-app", () => {
+  const { stack } = createAgentVolumeApp();
+  const template = Template.fromStack(stack);
+
+  it("creates exactly one VPC", () => {
+    template.resourceCountIs("AWS::EC2::VPC", 1);
+  });
+
+  it("creates exactly one EC2 instance", () => {
+    template.resourceCountIs("AWS::EC2::Instance", 1);
+  });
+
+  it("creates exactly one persistent EBS volume", () => {
+    template.resourceCountIs("AWS::EC2::Volume", 1);
+  });
+
+  it("retains the volume by default (the agent-volume use case)", () => {
+    template.hasResource("AWS::EC2::Volume", {
+      DeletionPolicy: "Retain",
+      UpdateReplacePolicy: "Retain",
+    });
+  });
+
+  it("creates a VolumeAttachment wiring instance to volume at /dev/sdf", () => {
+    template.resourceCountIs("AWS::EC2::VolumeAttachment", 1);
+    template.hasResourceProperties("AWS::EC2::VolumeAttachment", {
+      Device: "/dev/sdf",
+    });
+  });
+
+  it("creates the per-attachment volumeStalledIo alarm", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/EBS",
+      MetricName: "VolumeStalledIOCheck",
+    });
+  });
+
+  it("creates an SNS topic for alarm actions", () => {
+    template.hasResourceProperties("AWS::SNS::Topic", {
+      DisplayName: "Agent Volume Alerts",
+    });
+  });
+
+  it("matches the expected synthesised template", () => {
+    expect(template.toJSON()).toMatchSnapshot();
+  });
+});

--- a/packages/examples/test/clean-desk-policy.test.ts
+++ b/packages/examples/test/clean-desk-policy.test.ts
@@ -1,10 +1,13 @@
 import { beforeAll, describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import { Size } from "aws-cdk-lib";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { Volume } from "aws-cdk-lib/aws-ec2";
 import { MockIntegration, RestApi } from "aws-cdk-lib/aws-apigateway";
 import { cleanDeskPolicy } from "../src/clean-desk-policy.js";
+import { createAgentVolumeApp } from "../src/agent-volume-app.js";
 import { createMockApiApp } from "../src/mock-api-app.js";
 import { createStaticWebsiteApp } from "../src/static-website/app.js";
 
@@ -23,6 +26,32 @@ describe("cleanDeskPolicy", () => {
     });
 
     template.hasResource("AWS::S3::Bucket", {
+      DeletionPolicy: "Delete",
+      UpdateReplacePolicy: "Delete",
+    });
+  });
+
+  it("overrides EBS Volume removal policy to DESTROY (overriding the RETAIN default)", () => {
+    const template = buildWithPolicy((stack) => {
+      new Volume(stack, "Vol", {
+        availabilityZone: "us-east-1a",
+        size: Size.gibibytes(10),
+      });
+    });
+
+    template.hasResource("AWS::EC2::Volume", {
+      DeletionPolicy: "Delete",
+      UpdateReplacePolicy: "Delete",
+    });
+  });
+
+  it("sets the agent-volume stack's persistent EBS volume to Delete", () => {
+    const app = new App();
+    cleanDeskPolicy(app);
+    const { stack } = createAgentVolumeApp(app);
+    const template = Template.fromStack(stack);
+
+    template.hasResource("AWS::EC2::Volume", {
       DeletionPolicy: "Delete",
       UpdateReplacePolicy: "Delete",
     });


### PR DESCRIPTION
## Summary

Closes #76. Adds a first-class API for the persistent-data-volume pattern, replacing the `afterBuild` workaround documented in the issue.

- **`createVolumeBuilder()`** — fluent builder for an EBS volume with well-architected defaults (`GP3`, `encrypted: true`, `autoEnableIo: true`, `removalPolicy: RemovalPolicy.RETAIN`). `availabilityZone` is exposed via a dedicated `Resolvable<string>` setter so it can be wired from a sibling `VpcBuilder`; `encryptionKey` accepts a `Resolvable<IKey>`.
- **`InstanceBuilder.attachVolume(key, volumeRef, opts)`** — mirrors the `addAlarm(key, configure)` shape, produces an `AWS::EC2::VolumeAttachment`, and synth-validates AZ alignment when both sides are concrete. The `volumeRef` accepts `Resolvable<VolumeBuilderResult> | Resolvable<IVolume>` so the most common call site (drop a `ref<VolumeBuilderResult>("data")` straight in) is two characters; externally-managed volumes still work.
- **Per-attachment `volumeStalledIo` alarm**, namespaced into the instance's existing `alarms` record under `${attachmentKey}.volumeStalledIo`, so `alarmActionsPolicy` keeps working without changes.
- **`InstanceBuilderResult.volumeAttachments: Record<string, CfnVolumeAttachment>`** — new field, empty when no attachments are configured.
- **`ComposureCDK-AgentVolumeStack` example** — VPC + EC2 + persistent volume + SNS alerts wired through `compose`.
- **`cleanDeskPolicy` extension** — registers a `Volume.PROPERTY_INJECTION_ID` injector so example/sandbox stacks override the secure `RETAIN` default and tear down cleanly.

## Logical commits

1. `feat(ec2): createVolumeBuilder with well-architected defaults` — `volume-builder.ts`, `volume-defaults.ts`, `volume-alarm-config.ts`, `volume-alarm-defaults.ts`, `volume-alarms.ts`, exports, README, unit tests.
2. `feat(ec2): InstanceBuilder.attachVolume with synth-time AZ validation` — adds the method, extends `InstanceBuilderResult.volumeAttachments`, wires per-attachment alarms into the existing `alarms` record, AZ-mismatch test + token-AZ skip test, README.
3. `docs(examples): persistent-volume agent stack` — new `packages/examples/src/agent-volume-app.ts` registered in `bin/app.ts`, README row, snapshot/synth tests, and the `cleanDeskPolicy` Volume injector + tests.

Each commit was reviewed via `/simplify` (reuse + quality + efficiency), and a final broader-scope `/simplify` was run across the full PR before the third commit landed. No ADR — per maintainer feedback on the plan, this is a feature in the ec2 package, not an architectural change.

## Open questions for review

A few points where I diverged from or refined the plan — flagging for review rather than burying in a commit message:

1. **`deleteOnTermination` removed from the attach options.** The plan and the original issue's `afterBuild` snippet both reference `deleteOnTermination`, but `AWS::EC2::VolumeAttachment` does not have that field — it only exists on instance block-device mappings. For an external attachment, the volume's lifecycle is governed entirely by its own `RemovalPolicy`. I dropped `deleteOnTermination` from `AttachVolumeOptions` so the `opts` param is just `{ device, recommendedAlarms? }`. Happy to add a passthrough to a synthetic block-device-mapping path instead if that's preferred — but the volume's `removalPolicy` is the more natural single source of truth.

2. **`volumeStalledIo` always emitted, not gated on Nitro.** Plan: "Open to either; default to 'always emit' for simplicity, document the Nitro-only behaviour in the JSDoc." I went with always-emit; on non-Nitro instances the alarm sits at `INSUFFICIENT_DATA` which `treatMissingData: NOT_BREACHING` makes harmless. Documented in both the JSDoc and the README. Happy to add a Nitro-family gate (matching the burstable-CPU-credit gate in `instance-alarms.ts`) if you'd rather skip the noise.

3. **`burstBalance` enabled for `gp2`/`st1`/`sc1` only.** Matches the plan. The set of burstable types lives in `volume-alarms.ts` as a `Set<EbsDeviceVolumeType>` — first-pass had the long-form aliases (`GENERAL_PURPOSE_SSD`, etc.) too, but `/simplify` flagged those as deduped-by-string redundancy and they're now removed.

4. **Instance AZ resolution for synth-time validation.** When `instanceProps.availabilityZone` is unset, I resolve via `vpc.selectSubnets(vpcSubnets).availabilityZones[0]` and skip the check if everything resolves to a token. The `try/catch { return undefined }` is intentionally broad — `selectSubnets` can throw for several unrelated reasons and the validation is best-effort. Comment explains the choice.

5. **`PendingVolumeAttachment` is `@internal` but exported.** It's imported by `instance-builder.ts` from the same package only and not re-exported in `index.ts`. Marked `@internal` per JSDoc convention; let me know if you'd rather it move into a shared internal module.

## Test plan

- [x] `npx nx run-many -t build typecheck test` — 15 projects, all green.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] New tests cover: secure defaults, ref-based AZ + encryption-key wiring, `removalPolicy` override, single + multi attachment, both `VolumeBuilderResult` and `IVolume` ref forms, AZ-mismatch error, AZ-token skip, duplicate-key rejection, recommended-alarm enable/disable, custom `addAlarm` alongside recommended, snapshot for the new example stack, and `cleanDeskPolicy` Volume override.
- [ ] Post-merge: smoke test will exercise `ComposureCDK-AgentVolumeStack` via the prefix-discovery path; no per-stack changes needed in `scripts/smoke-test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)