### PR TITLE
feat(route53): add [COPY_STATE] to HealthCheck/HealthCheckAlarmBuilder (#84)

### DIFF
--- a/packages/route53/src/health-check-alarm-builder.ts
+++ b/packages/route53/src/health-check-alarm-builder.ts
@@ -2,7 +2,7 @@ import { type IHealthCheck } from "aws-cdk-lib/aws-route53";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Annotations, Stack, Token } from "aws-cdk-lib";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms } from "@composurecdk/cloudwatch";
@@ -154,6 +154,12 @@ class HealthCheckAlarmBuilder implements Lifecycle<HealthCheckAlarmBuilderResult
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IHealthCheck>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: HealthCheckAlarmBuilder): void {
+    target.#healthCheck = this.#healthCheck;
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(

--- a/packages/route53/src/health-check-builder.ts
+++ b/packages/route53/src/health-check-builder.ts
@@ -1,7 +1,7 @@
 import { HealthCheck, type HealthCheckProps, type IHealthCheck } from "aws-cdk-lib/aws-route53";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
-import { type Lifecycle } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { HealthCheckAlarmConfig } from "./health-check-alarm-config.js";
@@ -94,6 +94,11 @@ class HealthCheckBuilder implements Lifecycle<HealthCheckBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IHealthCheck>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: HealthCheckBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string): HealthCheckBuilderResult {

--- a/packages/route53/test/health-check-alarm-builder.test.ts
+++ b/packages/route53/test/health-check-alarm-builder.test.ts
@@ -4,6 +4,7 @@ import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { HealthCheckType, type IHealthCheck } from "aws-cdk-lib/aws-route53";
 import { compose, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import type { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import { createHealthCheckBuilder } from "../src/health-check-builder.js";
 import {
@@ -224,6 +225,38 @@ describe("createHealthCheckAlarmBuilder", () => {
         Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
       );
       expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #healthCheck and #customAlarms across .copy()", () => {
+      const { result: healthCheckResult } = buildHealthCheck();
+
+      assertCopyPreservesState({
+        factory: () =>
+          createHealthCheckAlarmBuilder().healthCheck(healthCheckResult).recommendedAlarms(false),
+        configure: (b) => {
+          b.addAlarm("firstCustom", connectionTimeAlarm);
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) =>
+            a
+              .metric(
+                (hc) =>
+                  new Metric({
+                    namespace: "AWS/Route53",
+                    metricName: "HealthCheckPercentageHealthy",
+                    dimensionsMap: { HealthCheckId: hc.healthCheckId },
+                    statistic: "Average",
+                  }),
+              )
+              .threshold(100)
+              .lessThan(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "AlarmStack", { env: ENV_US_EAST_1 }), "Alarms"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
     });
   });
 });

--- a/packages/route53/test/health-check-builder.test.ts
+++ b/packages/route53/test/health-check-builder.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
-import { HealthCheckType } from "aws-cdk-lib/aws-route53";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { HealthCheckType, type IHealthCheck } from "aws-cdk-lib/aws-route53";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createHealthCheckBuilder } from "../src/health-check-builder.js";
 
 const ENV_US_EAST_1 = { account: "123456789012", region: "us-east-1" };
@@ -107,6 +109,36 @@ describe("createHealthCheckBuilder", () => {
         Match.stringLikeRegexp("Route 53 health-check metrics are emitted"),
       );
       expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #customAlarms across .copy()", () => {
+      const connectionTimeMetric = (hc: IHealthCheck): Metric =>
+        new Metric({
+          namespace: "AWS/Route53",
+          metricName: "ConnectionTime",
+          dimensionsMap: { HealthCheckId: hc.healthCheckId },
+          statistic: "Average",
+          period: Duration.minutes(1),
+        });
+
+      assertCopyPreservesState({
+        factory: () =>
+          createHealthCheckBuilder().type(HealthCheckType.HTTPS).fqdn("api.example.com"),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) =>
+            a.metric(connectionTimeMetric).threshold(2000).greaterThan(),
+          );
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) =>
+            a.metric(connectionTimeMetric).threshold(3000).greaterThan(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "S", { env: ENV_US_EAST_1 }), "HealthCheck"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

PR 8 of issue #84 — adds `[COPY_STATE]` to `HealthCheckBuilder` (`#customAlarms`) and `HealthCheckAlarmBuilder` (`#healthCheck`, `#customAlarms`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

## Test plan

- [x] `npx nx test route53` — 97 tests pass (2 new)
- [x] Both new tests fail with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)