### PR TITLE
ci: support example stacks pinned outside the sandbox primary region

### DIFF
--- a/.github/cloudformation/github-oidc-role.yml
+++ b/.github/cloudformation/github-oidc-role.yml
@@ -2,6 +2,8 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   GitHub Actions OIDC federation for ComposureCDK deploy-test pipeline.
   Deploy this stack once in your sandbox account before running the workflow.
+  IAM resources (role, managed policy, OIDC provider) are global, so a single
+  deployment covers every region the workflow operates in.
 
   Usage:
     aws cloudformation deploy \
@@ -9,6 +11,9 @@ Description: >
       --stack-name github-actions-oidc \
       --parameter-overrides GitHubOrg=laazyj RepoName=composureCDK \
       --capabilities CAPABILITY_NAMED_IAM
+    aws cloudformation update-termination-protection \
+      --stack-name github-actions-oidc \
+      --enable-termination-protection
 
 Parameters:
   GitHubOrg:
@@ -73,6 +78,8 @@ Resources:
   # so tag conditions using "ComposureCDK-*" limit access to resources belonging
   # to example stacks without needing to enumerate each stack by name.
   # New examples automatically get coverage as long as they follow the prefix.
+  # Region segments in resource ARNs use `*`: the security boundary is the
+  # tag-condition / stack-name pattern, not the region. See docs/ci.md.
   DeployTestPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -100,7 +107,7 @@ Resources:
             Action:
               - ssm:GetParameter
             Resource:
