### PR TITLE
feat(iam): add [COPY_STATE] to Role/ManagedPolicyBuilder (#84)

### DIFF
--- a/packages/iam/src/managed-policy-builder.ts
+++ b/packages/iam/src/managed-policy-builder.ts
@@ -1,6 +1,6 @@
 import { ManagedPolicy, type ManagedPolicyProps, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { IConstruct } from "constructs";
-import { Builder, type IBuilder, type Lifecycle } from "@composurecdk/core";
+import { Builder, COPY_STATE, type IBuilder, type Lifecycle } from "@composurecdk/core";
 import { StatementBuilder } from "./statement-builder.js";
 
 /**
@@ -55,6 +55,11 @@ class ManagedPolicyBuilder implements Lifecycle<ManagedPolicyBuilderResult> {
   addStatements(statements: (PolicyStatement | StatementBuilder)[]): this {
     this.#extraStatements.push(...statements);
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: ManagedPolicyBuilder): void {
+    target.#extraStatements.push(...this.#extraStatements);
   }
 
   build(scope: IConstruct, id: string): ManagedPolicyBuilderResult {

--- a/packages/iam/src/role-builder.ts
+++ b/packages/iam/src/role-builder.ts
@@ -6,7 +6,7 @@ import {
   type RoleProps,
 } from "aws-cdk-lib/aws-iam";
 import type { IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { ROLE_DEFAULTS } from "./role-defaults.js";
 import { StatementBuilder } from "./statement-builder.js";
@@ -114,6 +114,11 @@ class RoleBuilder implements Lifecycle<RoleBuilderResult> {
   ): this {
     this.#inlinePolicies.push({ name, statements });
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: RoleBuilder): void {
+    target.#inlinePolicies.push(...this.#inlinePolicies);
   }
 
   build(scope: IConstruct, id: string, context: Record<string, object> = {}): RoleBuilderResult {

--- a/packages/iam/test/managed-policy-builder.test.ts
+++ b/packages/iam/test/managed-policy-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createManagedPolicyBuilder } from "../src/managed-policy-builder.js";
 import { createStatementBuilder } from "../src/statement-builder.js";
 
@@ -64,6 +65,39 @@ describe("ManagedPolicyBuilder", () => {
           Match.objectLike({ Action: "s3:PutObject" }),
         ]),
       }),
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #extraStatements across .copy()", () => {
+      assertCopyPreservesState({
+        factory: () => createManagedPolicyBuilder().managedPolicyName("test"),
+        configure: (b) => {
+          b.addStatements([
+            new PolicyStatement({
+              actions: ["s3:GetObject"],
+              resources: ["arn:aws:s3:::bucket-1/*"],
+            }),
+          ]);
+        },
+        mutate: (b) => {
+          b.addStatements([
+            new PolicyStatement({
+              actions: ["s3:PutObject"],
+              resources: ["arn:aws:s3:::bucket-2/*"],
+            }),
+          ]);
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Policy"),
+        inspect: (r) => {
+          const stack = Stack.of(r.policy);
+          const policies = Template.fromStack(stack).findResources("AWS::IAM::ManagedPolicy");
+          const entry = Object.values(policies)[0] as
+            | { Properties: { PolicyDocument: { Statement: { Action: string }[] } } }
+            | undefined;
+          return (entry?.Properties.PolicyDocument.Statement ?? []).map((s) => s.Action).sort();
+        },
+      });
     });
   });
 });

--- a/packages/iam/test/role-builder.test.ts
+++ b/packages/iam/test/role-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { ManagedPolicy, PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createRoleBuilder } from "../src/role-builder.js";
 import { createStatementBuilder, WildcardResourceError } from "../src/statement-builder.js";
 
@@ -167,6 +168,32 @@ describe("RoleBuilder", () => {
             ]),
           }),
         ]),
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #inlinePolicies across .copy()", () => {
+      assertCopyPreservesState({
+        factory: () => createRoleBuilder().assumedBy(new ServicePrincipal("lambda.amazonaws.com")),
+        configure: (b) => {
+          b.addInlinePolicyStatements("first", [
+            new PolicyStatement({
+              actions: ["s3:GetObject"],
+              resources: ["arn:aws:s3:::bucket-1/*"],
+            }),
+          ]);
+        },
+        mutate: (b) => {
+          b.addInlinePolicyStatements("second", [
+            new PolicyStatement({
+              actions: ["s3:PutObject"],
+              resources: ["arn:aws:s3:::bucket-2/*"],
+            }),
+          ]);
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Role"),
+        inspect: (r) => Object.keys(r.inlinePolicies).sort(),
       });
     });
   });


### PR DESCRIPTION
## Summary

PR 6 of issue #84 — adds `[COPY_STATE]` to `RoleBuilder` (`#inlinePolicies`) and `ManagedPolicyBuilder` (`#extraStatements`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

## Test plan

- [x] `npx nx test iam` — 22 tests pass (2 new)
- [x] Both new tests fail with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)