### PR TITLE
feat(eslint): add builder-must-implement-copy-state rule (#84)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,6 +105,132 @@ const lifecycleContextParamRule = {
   },
 };
 
+/**
+ * Flags builder classes (passed as the first arg to `Builder()` or
+ * `taggedBuilder()`) that hold private state without a `[COPY_STATE]` hook.
+ * Per ADR-0005, `.copy()` shallow-clones `props`; non-`props` state needs
+ * `[COPY_STATE]` to carry it onto the cloned instance, otherwise `.copy()`
+ * silently drops it and breaks both variant authoring and strategy hand-off.
+ *
+ * The rule checks for *existence* of the hook, not correctness — a hook
+ * that copies three of five fields will pass. The companion test helper
+ * `assertCopyPreservesState` (`@composurecdk/core/testing`) closes the
+ * correctness gap on the test side.
+ *
+ * **Per-field opt-out.** Annotate a field with a leading
+ * `// @copy-state: ignore -- justification` comment to exempt it (e.g.
+ * for cache-shaped state that's regenerated per build). The justification
+ * after `--` is required.
+ */
+const builderCopyStateRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Builder classes with private fields must implement `[COPY_STATE]` " +
+        "(or annotate fields with `// @copy-state: ignore -- reason`). See ADR-0005.",
+    },
+    schema: [],
+    messages: {
+      missingHook:
+        "Builder class `{{className}}` has private field(s) {{fields}} but no `[COPY_STATE]` hook. " +
+        "Without the hook, `.copy()` silently drops these fields. " +
+        "Implement `[COPY_STATE](target) { … }` (see ADR-0005) or annotate each field with " +
+        "`// @copy-state: ignore -- reason`.",
+      ignoreMarkerNeedsJustification:
+        "`@copy-state: ignore` on field `{{field}}` must include a justification after `--` " +
+        "(e.g. `// @copy-state: ignore -- regenerated per build`). The reason survives refactors " +
+        "and shows up in code review.",
+    },
+  },
+  create(ctx) {
+    const sourceCode = ctx.sourceCode;
+    const builderFactoryNames = new Set();
+    const classNodes = new Map();
+    const builderClassNames = new Set();
+    return {
+      ImportDeclaration(node) {
+        if (
+          node.source.value !== "@composurecdk/core" &&
+          node.source.value !== "@composurecdk/cloudformation"
+        ) {
+          return;
+        }
+        for (const spec of node.specifiers) {
+          if (spec.type !== "ImportSpecifier") continue;
+          if (spec.imported.name === "Builder" || spec.imported.name === "taggedBuilder") {
+            builderFactoryNames.add(spec.local.name);
+          }
+        }
+      },
+      ClassDeclaration(node) {
+        if (node.id) classNodes.set(node.id.name, node);
+      },
+      CallExpression(node) {
+        if (node.callee.type !== "Identifier") return;
+        if (!builderFactoryNames.has(node.callee.name)) return;
+        const arg = node.arguments[0];
+        if (arg && arg.type === "Identifier") builderClassNames.add(arg.name);
+      },
+      "Program:exit"() {
+        for (const className of builderClassNames) {
+          const classNode = classNodes.get(className);
+          if (!classNode) continue;
+
+          const privateFields = [];
+          let hasCopyStateHook = false;
+          for (const member of classNode.body.body) {
+            if (member.type === "PropertyDefinition" && member.key.type === "PrivateIdentifier") {
+              privateFields.push(member);
+            } else if (
+              member.type === "MethodDefinition" &&
+              member.computed === true &&
+              member.key.type === "Identifier" &&
+              member.key.name === "COPY_STATE"
+            ) {
+              hasCopyStateHook = true;
+            }
+          }
+
+          const fieldsNeedingHook = [];
+          for (const field of privateFields) {
+            const ignoreState = readIgnoreMarker(field, sourceCode);
+            if (ignoreState === "valid") continue;
+            if (ignoreState === "missing-justification") {
+              ctx.report({
+                node: field,
+                messageId: "ignoreMarkerNeedsJustification",
+                data: { field: `#${field.key.name}` },
+              });
+              continue;
+            }
+            fieldsNeedingHook.push(`#${field.key.name}`);
+          }
+
+          if (!hasCopyStateHook && fieldsNeedingHook.length > 0) {
+            ctx.report({
+              node: classNode.id ?? classNode,
+              messageId: "missingHook",
+              data: { className, fields: fieldsNeedingHook.join(", ") },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+function readIgnoreMarker(fieldNode, sourceCode) {
+  const comments = sourceCode.getCommentsBefore(fieldNode);
+  for (const comment of comments) {
+    const match = /@copy-state:\s*ignore(.*)$/i.exec(comment.value);
+    if (!match) continue;
+    const tail = match[1] ?? "";
+    return /--\s*\S/.test(tail) ? "valid" : "missing-justification";
+  }
+  return "absent";
+}
+
 export default defineConfig(
   { ignores: ["**/dist/", "**/node_modules/", "**/cdk.out/"] },
   eslint.configs.recommended,
@@ -141,12 +267,14 @@ export default defineConfig(
         rules: {
           "lifecycle-build-context-required": lifecycleContextParamRule,
           "builder-must-be-tagged": builderTaggingRule,
+          "builder-must-implement-copy-state": builderCopyStateRule,
         },
       },
     },
     rules: {
       "composurecdk/lifecycle-build-context-required": "error",
       "composurecdk/builder-must-be-tagged": "error",
+      "composurecdk/builder-must-implement-copy-state": "error",
       "no-restricted-syntax": [
         "error",
         {


### PR DESCRIPTION
## Summary

PR 11 (terminal) of issue #84 — adds the ESLint rule `composurecdk/builder-must-implement-copy-state` that enforces ADR-0005 going forward.

**Stacked on #87** (PR 0). **Depends on PRs #88–#97** (the per-package fixes) being merged before this rule passes CI on `main`.

## How the rule works

- Triggers on any class passed as the first arg to `Builder()` or `taggedBuilder()` from `@composurecdk/core`/`@composurecdk/cloudformation`.
- Collects every `PropertyDefinition` whose key is a `PrivateIdentifier`.
- Reports a class-level error listing unhandled fields when no computed `[COPY_STATE]` `MethodDefinition` is present.
- Filters out `MethodDefinition` nodes (private methods) — those are behaviour, not state.
- Per-field opt-out: leading comment `// @copy-state: ignore -- reason`. Marker without justification gets its own error so the reason survives refactors.
- Checks for *existence* of the hook, not correctness — that's what `assertCopyPreservesState` is for.

## Verification

I confirmed the rule fires correctly:

- On a clean main (no per-package fixes): reports 17 errors across 9 builders, with field names listed.
- On a verification merge of PRs 1–10 + this rule: lint passes cleanly.
- Marker without justification: errors with a clear "include `--`" message.
- Marker with justification: no error.

## Expected CI state for this PR

This PR's branch is built on top of PR 0 only — it will fail CI on its own commit until PRs 1–10 are merged into `main` and this branch is rebased. That failure mode IS the forcing function the issue describes ("PR 11 will fail CI on any branch that hasn't yet absorbed PRs 1–10").

## Open question for review

The rule's import-detection considers both `@composurecdk/core` (`Builder`) and `@composurecdk/cloudformation` (`taggedBuilder`) as the entry points. If a future package adds another builder factory wrapper, that wrapper's import source would need adding to the rule. Worth adding a comment or making the source list configurable via the rule's schema? My read: leave it for now — the existing `builder-must-be-tagged` rule has the same shape and we'd touch them together if a third factory ships.

## Test plan

- [x] Rule correctly reports missing hooks with field names listed
- [x] Rule passes when all per-package fixes are present (verified on integration merge of PRs 1–10)
- [x] `// @copy-state: ignore -- reason` exempts a field; missing-`--` reports its own error
- [x] `npm run format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)