### PR TITLE
feat(lambda): add [COPY_STATE] to FunctionBuilder (#84)

### DIFF
--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -2,7 +2,7 @@ import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Function as LambdaFunction, type FunctionProps } from "aws-cdk-lib/aws-lambda";
 import type { LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import { type Lifecycle } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import { createLogGroupBuilder } from "@composurecdk/logs";
@@ -121,6 +121,11 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<LambdaFunction>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: FunctionBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string): FunctionBuilderResult {

--- a/packages/lambda/test/function-builder.test.ts
+++ b/packages/lambda/test/function-builder.test.ts
@@ -2,8 +2,17 @@ import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match } from "aws-cdk-lib/assertions";
 import { Template } from "aws-cdk-lib/assertions";
-import { Code, LoggingFormat, Runtime, Tracing, Architecture } from "aws-cdk-lib/aws-lambda";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  Architecture,
+  Code,
+  type Function as LambdaFunction,
+  LoggingFormat,
+  Runtime,
+  Tracing,
+} from "aws-cdk-lib/aws-lambda";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createFunctionBuilder } from "../src/function-builder.js";
 
 function synthTemplate(
@@ -379,6 +388,37 @@ describe("FunctionBuilder", () => {
       expect(Object.values(logGroups)[0]?.Properties.Tags).toEqual(
         expect.arrayContaining([{ Key: "Owner", Value: "platform" }]),
       );
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #customAlarms across .copy()", () => {
+      const errorMetric = (fn: LambdaFunction): Metric =>
+        new Metric({
+          namespace: "AWS/Lambda",
+          metricName: "Errors",
+          dimensionsMap: { FunctionName: fn.functionName },
+          statistic: "Sum",
+          period: Duration.minutes(5),
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createFunctionBuilder()
+            .runtime(Runtime.NODEJS_22_X)
+            .handler("index.handler")
+            .code(Code.fromInline("exports.handler = async () => {}")),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) => a.metric(errorMetric).threshold(1).greaterThanOrEqual());
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) =>
+            a.metric(errorMetric).threshold(5).greaterThanOrEqual(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Function"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

PR 7 of issue #84 — adds `[COPY_STATE]` to `FunctionBuilder` (`#customAlarms`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

## Test plan

- [x] `npx nx test lambda` — 55 tests pass (1 new)
- [x] New test fails with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)