### PR TITLE
feat(cloudfront): add [COPY_STATE] to Distribution/CloudFrontAlarmBuilder (#84)

### DIFF
--- a/packages/cloudfront/src/cloudfront-alarm-builder.ts
+++ b/packages/cloudfront/src/cloudfront-alarm-builder.ts
@@ -2,7 +2,7 @@ import { type Distribution } from "aws-cdk-lib/aws-cloudfront";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Annotations, Stack, Token } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
@@ -168,6 +168,12 @@ class CloudFrontAlarmBuilder implements Lifecycle<CloudFrontAlarmBuilderResult> 
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<Distribution>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: CloudFrontAlarmBuilder): void {
+    target.#distribution = this.#distribution;
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -15,7 +15,7 @@ import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type Bucket, type IBucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import {
@@ -403,6 +403,14 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
     this.#behaviorSlugs.set(slug, pathPattern);
     this.#additionalBehaviors.set(pathPattern, config);
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: DistributionBuilder): void {
+    target.#origin = this.#origin;
+    for (const [k, v] of this.#additionalBehaviors) target.#additionalBehaviors.set(k, v);
+    for (const [k, v] of this.#behaviorSlugs) target.#behaviorSlugs.set(k, v);
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(

--- a/packages/cloudfront/test/cloudfront-alarm-builder.test.ts
+++ b/packages/cloudfront/test/cloudfront-alarm-builder.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { HttpOrigin, S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
-import { FunctionCode, FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
+import { type Distribution, FunctionCode, FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
 import { compose, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createDistributionBuilder } from "../src/distribution-builder.js";
 import {
   createCloudFrontAlarmBuilder,
@@ -403,5 +404,37 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     expect(entries).toHaveLength(2);
     expect(entries.map((e) => e.pathPattern)).toEqual([null, "/api/*"]);
     expect(entries.every((e) => e.eventType === FunctionEventType.VIEWER_REQUEST)).toBe(true);
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #distribution and #customAlarms across .copy()", () => {
+      const { result: distributionResult } = buildDistribution();
+
+      const requestMetric = (dist: Distribution): Metric =>
+        new Metric({
+          namespace: "AWS/CloudFront",
+          metricName: "Requests",
+          dimensionsMap: { DistributionId: dist.distributionId, Region: "Global" },
+          statistic: "Sum",
+          period: Duration.minutes(5),
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createCloudFrontAlarmBuilder().distribution(distributionResult).recommendedAlarms(false),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) =>
+            a.metric(requestMetric).threshold(1000).greaterThanOrEqual(),
+          );
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) =>
+            a.metric(requestMetric).threshold(2000).greaterThanOrEqual(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "AlarmStack"), "Alarms"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
+    });
   });
 });

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
-import { CachePolicy, PriceClass, ViewerProtocolPolicy } from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin, S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import {
+  CachePolicy,
+  type Distribution,
+  PriceClass,
+  ViewerProtocolPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { type BucketBuilderResult } from "@composurecdk/s3";
 import { createDistributionBuilder } from "../src/distribution-builder.js";
 
@@ -553,6 +560,53 @@ describe("DistributionBuilder", () => {
 
       const [, distResource] = distribution;
       expect(distResource.DependsOn).toBeUndefined();
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #origin, #additionalBehaviors, and #customAlarms across .copy()", () => {
+      const requestMetric = (dist: Distribution): Metric =>
+        new Metric({
+          namespace: "AWS/CloudFront",
+          metricName: "Requests",
+          dimensionsMap: { DistributionId: dist.distributionId, Region: "Global" },
+          statistic: "Sum",
+          period: Duration.minutes(5),
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createDistributionBuilder()
+            .origin(new HttpOrigin("origin.example.com"))
+            .accessLogs(false)
+            .recommendedAlarms(false),
+        configure: (b) => {
+          b.behavior("/api/*", {
+            origin: new HttpOrigin("api.example.com"),
+          }).addAlarm("firstCustom", (a) =>
+            a.metric(requestMetric).threshold(1000).greaterThanOrEqual(),
+          );
+        },
+        mutate: (b) => {
+          b.behavior("/cdn/*", {
+            origin: new HttpOrigin("cdn.example.com"),
+          }).addAlarm("secondCustom", (a) =>
+            a.metric(requestMetric).threshold(2000).greaterThanOrEqual(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Distribution"),
+        inspect: (r) => {
+          const stack = Stack.of(r.distribution);
+          const template = Template.fromStack(stack);
+          const dists = Object.values(template.findResources("AWS::CloudFront::Distribution")) as {
+            Properties: { DistributionConfig: { CacheBehaviors?: { PathPattern: string }[] } };
+          }[];
+          const patterns = (dists[0]?.Properties.DistributionConfig.CacheBehaviors ?? [])
+            .map((cb) => cb.PathPattern)
+            .sort();
+          return { patterns, alarms: Object.keys(r.alarms).sort() };
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

PR 4 of issue #84 — adds `[COPY_STATE]` to `DistributionBuilder` (`#origin`, `#additionalBehaviors`, `#behaviorSlugs`, `#customAlarms`) and `CloudFrontAlarmBuilder` (`#distribution`, `#customAlarms`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

Maps are reconstructed; entries (origin refs, behavior configs, alarm builders) are shared by reference per ADR-0005's elements-shared rule.

## Test plan

- [x] `npx nx test cloudfront` — 106 tests pass (2 new)
- [x] Both new tests fail with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)