### PR TITLE
fix(sns)!: route SubscriptionBuilder through ITopicSubscription.bind()

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -50,7 +50,7 @@ The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.
 | `numberOfNotificationsRedrivenToDlq`                | NumberOfNotificationsRedrivenToDlq (Sum, 1 min)                 | > 0               | Always[^dlq] |
 | `numberOfNotificationsFailedToRedriveToDlq`         | NumberOfNotificationsFailedToRedriveToDlq (Sum, 1 min)          | > 0               | Always[^dlq] |
 
-[^dlq]: Metric only emits when a subscription on the topic has a dead-letter queue attached and SNS attempts redrive. `TreatMissingData` defaults to `notBreaching`, so the alarm stays quiet on topics without DLQs. Attach a DLQ via the `SubscriptionBuilder`'s `.deadLetterQueue(...)` — see [SNS DLQ docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html).
+[^dlq]: Metric only emits when a subscription on the topic has a dead-letter queue attached and SNS attempts redrive. `TreatMissingData` defaults to `notBreaching`, so the alarm stays quiet on topics without DLQs. Attach a DLQ on the `ITopicSubscription` itself (e.g. `new LambdaSubscription(fn, { deadLetterQueue: dlq })`) — see [SNS DLQ docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html).
 
 The defaults are exported as `TOPIC_ALARM_DEFAULTS` for visibility and testing:
 