-              - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-bootstrap/*
+              - !Sub arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/cdk-bootstrap/*
 
           # CloudFormation — mutating actions scoped to ComposureCDK- stacks.
           # Resource ARNs are string patterns evaluated at request time;
@@ -121,7 +128,7 @@ Resources:
               - cloudformation:GetTemplateSummary
               - cloudformation:ListStackResources
             Resource:
-              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/ComposureCDK-*
+              - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/ComposureCDK-*
           # ListStacks is read-only (names and statuses only) and cannot
           # be scoped to specific stacks. Needed by the smoke test to
           # discover ComposureCDK-* stacks.
@@ -153,7 +160,7 @@ Resources:
               - lambda:CreateFunction
               - lambda:TagResource
             Resource:
-              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:*
             Condition:
               StringLike:
                 aws:RequestTag/aws:cloudformation:stack-name: ComposureCDK-*
@@ -170,7 +177,7 @@ Resources:
               - lambda:UntagResource
               - lambda:ListTags
             Resource:
-              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:*
             Condition:
               StringLike:
                 aws:ResourceTag/aws:cloudformation:stack-name: ComposureCDK-*
@@ -187,8 +194,8 @@ Resources:
               - apigateway:PATCH
               - apigateway:DELETE
             Resource:
-              - !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}::/restapis*
-              - !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}::/tags*
+              - !Sub arn:${AWS::Partition}:apigateway:*::/restapis*
+              - !Sub arn:${AWS::Partition}:apigateway:*::/tags*
 
           # CloudWatch Logs — scoped by CloudFormation stack-name tag.
           - Sid: LogsCreate
@@ -198,7 +205,7 @@ Resources:
               - logs:TagResource
               - logs:TagLogGroup
             Resource:
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+              - !Sub arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:*
             Condition:
               StringLike:
                 aws:RequestTag/aws:cloudformation:stack-name: ComposureCDK-*
@@ -214,7 +221,7 @@ Resources:
               - logs:ListTagsForResource
               - logs:ListTagsLogGroup
             Resource:
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+              - !Sub arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:*
             Condition:
               StringLike:
                 aws:ResourceTag/aws:cloudformation:stack-name: ComposureCDK-*

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -63,13 +63,24 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Check for in-progress ComposureCDK stacks
+        env:
+          # Sandbox primary plus every region any example pins via
+          # stack `env.region`. Keep in sync with SWEEP_REGIONS in
+          # sandbox-cleanup.yml.
+          CHECK_REGIONS: ${{ vars.AWS_REGION }} us-east-1
         run: |
-          in_progress=$(aws cloudformation list-stacks \
-            --stack-status-filter CREATE_IN_PROGRESS UPDATE_IN_PROGRESS DELETE_IN_PROGRESS UPDATE_ROLLBACK_IN_PROGRESS ROLLBACK_IN_PROGRESS REVIEW_IN_PROGRESS \
-            --query "StackSummaries[?starts_with(StackName, 'ComposureCDK-')].StackName" \
-            --output text)
-          if [ -n "$in_progress" ]; then
-            echo "::error::CloudFormation operations in progress on ComposureCDK-* stacks: $in_progress"
+          fail=0
+          for region in $CHECK_REGIONS; do
+            in_progress=$(aws cloudformation list-stacks --region "$region" \
+              --stack-status-filter CREATE_IN_PROGRESS UPDATE_IN_PROGRESS DELETE_IN_PROGRESS UPDATE_ROLLBACK_IN_PROGRESS ROLLBACK_IN_PROGRESS REVIEW_IN_PROGRESS \
+              --query "StackSummaries[?starts_with(StackName, 'ComposureCDK-')].StackName" \
+              --output text)
+            if [ -n "$in_progress" ]; then
+              echo "::error::CloudFormation operations in progress in $region on ComposureCDK-* stacks: $in_progress"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
             echo "Wait for sandbox-cleanup to complete or trigger it manually before retrying."
             exit 1
           fi

--- a/.github/workflows/sandbox-cleanup.yml
+++ b/.github/workflows/sandbox-cleanup.yml
@@ -63,6 +63,8 @@ jobs:
       - name: CDK Destroy (current app)
         working-directory: packages/examples
         run: |
+          # cdk destroy honours each stack's env.region; the OIDC role must
+          # cover every region any example pins.
           for attempt in 1 2 3; do
             echo "=== Destroy attempt $attempt ==="
             if npx cdk destroy --all --force --concurrency 5 2>&1; then
@@ -75,46 +77,70 @@ jobs:
           echo "::warning::cdk destroy --all did not fully succeed; orphan sweep will catch what remains."
 
       - name: Orphan sweep (delete any leftover ComposureCDK-* stacks)
+        env:
+          # Sandbox primary plus every region any example pins via
+          # stack `env.region`. Keep in sync with CHECK_REGIONS in
+          # deploy-test.yml.
+          SWEEP_REGIONS: ${{ vars.AWS_REGION }} us-east-1
         run: |
           # Catches stacks from removed examples (e.g. lambda-api-app,
-          # strategy-stack-app) that are no longer in the current cdk app.
-          orphans=$(aws cloudformation list-stacks \
-            --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_FAILED UPDATE_FAILED DELETE_FAILED \
-            --query "StackSummaries[?starts_with(StackName, 'ComposureCDK-')].StackName" \
-            --output text)
-          if [ -z "$orphans" ]; then
-            echo "No orphan ComposureCDK-* stacks remain."
-            exit 0
-          fi
-          echo "Found orphan stacks: $orphans"
-          deletable=()
-          skipped_cloudfront=()
-          for stack in $orphans; do
-            # Raw delete-stack on a CloudFront-bearing stack would leave it
-            # stuck in DELETE_FAILED (distribution must be disabled first,
-            # then propagated globally). Surface and skip; CDK destroy
-            # handles the disable-then-delete dance for in-app stacks.
-            cf=$(aws cloudformation list-stack-resources \
-              --stack-name "$stack" \
-              --query "StackResourceSummaries[?ResourceType=='AWS::CloudFront::Distribution'].LogicalResourceId" \
+          # strategy-stack-app) that are no longer in the current cdk app,
+          # plus anything cdk destroy --all could not finish.
+          sweep_region() {
+            local region="$1"
+            echo "::group::Orphan sweep in $region"
+            local orphans
+            orphans=$(aws cloudformation list-stacks --region "$region" \
+              --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_FAILED UPDATE_FAILED DELETE_FAILED \
+              --query "StackSummaries[?starts_with(StackName, 'ComposureCDK-')].StackName" \
               --output text)
-            if [ -n "$cf" ]; then
-              echo "::error::Stack $stack contains CloudFront distribution(s) [$cf]; skipping raw delete. Disable the distribution(s) manually (or re-run cdk destroy from a branch where $stack is defined) before re-triggering sandbox-cleanup."
-              skipped_cloudfront+=("$stack")
-              continue
+            if [ -z "$orphans" ]; then
+              echo "No orphan ComposureCDK-* stacks remain in $region."
+              echo "::endgroup::"
+              return 0
             fi
-            deletable+=("$stack")
+            echo "Found orphan stacks in $region: $orphans"
+            local -a deletable=()
+            local -a skipped=()
+            local stack cf
+            for stack in $orphans; do
+              # Raw delete-stack on a CloudFront-bearing stack would leave
+              # it stuck in DELETE_FAILED (distribution must be disabled
+              # first, then propagated globally). Surface and skip; CDK
+              # destroy handles the disable-then-delete dance for in-app
+              # stacks.
+              cf=$(aws cloudformation list-stack-resources --region "$region" \
+                --stack-name "$stack" \
+                --query "StackResourceSummaries[?ResourceType=='AWS::CloudFront::Distribution'].LogicalResourceId" \
+                --output text)
+              if [ -n "$cf" ]; then
+                echo "::error::Stack $stack ($region) contains CloudFront distribution(s) [$cf]; skipping raw delete. Disable the distribution(s) manually (or re-run cdk destroy from a branch where $stack is defined) before re-triggering sandbox-cleanup."
+                skipped+=("$stack")
+                continue
+              fi
+              deletable+=("$stack")
+            done
+            for stack in "${deletable[@]}"; do
+              echo "Deleting $stack in $region..."
+              aws cloudformation delete-stack --region "$region" --stack-name "$stack"
+            done
+            for stack in "${deletable[@]}"; do
+              echo "Waiting for $stack ($region) to delete..."
+              aws cloudformation wait stack-delete-complete --region "$region" --stack-name "$stack" || \
+                echo "::warning::$stack ($region) did not finish deleting cleanly; check the AWS console."
+            done
+            echo "::endgroup::"
+            if [ ${#skipped[@]} -ne 0 ]; then
+              return 1
+            fi
+            return 0
+          }
+
+          fail=0
+          for region in $SWEEP_REGIONS; do
+            sweep_region "$region" || fail=1
           done
-          for stack in "${deletable[@]}"; do
-            echo "Deleting $stack..."
-            aws cloudformation delete-stack --stack-name "$stack"
-          done
-          for stack in "${deletable[@]}"; do
-            echo "Waiting for $stack to delete..."
-            aws cloudformation wait stack-delete-complete --stack-name "$stack" || \
-              echo "::warning::$stack did not finish deleting cleanly; check the AWS console."
-          done
-          if [ ${#skipped_cloudfront[@]} -ne 0 ]; then
-            echo "::error::Skipped ${#skipped_cloudfront[@]} CloudFront-bearing orphan stack(s); manual cleanup required."
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more regions had CloudFront-bearing orphan stack(s); manual cleanup required."
             exit 1
           fi

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -143,13 +143,19 @@ One-time setup for the deploy-test workflow.
 
 ### 1. Bootstrap CDK
 
+Bootstrap every region the workflow deploys into. Currently:
+
+- The sandbox primary region (whatever `AWS_REGION` is set to on the `sandbox` GitHub environment), and
+- `us-east-1`, required by `ComposureCDK-DnsZoneStack` because Route 53 query logging only accepts log groups in that region.
+
 ```sh
 npx cdk bootstrap aws://ACCOUNT_ID/REGION
+npx cdk bootstrap aws://ACCOUNT_ID/us-east-1
 ```
 
 ### 2. Deploy the OIDC stack
 
-`.github/cloudformation/github-oidc-role.yml` creates a GitHub OIDC provider (or references an existing one) and a least-privilege IAM role scoped to `ComposureCDK-*` stacks.
+`.github/cloudformation/github-oidc-role.yml` creates a GitHub OIDC provider (or references an existing one) and a least-privilege IAM role scoped to `ComposureCDK-*` stacks. The role, managed policy, and OIDC provider are global IAM resources, so this stack only needs to be deployed **once**, regardless of how many regions the workflow targets. The policy's resource ARNs use `*` for the region segment; the security boundary is the `ComposureCDK-` tag-condition / stack-name pattern, not the region.
 
 ```sh
 aws cloudformation deploy \
@@ -157,7 +163,12 @@ aws cloudformation deploy \
   --stack-name github-actions-oidc \
   --parameter-overrides GitHubOrg=laazyj RepoName=composureCDK \
   --capabilities CAPABILITY_NAMED_IAM
+aws cloudformation update-termination-protection \
+  --stack-name github-actions-oidc \
+  --enable-termination-protection
 ```
+
+Termination protection is enabled separately (CFN templates cannot self-protect). Without it, an accidental `delete-stack` on this stack would tear down the role mid-deploy and break every workflow run. Re-runs of `aws cloudformation deploy` are unaffected — termination protection only blocks deletion.
 
 If the account already has a GitHub OIDC provider, pass its ARN to avoid a duplicate:
 


### PR DESCRIPTION
## Summary

Prerequisite for #101. PR #101 pins `ComposureCDK-DnsZoneStack` to `us-east-1` (Route 53 query logging requires log groups to live there) while the rest of the example suite continues to deploy to the sandbox primary region. Three CI surfaces need multi-region awareness so that pinning works end to end:

- **OIDC role** (`.github/cloudformation/github-oidc-role.yml`) — widen `${AWS::Region}` segments in resource ARNs to `*`. IAM is global, so the role still deploys once. The security boundary remains the `ComposureCDK-` tag-condition / stack-name pattern; the region segment was never additive on top of those.
- **`sandbox-cleanup.yml`** — orphan-sweep extracted into a `sweep_region()` shell function and looped over `SWEEP_REGIONS = vars.AWS_REGION + us-east-1`. `cdk destroy --all` already honours each stack's pinned `env.region` and tears down cross-region stacks in the same invocation, but the orphan sweep is the safety net.
- **`deploy-test.yml`** — the in-progress check now loops over `CHECK_REGIONS`, kept in sync with `sandbox-cleanup`.

`docs/ci.md` updated to instruct operators to bootstrap `us-east-1` alongside the primary region and to enable termination protection on the OIDC stack post-deploy (CFN templates can't self-protect).

## Operator actions when this lands

1. Re-run `aws cloudformation deploy` against `github-oidc-role.yml` to refresh the managed policy. Role ARN, role name, OIDC provider ARN, and trust policy are unchanged — no GitHub environment changes needed.
2. `aws cloudformation update-termination-protection --stack-name github-actions-oidc --enable-termination-protection`.
3. `npx cdk bootstrap aws://<account>/us-east-1` if not already done.

## Test plan

- [x] Re-deploy the OIDC stack in the sandbox account; verify role ARN and trust policy are unchanged.
- [ ] Trigger **Actions → Deploy Test → Run workflow** against `sandbox`; confirm the in-progress check passes for both regions and `cdk deploy --all` succeeds (the `DnsZoneStack` portion of #101 is the integration surface — that stack needs #101 merged on top to actually pin to `us-east-1`).
- [ ] Trigger **Actions → Sandbox Cleanup**; confirm the orphan sweep runs in both regions and reports per-region group output.