### PR TITLE
feat(apigateway): add [COPY_STATE] to RestApi/SpecRestApiBuilder (#84)

### DIFF
--- a/packages/apigateway/src/resource-builder.ts
+++ b/packages/apigateway/src/resource-builder.ts
@@ -71,6 +71,24 @@ export class ResourceBuilder {
     return this;
   }
 
+  /**
+   * Copies this builder's resource tree onto `target`. Used by
+   * `RestApiBuilder.[COPY_STATE]` per ADR-0005's containers-fresh,
+   * elements-shared rule: the `methods` array and `children` Map are
+   * reconstructed on `target`, but `MethodDefinition` and child
+   * `ResourceDefinition` entries are shared by reference. Sharing the
+   * child entries is safe because the public API (`addResource`)
+   * replaces a child wholesale rather than mutating it in place.
+   *
+   * @internal
+   */
+  copyInto(target: ResourceBuilder): void {
+    target.definition.methods.push(...this.definition.methods);
+    for (const [pathPart, childDef] of this.definition.children) {
+      target.definition.children.set(pathPart, childDef);
+    }
+  }
+
   /** @internal */
   applyTo(resource: IResource, context: Record<string, object> = {}): void {
     for (const method of this.definition.methods) {

--- a/packages/apigateway/src/rest-api-builder.ts
+++ b/packages/apigateway/src/rest-api-builder.ts
@@ -6,7 +6,7 @@ import {
   type RestApiProps,
 } from "aws-cdk-lib/aws-apigateway";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { RestApiBuilderPropsBase, RestApiBuilderResultBase } from "./builder-common.js";
@@ -97,6 +97,20 @@ class RestApiBuilder implements Lifecycle<RestApiBuilderResult> {
   addResource(pathPart: string, configure?: (resource: ResourceBuilder) => void): this {
     this.#root.addResource(pathPart, configure);
     return this;
+  }
+
+  /**
+   * Copies non-`props` state onto a freshly cloned builder. The resource
+   * tree is deep-cloned via `ResourceBuilder.copyInto` so mutations on
+   * either side after `.copy()` do not leak; the alarm-builder array is
+   * spread into a fresh container with elements shared by reference per
+   * ADR-0005's shallow-clone stance.
+   *
+   * @internal
+   */
+  [COPY_STATE](target: RestApiBuilder): void {
+    this.#root.copyInto(target.#root);
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string, context?: Record<string, object>): RestApiBuilderResult {

--- a/packages/apigateway/src/spec-rest-api-builder.ts
+++ b/packages/apigateway/src/spec-rest-api-builder.ts
@@ -1,6 +1,6 @@
 import { type RestApiBase, SpecRestApi, type SpecRestApiProps } from "aws-cdk-lib/aws-apigateway";
 import { type IConstruct } from "constructs";
-import { type Lifecycle } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { RestApiBuilderPropsBase, RestApiBuilderResultBase } from "./builder-common.js";
@@ -55,6 +55,11 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<RestApiBase>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: SpecRestApiBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string): SpecRestApiBuilderResult {

--- a/packages/apigateway/test/rest-api-builder.test.ts
+++ b/packages/apigateway/test/rest-api-builder.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import {
   LogGroupLogDestination,
   MethodLoggingLevel,
   MockIntegration,
   PassthroughBehavior,
+  type RestApiBase,
 } from "aws-cdk-lib/aws-apigateway";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createRestApiBuilder } from "../src/rest-api-builder.js";
 
 function mockIntegration(body: Record<string, unknown>) {
@@ -341,6 +344,61 @@ describe("RestApiBuilder", () => {
         AccessLogSetting: {
           DestinationArn: Match.anyValue(),
         },
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #root resource tree across .copy()", () => {
+      assertCopyPreservesState({
+        factory: () => createRestApiBuilder(),
+        configure: (b) => {
+          b.addResource("first", (r) => r.addMethod("GET", stubIntegration, methodResponse200));
+        },
+        mutate: (b) => {
+          b.addResource("second", (r) => r.addMethod("GET", stubIntegration, methodResponse200));
+        },
+        build: (b) => {
+          const stack = new Stack(new App(), "S");
+          return b.build(stack, "Api");
+        },
+        inspect: (r) => {
+          const stack = Stack.of(r.api);
+          const resources = Template.fromStack(stack).findResources("AWS::ApiGateway::Resource");
+          return Object.values(resources)
+            .map((res) => (res as { Properties: { PathPart: string } }).Properties.PathPart)
+            .sort();
+        },
+      });
+    });
+
+    it("preserves #customAlarms across .copy()", () => {
+      const errorMetric = (api: RestApiBase): Metric =>
+        new Metric({
+          namespace: "AWS/ApiGateway",
+          metricName: "5XXError",
+          dimensionsMap: { ApiName: api.restApiName },
+          statistic: "Sum",
+          period: Duration.minutes(1),
+        });
+
+      assertCopyPreservesState({
+        factory: () => createRestApiBuilder().addMethod("GET", stubIntegration, methodResponse200),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (alarm) =>
+            alarm.metric(errorMetric).threshold(1).greaterThanOrEqual(),
+          );
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (alarm) =>
+            alarm.metric(errorMetric).threshold(5).greaterThanOrEqual(),
+          );
+        },
+        build: (b) => {
+          const stack = new Stack(new App(), "S");
+          return b.build(stack, "Api");
+        },
+        inspect: (r) => Object.keys(r.alarms).sort(),
       });
     });
   });

