### PR TITLE
feat(sns): add [COPY_STATE] to TopicBuilder (#84)

### DIFF
--- a/packages/sns/src/topic-builder.ts
+++ b/packages/sns/src/topic-builder.ts
@@ -7,7 +7,7 @@ import {
   type TopicProps,
 } from "aws-cdk-lib/aws-sns";
 import { type IConstruct } from "constructs";
-import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { TopicAlarmConfig } from "./topic-alarm-config.js";
@@ -138,6 +138,12 @@ class TopicBuilder implements Lifecycle<TopicBuilderResult> {
     }
     this.#subscriptions.push({ key, subscription });
     return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: TopicBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
+    target.#subscriptions.push(...this.#subscriptions);
   }
 
   build(scope: IConstruct, id: string, context?: Record<string, object>): TopicBuilderResult {

--- a/packages/sns/test/topic-builder.test.ts
+++ b/packages/sns/test/topic-builder.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { type ITopic } from "aws-cdk-lib/aws-sns";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import {
   EmailSubscription,
@@ -9,6 +11,7 @@ import {
   SqsSubscription,
 } from "aws-cdk-lib/aws-sns-subscriptions";
 import { ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createTopicBuilder } from "../src/topic-builder.js";
 
 function synthTemplate(
@@ -210,6 +213,40 @@ describe("TopicBuilder", () => {
       const template = synthTemplate((b) => b.enforceSSL(false));
 
       template.resourceCountIs("AWS::SNS::TopicPolicy", 0);
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #customAlarms and #subscriptions across .copy()", () => {
+      const failedMetric = (topic: ITopic): Metric =>
+        new Metric({
+          namespace: "AWS/SNS",
+          metricName: "NumberOfNotificationsFailed",
+          dimensionsMap: { TopicName: topic.topicName },
+          statistic: "Sum",
+          period: Duration.minutes(5),
+        });
+
+      assertCopyPreservesState({
+        factory: () => createTopicBuilder().recommendedAlarms(false),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) =>
+            a.metric(failedMetric).threshold(1).greaterThanOrEqual(),
+          );
+          b.addSubscription("first", new EmailSubscription("first@example.com"));
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) =>
+            a.metric(failedMetric).threshold(5).greaterThanOrEqual(),
+          );
+          b.addSubscription("second", new EmailSubscription("second@example.com"));
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Topic"),
+        inspect: (r) => ({
+          alarms: Object.keys(r.alarms).sort(),
+          subscriptions: Object.keys(r.subscriptions).sort(),
+        }),
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

PR 10 of issue #84 — adds `[COPY_STATE]` to `TopicBuilder` (`#customAlarms`, `#subscriptions`) per ADR-0005.

**Stacked on #87** (PR 0 — the helper). Will rebase onto `main` once #87 lands.

## Test plan

- [x] `npx nx test sns` — 48 tests pass (1 new)
- [x] New test fails with the source change stashed
- [x] `npm run lint` clean; `npm run format:check` clean; `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)