### PR TITLE
test(examples): execute functions in smoke tests

### DIFF
--- a/.github/cloudformation/github-oidc-role.yml
+++ b/.github/cloudformation/github-oidc-role.yml
@@ -176,6 +176,8 @@ Resources:
               - lambda:RemovePermission
               - lambda:UntagResource
               - lambda:ListTags
+              # Smoke test invokes example functions for verification
+              - lambda:InvokeFunction
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:*
             Condition:
@@ -220,6 +222,8 @@ Resources:
               - logs:UntagResource
               - logs:ListTagsForResource
               - logs:ListTagsLogGroup
+              # Smoke test reads example log groups for verification
+              - logs:FilterLogEvents
             Resource:
               - !Sub arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:*
             Condition:

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -11,6 +11,10 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 const STACK_PREFIX = "ComposureCDK-";
 
@@ -166,6 +170,114 @@ try {
   }
 } catch (err) {
   fail(`${WEBSITE_STACK} — ${err.message}`);
+}
+
+// --- Lambda invoke checks ---------------------------------------------------
+
+console.log("\n=== Lambda invoke checks ===\n");
+
+const DUAL_FUNCTION_STACK = "ComposureCDK-DualFunctionStack";
+
+try {
+  const { StackResourceSummaries: dfResources } = aws(
+    "cloudformation",
+    "list-stack-resources",
+    "--stack-name",
+    DUAL_FUNCTION_STACK,
+    "--output",
+    "json",
+  );
+  const apiFn = dfResources.find(
+    (r) => r.ResourceType === "AWS::Lambda::Function" && /api/i.test(r.LogicalResourceId),
+  );
+
+  if (!apiFn) {
+    fail(`${DUAL_FUNCTION_STACK} — api Lambda not found`);
+  } else {
+    const fnName = apiFn.PhysicalResourceId;
+    const cfg = aws(
+      "lambda",
+      "get-function-configuration",
+      "--function-name",
+      fnName,
+      "--output",
+      "json",
+    );
+    // Lambda's default log group is /aws/lambda/<name>; this stack overrides
+    // it via LoggingConfig so resolve from the live config rather than guess.
+    const logGroup = cfg.LoggingConfig?.LogGroup ?? `/aws/lambda/${fnName}`;
+
+    const outputFile = join(tmpdir(), `composurecdk-smoke-invoke-${process.pid}.json`);
+    const invokeStartMs = Date.now();
+    let responsePayload;
+    let invokeMeta;
+    try {
+      invokeMeta = aws(
+        "lambda",
+        "invoke",
+        "--function-name",
+        fnName,
+        "--payload",
+        "{}",
+        "--cli-binary-format",
+        "raw-in-base64-out",
+        "--output",
+        "json",
+        outputFile,
+      );
+      responsePayload = JSON.parse(readFileSync(outputFile, "utf8"));
+    } finally {
+      rmSync(outputFile, { force: true });
+    }
+
+    const okInvoke =
+      invokeMeta.StatusCode === 200 &&
+      !invokeMeta.FunctionError &&
+      responsePayload.statusCode === 200;
+
+    if (okInvoke) {
+      pass(`${fnName} — invoked, response.statusCode=200`);
+    } else {
+      fail(
+        `${fnName} — invoke StatusCode=${invokeMeta.StatusCode}, FunctionError=${invokeMeta.FunctionError ?? "none"}, payload=${JSON.stringify(responsePayload)}`,
+      );
+    }
+
+    // Poll the log group for events emitted by this invocation. The invoke
+    // API's --log-type Tail returns runtime-captured stdout, which doesn't
+    // prove the execution role's CloudWatch Logs permissions — only events
+    // landing in the log group do.
+    const filterArgs = [
+      "logs",
+      "filter-log-events",
+      "--log-group-name",
+      logGroup,
+      "--start-time",
+      String(invokeStartMs - 5_000),
+      "--max-items",
+      "1",
+      "--output",
+      "json",
+    ];
+    let logsSeen = false;
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      const { events } = aws(...filterArgs);
+      if (events && events.length > 0) {
+        logsSeen = true;
+        break;
+      }
+      await delay(2_000);
+    }
+
+    if (logsSeen) {
+      pass(`${logGroup} — execution role wrote logs`);
+    } else {
+      fail(`${logGroup} — no log events after 30s`);
+    }
+  }
+} catch (err) {
+  fail(`${DUAL_FUNCTION_STACK} — ${err.message}`);
 }
 
 // --- EC2 instance checks ----------------------------------------------------


### PR DESCRIPTION
The lambda package now creates its own IAM roles for Lambda executions, following AWS Well Architected guidance. The smoke test will now execute a Lambda and verify it is logging to CloudWatch to validate the correct permissions are assigned to this role.
