### PR TITLE
feat(core): add assertCopyPreservesState test helper for ADR-0005 (#84)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./testing": {
+      "import": "./dist/testing.js",
+      "types": "./dist/testing.d.ts"
     }
   },
   "files": [

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -1,0 +1,136 @@
+/**
+ * Asserts that {@link IBuilder.copy | `.copy()`} returns an independent
+ * builder that preserves non-`props` state set via {@link COPY_STATE}.
+ *
+ * The helper is the standard way per-package tests verify each accumulator
+ * a builder holds outside `props`. It executes the following sequence and
+ * asserts the two invariants implied by ADR-0005:
+ *
+ * 1. Build a **baseline**: `factory()` then `configure()`.
+ * 2. Build the **copy**: `factory()`, `configure()`, then `.copy()`.
+ *    Apply `mutate()` to the original *after* the copy is taken.
+ * 3. Build the **original** (now carrying both `configure` and `mutate`).
+ *
+ * Note that the baseline is constructed via `factory()` rather than via
+ * `.copy()` — using `.copy()` would make the helper unable to detect a
+ * broken `[COPY_STATE]`, since both the "baseline" and the "copy" would
+ * drop the same state and still match.
+ *
+ * Then:
+ *
+ * - `inspect(copyResult)` must deep-equal `inspect(baselineResult)` —
+ *   the copy preserved exactly the state that `configure` set up.
+ *   A failure here means `[COPY_STATE]` is missing, incomplete, or buggy.
+ * - `inspect(originalResult)` must deep-not-equal `inspect(baselineResult)` —
+ *   `mutate` actually changed inspectable state. Without this sanity
+ *   check, a no-op `mutate` would let the first assertion pass
+ *   trivially, hiding an isolation bug.
+ *
+ * @param args.factory - Returns a fresh, unconfigured builder. Called
+ *   twice — the helper builds two independent instances so that the
+ *   build calls don't share construct scopes and so the baseline does
+ *   not depend on `.copy()`.
+ * @param args.configure - Applies the state under test (e.g. adds a
+ *   `customAlarm`, configures `#vpc`, appends a `subscription`). Called
+ *   on the baseline and on the original.
+ * @param args.mutate - Applied to the original *after* the copy is taken.
+ *   Must change something the `inspect` callback can see — typically a
+ *   second `configure`-shaped call that adds another item to the
+ *   accumulator under test.
+ * @param args.build - Calls `.build(scope, id)` against a fresh CDK
+ *   scope. Three separate scopes are required (one per build) — return a
+ *   freshly constructed scope each call. Reusing a scope across calls
+ *   surfaces as a CDK duplicate-id error rather than a silent leak.
+ * @param args.inspect - Extracts the slice of the build result whose
+ *   shape depends on the state under test (e.g.
+ *   `result => Object.keys(result.alarms)`).
+ *
+ * @example
+ * ```ts
+ * import { App, Stack } from "aws-cdk-lib";
+ * import { assertCopyPreservesState } from "@composurecdk/core/testing";
+ *
+ * assertCopyPreservesState({
+ *   factory: () => createCertificateBuilder().domainName("example.com"),
+ *   configure: (b) => b.customAlarm({ id: "FirstAlarm", ... }),
+ *   mutate: (b) => b.customAlarm({ id: "SecondAlarm", ... }),
+ *   build: (b) => b.build(new Stack(new App(), "S"), "Cert"),
+ *   inspect: (r) => Object.keys(r.alarms).sort(),
+ * });
+ * ```
+ */
+export function assertCopyPreservesState<B extends { copy(): B }, R>(args: {
+  factory: () => B;
+  configure: (builder: B) => void;
+  mutate: (builder: B) => void;
+  build: (builder: B) => R;
+  inspect: (result: R) => unknown;
+}): void {
+  const { factory, configure, mutate, build, inspect } = args;
+
+  const baseline = factory();
+  configure(baseline);
+  const baselineState = inspect(build(baseline));
+
+  const original = factory();
+  configure(original);
+  if (typeof (original as { copy?: unknown }).copy !== "function") {
+    throw new Error(
+      "assertCopyPreservesState: builder returned by `factory` has no `.copy()` method. " +
+        "Pass a builder produced by `Builder()` / `taggedBuilder()` from `@composurecdk/core` / `@composurecdk/cloudformation`.",
+    );
+  }
+  const copy = original.copy();
+  mutate(original);
+
+  const originalState = inspect(build(original));
+  const copyState = inspect(build(copy));
+
+  if (deepEqual(originalState, baselineState)) {
+    throw new Error(
+      "assertCopyPreservesState: `mutate` did not change inspectable state on the original — " +
+        "the test cannot detect a leak through `.copy()`. Make `mutate` and `inspect` cover " +
+        "the same accumulator.\n" +
+        `  baseline: ${format(baselineState)}\n` +
+        `  original: ${format(originalState)}`,
+    );
+  }
+  if (!deepEqual(copyState, baselineState)) {
+    throw new Error(
+      "assertCopyPreservesState: `.copy()` did not preserve state set by `configure`. " +
+        "The builder is missing, incomplete, or has a buggy `[COPY_STATE]` hook (see ADR-0005).\n" +
+        `  baseline: ${format(baselineState)}\n` +
+        `  copy:     ${format(copyState)}`,
+    );
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== "object" || a === null) return false;
+  if (typeof b !== "object" || b === null) return false;
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+  if (Array.isArray(b)) return false;
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  const bRec = b as Record<string, unknown>;
+  return aKeys.every(
+    (k) =>
+      Object.prototype.hasOwnProperty.call(bRec, k) &&
+      deepEqual((a as Record<string, unknown>)[k], bRec[k]),
+  );
+}
+
+function format(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/core/test/testing.test.ts
+++ b/packages/core/test/testing.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import { Builder, COPY_STATE, type IBuilder } from "../src/builder.js";
+import { assertCopyPreservesState } from "../src/testing.js";
+
+interface Props {
+  name: string;
+}
+
+class WithAccumulator {
+  props: Partial<Props> = {};
+  readonly #items: string[] = [];
+
+  add(value: string): this {
+    this.#items.push(value);
+    return this;
+  }
+
+  items(): readonly string[] {
+    return this.#items;
+  }
+
+  [COPY_STATE](next: WithAccumulator): void {
+    next.#items.push(...this.#items);
+  }
+}
+
+class WithoutCopyState {
+  props: Partial<Props> = {};
+  readonly #items: string[] = [];
+
+  add(value: string): this {
+    this.#items.push(value);
+    return this;
+  }
+
+  items(): readonly string[] {
+    return this.#items;
+  }
+}
+
+interface BuildResult {
+  items: readonly string[];
+}
+
+function buildResult(b: IBuilder<Props, WithAccumulator | WithoutCopyState>): BuildResult {
+  return { items: [...b.items()] };
+}
+
+describe("assertCopyPreservesState", () => {
+  it("passes when [COPY_STATE] preserves accumulator state across .copy()", () => {
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => Builder<Props, WithAccumulator>(WithAccumulator),
+        configure: (b) => {
+          b.add("first");
+        },
+        mutate: (b) => {
+          b.add("after-copy");
+        },
+        build: buildResult,
+        inspect: (r) => r.items,
+      });
+    }).not.toThrow();
+  });
+
+  it("fails when [COPY_STATE] is missing — copy diverges from baseline", () => {
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => Builder<Props, WithoutCopyState>(WithoutCopyState),
+        configure: (b) => {
+          b.add("first");
+        },
+        mutate: (b) => {
+          b.add("after-copy");
+        },
+        build: buildResult,
+        inspect: (r) => r.items,
+      });
+    }).toThrow(/COPY_STATE/);
+  });
+
+  it("fails when `mutate` is a no-op so the helper cannot detect a leak", () => {
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => Builder<Props, WithAccumulator>(WithAccumulator),
+        configure: (b) => {
+          b.add("first");
+        },
+        mutate: () => {
+          /* no-op */
+        },
+        build: buildResult,
+        inspect: (r) => r.items,
+      });
+    }).toThrow(/mutate.*did not change/);
+  });
+
+  it("fails when `mutate` changes state that `inspect` does not surface", () => {
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => Builder<Props, WithAccumulator>(WithAccumulator),
+        configure: (b) => {
+          b.add("first");
+        },
+        // Mutates a prop, not the accumulator that `inspect` returns.
+        mutate: (b) => {
+          b.name("changed");
+        },
+        build: buildResult,
+        inspect: (r) => r.items,
+      });
+    }).toThrow(/mutate.*did not change/);
+  });
+
+  it("invokes build three times, each on a distinct builder instance", () => {
+    const seen: object[] = [];
+    assertCopyPreservesState({
+      factory: () => Builder<Props, WithAccumulator>(WithAccumulator),
+      configure: (b) => {
+        b.add("first");
+      },
+      mutate: (b) => {
+        b.add("after-copy");
+      },
+      build: (b) => {
+        seen.push(b);
+        return buildResult(b);
+      },
+      inspect: (r) => r.items,
+    });
+    expect(seen).toHaveLength(3);
+    expect(new Set(seen).size).toBe(3);
+  });
+
+  it("fails with a clear error when the builder lacks .copy()", () => {
+    const noCopyBuilder = {
+      props: {} as Partial<Props>,
+      add() {
+        return this;
+      },
+      items: () => [] as readonly string[],
+    };
+
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => noCopyBuilder as unknown as IBuilder<Props, WithAccumulator>,
+        configure: () => {
+          /* no-op */
+        },
+        mutate: () => {
+          /* no-op */
+        },
+        build: buildResult,
+        inspect: (r) => r.items,
+      });
+    }).toThrow(/no `\.copy\(\)` method/);
+  });
+
+  it("compares non-trivially structured inspectable state via deep equality", () => {
+    interface NestedResult {
+      tree: { children: { name: string }[] };
+    }
+    class Tree {
+      props: Partial<Props> = {};
+      readonly #children: { name: string }[] = [];
+
+      addChild(name: string): this {
+        this.#children.push({ name });
+        return this;
+      }
+
+      snapshot(): NestedResult {
+        return { tree: { children: this.#children.map((c) => ({ ...c })) } };
+      }
+
+      [COPY_STATE](next: Tree): void {
+        next.#children.push(...this.#children.map((c) => ({ ...c })));
+      }
+    }
+
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => Builder<Props, Tree>(Tree),
+        configure: (b) => {
+          b.addChild("a");
+        },
+        mutate: (b) => {
+          b.addChild("b");
+        },
+        build: (b) => b.snapshot(),
+        inspect: (r) => r.tree.children,
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

PR 0 of issue #84 — adds the shared `assertCopyPreservesState` test helper that PRs 1–10 will use to verify each builder's `[COPY_STATE]` hook (ADR-0005). Structurally independent: changes no builder behaviour.

- New subpath export `@composurecdk/core/testing` exposing `assertCopyPreservesState`.
- Helper builds three independent instances — baseline (fresh from `factory`, *not* `.copy()`), mutated original, and copy — and asserts copy ≡ baseline while original ≢ baseline.
- Inline `deepEqual` / `format` rather than `node:assert` so core's compile doesn't pull `@types/node` and consumers' regex assertions don't couple to `AssertionError` formatting.
- Five test cases covering happy path, missing hook, no-op `mutate`, mismatched `mutate`/`inspect`, missing `.copy()`, distinct-instance-per-build, and nested object inspection.

## Why factory + configure rather than a single configured builder?

Using `.copy()` to derive the baseline (as a smaller API would imply) makes the helper unable to detect the very bug we're testing for: under a missing `[COPY_STATE]`, both the "baseline" and the "copy" would drop the same state and still match. The baseline must come from a fresh `factory()` path that doesn't depend on `.copy()`.

## Open questions for review

1. **Inline `deepEqual` scope.** The implementation handles plain objects and arrays (the shape every per-package `inspect` callback in the plan produces). It doesn't handle `Set`/`Map`/`Date`/`RegExp` — those don't appear in the listed accumulators, but if a future inspector returns one we'd need to extend it. Comfortable shipping the simple form, or would you prefer to lean on a small helper from somewhere?
2. **Subpath vs co-located.** I went with the new `@composurecdk/core/testing` subpath since the issue suggests it. Alternative was co-locating in `core` test helpers (private to `core`'s tests) and re-exporting via package boundaries — the subpath is cleaner for downstream packages to consume, and keeps the helper out of the main runtime entry. Confirm?
3. **Three builds per call.** The efficiency reviewer suggested folding to two by deriving baseline via `.copy()`; I rejected for the reason above. Wall-time across all 10 per-package PRs is ~one extra synth per accumulator under test — happy to revisit if synth latency stacks up in the test suite, but I'd rather take the cost than the false-negative risk.

## Test plan

- [x] `npx nx test core` — 100 tests pass (5 new for the helper + 1 nested-object case)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build` succeeds; `dist/testing.{js,d.ts}` emitted as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)