### PR TITLE
feat(budgets): add [COPY_STATE] to Budget/BudgetAlarmBuilder (#84)

### DIFF
--- a/packages/budgets/src/budget-alarm-builder.ts
+++ b/packages/budgets/src/budget-alarm-builder.ts
@@ -2,7 +2,7 @@ import { type CfnBudget } from "aws-cdk-lib/aws-budgets";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Annotations, Stack, Token } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
@@ -168,6 +168,12 @@ class BudgetAlarmBuilder implements Lifecycle<BudgetAlarmBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<CfnBudget>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: BudgetAlarmBuilder): void {
+    target.#budget = this.#budget;
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string, context?: Record<string, object>): BudgetAlarmBuilderResult {

--- a/packages/budgets/src/budget-builder.ts
+++ b/packages/budgets/src/budget-builder.ts
@@ -2,7 +2,7 @@ import { CfnBudget, type CfnBudgetProps } from "aws-cdk-lib/aws-budgets";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import type { ITopic, TopicPolicy } from "aws-cdk-lib/aws-sns";
 import type { IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { Builder, COPY_STATE, type IBuilder, type Lifecycle } from "@composurecdk/core";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { BudgetAlarmConfig } from "./alarm-config.js";
 import { buildBudgetAlarms } from "./budget-alarm-builder.js";
@@ -228,6 +228,12 @@ class BudgetBuilder implements Lifecycle<BudgetBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<CfnBudget>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: BudgetBuilder): void {
+    target.#notifications.push(...this.#notifications);
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string, context: Record<string, object> = {}): BudgetBuilderResult {

--- a/packages/budgets/test/budget-alarm-builder.test.ts
+++ b/packages/budgets/test/budget-alarm-builder.test.ts
@@ -4,6 +4,7 @@ import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { type CfnBudget } from "aws-cdk-lib/aws-budgets";
 import { compose, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import type { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import { createBudgetBuilder } from "../src/budget-builder.js";
 import {
@@ -279,6 +280,37 @@ describe("createBudgetAlarmBuilder", () => {
         Match.stringLikeRegexp("AWS/Billing EstimatedCharges"),
       );
       expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #budget and #customAlarms across .copy()", () => {
+      const { result: budgetResult } = buildBudget();
+
+      assertCopyPreservesState({
+        factory: () => createBudgetAlarmBuilder().budget(budgetResult).recommendedAlarms(false),
+        configure: (b) => {
+          b.addAlarm("firstCustom", ec2EstimatedCharges);
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) =>
+            a
+              .metric(
+                () =>
+                  new Metric({
+                    namespace: "AWS/Billing",
+                    metricName: "EstimatedCharges",
+                    dimensionsMap: { Currency: "USD", ServiceName: "AmazonS3" },
+                    statistic: "Maximum",
+                  }),
+              )
+              .threshold(100)
+              .greaterThan(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "AlarmStack", { env: ENV_US_EAST_1 }), "Alarms"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
     });
   });
 });

--- a/packages/budgets/test/budget-builder.test.ts
+++ b/packages/budgets/test/budget-builder.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createBudgetBuilder } from "../src/budget-builder.js";
 import { email } from "../src/email.js";
 import type { NotifySubscribers } from "../src/notifications.js";
@@ -377,6 +379,63 @@ describe("BudgetBuilder", () => {
             }),
           }),
         ]),
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #notifications across .copy()", () => {
+      assertCopyPreservesState({
+        factory: () => createBudgetBuilder().budgetName("Account").limit({ amount: 1000 }),
+        configure: (b) => {
+          b.notifyOnActual(80, { emails: [email("first@example.com")] });
+        },
+        mutate: (b) => {
+          b.notifyOnForecasted(100, { emails: [email("second@example.com")] });
+        },
+        build: (b) => b.build(newStack(), "Budget"),
+        inspect: (r) => {
+          const template = Template.fromStack(Stack.of(r.budget));
+          const budgets = template.findResources("AWS::Budgets::Budget");
+          const entry = Object.values(budgets)[0] as
+            | { Properties: { NotificationsWithSubscribers?: { Notification: object }[] } }
+            | undefined;
+          return (entry?.Properties.NotificationsWithSubscribers ?? []).map((n) => n.Notification);
+        },
+      });
+    });
+
+    it("preserves #customAlarms across .copy()", () => {
+      const billingMetric = (): Metric =>
+        new Metric({
+          namespace: "AWS/Billing",
+          metricName: "EstimatedCharges",
+          dimensionsMap: { Currency: "USD" },
+          statistic: "Maximum",
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createBudgetBuilder()
+            .budgetName("Account")
+            .limit({ amount: 1000 })
+            .recommendedAlarms(false),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (alarm) =>
+            alarm.metric(billingMetric).threshold(500).greaterThan(),
+          );
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (alarm) =>
+            alarm.metric(billingMetric).threshold(800).greaterThan(),
+          );
+        },
+        build: (b) =>
+          b.build(
+            new Stack(new App(), "S", { env: { account: "123456789012", region: "us-east-1" } }),
+            "Budget",
+          ),
+        inspect: (r) => Object.keys(r.alarms).sort(),
       });
     });
   });


### PR DESCRIPTION
## Summary

PR 3 of issue #84 — adds `[COPY_STATE]` to `BudgetBuilder` (`#notifications`, `#customAlarms`) and `BudgetAlarmBuilder` (`#budget`, `#customAlarms`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

`#budget` is a `Resolvable<BudgetBuilderResult>` — a single ref, shared by reference between original and copy per ADR-0005's elements-shared rule. The two arrays are spread into fresh containers.

## Test plan

- [x] `npx nx test budgets` — 70 tests pass (3 new)
- [x] All three new tests fail with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)