### PR TITLE
feat(s3): add [COPY_STATE] to Bucket/BucketDeploymentBuilder (#84)

### DIFF
--- a/packages/s3/src/bucket-builder.ts
+++ b/packages/s3/src/bucket-builder.ts
@@ -2,7 +2,7 @@ import { RemovalPolicy } from "aws-cdk-lib";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket, type BucketProps, type IBucket } from "aws-cdk-lib/aws-s3";
 import { type IConstruct } from "constructs";
-import { type Lifecycle } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { BucketAlarmConfig } from "./alarm-config.js";
@@ -118,6 +118,11 @@ class BucketBuilder implements Lifecycle<BucketBuilderResult> {
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<Bucket>(key)));
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: BucketBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
   }
 
   build(scope: IConstruct, id: string): BucketBuilderResult {

--- a/packages/s3/src/bucket-deployment-builder.ts
+++ b/packages/s3/src/bucket-deployment-builder.ts
@@ -3,7 +3,7 @@ import { type IBucket } from "aws-cdk-lib/aws-s3";
 import { type IDistribution } from "aws-cdk-lib/aws-cloudfront";
 import type { LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { createLogGroupBuilder } from "@composurecdk/logs";
 import { effectiveDefaults } from "./bucket-deployment-defaults.js";
@@ -90,6 +90,12 @@ class BucketDeploymentBuilder implements Lifecycle<BucketDeploymentBuilderResult
   distribution(distribution: Resolvable<IDistribution>): this {
     this.#distribution = distribution;
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: BucketDeploymentBuilder): void {
+    target.#destinationBucket = this.#destinationBucket;
+    target.#distribution = this.#distribution;
   }
 
   build(

--- a/packages/s3/test/bucket-builder.test.ts
+++ b/packages/s3/test/bucket-builder.test.ts
@@ -3,6 +3,7 @@ import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createBucketBuilder } from "../src/bucket-builder.js";
 
 function synthTemplate(
@@ -532,6 +533,31 @@ describe("BucketBuilder", () => {
           { Key: "Environment", Value: "prod" },
         ]),
       );
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #customAlarms across .copy()", () => {
+      const sizeMetric = (bucket: Bucket): Metric =>
+        new Metric({
+          namespace: "AWS/S3",
+          metricName: "BucketSizeBytes",
+          dimensionsMap: { BucketName: bucket.bucketName, StorageType: "StandardStorage" },
+          statistic: "Average",
+          period: Duration.days(1),
+        });
+
+      assertCopyPreservesState({
+        factory: () => createBucketBuilder().serverAccessLogs(false),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) => a.metric(sizeMetric).threshold(1e9).greaterThan());
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) => a.metric(sizeMetric).threshold(5e9).greaterThan());
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Bucket"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
     });
   });
 });

--- a/packages/s3/test/bucket-deployment-builder.test.ts
+++ b/packages/s3/test/bucket-deployment-builder.test.ts
@@ -6,7 +6,8 @@ import { Distribution } from "aws-cdk-lib/aws-cloudfront";
 import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Source } from "aws-cdk-lib/aws-s3-deployment";
-import { Ref } from "@composurecdk/core";
+import { Ref, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createBucketDeploymentBuilder } from "../src/bucket-deployment-builder.js";
 import { BUCKET_DEPLOYMENT_DEFAULTS } from "../src/bucket-deployment-defaults.js";
 
@@ -321,6 +322,45 @@ describe("BucketDeploymentBuilder", () => {
       template.resourceCountIs("AWS::Logs::LogGroup", 1);
       template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 7,
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #destinationBucket and #distribution across .copy()", () => {
+      const bucketRefA = ref<{ bucket: Bucket }>("bucketA").map((r) => r.bucket);
+      const bucketRefB = ref<{ bucket: Bucket }>("bucketB").map((r) => r.bucket);
+
+      assertCopyPreservesState({
+        factory: () => createBucketDeploymentBuilder().sources([Source.asset("./test")]),
+        configure: (b) => {
+          b.destinationBucket(bucketRefA);
+        },
+        // Switching to a different ref on the original after copy. The copy
+        // must keep using bucketA — proven by the synthesised
+        // DestinationBucketName diverging between original and copy.
+        mutate: (b) => {
+          b.destinationBucket(bucketRefB);
+        },
+        build: (b) => {
+          const stack = new Stack(new App(), "S");
+          const bucketA = new Bucket(stack, "BucketA");
+          const bucketB = new Bucket(stack, "BucketB");
+          return b.build(stack, "Deploy", {
+            bucketA: { bucket: bucketA },
+            bucketB: { bucket: bucketB },
+          });
+        },
+        inspect: (r) => {
+          const stack = Stack.of(r.deployment);
+          const deployments = Template.fromStack(stack).findResources(
+            "Custom::CDKBucketDeployment",
+          );
+          const entry = Object.values(deployments)[0] as
+            | { Properties: { DestinationBucketName: unknown } }
+            | undefined;
+          return JSON.stringify(entry?.Properties.DestinationBucketName);
+        },
       });
     });
   });


### PR DESCRIPTION
## Summary

PR 9 of issue #84 — adds `[COPY_STATE]` to `BucketBuilder` (`#customAlarms`) and `BucketDeploymentBuilder` (`#destinationBucket`, `#distribution`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

## Test plan

- [x] `npx nx test s3` — 79 tests pass (2 new)
- [x] Both new tests fail with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)