### PR TITLE
feat(acm): add [COPY_STATE] to CertificateBuilder (#84)

### DIFF
--- a/packages/acm/src/certificate-builder.ts
+++ b/packages/acm/src/certificate-builder.ts
@@ -7,7 +7,7 @@ import {
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import type { IHostedZone } from "aws-cdk-lib/aws-route53";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { CertificateAlarmConfig } from "./alarm-config.js";
@@ -133,6 +133,17 @@ class CertificateBuilder implements Lifecycle<CertificateBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<ICertificate>(key)));
     return this;
+  }
+
+  /**
+   * Copies non-`props` state onto a freshly cloned builder. Per ADR-0005,
+   * the array is spread into a fresh container; the
+   * {@link AlarmDefinitionBuilder} elements are shared by reference.
+   *
+   * @internal
+   */
+  [COPY_STATE](target: CertificateBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string, context?: Record<string, object>): CertificateBuilderResult {

--- a/packages/acm/test/certificate-builder.test.ts
+++ b/packages/acm/test/certificate-builder.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { CertificateValidation, KeyAlgorithm } from "aws-cdk-lib/aws-certificatemanager";
+import {
+  CertificateValidation,
+  KeyAlgorithm,
+  type ICertificate,
+} from "aws-cdk-lib/aws-certificatemanager";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { PublicHostedZone } from "aws-cdk-lib/aws-route53";
 import { ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createCertificateBuilder } from "../src/certificate-builder.js";
 import { CERTIFICATE_DEFAULTS } from "../src/defaults.js";
 
@@ -152,6 +158,39 @@ describe("CertificateBuilder", () => {
       template.hasResourceProperties("AWS::CertificateManager::Certificate", {
         KeyAlgorithm: "EC_prime256v1",
         CertificateTransparencyLoggingPreference: "DISABLED",
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #customAlarms across .copy()", () => {
+      const expiryMetric = (cert: ICertificate): Metric =>
+        new Metric({
+          namespace: "AWS/CertificateManager",
+          metricName: "DaysToExpiry",
+          dimensionsMap: { CertificateArn: cert.certificateArn },
+          statistic: "Minimum",
+          period: Duration.days(1),
+        });
+
+      assertCopyPreservesState({
+        factory: () => createCertificateBuilder().domainName("example.com"),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (alarm) =>
+            alarm.metric(expiryMetric).threshold(10).lessThanOrEqual(),
+          );
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (alarm) =>
+            alarm.metric(expiryMetric).threshold(20).lessThanOrEqual(),
+          );
+        },
+        build: (b) => {
+          const stack = newStack();
+          const zone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+          return b.validationZone(zone).build(stack, "Cert");
+        },
+        inspect: (r) => Object.keys(r.alarms).sort(),
       });
     });
   });


### PR DESCRIPTION
## Summary

PR 1 of issue #84 — adds `[COPY_STATE]` to `CertificateBuilder` so `.copy()` carries `#customAlarms` to the cloned instance per ADR-0005.

**Stacked on #87** (PR 0 — the `assertCopyPreservesState` helper). Will rebase onto `main` once #87 lands.

- `packages/acm/src/certificate-builder.ts` — adds the hook; spreads the array into a fresh container, sharing `AlarmDefinitionBuilder` elements by reference (matches ADR-0005's shallow-clone stance).
- `packages/acm/test/certificate-builder.test.ts` — verifies via `assertCopyPreservesState` from `@composurecdk/core/testing`.

## Verification

I confirmed the test catches the missing-hook regression by stashing the source change and re-running: the helper reports

```
Error: assertCopyPreservesState: `.copy()` did not preserve state set by `configure`.
The builder is missing, incomplete, or has a buggy `[COPY_STATE]` hook (see ADR-0005).
```

## Test plan

- [x] `npx nx test acm` — 23 tests pass (1 new)
- [x] Verified test fails with the source change stashed (regression detection works)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)