### PR TITLE
feat(ec2): add [COPY_STATE] to Instance/VolumeBuilder (#84)

### DIFF
--- a/packages/ec2/src/instance-builder.ts
+++ b/packages/ec2/src/instance-builder.ts
@@ -9,7 +9,7 @@ import {
 } from "aws-cdk-lib/aws-ec2";
 import { type IRole } from "aws-cdk-lib/aws-iam";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { InstanceAlarmConfig } from "./instance-alarm-config.js";
@@ -231,6 +231,13 @@ class InstanceBuilder implements Lifecycle<InstanceBuilderResult> {
     }
     this.#volumeAttachments.push({ key, volumeRef, options });
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: InstanceBuilder): void {
+    target.#vpc = this.#vpc;
+    target.#customAlarms.push(...this.#customAlarms);
+    target.#volumeAttachments.push(...this.#volumeAttachments);
   }
 
   build(scope: IConstruct, id: string, context?: Record<string, object>): InstanceBuilderResult {

--- a/packages/ec2/src/volume-builder.ts
+++ b/packages/ec2/src/volume-builder.ts
@@ -2,7 +2,7 @@ import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Volume, type VolumeProps } from "aws-cdk-lib/aws-ec2";
 import { type IKey } from "aws-cdk-lib/aws-kms";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { VolumeAlarmConfig } from "./volume-alarm-config.js";
@@ -156,6 +156,12 @@ class VolumeBuilder implements Lifecycle<VolumeBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<Volume>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: VolumeBuilder): void {
+    target.#availabilityZone = this.#availabilityZone;
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string, context?: Record<string, object>): VolumeBuilderResult {

--- a/packages/ec2/test/instance-builder.test.ts
+++ b/packages/ec2/test/instance-builder.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Size, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import {
+  type IVolume,
+  type IVpc,
+  type Instance,
   InstanceClass,
   InstanceSize,
   InstanceType,
   KeyPair,
   MachineImage,
   SecurityGroup,
+  Volume,
   Vpc,
 } from "aws-cdk-lib/aws-ec2";
 import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createInstanceBuilder } from "../src/instance-builder.js";
 import { createVpcBuilder } from "../src/vpc-builder.js";
 
@@ -216,6 +222,53 @@ describe("InstanceBuilder", () => {
       const template = Template.fromStack(stack);
       // VPC default SG + the user's SG. No extra instance-created SG.
       template.resourceCountIs("AWS::EC2::SecurityGroup", 1);
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #vpc, #customAlarms, and #volumeAttachments across .copy()", () => {
+      interface InfraEntry {
+        vpc: IVpc;
+        volume: IVolume;
+      }
+      const vpcRef = ref<InfraEntry>("infra").map((r) => r.vpc);
+      const volumeRef = ref<InfraEntry>("infra").map((r) => r.volume);
+
+      const cpuMetric = (instance: Instance): Metric =>
+        new Metric({
+          namespace: "AWS/EC2",
+          metricName: "CPUUtilization",
+          dimensionsMap: { InstanceId: instance.instanceId },
+          statistic: "Average",
+          period: Duration.minutes(5),
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createInstanceBuilder()
+            .vpc(vpcRef)
+            .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
+            .machineImage(MachineImage.latestAmazonLinux2023())
+            .recommendedAlarms(false),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) => a.metric(cpuMetric).threshold(80).greaterThanOrEqual());
+          b.attachVolume("first", volumeRef, { device: "/dev/sdf" });
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) => a.metric(cpuMetric).threshold(90).greaterThanOrEqual());
+          b.attachVolume("second", volumeRef, { device: "/dev/sdg" });
+        },
+        build: (b) => {
+          const stack = new Stack(new App(), "S");
+          const vpc = new Vpc(stack, "Vpc", { maxAzs: 2, natGateways: 0 });
+          const volume = new Volume(stack, "ExternalVolume", {
+            availabilityZone: vpc.availabilityZones[0],
+            size: Size.gibibytes(10),
+          });
+          return b.build(stack, "Instance", { infra: { vpc, volume } });
+        },
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
     });
   });
 });

--- a/packages/ec2/test/volume-builder.test.ts
+++ b/packages/ec2/test/volume-builder.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { App, RemovalPolicy, Size, Stack } from "aws-cdk-lib";
+import { App, Duration, RemovalPolicy, Size, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { EbsDeviceVolumeType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { EbsDeviceVolumeType, type Volume, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Key } from "aws-cdk-lib/aws-kms";
 import { ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createVolumeBuilder } from "../src/volume-builder.js";
 import { createVpcBuilder } from "../src/vpc-builder.js";
 
@@ -147,6 +149,34 @@ describe("VolumeBuilder", () => {
 
       template.hasResourceProperties("AWS::EC2::Volume", {
         MultiAttachEnabled: true,
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #availabilityZone and #customAlarms across .copy()", () => {
+      const idleMetric = (volume: Volume): Metric =>
+        new Metric({
+          namespace: "AWS/EBS",
+          metricName: "VolumeIdleTime",
+          dimensionsMap: { VolumeId: volume.volumeId },
+          statistic: "Average",
+          period: Duration.minutes(5),
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createVolumeBuilder().availabilityZone("us-east-1a").size(Size.gibibytes(50)),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) => a.metric(idleMetric).threshold(60).greaterThanOrEqual());
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) =>
+            a.metric(idleMetric).threshold(120).greaterThanOrEqual(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Volume"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
       });
     });
   });


### PR DESCRIPTION
## Summary

PR 5 of issue #84 — adds `[COPY_STATE]` to `InstanceBuilder` (`#vpc`, `#customAlarms`, `#volumeAttachments`) and `VolumeBuilder` (`#availabilityZone`, `#customAlarms`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

## Test plan

- [x] `npx nx test ec2` — 89 tests pass (2 new)
- [x] Both new tests fail with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)