### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+## 0.7.0 (2026-05-08)
+
+### 🚀 Features
+
+- ⚠️ roll taggedBuilder out across remaining builders + lint enforcement ([1e6a517](https://github.com/laazyj/composureCDK/commit/1e6a517))
+- **acm:** add [COPY_STATE] hook to CertificateBuilder ([#88](https://github.com/laazyj/composureCDK/pull/88), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **apigateway:** add [COPY_STATE] to RestApi/SpecRestApiBuilder ([#89](https://github.com/laazyj/composureCDK/pull/89), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **budgets:** add [COPY_STATE] to Budget/BudgetAlarmBuilder ([#90](https://github.com/laazyj/composureCDK/pull/90), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **cloudformation:** add taggedBuilder wrapper, tag validator, and result-walker ([#66](https://github.com/laazyj/composureCDK/issues/66))
+- ⚠️ **cloudformation:** route StackBuilder through taggedBuilder, drop bespoke #tags ([5246f65](https://github.com/laazyj/composureCDK/commit/5246f65))
+- **cloudformation:** add tags() afterBuild helper, ADR-0006, docs, example ([76b302b](https://github.com/laazyj/composureCDK/commit/76b302b))
+- **cloudfront:** add [COPY_STATE] to Distribution/CloudFrontAlarmBuilder ([#91](https://github.com/laazyj/composureCDK/pull/91), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **core:** add assertCopyPreservesState test helper at /testing subpath ([55911a0](https://github.com/laazyj/composureCDK/commit/55911a0))
+- **ec2:** createVolumeBuilder with well-architected defaults ([#76](https://github.com/laazyj/composureCDK/issues/76))
+- **ec2:** InstanceBuilder.attachVolume with synth-time AZ validation ([#76](https://github.com/laazyj/composureCDK/issues/76))
+- **ec2:** add [COPY_STATE] to Instance/VolumeBuilder ([#92](https://github.com/laazyj/composureCDK/pull/92), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **eslint:** add builder-must-implement-copy-state rule ([#98](https://github.com/laazyj/composureCDK/pull/98), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **events:** add @composurecdk/events with RuleBuilder, target helpers, alarms ([#85](https://github.com/laazyj/composureCDK/pull/85), [#67](https://github.com/laazyj/composureCDK/issues/67))
+- **iam:** add [COPY_STATE] to Role/ManagedPolicyBuilder ([#93](https://github.com/laazyj/composureCDK/pull/93), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **lambda:** add [COPY_STATE] to FunctionBuilder ([#94](https://github.com/laazyj/composureCDK/pull/94), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **route53:** add [COPY_STATE] to HealthCheck/HealthCheckAlarmBuilder ([#95](https://github.com/laazyj/composureCDK/pull/95), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- ⚠️ **s3:** wire BucketBuilder to taggedBuilder for builder-level .tag() / .tags() ([a8bd4d0](https://github.com/laazyj/composureCDK/commit/a8bd4d0))
+- **s3:** add [COPY_STATE] to Bucket/BucketDeploymentBuilder ([#96](https://github.com/laazyj/composureCDK/pull/96), [#84](https://github.com/laazyj/composureCDK/issues/84))
+- **sns:** add [COPY_STATE] to TopicBuilder ([#97](https://github.com/laazyj/composureCDK/pull/97), [#84](https://github.com/laazyj/composureCDK/issues/84))
+
+### ⚠️ Breaking Changes
+
+- roll taggedBuilder out across remaining builders + lint enforcement ([1e6a517](https://github.com/laazyj/composureCDK/commit/1e6a517))
+  the migrated builders' `IXxxBuilder` aliases now
+  structurally extend `ITaggedBuilder` instead of `IBuilder`. Pure
+  consumers that destructure or annotate against the old shape need to
+  recompile. Pre-1.0; release-please will pick up the bump.
+- **cloudformation:** route StackBuilder through taggedBuilder, drop bespoke #tags ([5246f65](https://github.com/laazyj/composureCDK/commit/5246f65))
+  `StackBuilder.tag()`'s duplicate-key behaviour: previously
+  silent (last-wins observable in CFN tags), now last-wins with a
+  `process.emitWarning`. Functionally compatible; previously-quiet duplicate
+  calls now emit a warning. Pre-1.0; release-please will pick up the bump.
+- **s3:** wire BucketBuilder to taggedBuilder for builder-level .tag() / .tags() ([a8bd4d0](https://github.com/laazyj/composureCDK/commit/a8bd4d0))
+  the `IBucketBuilder` alias structurally extends
+  `ITaggedBuilder` instead of `IBuilder`. Pre-1.0; release-please will
+  pick up the bump.
+
+### ❤️ Thank You
+
+- Claude (laazyj)
+- Claude Opus 4.7 (1M context)
+- Jason Duffett
+
 ## 0.6.0 (2026-05-07)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -7768,7 +7768,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7778,16 +7778,16 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7797,17 +7797,17 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
-        "@composurecdk/logs": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/logs": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7817,16 +7817,16 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7836,14 +7836,14 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7853,17 +7853,17 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
-        "@composurecdk/s3": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/s3": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7879,7 +7879,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -7895,7 +7895,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -7905,17 +7905,17 @@
         "vitest": "^4.1.2"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
-        "@composurecdk/logs": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/logs": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7930,7 +7930,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7940,15 +7940,15 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.250.0",
@@ -7961,22 +7961,22 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/apigateway": "^0.6.0",
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudfront": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
-        "@composurecdk/ec2": "^0.6.0",
-        "@composurecdk/events": "^0.6.0",
-        "@composurecdk/lambda": "^0.6.0",
-        "@composurecdk/route53": "^0.6.0",
-        "@composurecdk/s3": "^0.6.0",
-        "@composurecdk/sns": "^0.6.0"
+        "@composurecdk/apigateway": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudfront": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/ec2": "^0.7.0",
+        "@composurecdk/events": "^0.7.0",
+        "@composurecdk/lambda": "^0.7.0",
+        "@composurecdk/route53": "^0.7.0",
+        "@composurecdk/s3": "^0.7.0",
+        "@composurecdk/sns": "^0.7.0"
       }
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -7986,15 +7986,15 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -8004,17 +8004,17 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
-        "@composurecdk/logs": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/logs": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -8024,15 +8024,15 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -8042,16 +8042,16 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -8061,17 +8061,17 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
-        "@composurecdk/logs": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/logs": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -8081,9 +8081,9 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.6.0",
-        "@composurecdk/cloudwatch": "^0.6.0",
-        "@composurecdk/core": "^0.6.0",
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
-    "@composurecdk/logs": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/logs": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
-    "@composurecdk/s3": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/s3": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
-    "@composurecdk/logs": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/logs": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {
@@ -22,17 +22,17 @@
     "constructs": "^10.6.0"
   },
   "peerDependencies": {
-    "@composurecdk/apigateway": "^0.6.0",
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/cloudfront": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
-    "@composurecdk/ec2": "^0.6.0",
-    "@composurecdk/events": "^0.6.0",
-    "@composurecdk/lambda": "^0.6.0",
-    "@composurecdk/route53": "^0.6.0",
-    "@composurecdk/s3": "^0.6.0",
-    "@composurecdk/sns": "^0.6.0"
+    "@composurecdk/apigateway": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/cloudfront": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/ec2": "^0.7.0",
+    "@composurecdk/events": "^0.7.0",
+    "@composurecdk/lambda": "^0.7.0",
+    "@composurecdk/route53": "^0.7.0",
+    "@composurecdk/s3": "^0.7.0",
+    "@composurecdk/sns": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
-    "@composurecdk/logs": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/logs": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -39,9 +39,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
-    "@composurecdk/logs": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/logs": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -35,9 +35,9 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.6.0",
-    "@composurecdk/cloudwatch": "^0.6.0",
-    "@composurecdk/core": "^0.6.0",
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },


### PR DESCRIPTION
Release **v0.7.0**.

Generated by `release-prepare` workflow run [#25560688384](https://github.com/laazyj/composureCDK/actions/runs/25560688384).

## Merge checklist

- [x] CI is green
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.7.0`, which triggers `release.yml` (deploy-test → npm publish).