--- a/packages/apigateway/test/spec-rest-api-builder.test.ts
+++ b/packages/apigateway/test/spec-rest-api-builder.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import {
   ApiDefinition,
   LogGroupLogDestination,
   MethodLoggingLevel,
+  type RestApiBase,
 } from "aws-cdk-lib/aws-apigateway";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createSpecRestApiBuilder } from "../src/spec-rest-api-builder.js";
 
 /** Minimal OpenAPI 3.0 spec with a single mock-integrated GET /pets endpoint. */
@@ -226,6 +229,39 @@ describe("SpecRestApiBuilder", () => {
         AccessLogSetting: {
           DestinationArn: Match.anyValue(),
         },
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #customAlarms across .copy()", () => {
+      const errorMetric = (api: RestApiBase): Metric =>
+        new Metric({
+          namespace: "AWS/ApiGateway",
+          metricName: "5XXError",
+          dimensionsMap: { ApiName: api.restApiName },
+          statistic: "Sum",
+          period: Duration.minutes(1),
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createSpecRestApiBuilder().apiDefinition(ApiDefinition.fromInline(minimalOpenApiSpec())),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (alarm) =>
+            alarm.metric(errorMetric).threshold(1).greaterThanOrEqual(),
+          );
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (alarm) =>
+            alarm.metric(errorMetric).threshold(5).greaterThanOrEqual(),
+          );
+        },
+        build: (b) => {
+          const stack = new Stack(new App(), "S");
+          return b.build(stack, "Api");
+        },
+        inspect: (r) => Object.keys(r.alarms).sort(),
       });
     });
   });


### PR DESCRIPTION
## Summary

PR 2 of issue #84 — adds `[COPY_STATE]` to `RestApiBuilder` (`#root`, `#customAlarms`) and `SpecRestApiBuilder` (`#customAlarms`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

- `ResourceBuilder.copyInto(target)` is the support method for the resource-tree copy. Top-level Map + methods array reconstructed; child entries shared by reference. This matches the containers-fresh/elements-shared rule because `addResource` always replaces a child wholesale — there is no public path that mutates a child's subtree in place.
- Tests use `assertCopyPreservesState` from `@composurecdk/core/testing`. Separate cases for the resource tree (asserting `AWS::ApiGateway::Resource` path parts in the synthesised template) and for the alarm accumulator.

## Open question for review

`copyInto`'s simpler one-level shape relies on the invariant that `addResource` always overwrites. If we later add an in-place child-mutation API (e.g. a `getResource` returning a live `ResourceBuilder`), `copyInto` will need to deep-clone. Worth a comment on `addResource` flagging that, or leave for the day it actually changes? My read: leave it. Flag if you'd prefer the comment.

## Verification

- [x] `npx nx test apigateway` — 76 tests pass (3 new)
- [x] All three new tests fail when source changes are stashed (regression detection works)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)