### PR TITLE
feat(events): add @composurecdk/events with RuleBuilder, target helpers, alarms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1833,6 +1833,10 @@
       "resolved": "packages/eslint-plugin",
       "link": true
     },
+    "node_modules/@composurecdk/events": {
+      "resolved": "packages/events",
+      "link": true
+    },
     "node_modules/@composurecdk/examples": {
       "resolved": "packages/examples",
       "link": true
@@ -7924,6 +7928,24 @@
         "eslint": "^10.0.0"
       }
     },
+    "packages/events": {
+      "name": "@composurecdk/events",
+      "version": "0.6.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "aws-cdk-lib": "^2.250.0",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@composurecdk/cloudwatch": "^0.6.0",
+        "@composurecdk/core": "^0.6.0",
+        "aws-cdk-lib": "^2.0.0",
+        "constructs": "^10.0.0"
+      }
+    },
     "packages/examples": {
       "name": "@composurecdk/examples",
       "version": "0.6.0",
@@ -7945,6 +7967,7 @@
         "@composurecdk/cloudwatch": "^0.6.0",
         "@composurecdk/core": "^0.6.0",
         "@composurecdk/ec2": "^0.6.0",
+        "@composurecdk/events": "^0.6.0",
         "@composurecdk/lambda": "^0.6.0",
         "@composurecdk/route53": "^0.6.0",
         "@composurecdk/s3": "^0.6.0",

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -1,0 +1,83 @@
+# @composurecdk/events
+
+EventBridge rule builder for [ComposureCDK](../../README.md).
+
+This package provides a fluent builder for EventBridge rules with secure, AWS-recommended defaults. It wraps the CDK [Rule](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.Rule.html) construct — refer to the CDK documentation for the full set of configurable properties.
+
+## Rule Builder
+
+```ts
+import { createRuleBuilder } from "@composurecdk/events";
+import { Schedule } from "aws-cdk-lib/aws-events";
+import { Duration } from "aws-cdk-lib";
+
+const rule = createRuleBuilder()
+  .schedule(Schedule.rate(Duration.minutes(15)))
+  .description("Idle stopper")
+  .build(stack, "IdleStopperSchedule");
+```
+
+Every [RuleProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.RuleProps.html) property is available as a fluent setter on the builder. The builder requires at least one of `schedule` or `eventPattern` to be set — an EventBridge rule with neither is inert.
+
+`Schedule` and `Match` (used for event-pattern matching) are imported directly from `aws-cdk-lib/aws-events` — this package does not re-export them, matching the convention used elsewhere in the library (e.g. `Runtime` from `aws-cdk-lib/aws-lambda`).
+
+### Cross-component event bus
+
+The `eventBus` property accepts a `Resolvable<IEventBus>` so the rule can attach to a custom bus built by another component:
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+
+compose(
+  {
+    bus: customEventBus,
+    rule: createRuleBuilder()
+      .eventBus(ref("bus", (r) => r.eventBus))
+      .eventPattern({ source: ["my.app"] }),
+  },
+  { bus: [], rule: ["bus"] },
+);
+```
+
+When omitted, the rule attaches to the account default bus, matching CDK's `RuleProps.eventBus` default.
+
+## Adding Targets
+
+Targets are registered via `addTarget(key, target)`, where `target` is a CDK [`IRuleTarget`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.IRuleTarget.html) (or a `Resolvable<IRuleTarget>` for cross-component wiring). Each target is exposed on `result.targets` under its key.
+
+```ts
+import { createRuleBuilder } from "@composurecdk/events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+
+const result = createRuleBuilder()
+  .schedule(Schedule.rate(Duration.minutes(15)))
+  .addTarget("stopper", new LambdaFunction(idleStopperFn))
+  .build(stack, "IdleStopperSchedule");
+
+result.targets.stopper; // IRuleTarget
+```
+
+For cross-component wiring inside a [`compose`](../core/README.md) system, pass a `ref` and use the matching target helper from this package (see [Target Helpers](#target-helpers) below):
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createRuleBuilder, lambdaTarget } from "@composurecdk/events";
+import { createFunctionBuilder, type FunctionBuilderResult } from "@composurecdk/lambda";
+
+const system = compose(
+  {
+    stopper: createFunctionBuilder()./* ... */,
+    idleStopperSchedule: createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget(
+        "stopper",
+        lambdaTarget(ref("stopper", (r: FunctionBuilderResult) => r.function)),
+      ),
+  },
+  { stopper: [], idleStopperSchedule: ["stopper"] },
+);
+```
+
+## Target Helpers
+
+_Coming in a follow-up commit in this PR — `lambdaTarget`, `sqsTarget`, `snsTarget`, `sfnStateMachineTarget`, `eventBusTarget`, `cloudWatchLogGroupTarget`._

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -41,6 +41,95 @@ compose(
 
 When omitted, the rule attaches to the account default bus, matching CDK's `RuleProps.eventBus` default.
 
+## Recommended Alarms
+
+The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EventBridge) by default. No alarm actions are configured — access alarms from the build result, or use the `alarmActionsPolicy` from `@composurecdk/cloudwatch` to wire them to an SNS topic in one place.
+
+| Alarm                            | Metric                                      | Default threshold | Created when |
+| -------------------------------- | ------------------------------------------- | ----------------- | ------------ |
+| `failedInvocations`              | FailedInvocations (Sum, 1 min)              | > 0               | Always       |
+| `throttledRules`                 | ThrottledRules (Sum, 1 min)                 | > 0               | Always       |
+| `invocationsSentToDlq`           | InvocationsSentToDlq (Sum, 1 min)           | > 0               | Always[^dlq] |
+| `invocationsFailedToBeSentToDlq` | InvocationsFailedToBeSentToDlq (Sum, 1 min) | > 0               | Always[^dlq] |
+
+[^dlq]: The DLQ metrics only emit data when at least one target on the rule has a `deadLetterQueue` configured and EventBridge attempts redrive. `TreatMissingData` defaults to `notBreaching`, so the alarm stays quiet on rules without DLQs. Attach a DLQ via the matching target helper's `deadLetterQueue` option — see [Cross-component DLQ wiring](#cross-component-dlq-wiring) below, and the [EventBridge DLQ docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-dlq.html).
+
+The defaults are exported as `RULE_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { RULE_ALARM_DEFAULTS } from "@composurecdk/events";
+```
+
+### Customizing thresholds
+
+Override individual alarm properties via `recommendedAlarms`. Unspecified fields keep their defaults.
+
+```ts
+const rule = createRuleBuilder()
+  .eventPattern({ source: ["my.app"] })
+  .recommendedAlarms({
+    failedInvocations: { threshold: 5, evaluationPeriods: 3 },
+  });
+```
+
+### Disabling alarms
+
+Disable all recommended alarms:
+
+```ts
+builder.recommendedAlarms(false);
+// or
+builder.recommendedAlarms({ enabled: false });
+```
+
+Disable individual alarms:
+
+```ts
+builder.recommendedAlarms({ throttledRules: false });
+```
+
+### Custom alarms
+
+Add custom alarms alongside the recommended ones via `addAlarm`. The callback receives an `AlarmDefinitionBuilder` typed to `IRule`, so the metric factory has access to the rule's properties. The Serverless Lens flags `RetryInvocationAttempts` as an early indicator of an undersized target — a good candidate for `addAlarm`:
+
+```ts
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Duration } from "aws-cdk-lib";
+
+createRuleBuilder()
+  .eventPattern({ source: ["my.app"] })
+  .addAlarm("retryAttempts", (alarm) =>
+    alarm
+      .metric(
+        (rule) =>
+          new Metric({
+            namespace: "AWS/Events",
+            metricName: "RetryInvocationAttempts",
+            dimensionsMap: { RuleName: rule.ruleName },
+            statistic: "Sum",
+            period: Duration.minutes(1),
+          }),
+      )
+      .threshold(10)
+      .greaterThan()
+      .description("Target is being undersized; retries are climbing."),
+  );
+```
+
+### Applying alarm actions
+
+Alarms are returned in the build result as `Record<string, Alarm>`:
+
+```ts
+const result = rule.build(stack, "MyRule");
+
+for (const alarm of Object.values(result.alarms)) {
+  alarm.addAlarmAction(new SnsAction(alertTopic));
+}
+```
+
+Or apply them stack-wide via `alarmActionsPolicy(stack, { defaults: { alarmActions: [new SnsAction(alertTopic)] } })` from `@composurecdk/cloudwatch` — same pattern used by the rest of the library, so a single SNS topic can fan out to function and rule alarms together.
+
 ## Adding Targets
 
 Targets are registered via `addTarget(key, target)`, where `target` is a CDK [`IRuleTarget`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.IRuleTarget.html) (or a `Resolvable<IRuleTarget>` for cross-component wiring). Each target is exposed on `result.targets` under its key.

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -80,4 +80,61 @@ const system = compose(
 
 ## Target Helpers
 
-_Coming in a follow-up commit in this PR — `lambdaTarget`, `sqsTarget`, `snsTarget`, `sfnStateMachineTarget`, `eventBusTarget`, `cloudWatchLogGroupTarget`._
+This package ships small free-function helpers that wrap the corresponding [`aws-events-targets`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events_targets-readme.html) constructs and accept a `Resolvable<I*>` for the underlying resource. Use them inside `addTarget` instead of constructing the CDK target classes directly — they make cross-component wiring with `ref(...)` work without an `afterBuild` hook.
+
+| Helper                     | Wraps                | Underlying resource |
+| -------------------------- | -------------------- | ------------------- |
+| `lambdaTarget`             | `LambdaFunction`     | `IFunction`         |
+| `sqsTarget`                | `SqsQueue`           | `IQueue`            |
+| `snsTarget`                | `SnsTopic`           | `ITopic`            |
+| `sfnStateMachineTarget`    | `SfnStateMachine`    | `IStateMachine`     |
+| `eventBusTarget`           | `EventBus`           | `IEventBus`         |
+| `cloudWatchLogGroupTarget` | `CloudWatchLogGroup` | `ILogGroup`         |
+
+The second argument is the matching CDK target props type (`LambdaFunctionProps`, `SqsQueueProps`, …) — refer to the CDK docs for available options. Common ones include `deadLetterQueue` (concrete `IQueue`), `retryAttempts`, `maxEventAge`, and target-specific input transforms (`event` / `input` / `message`).
+
+Other CDK target types (API Gateway, ECS task, Batch job, Kinesis, Firehose, AppSync, …) are not yet wrapped — pass them inline as a regular `IRuleTarget` until a wrapper helper lands.
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import {
+  createRuleBuilder,
+  lambdaTarget,
+  sqsTarget,
+} from "@composurecdk/events";
+import {
+  createFunctionBuilder,
+  type FunctionBuilderResult,
+} from "@composurecdk/lambda";
+
+compose(
+  {
+    handler: createFunctionBuilder()./* ... */,
+    rule: createRuleBuilder()
+      .eventPattern({ source: ["aws.s3"], detailType: ["Object Created"] })
+      .addTarget(
+        "primary",
+        lambdaTarget(ref("handler", (r: FunctionBuilderResult) => r.function), {
+          retryAttempts: 2,
+        }),
+      ),
+  },
+  { handler: [], rule: ["handler"] },
+);
+```
+
+### Cross-component DLQ wiring
+
+Each helper takes a single `Resolvable` for its primary resource. Secondary props such as `deadLetterQueue` accept the concrete CDK type (`IQueue` for most targets). When the DLQ is also a sibling-component output, construct the helper inside `ref().map()` and have the dependency component expose both the resource and the queue:
+
+```ts
+.addTarget(
+  "stopper",
+  ref<{ fn: IFunction; dlq: IQueue }>(
+    "stopperBundle",
+    (b) => lambdaTarget(b.fn, { deadLetterQueue: b.dlq }),
+  ),
+)
+```
+
+A dedicated DLQ component (`createQueueBuilder`-style) — and helpers that accept `Resolvable<IQueue>` for the DLQ directly — are out of scope for this PR; track as a follow-up if a use case emerges.

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@composurecdk/events",
+  "version": "0.6.0",
+  "description": "Composable EventBridge rule builder with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/events"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "peerDependencies": {
+    "@composurecdk/cloudwatch": "^0.6.0",
+    "@composurecdk/core": "^0.6.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "aws-cdk-lib": "^2.250.0",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/events/src/defaults.ts
+++ b/packages/events/src/defaults.ts
@@ -1,0 +1,12 @@
+import type { RuleProps } from "aws-cdk-lib/aws-events";
+
+/**
+ * Defaults applied to every EventBridge rule built with
+ * {@link createRuleBuilder}.
+ *
+ * Intentionally empty: the L2 {@link RuleProps} defaults already align with
+ * AWS recommendations (`enabled: true`, default account event bus). No
+ * additional secure default exists at this layer — DLQs are caller-owned and
+ * configured per target, not on the rule itself.
+ */
+export const RULE_DEFAULTS: Partial<RuleProps> = {};

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -5,3 +5,9 @@ export {
   type RuleBuilderResult,
 } from "./rule-builder.js";
 export { RULE_DEFAULTS } from "./defaults.js";
+export { lambdaTarget } from "./targets/lambda-target.js";
+export { sqsTarget } from "./targets/sqs-target.js";
+export { snsTarget } from "./targets/sns-target.js";
+export { sfnStateMachineTarget } from "./targets/sfn-state-machine-target.js";
+export { eventBusTarget } from "./targets/event-bus-target.js";
+export { cloudWatchLogGroupTarget } from "./targets/cloud-watch-log-group-target.js";

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -5,6 +5,8 @@ export {
   type RuleBuilderResult,
 } from "./rule-builder.js";
 export { RULE_DEFAULTS } from "./defaults.js";
+export { type RuleAlarmConfig } from "./rule-alarm-config.js";
+export { RULE_ALARM_DEFAULTS } from "./rule-alarm-defaults.js";
 export { lambdaTarget } from "./targets/lambda-target.js";
 export { sqsTarget } from "./targets/sqs-target.js";
 export { snsTarget } from "./targets/sns-target.js";

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  createRuleBuilder,
+  type IRuleBuilder,
+  type RuleBuilderProps,
+  type RuleBuilderResult,
+} from "./rule-builder.js";
+export { RULE_DEFAULTS } from "./defaults.js";

--- a/packages/events/src/rule-alarm-config.ts
+++ b/packages/events/src/rule-alarm-config.ts
@@ -1,0 +1,62 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for an EventBridge rule.
+ * All applicable alarms are enabled by default with AWS-recommended thresholds.
+ * Set individual alarms to `false` to disable them, or provide an
+ * {@link AlarmConfig} to tune thresholds.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EventBridge
+ * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-monitoring-events-best-practices.html
+ */
+export interface RuleAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when EventBridge fails to deliver matched events to a target.
+   *
+   * Metric: `AWS/Events FailedInvocations`, statistic Sum, period 1 minute.
+   * Default threshold: > 0 failures.
+   *
+   * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-monitoring-events-best-practices.html
+   */
+  failedInvocations?: AlarmConfig | false;
+
+  /**
+   * Alarm when invocations are throttled (e.g. by service-side concurrency
+   * limits or quota).
+   *
+   * Metric: `AWS/Events ThrottledRules`, statistic Sum, period 1 minute.
+   * Default threshold: > 0 throttles.
+   */
+  throttledRules?: AlarmConfig | false;
+
+  /**
+   * Alarm when events that could not be delivered are sent to a target's
+   * dead-letter queue. Only emits data when at least one target has a DLQ
+   * attached and EventBridge attempts redrive; {@link TreatMissingData.NOT_BREACHING}
+   * keeps it quiet otherwise.
+   *
+   * Metric: `AWS/Events InvocationsSentToDlq`, statistic Sum, period 1 minute.
+   * Default threshold: > 0 redrives.
+   *
+   * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-dlq.html
+   */
+  invocationsSentToDlq?: AlarmConfig | false;
+
+  /**
+   * Alarm when events could not even be delivered to a dead-letter queue.
+   * Indicates a misconfiguration (e.g. missing EventBridge permission on
+   * the DLQ) that results in event loss.
+   *
+   * Metric: `AWS/Events InvocationsFailedToBeSentToDlq`, statistic Sum,
+   * period 1 minute.
+   * Default threshold: > 0 failed redrives.
+   */
+  invocationsFailedToBeSentToDlq?: AlarmConfig | false;
+}

--- a/packages/events/src/rule-alarm-defaults.ts
+++ b/packages/events/src/rule-alarm-defaults.ts
@@ -1,0 +1,51 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+
+interface RuleAlarmDefaults {
+  enabled: true;
+  failedInvocations: AlarmConfigDefaults;
+  throttledRules: AlarmConfigDefaults;
+  invocationsSentToDlq: AlarmConfigDefaults;
+  invocationsFailedToBeSentToDlq: AlarmConfigDefaults;
+}
+
+/**
+ * AWS-recommended default alarm configuration for EventBridge rules.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EventBridge
+ */
+export const RULE_ALARM_DEFAULTS: RuleAlarmDefaults = {
+  enabled: true,
+
+  /** Any failure to deliver a matched event is worth investigating; threshold 0. */
+  failedInvocations: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any throttling indicates a quota or downstream-concurrency problem; threshold 0. */
+  throttledRules: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any redrive to a target DLQ indicates a delivery failure worth investigating; threshold 0. */
+  invocationsSentToDlq: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any failure to redrive to a DLQ means event loss; threshold 0. */
+  invocationsFailedToBeSentToDlq: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};

--- a/packages/events/src/rule-alarms.ts
+++ b/packages/events/src/rule-alarms.ts
@@ -1,0 +1,138 @@
+import { Duration } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import type { IRule } from "aws-cdk-lib/aws-events";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { RuleAlarmConfig } from "./rule-alarm-config.js";
+import { RULE_ALARM_DEFAULTS } from "./rule-alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.minutes(1);
+const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+
+function ruleMetric(rule: IRule, metricName: string): Metric {
+  return new Metric({
+    namespace: "AWS/Events",
+    metricName,
+    dimensionsMap: { RuleName: rule.ruleName },
+    statistic: "Sum",
+    period: METRIC_PERIOD,
+  });
+}
+
+/**
+ * Resolves the recommended alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s for an EventBridge rule.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EventBridge
+ */
+export function resolveRuleAlarmDefinitions(
+  rule: IRule,
+  config: RuleAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.failedInvocations !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.failedInvocations,
+      RULE_ALARM_DEFAULTS.failedInvocations,
+    );
+    definitions.push({
+      key: "failedInvocations",
+      alarmName: cfg.alarmName,
+      metric: ruleMetric(rule, "FailedInvocations"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `EventBridge rule is failing to invoke targets. Threshold: > ${String(cfg.threshold)} failures in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.throttledRules !== false) {
+    const cfg = resolveAlarmConfig(config?.throttledRules, RULE_ALARM_DEFAULTS.throttledRules);
+    definitions.push({
+      key: "throttledRules",
+      alarmName: cfg.alarmName,
+      metric: ruleMetric(rule, "ThrottledRules"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `EventBridge rule is being throttled, indicating quota or downstream concurrency limits. Threshold: > ${String(cfg.threshold)} throttles in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.invocationsSentToDlq !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.invocationsSentToDlq,
+      RULE_ALARM_DEFAULTS.invocationsSentToDlq,
+    );
+    definitions.push({
+      key: "invocationsSentToDlq",
+      alarmName: cfg.alarmName,
+      metric: ruleMetric(rule, "InvocationsSentToDlq"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `EventBridge rule is redriving events to a target dead-letter queue. Threshold: > ${String(cfg.threshold)} redrives in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.invocationsFailedToBeSentToDlq !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.invocationsFailedToBeSentToDlq,
+      RULE_ALARM_DEFAULTS.invocationsFailedToBeSentToDlq,
+    );
+    definitions.push({
+      key: "invocationsFailedToBeSentToDlq",
+      alarmName: cfg.alarmName,
+      metric: ruleMetric(rule, "InvocationsFailedToBeSentToDlq"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description: `EventBridge rule failed to redrive an event to a target dead-letter queue; events may be lost. Threshold: > ${String(cfg.threshold)} failed redrives in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates AWS-recommended CloudWatch alarms for an EventBridge rule,
+ * merging recommended definitions with any custom alarm builders.
+ *
+ * @param scope - CDK construct scope for creating alarm constructs.
+ * @param id - Base identifier for alarm construct ids.
+ * @param rule - The EventBridge rule to create alarms for.
+ * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @returns A record mapping alarm keys to their created Alarm constructs.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EventBridge
+ */
+export function createRuleAlarms(
+  scope: IConstruct,
+  id: string,
+  rule: IRule,
+  config: RuleAlarmConfig | false | undefined,
+  customAlarms: AlarmDefinitionBuilder<IRule>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? RULE_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveRuleAlarmDefinitions(rule, config);
+  const custom = customAlarms.map((b) => b.resolve(rule));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/events/src/rule-builder.ts
+++ b/packages/events/src/rule-builder.ts
@@ -1,4 +1,11 @@
-import { type IEventBus, type IRuleTarget, Rule, type RuleProps } from "aws-cdk-lib/aws-events";
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  type IEventBus,
+  type IRule,
+  type IRuleTarget,
+  Rule,
+  type RuleProps,
+} from "aws-cdk-lib/aws-events";
 import { type IConstruct } from "constructs";
 import {
   Builder,
@@ -8,7 +15,10 @@ import {
   resolve,
   type Resolvable,
 } from "@composurecdk/core";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import { RULE_DEFAULTS } from "./defaults.js";
+import type { RuleAlarmConfig } from "./rule-alarm-config.js";
+import { createRuleAlarms } from "./rule-alarms.js";
 
 /**
  * Configuration properties for the EventBridge rule builder.
@@ -27,6 +37,21 @@ export interface RuleBuilderProps extends Omit<RuleProps, "targets" | "eventBus"
    * default.
    */
   eventBus?: Resolvable<IEventBus>;
+
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates recommended alarms with sensible
+   * thresholds for every applicable metric. Individual alarms can be
+   * customized or disabled. Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification methods
+   * are user-specific. Access alarms from the build result or apply them
+   * via the {@link alarmActionsPolicy} from `@composurecdk/cloudwatch`.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#EventBridge
+   */
+  recommendedAlarms?: RuleAlarmConfig | false;
 }
 
 /**
@@ -36,6 +61,15 @@ export interface RuleBuilderProps extends Omit<RuleProps, "targets" | "eventBus"
 export interface RuleBuilderResult {
   /** The EventBridge rule construct created by the builder. */
   rule: Rule;
+
+  /**
+   * CloudWatch alarms created for the rule, keyed by alarm key.
+   *
+   * Includes both AWS-recommended alarms and any custom alarms added via
+   * {@link IRuleBuilder.addAlarm}. No alarm actions are configured —
+   * apply them via the result or an {@link alarmActionsPolicy}.
+   */
+  alarms: Record<string, Alarm>;
 
   /**
    * Resolved {@link IRuleTarget}s registered via
@@ -85,7 +119,21 @@ interface TargetEntry {
 
 class RuleBuilder implements Lifecycle<RuleBuilderResult> {
   props: Partial<RuleBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<IRule>[] = [];
   readonly #targets: TargetEntry[] = [];
+
+  /**
+   * Register a custom CloudWatch alarm on the rule. The configure callback
+   * receives an {@link AlarmDefinitionBuilder} typed to {@link IRule} so the
+   * metric factory has access to the rule's properties.
+   */
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<IRule>) => AlarmDefinitionBuilder<IRule>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IRule>(key)));
+    return this;
+  }
 
   /**
    * Register a target to be attached to the rule at build time.
@@ -108,7 +156,7 @@ class RuleBuilder implements Lifecycle<RuleBuilderResult> {
 
   build(scope: IConstruct, id: string, context?: Record<string, object>): RuleBuilderResult {
     const ctx = context ?? {};
-    const { eventBus, ...rest } = this.props;
+    const { eventBus, recommendedAlarms: alarmConfig, ...rest } = this.props;
 
     if (rest.schedule === undefined && rest.eventPattern === undefined) {
       throw new Error(
@@ -132,12 +180,15 @@ class RuleBuilder implements Lifecycle<RuleBuilderResult> {
       targets[entry.key] = resolved;
     }
 
-    return { rule, targets };
+    const alarms = createRuleAlarms(scope, id, rule, alarmConfig, this.#customAlarms);
+
+    return { rule, alarms, targets };
   }
 
-  /** Deep-clones the target accumulator so `.copy()` produces an independent builder. */
+  /** Deep-clones accumulator state so `.copy()` produces an independent builder. */
   [COPY_STATE](next: RuleBuilder): void {
     next.#targets.push(...this.#targets);
+    next.#customAlarms.push(...this.#customAlarms);
   }
 }
 

--- a/packages/events/src/rule-builder.ts
+++ b/packages/events/src/rule-builder.ts
@@ -1,0 +1,173 @@
+import { type IEventBus, type IRuleTarget, Rule, type RuleProps } from "aws-cdk-lib/aws-events";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  COPY_STATE,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { RULE_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the EventBridge rule builder.
+ *
+ * Extends the CDK {@link RuleProps} but accepts a {@link Resolvable} for
+ * `eventBus` so the rule can be wired to a sibling component (or a custom
+ * event bus built elsewhere) via {@link ref} inside a {@link compose}d
+ * system. `targets` is excluded — use {@link IRuleBuilder.addTarget} so each
+ * target can carry its own `Resolvable` and be exposed in the build result.
+ */
+export interface RuleBuilderProps extends Omit<RuleProps, "targets" | "eventBus"> {
+  /**
+   * The event bus the rule listens on. Accepts a concrete {@link IEventBus} or
+   * a {@link Ref} to another component's output. When omitted, the rule
+   * attaches to the account default bus, matching CDK's `RuleProps.eventBus`
+   * default.
+   */
+  eventBus?: Resolvable<IEventBus>;
+}
+
+/**
+ * The build output of an {@link IRuleBuilder}. Contains the CDK constructs
+ * created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface RuleBuilderResult {
+  /** The EventBridge rule construct created by the builder. */
+  rule: Rule;
+
+  /**
+   * Resolved {@link IRuleTarget}s registered via
+   * {@link IRuleBuilder.addTarget}, keyed by the key passed to that call.
+   *
+   * Always present — `{}` when no targets were added.
+   */
+  targets: Record<string, IRuleTarget>;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS EventBridge rule.
+ *
+ * Each configuration property from the CDK {@link RuleProps} is exposed as
+ * an overloaded method: call with a value to set it (returns the builder for
+ * chaining), or call with no arguments to read the current value.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates an
+ * EventBridge rule with the configured properties and returns a
+ * {@link RuleBuilderResult}.
+ *
+ * Targets are registered via {@link addTarget} and accept a
+ * {@link Resolvable}, so cross-component wiring (a sibling Lambda, queue,
+ * topic, …) flows through the same {@link Ref} machinery as everything else.
+ *
+ * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.Rule.html
+ *
+ * @example
+ * ```ts
+ * import { Schedule } from "aws-cdk-lib/aws-events";
+ * import { Duration } from "aws-cdk-lib";
+ *
+ * const rule = createRuleBuilder()
+ *   .schedule(Schedule.rate(Duration.minutes(15)))
+ *   .description("Idle stopper")
+ *   .addTarget("stopper", lambdaTarget(idleStopperFn));
+ * ```
+ */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Events::Rule has no Tags property
+export type IRuleBuilder = IBuilder<RuleBuilderProps, RuleBuilder>;
+
+interface TargetEntry {
+  key: string;
+  target: Resolvable<IRuleTarget>;
+}
+
+class RuleBuilder implements Lifecycle<RuleBuilderResult> {
+  props: Partial<RuleBuilderProps> = {};
+  readonly #targets: TargetEntry[] = [];
+
+  /**
+   * Register a target to be attached to the rule at build time.
+   *
+   * Accepts any concrete {@link IRuleTarget} (the lightweight helpers in
+   * `./targets/` produce these) or a {@link Resolvable} so targets that wire
+   * cross-component references can be declared at configuration time. The
+   * resolved target is exposed on {@link RuleBuilderResult.targets} under
+   * `key`.
+   */
+  addTarget(key: string, target: Resolvable<IRuleTarget>): this {
+    if (this.#targets.some((t) => t.key === key)) {
+      throw new Error(
+        `RuleBuilder.addTarget: duplicate key "${key}". Each target must use a unique key.`,
+      );
+    }
+    this.#targets.push({ key, target });
+    return this;
+  }
+
+  build(scope: IConstruct, id: string, context?: Record<string, object>): RuleBuilderResult {
+    const ctx = context ?? {};
+    const { eventBus, ...rest } = this.props;
+
+    if (rest.schedule === undefined && rest.eventPattern === undefined) {
+      throw new Error(
+        `RuleBuilder "${id}": at least one of .schedule(...) or .eventPattern(...) must be set. ` +
+          "An EventBridge rule with neither is inert and never matches.",
+      );
+    }
+
+    const mergedProps: RuleProps = {
+      ...RULE_DEFAULTS,
+      ...rest,
+      ...(eventBus !== undefined && { eventBus: resolve(eventBus, ctx) }),
+    };
+
+    const rule = new Rule(scope, id, mergedProps);
+
+    const targets: Record<string, IRuleTarget> = {};
+    for (const entry of this.#targets) {
+      const resolved = resolve(entry.target, ctx);
+      rule.addTarget(resolved);
+      targets[entry.key] = resolved;
+    }
+
+    return { rule, targets };
+  }
+
+  /** Deep-clones the target accumulator so `.copy()` produces an independent builder. */
+  [COPY_STATE](next: RuleBuilder): void {
+    next.#targets.push(...this.#targets);
+  }
+}
+
+/**
+ * Creates a new {@link IRuleBuilder} for configuring an AWS EventBridge rule.
+ *
+ * This is the entry point for defining an EventBridge rule component. The
+ * returned builder exposes every {@link RuleBuilderProps} property as a
+ * fluent setter/getter and implements {@link Lifecycle} for use with
+ * {@link compose}.
+ *
+ * @example
+ * ```ts
+ * import { compose, ref } from "@composurecdk/core";
+ * import { createRuleBuilder, lambdaTarget } from "@composurecdk/events";
+ * import { Schedule } from "aws-cdk-lib/aws-events";
+ * import { Duration } from "aws-cdk-lib";
+ *
+ * const system = compose(
+ *   {
+ *     stopper: createFunctionBuilder()...,
+ *     idleStopperSchedule: createRuleBuilder()
+ *       .schedule(Schedule.rate(Duration.minutes(15)))
+ *       .addTarget("stopper", lambdaTarget(ref("stopper", (r) => r.function))),
+ *   },
+ *   { stopper: [], idleStopperSchedule: ["stopper"] },
+ * );
+ * ```
+ */
+export function createRuleBuilder(): IRuleBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::Events::Rule has no Tags property
+  return Builder<RuleBuilderProps, RuleBuilder>(RuleBuilder);
+}

--- a/packages/events/src/targets/cloud-watch-log-group-target.ts
+++ b/packages/events/src/targets/cloud-watch-log-group-target.ts
@@ -1,0 +1,24 @@
+import type { IRuleTarget } from "aws-cdk-lib/aws-events";
+import { CloudWatchLogGroup, type LogGroupProps } from "aws-cdk-lib/aws-events-targets";
+import type { ILogGroup } from "aws-cdk-lib/aws-logs";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Wraps a CloudWatch log group as an EventBridge {@link IRuleTarget},
+ * deferring resolution if the log group is a {@link Ref} to a sibling
+ * component's output.
+ *
+ * Mirrors the {@link CloudWatchLogGroup} target from `aws-events-targets`,
+ * useful for audit / debug logging. `props` accepts
+ * {@link LogGroupProps.logEvent} (preferred over the deprecated `event`)
+ * to control the log payload, plus the inherited DLQ/retry options.
+ */
+export function cloudWatchLogGroupTarget(
+  logGroup: Resolvable<ILogGroup>,
+  props?: LogGroupProps,
+): Resolvable<IRuleTarget> {
+  if (isRef(logGroup)) {
+    return logGroup.map((resolved) => new CloudWatchLogGroup(resolved, props));
+  }
+  return new CloudWatchLogGroup(logGroup, props);
+}

--- a/packages/events/src/targets/event-bus-target.ts
+++ b/packages/events/src/targets/event-bus-target.ts
@@ -1,0 +1,22 @@
+import type { IEventBus, IRuleTarget } from "aws-cdk-lib/aws-events";
+import { EventBus as EventBusTarget, type EventBusProps } from "aws-cdk-lib/aws-events-targets";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Wraps an EventBridge bus as an {@link IRuleTarget}, deferring resolution
+ * if the bus is a {@link Ref} to a sibling component's output.
+ *
+ * Mirrors the {@link EventBusTarget} target from `aws-events-targets` —
+ * useful for cross-bus or cross-account routing. `props` accepts
+ * {@link EventBusProps.role} (otherwise CDK creates one) and a per-target
+ * `deadLetterQueue`. Note: bus targets do **not** support retry policy
+ * configuration, per CDK's {@link EventBusProps} (it intentionally does not
+ * extend the retry base).
+ */
+export function eventBusTarget(
+  bus: Resolvable<IEventBus>,
+  props?: EventBusProps,
+): Resolvable<IRuleTarget> {
+  if (isRef(bus)) return bus.map((resolved) => new EventBusTarget(resolved, props));
+  return new EventBusTarget(bus, props);
+}

--- a/packages/events/src/targets/lambda-target.ts
+++ b/packages/events/src/targets/lambda-target.ts
@@ -1,0 +1,37 @@
+import type { IRuleTarget } from "aws-cdk-lib/aws-events";
+import { LambdaFunction, type LambdaFunctionProps } from "aws-cdk-lib/aws-events-targets";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Wraps a Lambda function as an EventBridge {@link IRuleTarget}, deferring
+ * resolution if the function is a {@link Ref} to a sibling component's
+ * output.
+ *
+ * Mirrors the {@link LambdaFunction} target from `aws-events-targets` —
+ * `props` accepts the same options ({@link LambdaFunctionProps.event} for
+ * input transformation, plus `deadLetterQueue`, `maxEventAge`,
+ * `retryAttempts` from {@link LambdaFunctionProps}'s base).
+ *
+ * Cross-component DLQ wiring (where the queue is built by another component)
+ * is supported by composing through `ref().map()` instead of passing the
+ * queue here directly:
+ *
+ * ```ts
+ * .addTarget(
+ *   "stopper",
+ *   ref<StopperBundle>("stopperBundle", b =>
+ *     lambdaTarget(b.fn, { deadLetterQueue: b.dlq }),
+ *   ),
+ * )
+ * ```
+ *
+ * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-dlq.html
+ */
+export function lambdaTarget(
+  fn: Resolvable<IFunction>,
+  props?: LambdaFunctionProps,
+): Resolvable<IRuleTarget> {
+  if (isRef(fn)) return fn.map((resolved) => new LambdaFunction(resolved, props));
+  return new LambdaFunction(fn, props);
+}

--- a/packages/events/src/targets/sfn-state-machine-target.ts
+++ b/packages/events/src/targets/sfn-state-machine-target.ts
@@ -1,0 +1,24 @@
+import type { IRuleTarget } from "aws-cdk-lib/aws-events";
+import { SfnStateMachine, type SfnStateMachineProps } from "aws-cdk-lib/aws-events-targets";
+import type { IStateMachine } from "aws-cdk-lib/aws-stepfunctions";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Wraps a Step Functions state machine as an EventBridge
+ * {@link IRuleTarget}, deferring resolution if the state machine is a
+ * {@link Ref} to a sibling component's output.
+ *
+ * Mirrors the {@link SfnStateMachine} target from `aws-events-targets` —
+ * `props` accepts {@link SfnStateMachineProps.input} for input
+ * transformation, an explicit `role` (otherwise CDK creates one), plus the
+ * inherited DLQ/retry options.
+ */
+export function sfnStateMachineTarget(
+  stateMachine: Resolvable<IStateMachine>,
+  props?: SfnStateMachineProps,
+): Resolvable<IRuleTarget> {
+  if (isRef(stateMachine)) {
+    return stateMachine.map((resolved) => new SfnStateMachine(resolved, props));
+  }
+  return new SfnStateMachine(stateMachine, props);
+}

--- a/packages/events/src/targets/sns-target.ts
+++ b/packages/events/src/targets/sns-target.ts
@@ -1,0 +1,23 @@
+import type { IRuleTarget } from "aws-cdk-lib/aws-events";
+import { SnsTopic, type SnsTopicProps } from "aws-cdk-lib/aws-events-targets";
+import type { ITopic } from "aws-cdk-lib/aws-sns";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Wraps an SNS topic as an EventBridge {@link IRuleTarget}, deferring
+ * resolution if the topic is a {@link Ref} to a sibling component's output.
+ *
+ * Mirrors the {@link SnsTopic} target from `aws-events-targets` — `props`
+ * accepts {@link SnsTopicProps.message} for input transformation, and the
+ * IAM `role` / `authorizeUsingRole` options for cross-account publishing.
+ *
+ * Note: SNS targets do not accept a per-target DLQ
+ * ({@link SnsTopicProps} does not extend the retry/DLQ base type).
+ */
+export function snsTarget(
+  topic: Resolvable<ITopic>,
+  props?: SnsTopicProps,
+): Resolvable<IRuleTarget> {
+  if (isRef(topic)) return topic.map((resolved) => new SnsTopic(resolved, props));
+  return new SnsTopic(topic, props);
+}

--- a/packages/events/src/targets/sqs-target.ts
+++ b/packages/events/src/targets/sqs-target.ts
@@ -1,0 +1,22 @@
+import type { IRuleTarget } from "aws-cdk-lib/aws-events";
+import { SqsQueue, type SqsQueueProps } from "aws-cdk-lib/aws-events-targets";
+import type { IQueue } from "aws-cdk-lib/aws-sqs";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Wraps an SQS queue as an EventBridge {@link IRuleTarget}, deferring
+ * resolution if the queue is a {@link Ref} to a sibling component's output.
+ *
+ * Mirrors the {@link SqsQueue} target from `aws-events-targets` — `props`
+ * accepts {@link SqsQueueProps.message} for input transformation,
+ * {@link SqsQueueProps.messageGroupId} (required for FIFO targets), plus the
+ * `deadLetterQueue` / `maxEventAge` / `retryAttempts` reliability options
+ * from the inherited base.
+ */
+export function sqsTarget(
+  queue: Resolvable<IQueue>,
+  props?: SqsQueueProps,
+): Resolvable<IRuleTarget> {
+  if (isRef(queue)) return queue.map((resolved) => new SqsQueue(resolved, props));
+  return new SqsQueue(queue, props);
+}

--- a/packages/events/test/rule-alarms.test.ts
+++ b/packages/events/test/rule-alarms.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { Code, Function as LambdaFn, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { createRuleBuilder } from "../src/rule-builder.js";
+
+function newStack(): Stack {
+  return new Stack(new App(), "TestStack");
+}
+
+function makeFn(stack: Stack): LambdaFn {
+  return new LambdaFn(stack, "Handler", {
+    runtime: Runtime.NODEJS_20_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => {};"),
+  });
+}
+
+describe("RuleBuilder recommended alarms", () => {
+  it("creates the four AWS-recommended alarms by default", () => {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    const result = createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .build(stack, "TestRule");
+
+    expect(Object.keys(result.alarms).sort()).toEqual([
+      "failedInvocations",
+      "invocationsFailedToBeSentToDlq",
+      "invocationsSentToDlq",
+      "throttledRules",
+    ]);
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FailedInvocations",
+      Namespace: "AWS/Events",
+      Statistic: "Sum",
+      Threshold: 0,
+      ComparisonOperator: "GreaterThanThreshold",
+      TreatMissingData: "notBreaching",
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "ThrottledRules",
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "InvocationsSentToDlq",
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "InvocationsFailedToBeSentToDlq",
+    });
+  });
+
+  it("dimensions every alarm by RuleName", () => {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .build(stack, "TestRule");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Dimensions: Match.arrayWith([
+        Match.objectLike({ Name: "RuleName", Value: Match.anyValue() }),
+      ]),
+    });
+  });
+
+  it("disables all recommended alarms when recommendedAlarms is false", () => {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    const result = createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .recommendedAlarms(false)
+      .build(stack, "TestRule");
+
+    expect(result.alarms).toEqual({});
+    Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
+  it("disables individual alarms when set to false", () => {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    const result = createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .recommendedAlarms({
+        throttledRules: false,
+        invocationsSentToDlq: false,
+        invocationsFailedToBeSentToDlq: false,
+      })
+      .build(stack, "TestRule");
+
+    expect(Object.keys(result.alarms)).toEqual(["failedInvocations"]);
+  });
+
+  it("emits actionable alarm descriptions including the threshold", () => {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .build(stack, "TestRule");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FailedInvocations",
+      AlarmDescription: Match.stringLikeRegexp("failing to invoke targets.*Threshold: > 0"),
+    });
+  });
+
+  it("layers user overrides onto defaults without replacing other fields", () => {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .recommendedAlarms({
+        failedInvocations: { threshold: 5, evaluationPeriods: 3 },
+      })
+      .build(stack, "TestRule");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FailedInvocations",
+      Threshold: 5,
+      EvaluationPeriods: 3,
+      // datapointsToAlarm and treatMissingData should still come from defaults
+      DatapointsToAlarm: 1,
+      TreatMissingData: "notBreaching",
+    });
+  });
+
+  it("supports addAlarm for custom rule alarms", () => {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    const result = createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .addAlarm("retryAttempts", (alarm) =>
+        alarm
+          .metric(
+            (rule) =>
+              new Metric({
+                namespace: "AWS/Events",
+                metricName: "RetryInvocationAttempts",
+                dimensionsMap: { RuleName: rule.ruleName },
+                statistic: "Sum",
+                period: Duration.minutes(1),
+              }),
+          )
+          .threshold(10)
+          .greaterThan()
+          .description("Targets are being undersized; retries are climbing."),
+      )
+      .build(stack, "TestRule");
+
+    expect(Object.keys(result.alarms).sort()).toEqual([
+      "failedInvocations",
+      "invocationsFailedToBeSentToDlq",
+      "invocationsSentToDlq",
+      "retryAttempts",
+      "throttledRules",
+    ]);
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "RetryInvocationAttempts",
+      Threshold: 10,
+    });
+  });
+});

--- a/packages/events/test/rule-builder.test.ts
+++ b/packages/events/test/rule-builder.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { EventBus, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { Code, Function as LambdaFn, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ref } from "@composurecdk/core";
+import { createRuleBuilder } from "../src/rule-builder.js";
+
+function newStack(): Stack {
+  return new Stack(new App(), "TestStack");
+}
+
+function makeFn(stack: Stack, id = "Handler"): LambdaFn {
+  return new LambdaFn(stack, id, {
+    runtime: Runtime.NODEJS_20_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => {};"),
+  });
+}
+
+describe("RuleBuilder", () => {
+  describe("build", () => {
+    it("creates a rule with a schedule", () => {
+      const stack = newStack();
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+        ScheduleExpression: "rate(15 minutes)",
+      });
+    });
+
+    it("creates a rule with an event pattern", () => {
+      const stack = newStack();
+      createRuleBuilder()
+        .eventPattern({ source: ["aws.s3"], detailType: ["Object Created"] })
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+        EventPattern: Match.objectLike({
+          source: ["aws.s3"],
+          "detail-type": ["Object Created"],
+        }),
+      });
+    });
+
+    it("supports both schedule and event pattern on the same rule", () => {
+      const stack = newStack();
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(5)))
+        .eventPattern({ source: ["my.app"] })
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+        ScheduleExpression: "rate(5 minutes)",
+        EventPattern: Match.objectLike({ source: ["my.app"] }),
+      });
+    });
+
+    it("throws if neither schedule nor event pattern is set", () => {
+      const stack = newStack();
+      const builder = createRuleBuilder().description("inert");
+
+      expect(() => builder.build(stack, "TestRule")).toThrow(
+        /at least one of \.schedule\(\.\.\.\) or \.eventPattern\(\.\.\.\) must be set/,
+      );
+    });
+
+    it("returns the rule on the result", () => {
+      const stack = newStack();
+      const result = createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(1)))
+        .build(stack, "TestRule");
+
+      expect(result.rule).toBeDefined();
+      expect(result.targets).toEqual({});
+    });
+  });
+
+  describe("addTarget", () => {
+    it("attaches a single target to the rule", () => {
+      const stack = newStack();
+      const fn = makeFn(stack);
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("handler", new LambdaFunction(fn))
+        .build(stack, "TestRule");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::Events::Rule", {
+        Targets: Match.arrayWith([Match.objectLike({ Id: "Target0" })]),
+      });
+      template.hasResourceProperties("AWS::Lambda::Permission", {
+        Action: "lambda:InvokeFunction",
+        Principal: "events.amazonaws.com",
+      });
+    });
+
+    it("attaches multiple targets in registration order", () => {
+      const stack = newStack();
+      const a = makeFn(stack, "A");
+      const b = makeFn(stack, "B");
+
+      const result = createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("primary", new LambdaFunction(a))
+        .addTarget("audit", new LambdaFunction(b))
+        .build(stack, "TestRule");
+
+      expect(Object.keys(result.targets)).toEqual(["primary", "audit"]);
+      Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+        Targets: Match.arrayWith([
+          Match.objectLike({ Id: "Target0" }),
+          Match.objectLike({ Id: "Target1" }),
+        ]),
+      });
+    });
+
+    it("throws when the same key is used twice", () => {
+      const stack = newStack();
+      const fn = makeFn(stack);
+      const builder = createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("handler", new LambdaFunction(fn));
+
+      expect(() => builder.addTarget("handler", new LambdaFunction(fn))).toThrow(
+        /duplicate key "handler"/,
+      );
+    });
+
+    it("resolves a Resolvable<IRuleTarget> from the compose context", () => {
+      const stack = newStack();
+      const fn = makeFn(stack);
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget(
+          "handler",
+          ref("handler", (r: { function: LambdaFn }) => new LambdaFunction(r.function)),
+        )
+        .build(stack, "TestRule", { handler: { function: fn } });
+
+      Template.fromStack(stack).resourceCountIs("AWS::Events::Rule", 1);
+    });
+  });
+
+  describe("eventBus", () => {
+    it("resolves a Resolvable<IEventBus> from the compose context", () => {
+      const stack = newStack();
+      const fn = makeFn(stack);
+      const bus = new EventBus(stack, "Bus", { eventBusName: "my-bus" });
+
+      createRuleBuilder()
+        .eventBus(ref("bus", (r: { eventBus: typeof bus }) => r.eventBus))
+        .eventPattern({ source: ["my.app"] })
+        .addTarget("handler", new LambdaFunction(fn))
+        .build(stack, "TestRule", { bus: { eventBus: bus } });
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+        EventBusName: { Ref: stack.getLogicalId(bus.node.defaultChild as never) },
+      });
+    });
+  });
+
+  describe("copy", () => {
+    it("clones registered targets so mutations on one builder do not affect the other", () => {
+      const stack = newStack();
+      const a = makeFn(stack, "A");
+      const b = makeFn(stack, "B");
+
+      const base = createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("a", new LambdaFunction(a));
+
+      const variant = base.copy().addTarget("b", new LambdaFunction(b));
+
+      expect(Object.keys(base.build(stack, "Base").targets)).toEqual(["a"]);
+      expect(Object.keys(variant.build(stack, "Variant").targets).sort()).toEqual(["a", "b"]);
+    });
+  });
+});

--- a/packages/events/test/targets/target-helpers.test.ts
+++ b/packages/events/test/targets/target-helpers.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { EventBus, Schedule } from "aws-cdk-lib/aws-events";
+import { Code, Function as LambdaFn, Runtime } from "aws-cdk-lib/aws-lambda";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { DefinitionBody, Pass, StateMachine } from "aws-cdk-lib/aws-stepfunctions";
+import { isRef, ref } from "@composurecdk/core";
+import { createRuleBuilder } from "../../src/rule-builder.js";
+import { lambdaTarget } from "../../src/targets/lambda-target.js";
+import { sqsTarget } from "../../src/targets/sqs-target.js";
+import { snsTarget } from "../../src/targets/sns-target.js";
+import { sfnStateMachineTarget } from "../../src/targets/sfn-state-machine-target.js";
+import { eventBusTarget } from "../../src/targets/event-bus-target.js";
+import { cloudWatchLogGroupTarget } from "../../src/targets/cloud-watch-log-group-target.js";
+
+function newStack(): Stack {
+  return new Stack(new App(), "TestStack");
+}
+
+function makeFn(stack: Stack, id = "Handler"): LambdaFn {
+  return new LambdaFn(stack, id, {
+    runtime: Runtime.NODEJS_20_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => {};"),
+  });
+}
+
+describe("target helpers", () => {
+  describe("lambdaTarget", () => {
+    it("returns a concrete IRuleTarget for a concrete function", () => {
+      const stack = newStack();
+      const fn = makeFn(stack);
+
+      const target = lambdaTarget(fn);
+
+      expect(isRef(target)).toBe(false);
+    });
+
+    it("returns a Ref<IRuleTarget> for a Ref<IFunction> and synths the rule", () => {
+      const stack = newStack();
+      const fn = makeFn(stack);
+
+      const target = lambdaTarget(ref("h", (r: { fn: LambdaFn }) => r.fn));
+      expect(isRef(target)).toBe(true);
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("handler", target)
+        .build(stack, "TestRule", { h: { fn } });
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Permission", {
+        Action: "lambda:InvokeFunction",
+        Principal: "events.amazonaws.com",
+      });
+    });
+
+    it("threads target props (DLQ, retry, input) through to the underlying target", () => {
+      const stack = newStack();
+      const fn = makeFn(stack);
+      const dlq = new Queue(stack, "Dlq");
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget(
+          "handler",
+          lambdaTarget(fn, {
+            deadLetterQueue: dlq,
+            retryAttempts: 2,
+            maxEventAge: Duration.hours(1),
+          }),
+        )
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+        Targets: Match.arrayWith([
+          Match.objectLike({
+            DeadLetterConfig: Match.objectLike({}),
+            RetryPolicy: { MaximumRetryAttempts: 2, MaximumEventAgeInSeconds: 3600 },
+          }),
+        ]),
+      });
+    });
+  });
+
+  describe("sqsTarget", () => {
+    it("attaches an SQS queue and grants SendMessage", () => {
+      const stack = newStack();
+      const queue = new Queue(stack, "Q");
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("queue", sqsTarget(queue))
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::SQS::QueuePolicy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(["sqs:SendMessage"]),
+              Principal: { Service: "events.amazonaws.com" },
+            }),
+          ]),
+        }),
+      });
+    });
+
+    it("returns a Ref for a Ref input", () => {
+      expect(isRef(sqsTarget(ref("q", (r: { q: Queue }) => r.q)))).toBe(true);
+    });
+  });
+
+  describe("snsTarget", () => {
+    it("attaches an SNS topic", () => {
+      const stack = newStack();
+      const topic = new Topic(stack, "T");
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("topic", snsTarget(topic))
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::SNS::TopicPolicy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: "sns:Publish",
+              Principal: { Service: "events.amazonaws.com" },
+            }),
+          ]),
+        }),
+      });
+    });
+  });
+
+  describe("sfnStateMachineTarget", () => {
+    it("attaches a state machine with an invoke role", () => {
+      const stack = newStack();
+      const sm = new StateMachine(stack, "SM", {
+        definitionBody: DefinitionBody.fromChainable(new Pass(stack, "P")),
+      });
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("sm", sfnStateMachineTarget(sm))
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([Match.objectLike({ Action: "states:StartExecution" })]),
+        }),
+      });
+    });
+  });
+
+  describe("eventBusTarget", () => {
+    it("attaches another bus and grants events:PutEvents", () => {
+      const stack = newStack();
+      const downstream = new EventBus(stack, "Downstream");
+
+      createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .addTarget("forward", eventBusTarget(downstream))
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([Match.objectLike({ Action: "events:PutEvents" })]),
+        }),
+      });
+    });
+  });
+
+  describe("cloudWatchLogGroupTarget", () => {
+    it("attaches the log group ARN as the target ARN on the rule", () => {
+      const stack = newStack();
+      const lg = new LogGroup(stack, "LG");
+      const lgLogicalId = stack.getLogicalId(lg.node.defaultChild as never);
+
+      createRuleBuilder()
+        .eventPattern({ source: ["my.app"] })
+        .addTarget("audit", cloudWatchLogGroupTarget(lg))
+        .build(stack, "TestRule");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+        Targets: Match.arrayWith([
+          Match.objectLike({
+            Arn: Match.objectLike({
+              "Fn::Join": Match.arrayWith([
+                Match.arrayWith([Match.objectLike({ Ref: lgLogicalId })]),
+              ]),
+            }),
+          }),
+        ]),
+      });
+    });
+  });
+});

--- a/packages/events/tsconfig.build.json
+++ b/packages/events/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/events/tsconfig.json
+++ b/packages/events/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -4,17 +4,17 @@ Example applications demonstrating ComposureCDK patterns. Each example is a self
 
 All example stacks use the `ComposureCDK-` name prefix. This convention enables the CI deploy-test pipeline to scope IAM permissions and discover stacks automatically — see [CI documentation](../../docs/ci.md#stack-naming-convention) for details. **New examples must follow this prefix.**
 
-| Stack                                                                                               | Description                                                                                      |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| [`ComposureCDK-DualFunctionStack`](src/dual-function-app.ts)                                        | Two Lambda functions (API handler + async worker) with different configurations                  |
-| [`ComposureCDK-MockApiStack`](src/mock-api-app.ts)                                                  | CRUD REST API with mock integrations and recommended alarms                                      |
-| [`ComposureCDK-MultiStackServiceStack` / `ComposureCDK-MultiStackApiStack`](src/multi-stack-app.ts) | REST API + Lambda split across two stacks via `.withStacks()`                                    |
-| [`ComposureCDK-StaticWebsiteStack`](src/static-website/app.ts)                                      | S3 + CloudFront static website with OAC, error pages, and content deployment                     |
-| [`ComposureCDK-OpenApiPetstoreStack`](src/openapi-petstore-app.ts)                                  | PetStore REST API defined by an inline OpenAPI 3.0 specification                                 |
-| [`ComposureCDK-DnsZoneStack`](src/dns-zone-app.ts)                                                  | Public Route 53 zone built with the BIND-style zone DSL, including a CloudFront `ALIAS` at `www` |
-| [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + EC2 instance with well-architected defaults, recommended alarms, and SNS alert wiring      |
-| [`ComposureCDK-AgentVolumeStack`](src/agent-volume-app.ts)                                          | VPC + EC2 instance with a persistent EBS data volume attached via `attachVolume` + alarm wiring  |
-| [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`      |
+| Stack                                                                                               | Description                                                                                                                          |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [`ComposureCDK-DualFunctionStack`](src/dual-function-app.ts)                                        | Two Lambda functions (API handler + async worker) with different configurations; worker on an EventBridge schedule via `RuleBuilder` |
+| [`ComposureCDK-MockApiStack`](src/mock-api-app.ts)                                                  | CRUD REST API with mock integrations and recommended alarms                                                                          |
+| [`ComposureCDK-MultiStackServiceStack` / `ComposureCDK-MultiStackApiStack`](src/multi-stack-app.ts) | REST API + Lambda split across two stacks via `.withStacks()`                                                                        |
+| [`ComposureCDK-StaticWebsiteStack`](src/static-website/app.ts)                                      | S3 + CloudFront static website with OAC, error pages, and content deployment                                                         |
+| [`ComposureCDK-OpenApiPetstoreStack`](src/openapi-petstore-app.ts)                                  | PetStore REST API defined by an inline OpenAPI 3.0 specification                                                                     |
+| [`ComposureCDK-DnsZoneStack`](src/dns-zone-app.ts)                                                  | Public Route 53 zone built with the BIND-style zone DSL, including a CloudFront `ALIAS` at `www`                                     |
+| [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + EC2 instance with well-architected defaults, recommended alarms, and SNS alert wiring                                          |
+| [`ComposureCDK-AgentVolumeStack`](src/agent-volume-app.ts)                                          | VPC + EC2 instance with a persistent EBS data volume attached via `attachVolume` + alarm wiring                                      |
+| [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`                                          |
 
 ## Prerequisites
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -28,6 +28,7 @@
     "@composurecdk/cloudfront": "^0.6.0",
     "@composurecdk/core": "^0.6.0",
     "@composurecdk/ec2": "^0.6.0",
+    "@composurecdk/events": "^0.6.0",
     "@composurecdk/lambda": "^0.6.0",
     "@composurecdk/route53": "^0.6.0",
     "@composurecdk/s3": "^0.6.0",

--- a/packages/examples/src/dual-function-app.ts
+++ b/packages/examples/src/dual-function-app.ts
@@ -1,14 +1,17 @@
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Schedule } from "aws-cdk-lib/aws-events";
 import { Code, Runtime, Tracing } from "aws-cdk-lib/aws-lambda";
-import { compose } from "@composurecdk/core";
+import { compose, ref } from "@composurecdk/core";
 import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
-import { createFunctionBuilder } from "@composurecdk/lambda";
+import { createRuleBuilder, lambdaTarget } from "@composurecdk/events";
+import { createFunctionBuilder, type FunctionBuilderResult } from "@composurecdk/lambda";
 import { createTopicBuilder } from "@composurecdk/sns";
 
 /**
  * Two Lambda functions — an API handler and an async worker — composed
- * into a single stack.
+ * into a single stack. The worker also runs on a 15-minute EventBridge
+ * schedule wired through `@composurecdk/events`.
  *
  * Demonstrates:
  * - Configuring multiple functions with different settings
@@ -17,7 +20,9 @@ import { createTopicBuilder } from "@composurecdk/sns";
  * - Customizing alarm thresholds on the worker
  * - Adding a custom alarm via `addAlarm`
  * - Using TopicBuilder for the alert topic with recommended alarms
- * - Routing every alarm to the alert topic via `alarmActionsPolicy`
+ * - Using RuleBuilder + lambdaTarget to schedule a sibling Lambda via `ref`
+ * - Routing every alarm (function + rule) to the alert topic via
+ *   `alarmActionsPolicy`
  */
 export function createDualFunctionApp(app = new App()) {
   const stack = new Stack(app, "ComposureCDK-DualFunctionStack");
@@ -58,8 +63,13 @@ export function createDualFunctionApp(app = new App()) {
           // Worker can tolerate occasional errors — only alarm after 5
           errors: { threshold: 5, evaluationPeriods: 3, datapointsToAlarm: 2 },
         }),
+
+      workerSchedule: createRuleBuilder()
+        .schedule(Schedule.rate(Duration.minutes(15)))
+        .description("Tick the worker every 15 minutes")
+        .addTarget("worker", lambdaTarget(ref("worker", (r: FunctionBuilderResult) => r.function))),
     },
-    { alerts: [], api: [], worker: [] },
+    { alerts: [], api: [], worker: [], workerSchedule: ["worker"] },
   ).build(stack, "DualFunctionApp");
 
   alarmActionsPolicy(stack, {

--- a/packages/examples/test/__snapshots__/dual-function-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/dual-function-app.test.ts.snap
@@ -512,6 +512,160 @@ exports[`dual-function-app > matches the expected synthesised template 1`] = `
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
+    "DualFunctionAppworkerSchedule05474C69": {
+      "Properties": {
+        "Description": "Tick the worker every 15 minutes",
+        "ScheduleExpression": "rate(15 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "DualFunctionAppworker219B5B02",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "DualFunctionAppworkerScheduleAllowEventRuleComposureCDKDualFunctionStackDualFunctionAppworkerDB0478460E2CCD77": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "DualFunctionAppworker219B5B02",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "DualFunctionAppworkerSchedule05474C69",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DualFunctionAppworkerScheduleFailedInvocationsAlarm7F68058F": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "DualFunctionAppalerts6076A01F",
+          },
+        ],
+        "AlarmDescription": "EventBridge rule is failing to invoke targets. Threshold: > 0 failures in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker-schedule/failed-invocations",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "RuleName",
+            "Value": {
+              "Ref": "DualFunctionAppworkerSchedule05474C69",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FailedInvocations",
+        "Namespace": "AWS/Events",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DualFunctionAppworkerScheduleInvocationsFailedToBeSentToDlqAlarmCE3C6E7F": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "DualFunctionAppalerts6076A01F",
+          },
+        ],
+        "AlarmDescription": "EventBridge rule failed to redrive an event to a target dead-letter queue; events may be lost. Threshold: > 0 failed redrives in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker-schedule/invocations-failed-to-be-sent-to-dlq",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "RuleName",
+            "Value": {
+              "Ref": "DualFunctionAppworkerSchedule05474C69",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "InvocationsFailedToBeSentToDlq",
+        "Namespace": "AWS/Events",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DualFunctionAppworkerScheduleInvocationsSentToDlqAlarm37DE1862": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "DualFunctionAppalerts6076A01F",
+          },
+        ],
+        "AlarmDescription": "EventBridge rule is redriving events to a target dead-letter queue. Threshold: > 0 redrives in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker-schedule/invocations-sent-to-dlq",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "RuleName",
+            "Value": {
+              "Ref": "DualFunctionAppworkerSchedule05474C69",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "InvocationsSentToDlq",
+        "Namespace": "AWS/Events",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DualFunctionAppworkerScheduleThrottledRulesAlarm6E846F0E": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "DualFunctionAppalerts6076A01F",
+          },
+        ],
+        "AlarmDescription": "EventBridge rule is being throttled, indicating quota or downstream concurrency limits. Threshold: > 0 throttles in 1 minute.",
+        "AlarmName": "composure-cdk-dual-function-stack/dual-function-app/worker-schedule/throttled-rules",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": [
+          {
+            "Name": "RuleName",
+            "Value": {
+              "Ref": "DualFunctionAppworkerSchedule05474C69",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRules",
+        "Namespace": "AWS/Events",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "DualFunctionAppworkerServiceRole2CE81560": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/packages/examples/test/dual-function-app.test.ts
+++ b/packages/examples/test/dual-function-app.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { createDualFunctionApp } from "../src/dual-function-app.js";
 
 describe("dual-function-app", () => {
@@ -34,6 +34,37 @@ describe("dual-function-app", () => {
       TracingConfig: { Mode: "Active" },
       Description: "Worker — processes requests asynchronously",
     });
+  });
+
+  it("schedules the worker every 15 minutes via an EventBridge rule", () => {
+    template.resourceCountIs("AWS::Events::Rule", 1);
+    template.hasResourceProperties("AWS::Events::Rule", {
+      ScheduleExpression: "rate(15 minutes)",
+      Description: "Tick the worker every 15 minutes",
+      Targets: Match.arrayWith([Match.objectLike({ Id: "Target0" })]),
+    });
+  });
+
+  it("grants EventBridge permission to invoke the worker", () => {
+    template.hasResourceProperties("AWS::Lambda::Permission", {
+      Action: "lambda:InvokeFunction",
+      Principal: "events.amazonaws.com",
+    });
+  });
+
+  it("creates the four AWS-recommended rule alarms", () => {
+    template.resourcePropertiesCountIs("AWS::CloudWatch::Alarm", { Namespace: "AWS/Events" }, 4);
+    for (const metricName of [
+      "FailedInvocations",
+      "ThrottledRules",
+      "InvocationsSentToDlq",
+      "InvocationsFailedToBeSentToDlq",
+    ]) {
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Namespace: "AWS/Events",
+        MetricName: metricName,
+      });
+    }
   });
 
   it("matches the expected synthesised template", () => {


### PR DESCRIPTION
Closes #67 (Phase 1 only — `.schedule()` shortcut on `FunctionBuilder` is not in scope, per the feedback on the issue).

## Summary

- New `@composurecdk/events` package providing `createRuleBuilder()` for AWS EventBridge rules, mirroring the shape of `@composurecdk/sns`.
- Six free-function target helpers (`lambdaTarget`, `sqsTarget`, `snsTarget`, `sfnStateMachineTarget`, `eventBusTarget`, `cloudWatchLogGroupTarget`) that accept a `Resolvable<I*>` for the underlying resource and defer construction until rule build time when the input is a `Ref`.
- AWS-recommended CloudWatch alarms (`FailedInvocations`, `ThrottledRules`, `InvocationsSentToDlq`, `InvocationsFailedToBeSentToDlq`) wired the same way as `TopicBuilder`'s alarms — same `recommendedAlarms<Config | false>` setter, same `addAlarm(key, configure)` escape hatch, same default thresholds.
- `ComposureCDK-DualFunctionStack` updated to schedule its async worker every 15 minutes via `createRuleBuilder()` + `lambdaTarget(ref(...))` — the existing `alarmActionsPolicy` on the stack now picks up the rule's recommended alarms in addition to the function alarms with no extra wiring.

The PR is broken into four logical commits:

1. `feat(events): add @composurecdk/events package with RuleBuilder` — package skeleton, `createRuleBuilder`, `addTarget`, build-time validation, `COPY_STATE` for the target accumulator.
2. `feat(events): add target helpers …` — the six target wrappers + tests.
3. `feat(events): add AWS-recommended CloudWatch alarms for RuleBuilder` — `RuleAlarmConfig`, `RULE_ALARM_DEFAULTS`, `createRuleAlarms`, integration into the builder, custom-alarm support.
4. `feat(examples): schedule the worker via RuleBuilder + lambdaTarget` — example update.

Each commit was reviewed via `/simplify` before staging, plus a final whole-PR `/simplify` pass.

## Open questions for review

1. **`COPY_STATE` asymmetry vs SNS.** `RuleBuilder` implements `[COPY_STATE]` to deep-clone `#targets` and `#customAlarms`. `TopicBuilder` has analogous private accumulators (`#subscriptions`, `#customAlarms`) and does **not** implement the hook — meaning `.copy()` on a topic with subscriptions/custom alarms silently drops them. Is that a bug to fix in `@composurecdk/sns` (and `FunctionBuilder` likewise) as a follow-up? I deliberately did not change SNS in this PR.

2. **DLQ wiring scope.** Each target helper accepts a single `Resolvable` for the primary resource; secondary props such as `deadLetterQueue` stay concrete. Cross-component DLQ wiring is currently documented as `ref<{fn, dlq}>("bundle", b => lambdaTarget(b.fn, { deadLetterQueue: b.dlq }))`. Supporting `deadLetterQueue: Resolvable<IQueue>` directly would require a new `Ref.from(resolver)` factory in `@composurecdk/core` (since `.map()` only carries one input). I skipped that surface change to keep this PR scoped — happy to add it in a follow-up if you'd prefer the helpers accept `Resolvable<IQueue>` first-class.

3. **Target helper coverage.** Shipped six helpers covering Lambda, SQS, SNS, Step Functions, EventBus, CloudWatch Logs. Other CDK targets (API Gateway, ECS task, Batch job, Kinesis, Firehose, AppSync, Redshift, …) are not yet wrapped — users can pass them inline as a regular `IRuleTarget`. Adding more is a per-target follow-up rather than a single PR.

4. **`IngestionToInvocationStartLatency` and `RetryInvocationAttempts` alarms.** Both are AWS-recommended early indicators but their thresholds are workload-specific. Following the SNS precedent, I left them out of `RULE_ALARM_DEFAULTS` and documented `RetryInvocationAttempts` as a candidate for `addAlarm()` in the README. Confirm that's the right call.

## Test plan

- [x] `npx nx build events` — clean build
- [x] `npx nx test events` — 27 tests pass (rule builder, alarms, target helpers)
- [x] `npx nx test examples` — 64 tests pass (existing suites + 3 new dual-function-app cases)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)