@@ -167,31 +167,47 @@ const system = compose(
 
 ## Subscription Builder
 
+Use `createSubscriptionBuilder` when subscribing to a **foreign** topic — one that is not built in the same `compose` system (for example, a topic owned by another stack or account). When the topic and its subscriptions are declared together, prefer [`TopicBuilder.addSubscription`](#adding-subscriptions-to-a-topic) instead.
+
 ```ts
 import { createSubscriptionBuilder } from "@composurecdk/sns";
-import { SubscriptionProtocol } from "aws-cdk-lib/aws-sns";
+import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
 
 const emailAlerts = createSubscriptionBuilder()
   .topic(budgetTopic)
-  .protocol(SubscriptionProtocol.EMAIL)
-  .endpoint("ops@example.com")
+  .subscription(new EmailSubscription("ops@example.com"))
   .build(stack, "BudgetEmailSubscription");
 ```
 
-Every [SubscriptionProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.SubscriptionProps.html) property is available as a fluent setter. `topic` and `deadLetterQueue` additionally accept a `Ref` so the subscription can be composed with a `TopicBuilder` (or any other component) without post-build wiring:
+The builder accepts any CDK [`ITopicSubscription`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.ITopicSubscription.html) (e.g. `EmailSubscription`, `LambdaSubscription`, `SqsSubscription`) and binds it via `ITopicSubscription.bind(topic)` — the same path CDK uses for `topic.addSubscription(...)`, so endpoint-specific wire-up (Lambda invoke permission, SQS queue policy, KMS decrypt grant) happens automatically. Subscription-specific options — dead-letter queue, filter policy, raw message delivery — are configured on the `ITopicSubscription` itself, matching CDK's own API:
+
+```ts
+import { LambdaSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+
+createSubscriptionBuilder()
+  .topic(orderEventsTopic)
+  .subscription(
+    new LambdaSubscription(handler, {
+      deadLetterQueue: dlq,
+      filterPolicy: { severity: SubscriptionFilter.stringFilter({ allowlist: ["HIGH"] }) },
+    }),
+  )
+  .build(stack, "OrderEventsHandler");
+```
+
+Both `.topic(...)` and `.subscription(...)` accept a `Ref`, so the builder composes cleanly with a `TopicBuilder` — or with any other component that produces the endpoint resource:
 
 ```ts
 import { compose, ref } from "@composurecdk/core";
 import { createTopicBuilder, createSubscriptionBuilder } from "@composurecdk/sns";
-import { SubscriptionProtocol } from "aws-cdk-lib/aws-sns";
+import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
 
 const system = compose(
   {
     budget: createTopicBuilder().topicName("budget-alerts"),
     email: createSubscriptionBuilder()
       .topic(ref("budget", (r) => r.topic))
-      .protocol(SubscriptionProtocol.EMAIL)
-      .endpoint("ops@example.com"),
+      .subscription(new EmailSubscription("ops@example.com")),
   },
   { budget: [], email: ["budget"] },
 );
@@ -199,11 +215,9 @@ const system = compose(
 
 ### Subscription reliability
 
-Attaching a dead-letter queue is the primary reliability control for SNS subscriptions ([AWS Well-Architected — Reliability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html), [SNS DLQ docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html)). Pass a queue via `.deadLetterQueue(queue)` or a `ref` to one; the builder does not create a DLQ automatically because the queue resource needs to be caller-owned.
+Attaching a dead-letter queue is the primary reliability control for SNS subscriptions ([AWS Well-Architected — Reliability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html), [SNS DLQ docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html)). Pass a queue to the `ITopicSubscription` constructor (e.g. `new EmailSubscription("ops@example.com", { deadLetterQueue: dlq })`); the builder does not create a DLQ automatically because the queue resource needs to be caller-owned.
 
 The CloudWatch metrics that surface delivery failures (`NumberOfNotificationsRedrivenToDlq`, `NumberOfNotificationsFailedToRedriveToDlq`) are topic-level, so the recommended alarms for them live on the `TopicBuilder` (see [Recommended Alarms](#recommended-alarms) above) and only report data once at least one subscription has a DLQ attached.
-
-Also note: `SubscriptionProtocol.HTTP` is allowed for compatibility; prefer `HTTPS` for transport encryption ([SNS security best practices](https://docs.aws.amazon.com/sns/latest/dg/sns-security-best-practices.html)).
 
 ## Examples
 

--- a/packages/sns/src/subscription-builder.ts
+++ b/packages/sns/src/subscription-builder.ts
@@ -1,5 +1,4 @@
-import { type ITopic, Subscription, type SubscriptionProps } from "aws-cdk-lib/aws-sns";
-import type { IQueue } from "aws-cdk-lib/aws-sqs";
+import { type ITopic, type ITopicSubscription, Subscription } from "aws-cdk-lib/aws-sns";
 import { type IConstruct } from "constructs";
 import {
   Builder,
@@ -12,14 +11,11 @@ import {
 /**
  * Configuration properties for the SNS subscription builder.
  *
- * Extends the CDK {@link SubscriptionProps} but accepts {@link Resolvable}
- * values for `topic` and `deadLetterQueue` so the builder can be wired to
- * other components via {@link ref} inside a {@link compose}d system.
+ * Both fields are required at build time. Both accept {@link Resolvable}
+ * values so the subscription can be wired to other components via
+ * {@link ref} inside a {@link compose}d system.
  */
-export interface SubscriptionBuilderProps extends Omit<
-  SubscriptionProps,
-  "topic" | "deadLetterQueue"
-> {
+export interface SubscriptionBuilderProps {
   /**
    * The topic to subscribe to. Accepts a concrete {@link ITopic} or a
    * {@link Ref} to another component's output (e.g. a `TopicBuilder`).
@@ -27,19 +23,18 @@ export interface SubscriptionBuilderProps extends Omit<
   topic: Resolvable<ITopic>;
 
   /**
-   * Dead-letter queue for messages that cannot be delivered to the
-   * subscribed endpoint. Accepts a concrete {@link IQueue} or a
-   * {@link Ref} to another component's output.
+   * The subscription to attach. Accepts any CDK
+   * {@link ITopicSubscription} (e.g. `EmailSubscription`,
+   * `LambdaSubscription`, `SqsSubscription`) or a {@link Ref} to one.
    *
-   * Attaching a DLQ is the primary reliability control for SNS
-   * subscriptions. Redrive and redrive-failure alarms are created on the
-   * subscribed {@link TopicBuilder} since the underlying metrics are
-   * topic-level.
-   *
-   * @see https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html
-   * @default - no dead letter queue
+   * The subscription is bound via `ITopicSubscription.bind(topic)`, which
+   * performs the endpoint-specific IAM/resource-policy wire-up (Lambda
+   * invoke permission, SQS queue policy, KMS decrypt grant, etc.).
+   * Subscription-specific options — dead-letter queue, filter policy, raw
+   * message delivery — are configured on the `ITopicSubscription` itself,
+   * matching CDK's own subscription API.
    */
-  deadLetterQueue?: Resolvable<IQueue>;
+  subscription: Resolvable<ITopicSubscription>;
 }
 
 /**
@@ -54,28 +49,33 @@ export interface SubscriptionBuilderResult {
 /**
  * A fluent builder for configuring and creating an AWS SNS subscription.
  *
- * Each configuration property from the CDK {@link SubscriptionProps} is
- * exposed as an overloaded method: call with a value to set it (returns the
- * builder for chaining), or call with no arguments to read the current
- * value.
- *
  * The builder implements {@link Lifecycle}, so it can be used directly as a
  * component in a {@link compose | composed system}. Its `topic` and
- * `deadLetterQueue` properties accept {@link Resolvable} values so they can
- * be supplied by another component's build output via {@link ref}.
+ * `subscription` properties accept {@link Resolvable} values so they can be
+ * supplied by another component's build output via {@link ref}.
+ *
+ * At build time, the configured `ITopicSubscription` is bound to the topic
+ * via `ITopicSubscription.bind(topic)` — the same path CDK uses for
+ * `topic.addSubscription(...)`. This ensures endpoint-specific wire-up
+ * (Lambda invoke permission, SQS queue policy, etc.) happens correctly.
  *
  * Recommended CloudWatch alarms related to subscription delivery (redrive
  * to DLQ, failed redrive to DLQ) are emitted against topic-level metrics,
  * so they live on {@link createTopicBuilder} rather than here.
  *
+ * Use this builder when subscribing to a *foreign* topic — one not built in
+ * the same `compose` system. For the common case where a topic and its
+ * subscriptions are declared together, use `TopicBuilder.addSubscription`.
+ *
  * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sns.Subscription.html
  *
  * @example
  * ```ts
+ * import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+ *
  * const emailAlerts = createSubscriptionBuilder()
  *   .topic(ref("topic", (r: TopicBuilderResult) => r.topic))
- *   .protocol(SubscriptionProtocol.EMAIL)
- *   .endpoint("ops@example.com");
+ *   .subscription(new EmailSubscription("ops@example.com"));
  * ```
  */
 // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::SNS::Subscription has no Tags property
@@ -89,39 +89,29 @@ class SubscriptionBuilder implements Lifecycle<SubscriptionBuilderResult> {
     id: string,
     context: Record<string, object> = {},
   ): SubscriptionBuilderResult {
-    const { topic, deadLetterQueue, protocol, endpoint, ...rest } = this.props;
+    const { topic, subscription } = this.props;
 
     if (topic === undefined) {
       throw new Error(
         `SubscriptionBuilder "${id}": topic is required. Call .topic(...) with an ITopic or a Ref before building.`,
       );
     }
-    if (protocol === undefined) {
+    if (subscription === undefined) {
       throw new Error(
-        `SubscriptionBuilder "${id}": protocol is required. Call .protocol(...) with a SubscriptionProtocol before building.`,
-      );
-    }
-    if (endpoint === undefined) {
-      throw new Error(
-        `SubscriptionBuilder "${id}": endpoint is required. Call .endpoint(...) with the subscriber endpoint before building.`,
+        `SubscriptionBuilder "${id}": subscription is required. Call .subscription(...) with an ITopicSubscription (e.g. EmailSubscription, LambdaSubscription, SqsSubscription) or a Ref before building.`,
       );
     }
 
     const resolvedTopic = resolve(topic, context);
-    const resolvedDlq =
-      deadLetterQueue !== undefined ? resolve(deadLetterQueue, context) : undefined;
+    const resolvedSubscription = resolve(subscription, context);
+    const subscriptionConfig = resolvedSubscription.bind(resolvedTopic);
 
-    const subscriptionProps: SubscriptionProps = {
-      ...rest,
-      protocol,
-      endpoint,
+    const built = new Subscription(scope, id, {
       topic: resolvedTopic,
-      ...(resolvedDlq !== undefined ? { deadLetterQueue: resolvedDlq } : {}),
-    };
+      ...subscriptionConfig,
+    });
 
-    const subscription = new Subscription(scope, id, subscriptionProps);
-
-    return { subscription };
+    return { subscription: built };
   }
 }
 
@@ -129,22 +119,23 @@ class SubscriptionBuilder implements Lifecycle<SubscriptionBuilderResult> {
  * Creates a new {@link ISubscriptionBuilder} for configuring an AWS SNS
  * subscription.
  *
- * This is the entry point for defining an SNS subscription component. The
- * returned builder exposes every {@link SubscriptionProps} property as a
- * fluent setter/getter and implements {@link Lifecycle} for use with
- * {@link compose}.
+ * The returned builder exposes `topic` and `subscription` as fluent
+ * setter/getters and implements {@link Lifecycle} for use with
+ * {@link compose}. Subscription-specific options (DLQ, filter policy, raw
+ * message delivery) are configured on the `ITopicSubscription` itself.
  *
  * @returns A fluent builder for an AWS SNS subscription.
  *
  * @example
  * ```ts
+ * import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+ *
  * const system = compose(
  *   {
  *     topic: createTopicBuilder().topicName("budget-alerts"),
  *     email: createSubscriptionBuilder()
  *       .topic(ref("topic", (r: TopicBuilderResult) => r.topic))
- *       .protocol(SubscriptionProtocol.EMAIL)
- *       .endpoint("ops@example.com"),
+ *       .subscription(new EmailSubscription("ops@example.com")),
  *   },
  *   { topic: [], email: ["topic"] },
  * );

--- a/packages/sns/test/subscription-builder.test.ts
+++ b/packages/sns/test/subscription-builder.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { SubscriptionFilter, SubscriptionProtocol, Topic } from "aws-cdk-lib/aws-sns";
+import { SubscriptionFilter, Topic } from "aws-cdk-lib/aws-sns";
+import {
+  EmailSubscription,
+  LambdaSubscription,
+  SqsSubscription,
+} from "aws-cdk-lib/aws-sns-subscriptions";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import { compose, ref } from "@composurecdk/core";
 import { createTopicBuilder } from "../src/topic-builder.js";
@@ -11,37 +17,36 @@ import {
 } from "../src/subscription-builder.js";
 import type { TopicBuilderResult } from "../src/topic-builder.js";
 
-function buildWithTopic(
-  configureFn?: (
-    builder: ReturnType<typeof createSubscriptionBuilder>,
-    topic: Topic,
-    stack: Stack,
-  ) => void,
-) {
+function buildEmail() {
   const app = new App();
   const stack = new Stack(app, "TestStack");
   const topic = new Topic(stack, "Topic");
-  const builder = createSubscriptionBuilder().topic(topic);
-  configureFn?.(builder, topic, stack);
-  const result = builder.build(stack, "Sub");
+  const result = createSubscriptionBuilder()
+    .topic(topic)
+    .subscription(new EmailSubscription("ops@example.com"))
+    .build(stack, "Sub");
   return { stack, topic, result, template: Template.fromStack(stack) };
+}
+
+function makeLambdaHandler(stack: Stack, id = "Handler") {
+  return new LambdaFunction(stack, id, {
+    runtime: Runtime.NODEJS_20_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => {};"),
+  });
 }
 
 describe("SubscriptionBuilder", () => {
   describe("build", () => {
     it("returns a SubscriptionBuilderResult with the subscription", () => {
-      const { result } = buildWithTopic((b) =>
-        b.protocol(SubscriptionProtocol.EMAIL).endpoint("ops@example.com"),
-      );
+      const { result } = buildEmail();
 
       expect(result).toBeDefined();
       expect(result.subscription).toBeDefined();
     });
 
     it("creates exactly one SNS subscription", () => {
-      const { template } = buildWithTopic((b) =>
-        b.protocol(SubscriptionProtocol.EMAIL).endpoint("ops@example.com"),
-      );
+      const { template } = buildEmail();
 
       template.resourceCountIs("AWS::SNS::Subscription", 1);
     });
@@ -49,80 +54,58 @@ describe("SubscriptionBuilder", () => {
     it("throws a descriptive error when topic is not set", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
-      const builder = createSubscriptionBuilder()
-        .protocol(SubscriptionProtocol.EMAIL)
-        .endpoint("ops@example.com");
+      const builder = createSubscriptionBuilder().subscription(
+        new EmailSubscription("ops@example.com"),
+      );
 
       expect(() => builder.build(stack, "Sub")).toThrow(
         /SubscriptionBuilder "Sub": topic is required/,
       );
     });
 
-    it("throws a descriptive error when protocol is not set", () => {
+    it("throws a descriptive error when subscription is not set", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const topic = new Topic(stack, "Topic");
-      const builder = createSubscriptionBuilder().topic(topic).endpoint("ops@example.com");
+      const builder = createSubscriptionBuilder().topic(topic);
 
       expect(() => builder.build(stack, "Sub")).toThrow(
-        /SubscriptionBuilder "Sub": protocol is required/,
-      );
-    });
-
-    it("throws a descriptive error when endpoint is not set", () => {
-      const app = new App();
-      const stack = new Stack(app, "TestStack");
-      const topic = new Topic(stack, "Topic");
-      const builder = createSubscriptionBuilder().topic(topic).protocol(SubscriptionProtocol.EMAIL);
-
-      expect(() => builder.build(stack, "Sub")).toThrow(
-        /SubscriptionBuilder "Sub": endpoint is required/,
+        /SubscriptionBuilder "Sub": subscription is required/,
       );
     });
   });
 
   describe("synthesised output", () => {
-    it("creates an email subscription matching the requested YAML shape", () => {
-      const { template } = buildWithTopic((b) =>
-        b.protocol(SubscriptionProtocol.EMAIL).endpoint("your-email@example.com"),
-      );
+    it("creates an email subscription with the expected protocol and endpoint", () => {
+      const { template } = buildEmail();
 
       template.hasResourceProperties("AWS::SNS::Subscription", {
         Protocol: "email",
-        Endpoint: "your-email@example.com",
+        Endpoint: "ops@example.com",
         TopicArn: Match.objectLike({ Ref: Match.stringLikeRegexp("^Topic") }),
       });
     });
 
-    it.each([
-      [SubscriptionProtocol.EMAIL, "email", "ops@example.com"],
-      [SubscriptionProtocol.EMAIL_JSON, "email-json", "ops@example.com"],
-      [SubscriptionProtocol.HTTPS, "https", "https://example.com/hook"],
-      [SubscriptionProtocol.HTTP, "http", "http://example.com/hook"],
-      [SubscriptionProtocol.SMS, "sms", "+15551234567"],
-    ])("creates a %s subscription", (protocol, expected, endpoint) => {
-      const { template } = buildWithTopic((b) => b.protocol(protocol).endpoint(endpoint));
+    it("emits the Lambda invoke permission for a LambdaSubscription", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const topic = new Topic(stack, "Topic");
+      const handler = makeLambdaHandler(stack);
 
-      template.hasResourceProperties("AWS::SNS::Subscription", {
-        Protocol: expected,
-        Endpoint: endpoint,
+      createSubscriptionBuilder()
+        .topic(topic)
+        .subscription(new LambdaSubscription(handler))
+        .build(stack, "Sub");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::SNS::Subscription", { Protocol: "lambda" });
+      template.hasResourceProperties("AWS::Lambda::Permission", {
+        Action: "lambda:InvokeFunction",
+        Principal: "sns.amazonaws.com",
       });
     });
 
-    it("applies a filter policy when configured", () => {
-      const { template } = buildWithTopic((b) =>
-        b
-          .protocol(SubscriptionProtocol.EMAIL)
-          .endpoint("ops@example.com")
-          .filterPolicy({ severity: SubscriptionFilter.stringFilter({ allowlist: ["HIGH"] }) }),
-      );
-
-      template.hasResourceProperties("AWS::SNS::Subscription", {
-        FilterPolicy: { severity: ["HIGH"] },
-      });
-    });
-
-    it("enables raw message delivery when explicitly opted in", () => {
+    it("emits the SQS queue policy for an SqsSubscription", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const topic = new Topic(stack, "Topic");
@@ -130,19 +113,46 @@ describe("SubscriptionBuilder", () => {
 
       createSubscriptionBuilder()
         .topic(topic)
-        .protocol(SubscriptionProtocol.SQS)
-        .endpoint(queue.queueArn)
-        .rawMessageDelivery(true)
+        .subscription(new SqsSubscription(queue))
+        .build(stack, "Sub");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::SNS::Subscription", { Protocol: "sqs" });
+      template.hasResourceProperties("AWS::SQS::QueuePolicy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: "sqs:SendMessage",
+              Effect: "Allow",
+              Principal: { Service: "sns.amazonaws.com" },
+            }),
+          ]),
+        }),
+      });
+    });
+
+    it("forwards subscription options (filter policy) configured on the ITopicSubscription", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const topic = new Topic(stack, "Topic");
+
+      createSubscriptionBuilder()
+        .topic(topic)
+        .subscription(
+          new EmailSubscription("ops@example.com", {
+            filterPolicy: {
+              severity: SubscriptionFilter.stringFilter({ allowlist: ["HIGH"] }),
+            },
+          }),
+        )
         .build(stack, "Sub");
 
       Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
-        RawMessageDelivery: true,
+        FilterPolicy: { severity: ["HIGH"] },
       });
     });
-  });
 
-  describe("dead-letter queue", () => {
-    it("attaches a DLQ via RedrivePolicy when provided", () => {
+    it("forwards a dead-letter queue configured on the ITopicSubscription", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const topic = new Topic(stack, "Topic");
@@ -150,13 +160,10 @@ describe("SubscriptionBuilder", () => {
 
       createSubscriptionBuilder()
         .topic(topic)
-        .deadLetterQueue(dlq)
-        .protocol(SubscriptionProtocol.EMAIL)
-        .endpoint("ops@example.com")
+        .subscription(new EmailSubscription("ops@example.com", { deadLetterQueue: dlq }))
         .build(stack, "Sub");
 
-      const template = Template.fromStack(stack);
-      template.hasResourceProperties("AWS::SNS::Subscription", {
+      Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
         RedrivePolicy: Match.objectLike({
           deadLetterTargetArn: Match.objectLike({
             "Fn::GetAtt": Match.arrayWith([Match.stringLikeRegexp("^Dlq")]),
@@ -166,15 +173,14 @@ describe("SubscriptionBuilder", () => {
     });
   });
 
-  describe("composition with TopicBuilder via ref", () => {
+  describe("composition via ref", () => {
     it("resolves a topic ref during build", () => {
       const system = compose(
         {
           topic: createTopicBuilder().topicName("budget-alerts").recommendedAlarms(false),
           email: createSubscriptionBuilder()
             .topic(ref<TopicBuilderResult>("topic").get("topic"))
-            .protocol(SubscriptionProtocol.EMAIL)
-            .endpoint("ops@example.com"),
+            .subscription(new EmailSubscription("ops@example.com")),
         },
         { topic: [], email: ["topic"] },
       );
@@ -195,6 +201,44 @@ describe("SubscriptionBuilder", () => {
         Protocol: "email",
         Endpoint: "ops@example.com",
         TopicArn: Match.objectLike({ Ref: Match.stringLikeRegexp("topic") }),
+      });
+    });
+
+    it("resolves a subscription ref to a Lambda built by a sibling component", () => {
+      const system = compose(
+        {
+          topic: createTopicBuilder().topicName("alerts").recommendedAlarms(false),
+          handler: {
+            build: (scope: Stack, id: string) => ({
+              function: new LambdaFunction(scope, id, {
+                runtime: Runtime.NODEJS_20_X,
+                handler: "index.handler",
+                code: Code.fromInline("exports.handler = async () => {};"),
+                timeout: Duration.seconds(5),
+              }),
+            }),
+          },
+          sub: createSubscriptionBuilder()
+            .topic(ref<TopicBuilderResult>("topic").get("topic"))
+            .subscription(
+              ref(
+                "handler",
+                (r: { function: LambdaFunction }) => new LambdaSubscription(r.function),
+              ),
+            ),
+        },
+        { topic: [], handler: [], sub: ["topic", "handler"] },
+      );
+
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      system.build(stack, "System");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::SNS::Subscription", { Protocol: "lambda" });
+      template.hasResourceProperties("AWS::Lambda::Permission", {
+        Action: "lambda:InvokeFunction",
+        Principal: "sns.amazonaws.com",
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes #38.

The standalone `SubscriptionBuilder` previously accepted raw `protocol` + `endpoint` (plus `filterPolicy`, `rawMessageDelivery`, `deadLetterQueue`) and constructed `new Subscription(...)` directly. That skipped `ITopicSubscription.bind(topic)`, which is what CDK uses to emit the endpoint-specific IAM/resource-policy wire-up — most visibly the `AWS::Lambda::Permission` for `LambdaSubscription` and the `AWS::SQS::QueuePolicy` for `SqsSubscription`. Result: silently broken subscriptions at deploy time when targeting Lambda or SQS.

Per the pre-agreed plan on the issue (Option 1, straight breaking change in a 0.x package, no deprecation): the builder's surface is now a single `.subscription(Resolvable<ITopicSubscription>)` setter alongside `.topic(...)`. Subscription-specific options live on the `ITopicSubscription` itself, matching CDK's own API and the pattern already adopted by `TopicBuilder.addSubscription` (#39).

## Changes

- **`packages/sns/src/subscription-builder.ts`** — rewrite. `SubscriptionBuilderProps` is now `{ topic, subscription }`, both `Resolvable<…>`. `build()` resolves both, calls `resolvedSubscription.bind(resolvedTopic)`, and spreads the resulting config into `new Subscription(scope, id, { topic, ...config })`.
- **`packages/sns/test/subscription-builder.test.ts`** — replaces protocol/endpoint cases. The two assertions that prove the bug is fixed:
  - `LambdaSubscription` → `AWS::Lambda::Permission` with `Action: lambda:InvokeFunction`, `Principal: sns.amazonaws.com`
  - `SqsSubscription` → `AWS::SQS::QueuePolicy` allowing `sqs:SendMessage` from `sns.amazonaws.com`
  - Plus tests that filter policy and DLQ configured on the `ITopicSubscription` flow through, and that both `topic` and `subscription` resolve correctly from a `compose` context.
- **`packages/sns/README.md`** — Subscription Builder section rewritten around the new API; framing now points users to `TopicBuilder.addSubscription` for the co-located case and positions the standalone builder for foreign-topic subscriptions. DLQ footnote on the alarms table updated to reflect the new attachment point.

## Breaking changes

The following builder methods are removed: `.protocol(...)`, `.endpoint(...)`, `.filterPolicy(...)`, `.rawMessageDelivery(...)`, `.deadLetterQueue(...)`. Migration is one-to-one — wrap the existing protocol/endpoint into the matching `ITopicSubscription` class from `aws-cdk-lib/aws-sns-subscriptions` and pass it to `.subscription(...)`. Subscription options (DLQ, filter policy, raw message delivery) move to that class's constructor.

```ts
// Before
createSubscriptionBuilder()
  .topic(topic)
  .protocol(SubscriptionProtocol.LAMBDA)
  .endpoint(fn.functionArn)
  .deadLetterQueue(dlq);

// After
createSubscriptionBuilder()
  .topic(topic)
  .subscription(new LambdaSubscription(fn, { deadLetterQueue: dlq }));
```

## Follow-up

Issue #35 (protocol-specific defaults) is the next PR. The plan there is re-scoped to fit this new API surface — see the comment I posted on #35 for the revised dispatch (off `SubscriptionTopicConfig.protocol` after `bind()`, rather than off a builder-level enum field).

## Test plan

- [x] `npx nx test sns` — 44/44 passing, including the two bug-fix assertions and the `Resolvable<ITopicSubscription>` composition case
- [x] `npm run lint`
- [x] `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)