### PR TITLE
feat(sqs): add @composurecdk/sqs with QueueBuilder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1865,6 +1865,10 @@
       "resolved": "packages/sns",
       "link": true
     },
+    "node_modules/@composurecdk/sqs": {
+      "resolved": "packages/sqs",
+      "link": true
+    },
     "node_modules/@dagrejs/graphlib": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
@@ -7973,7 +7977,8 @@
         "@composurecdk/lambda": "^0.7.0",
         "@composurecdk/route53": "^0.7.0",
         "@composurecdk/s3": "^0.7.0",
-        "@composurecdk/sns": "^0.7.0"
+        "@composurecdk/sns": "^0.7.0",
+        "@composurecdk/sqs": "^0.7.0"
       }
     },
     "packages/iam": {
@@ -8076,6 +8081,25 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
+      "version": "0.7.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.2",
+        "aws-cdk-lib": "^2.253.1",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@composurecdk/cloudformation": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.7.0",
+        "@composurecdk/core": "^0.7.0",
+        "aws-cdk-lib": "^2.0.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "packages/sqs": {
+      "name": "@composurecdk/sqs",
       "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -15,7 +15,7 @@ All example stacks use the `ComposureCDK-` name prefix. This convention enables 
 | [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + EC2 instance with well-architected defaults, recommended alarms, and SNS alert wiring                                          |
 | [`ComposureCDK-AgentVolumeStack`](src/agent-volume-app.ts)                                          | VPC + EC2 instance with a persistent EBS data volume attached via `attachVolume` + alarm wiring                                      |
 | [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`                                          |
-| [`ComposureCDK-OrderProcessorStack`](src/order-processor-app.ts)                                    | SQS work queue with recommended alarms wired to a sibling SNS alert topic via `alarmActionsPolicy`                                   |
+| [`ComposureCDK-OrderProcessorStack`](src/order-processor-app.ts)                                    | SQS work queue feeding a Lambda consumer via an SQS event source, with recommended alarms wired to a sibling SNS alert topic         |
 
 ## Prerequisites
 

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -15,6 +15,7 @@ All example stacks use the `ComposureCDK-` name prefix. This convention enables 
 | [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + EC2 instance with well-architected defaults, recommended alarms, and SNS alert wiring                                          |
 | [`ComposureCDK-AgentVolumeStack`](src/agent-volume-app.ts)                                          | VPC + EC2 instance with a persistent EBS data volume attached via `attachVolume` + alarm wiring                                      |
 | [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`                                          |
+| [`ComposureCDK-OrderProcessorStack`](src/order-processor-app.ts)                                    | SQS work queue with recommended alarms wired to a sibling SNS alert topic via `alarmActionsPolicy`                                   |
 
 ## Prerequisites
 

--- a/packages/examples/bin/app.ts
+++ b/packages/examples/bin/app.ts
@@ -8,6 +8,7 @@ import { createEc2App } from "../src/ec2-app.js";
 import { createMockApiApp } from "../src/mock-api-app.js";
 import { createMultiStackApp } from "../src/multi-stack-app.js";
 import { createOpenApiPetstoreApp } from "../src/openapi-petstore-app.js";
+import { createOrderProcessorApp } from "../src/order-processor-app.js";
 import { createStaticWebsiteApp } from "../src/static-website/app.js";
 import { createTaggedSystemApp } from "../src/tagged-system-app.js";
 
@@ -21,6 +22,7 @@ createEc2App(app);
 createMockApiApp(app);
 createMultiStackApp(app);
 createOpenApiPetstoreApp(app);
+createOrderProcessorApp(app);
 createStaticWebsiteApp(app);
 createTaggedSystemApp(app);
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -32,7 +32,8 @@
     "@composurecdk/lambda": "^0.7.0",
     "@composurecdk/route53": "^0.7.0",
     "@composurecdk/s3": "^0.7.0",
-    "@composurecdk/sns": "^0.7.0"
+    "@composurecdk/sns": "^0.7.0",
+    "@composurecdk/sqs": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/packages/examples/src/order-processor-app.ts
+++ b/packages/examples/src/order-processor-app.ts
@@ -1,0 +1,69 @@
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { compose } from "@composurecdk/core";
+import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
+import { createTopicBuilder } from "@composurecdk/sns";
+import { createQueueBuilder } from "@composurecdk/sqs";
+
+/**
+ * A primary SQS work queue paired with an SNS alert topic. The queue
+ * gets ComposureCDK's recommended SQS alarms by default (oldest-message
+ * age, in-flight near-quota); a custom alarm watches empty-receive rate
+ * as a low-traffic signal. `alarmActionsPolicy` wires every alarm in the
+ * stack to publish to the alert topic, so adding more alarms later
+ * (recommended or custom) is automatic.
+ *
+ * Demonstrates:
+ * - `createQueueBuilder` with secure defaults (enforceSSL, SSE-SQS, long polling)
+ * - Custom retention via `.retentionPeriod`
+ * - Tuning a recommended alarm threshold via `recommendedAlarms`
+ * - Adding a workload-specific alarm via `addAlarm`
+ * - Composing the queue alongside `createTopicBuilder` and routing all
+ *   alarm actions through `alarmActionsPolicy`
+ */
+export function createOrderProcessorApp(app = new App()) {
+  const stack = new Stack(app, "ComposureCDK-OrderProcessorStack");
+
+  const { alerts } = compose(
+    {
+      alerts: createTopicBuilder().displayName("Order Processor Alerts"),
+
+      orders: createQueueBuilder()
+        .queueName("orders")
+        // Visibility timeout > expected processing time. Workload-specific —
+        // not defaulted by the builder.
+        .visibilityTimeout(Duration.minutes(2))
+        // Retain undelivered work for the full SQS maximum so a downstream
+        // incident can be replayed.
+        .retentionPeriod(Duration.days(14))
+        .recommendedAlarms({
+          // This queue's SLA is tighter than the 5-minute default. Alert
+          // when the oldest message has waited more than 1 minute and the
+          // condition holds for two consecutive evaluations.
+          approximateAgeOfOldestMessage: {
+            threshold: 60,
+            evaluationPeriods: 2,
+            datapointsToAlarm: 2,
+          },
+        })
+        .addAlarm("highEmptyReceiveRate", (alarm) =>
+          alarm
+            .metric((queue) => queue.metricNumberOfEmptyReceives({ period: Duration.minutes(5) }))
+            .threshold(500)
+            .greaterThan()
+            .description(
+              (def) =>
+                `Consumers are polling but the queue is mostly empty — consider tuning concurrency or pausing pollers. ` +
+                `Threshold: > ${String(def.threshold)} empty receives per 5 minutes.`,
+            ),
+        ),
+    },
+    { alerts: [], orders: [] },
+  ).build(stack, "OrderProcessor");
+
+  alarmActionsPolicy(stack, {
+    defaults: { alarmActions: [new SnsAction(alerts.topic)] },
+  });
+
+  return { stack };
+}

--- a/packages/examples/src/order-processor-app.ts
+++ b/packages/examples/src/order-processor-app.ts
@@ -1,30 +1,38 @@
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { compose } from "@composurecdk/core";
 import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
+import { createFunctionBuilder } from "@composurecdk/lambda";
 import { createTopicBuilder } from "@composurecdk/sns";
 import { createQueueBuilder } from "@composurecdk/sqs";
 
 /**
- * A primary SQS work queue paired with an SNS alert topic. The queue
- * gets ComposureCDK's recommended SQS alarms by default (oldest-message
- * age, in-flight near-quota); a custom alarm watches empty-receive rate
- * as a low-traffic signal. `alarmActionsPolicy` wires every alarm in the
- * stack to publish to the alert topic, so adding more alarms later
- * (recommended or custom) is automatic.
+ * A primary SQS work queue feeding a Lambda consumer, paired with an SNS
+ * alert topic. The queue gets ComposureCDK's recommended SQS alarms by
+ * default (oldest-message age, in-flight near-quota); the processor gets
+ * the recommended Lambda alarms (errors, throttles — the duration alarm
+ * is timeout-relative and the processor leaves timeout at the CDK
+ * default, so it is not emitted); a custom alarm watches empty-receive
+ * rate as a low-traffic signal. `alarmActionsPolicy` wires every alarm in
+ * the stack to publish to the alert topic, so adding more alarms later is
+ * automatic.
  *
  * Demonstrates:
  * - `createQueueBuilder` with secure defaults (enforceSSL, SSE-SQS, long polling)
  * - Custom retention via `.retentionPeriod`
  * - Tuning a recommended alarm threshold via `recommendedAlarms`
  * - Adding a workload-specific alarm via `addAlarm`
+ * - Wiring the queue to a `createFunctionBuilder` consumer as an SQS event
+ *   source (see the wiring note below)
  * - Composing the queue alongside `createTopicBuilder` and routing all
  *   alarm actions through `alarmActionsPolicy`
  */
 export function createOrderProcessorApp(app = new App()) {
   const stack = new Stack(app, "ComposureCDK-OrderProcessorStack");
 
-  const { alerts } = compose(
+  const { alerts, orders, processor } = compose(
     {
       alerts: createTopicBuilder().displayName("Order Processor Alerts"),
 
@@ -57,9 +65,28 @@ export function createOrderProcessorApp(app = new App()) {
                 `Threshold: > ${String(def.threshold)} empty receives per 5 minutes.`,
             ),
         ),
+
+      processor: createFunctionBuilder()
+        .runtime(Runtime.NODEJS_22_X)
+        .handler("index.handler")
+        // Logs each order so the post-deploy smoke test can prove the
+        // consumer is wired and the execution role can read the queue.
+        .code(
+          Code.fromInline(
+            "exports.handler = async (event) => { for (const r of event.Records) console.log('processed order', r.body); };",
+          ),
+        )
+        .memorySize(256)
+        .description("Order processor — consumes and processes order messages"),
     },
-    { alerts: [], orders: [] },
+    { alerts: [], orders: [], processor: [] },
   ).build(stack, "OrderProcessor");
+
+  // SQS-to-Lambda wiring. ComposureCDK has no event-source helper yet
+  // (see https://github.com/laazyj/composureCDK/issues/118), so the event
+  // source is attached directly to the built function. `SqsEventSource`
+  // also grants the execution role permission to consume the queue.
+  processor.function.addEventSource(new SqsEventSource(orders.queue));
 
   alarmActionsPolicy(stack, {
     defaults: { alarmActions: [new SnsAction(alerts.topic)] },

--- a/packages/examples/test/order-processor-app.test.ts
+++ b/packages/examples/test/order-processor-app.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "vitest";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { createOrderProcessorApp } from "../src/order-processor-app.js";
+
+describe("order-processor-app", () => {
+  const { stack } = createOrderProcessorApp();
+  const template = Template.fromStack(stack);
+
+  it("creates one SQS queue", () => {
+    template.resourceCountIs("AWS::SQS::Queue", 1);
+  });
+
+  it("creates one SNS alert topic", () => {
+    template.resourceCountIs("AWS::SNS::Topic", 1);
+  });
+
+  it("configures the queue with the requested visibility timeout and retention", () => {
+    template.hasResourceProperties("AWS::SQS::Queue", {
+      QueueName: "orders",
+      VisibilityTimeout: 120,
+      MessageRetentionPeriod: 1_209_600,
+      ReceiveMessageWaitTimeSeconds: 20,
+      SqsManagedSseEnabled: true,
+    });
+  });
+
+  it("emits an enforceSSL queue policy", () => {
+    template.hasResourceProperties("AWS::SQS::QueuePolicy", {
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Deny",
+            Action: "sqs:*",
+            Condition: { Bool: { "aws:SecureTransport": "false" } },
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("creates the tuned approximateAgeOfOldestMessage alarm (60s, 2 of 2)", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "ApproximateAgeOfOldestMessage",
+      Namespace: "AWS/SQS",
+      Threshold: 60,
+      EvaluationPeriods: 2,
+      DatapointsToAlarm: 2,
+      ComparisonOperator: "GreaterThanThreshold",
+    });
+  });
+
+  it("creates the default approximateNumberOfMessagesNotVisible alarm at 90,000", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "ApproximateNumberOfMessagesNotVisible",
+      Namespace: "AWS/SQS",
+      Threshold: 90_000,
+    });
+  });
+
+  it("creates the custom highEmptyReceiveRate alarm", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "NumberOfEmptyReceives",
+      Namespace: "AWS/SQS",
+      Threshold: 500,
+      ComparisonOperator: "GreaterThanThreshold",
+    });
+  });
+
+  it("routes queue alarms to the alert topic via alarmActionsPolicy", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "ApproximateAgeOfOldestMessage",
+      AlarmActions: Match.arrayWith([Match.objectLike({ Ref: Match.stringLikeRegexp("alerts") })]),
+    });
+  });
+
+  it("creates the four SNS topic recommended alarms plus the three queue alarms", () => {
+    // Topic ships 4 recommended alarms; queue ships 2 recommended + 1 custom.
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 7);
+  });
+});

--- a/packages/examples/test/order-processor-app.test.ts
+++ b/packages/examples/test/order-processor-app.test.ts
@@ -14,6 +14,17 @@ describe("order-processor-app", () => {
     template.resourceCountIs("AWS::SNS::Topic", 1);
   });
 
+  it("creates one Lambda consumer wired to the queue via an event source", () => {
+    template.resourceCountIs("AWS::Lambda::Function", 1);
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Runtime: "nodejs22.x",
+      Handler: "index.handler",
+      MemorySize: 256,
+      Description: "Order processor — consumes and processes order messages",
+    });
+    template.resourceCountIs("AWS::Lambda::EventSourceMapping", 1);
+  });
+
   it("configures the queue with the requested visibility timeout and retention", () => {
     template.hasResourceProperties("AWS::SQS::Queue", {
       QueueName: "orders",
@@ -73,8 +84,15 @@ describe("order-processor-app", () => {
     });
   });
 
-  it("creates the four SNS topic recommended alarms plus the three queue alarms", () => {
-    // Topic ships 4 recommended alarms; queue ships 2 recommended + 1 custom.
-    template.resourceCountIs("AWS::CloudWatch::Alarm", 7);
+  it("creates the recommended Lambda alarms for the consumer", () => {
+    // errors + throttles. The duration alarm is timeout-relative and the
+    // consumer leaves timeout at the CDK default, so it is not emitted.
+    template.resourcePropertiesCountIs("AWS::CloudWatch::Alarm", { Namespace: "AWS/Lambda" }, 2);
+  });
+
+  it("creates the topic, queue, and consumer recommended alarms", () => {
+    // Topic ships 4 recommended; queue ships 2 recommended + 1 custom;
+    // the Lambda consumer ships 2 recommended (errors, throttles).
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 9);
   });
 });

--- a/packages/examples/test/smoke/_helpers.mjs
+++ b/packages/examples/test/smoke/_helpers.mjs
@@ -67,6 +67,24 @@ export function findStackResources(aws, stackName, { type, namePattern } = {}) {
   });
 }
 
+/**
+ * Resolves a Lambda function's CloudWatch log group from its live config.
+ * Lambda's default log group is `/aws/lambda/<name>`, but examples may
+ * override it via `LoggingConfig` — resolve from the live config rather
+ * than guess.
+ */
+export function resolveLambdaLogGroup(aws, fnName) {
+  const cfg = aws(
+    "lambda",
+    "get-function-configuration",
+    "--function-name",
+    fnName,
+    "--output",
+    "json",
+  );
+  return cfg.LoggingConfig?.LogGroup ?? `/aws/lambda/${fnName}`;
+}
+
 export async function pollUntil(predicate, { timeoutMs = 30_000, intervalMs = 2_000 } = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {

--- a/packages/examples/test/smoke/dual-function.smoke.mjs
+++ b/packages/examples/test/smoke/dual-function.smoke.mjs
@@ -3,7 +3,7 @@ import { readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { findStackResources, pollUntil } from "./_helpers.mjs";
+import { findStackResources, pollUntil, resolveLambdaLogGroup } from "./_helpers.mjs";
 
 const STACK = "ComposureCDK-DualFunctionStack";
 
@@ -20,17 +20,7 @@ export default {
     }
 
     const fnName = apiFn.PhysicalResourceId;
-    const cfg = aws(
-      "lambda",
-      "get-function-configuration",
-      "--function-name",
-      fnName,
-      "--output",
-      "json",
-    );
-    // Lambda's default log group is /aws/lambda/<name>; this stack overrides
-    // it via LoggingConfig so resolve from the live config rather than guess.
-    const logGroup = cfg.LoggingConfig?.LogGroup ?? `/aws/lambda/${fnName}`;
+    const logGroup = resolveLambdaLogGroup(aws, fnName);
 
     const outputFile = join(tmpdir(), `composurecdk-smoke-invoke-${process.pid}.json`);
     const invokeStartMs = Date.now();

--- a/packages/examples/test/smoke/order-processor.smoke.mjs
+++ b/packages/examples/test/smoke/order-processor.smoke.mjs
@@ -1,0 +1,73 @@
+import { findStackResources, pollUntil, resolveLambdaLogGroup } from "./_helpers.mjs";
+
+const STACK = "ComposureCDK-OrderProcessorStack";
+
+export default {
+  name: "SQS order processing checks",
+  run: async ({ aws, pass, fail }) => {
+    const [queue] = findStackResources(aws, STACK, { type: "AWS::SQS::Queue" });
+    if (!queue) {
+      fail(`${STACK} — orders queue not found`);
+      return;
+    }
+    // PhysicalResourceId of an AWS::SQS::Queue is the queue URL.
+    const queueUrl = queue.PhysicalResourceId;
+
+    const [processorFn] = findStackResources(aws, STACK, {
+      type: "AWS::Lambda::Function",
+      namePattern: /processor/i,
+    });
+    if (!processorFn) {
+      fail(`${STACK} — processor Lambda not found`);
+      return;
+    }
+    const fnName = processorFn.PhysicalResourceId;
+    const logGroup = resolveLambdaLogGroup(aws, fnName);
+
+    // Unique marker so the log poll can't match a stale event from a
+    // previous run.
+    const marker = `smoke-${process.pid}-${Date.now()}`;
+    const sendStartMs = Date.now();
+    aws(
+      "sqs",
+      "send-message",
+      "--queue-url",
+      queueUrl,
+      "--message-body",
+      marker,
+      "--output",
+      "json",
+    );
+    pass(`${queueUrl} — order message sent`);
+
+    // The event source delivers the message to the consumer; a log line
+    // carrying the marker proves the function was invoked AND its
+    // execution role could read the queue and write logs.
+    const processed = await pollUntil(
+      () => {
+        const { events } = aws(
+          "logs",
+          "filter-log-events",
+          "--log-group-name",
+          logGroup,
+          "--start-time",
+          String(sendStartMs - 5_000),
+          "--filter-pattern",
+          `"${marker}"`,
+          "--max-items",
+          "1",
+          "--output",
+          "json",
+        );
+        return events && events.length > 0;
+      },
+      { timeoutMs: 60_000, intervalMs: 3_000 },
+    );
+
+    if (processed) {
+      pass(`${fnName} — consumed and logged the order message`);
+    } else {
+      fail(`${logGroup} — order message ${marker} not processed within 60s`);
+    }
+  },
+};

--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -1,0 +1,131 @@
+# @composurecdk/sqs
+
+SQS queue builder for [ComposureCDK](../../README.md).
+
+This package provides a fluent builder for SQS queues with secure, AWS-recommended defaults and built-in CloudWatch alarms. It wraps the CDK [Queue](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.Queue.html) construct — refer to the CDK documentation for the full set of configurable properties.
+
+## Queue Builder
+
+```ts
+import { Duration } from "aws-cdk-lib";
+import { createQueueBuilder } from "@composurecdk/sqs";
+
+const orders = createQueueBuilder()
+  .queueName("orders")
+  .visibilityTimeout(Duration.seconds(60))
+  .build(stack, "Orders");
+```
+
+Every [QueueProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html) property is available as a fluent setter on the builder. FIFO queues are supported via the standard `fifo`, `contentBasedDeduplication`, and `fifoThroughputLimit` props — no FIFO-specific defaults are applied.
+
+## Secure Defaults
+
+`createQueueBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.
+
+| Property                 | Default                       | Rationale                                                                                                                                                                                                                                                             |
+| ------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enforceSSL`             | `true`                        | Denies any request that doesn't use TLS (resource policy `Deny` on `aws:SecureTransport: false`). Mirrors the SNS topic default. ([SNS/SQS security best practices](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-security-best-practices.html)) |
+| `encryption`             | `QueueEncryption.SQS_MANAGED` | Encrypts at rest with the SQS-managed key (SSE-SQS). KMS encryption is opt-in via `.encryption(QueueEncryption.KMS)` + `.encryptionMasterKey(key)`. ([SQS data protection](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-data-protection.html))  |
+| `receiveMessageWaitTime` | `Duration.seconds(20)`        | Enables [long polling](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling) — fewer empty receives, lower cost, lower latency. 20s is the SQS maximum.                                                    |
+
+`visibilityTimeout` is intentionally not defaulted — it must match the longest consumer processing time, which is workload-specific. `retentionPeriod` is also left at CDK's default of 4 days; bump it to 14 days if you need a longer replay window.
+
+The defaults are exported as `QUEUE_DEFAULTS` for visibility and testing:
+
+```ts
+import { QUEUE_DEFAULTS } from "@composurecdk/sqs";
+```
+
+### Overriding defaults
+
+```ts
+const queue = createQueueBuilder()
+  .queueName("my-queue")
+  .enforceSSL(false)
+  .receiveMessageWaitTime(Duration.seconds(0))
+  .build(stack, "MyQueue");
+```
+
+## Recommended Alarms
+
+The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS) by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.
+
+| Alarm                                   | Metric                                               | Default threshold | Rationale                                                                                                                                                                                                     |
+| --------------------------------------- | ---------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `approximateAgeOfOldestMessage`         | `ApproximateAgeOfOldestMessage` (Max, 1 min)         | > 300s (5 min)    | Primary "consumer falling behind" signal. Conservative starting point — tune to your SLA and `retentionPeriod`.                                                                                               |
+| `approximateNumberOfMessagesNotVisible` | `ApproximateNumberOfMessagesNotVisible` (Max, 1 min) | > 90,000          | 75% of the [120k in-flight messages](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight) per-queue quota. Proactive guardrail before receives are rejected. |
+
+These defaults target primary queues; dead-letter queues need different thresholds (any message on a DLQ is itself an alert).
+
+The third AWS-recommended SQS alarm, `ApproximateNumberOfMessagesVisible`, is not enabled by default — its useful threshold depends entirely on the application's processing capacity, and any generic value would be either noise or silence. Use `addAlarm` (see [Custom alarms](#custom-alarms)) to add it for workloads where you know the right threshold.
+
+The defaults are exported as `QUEUE_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { QUEUE_ALARM_DEFAULTS } from "@composurecdk/sqs";
+```
+
+### Customizing thresholds
+
+Override individual alarm properties via `recommendedAlarms`. Unspecified fields keep their defaults.
+
+```ts
+const queue = createQueueBuilder()
+  .queueName("orders")
+  .recommendedAlarms({
+    approximateAgeOfOldestMessage: { threshold: 60, evaluationPeriods: 3 },
+  });
+```
+
+### Disabling alarms
+
+Disable all recommended alarms:
+
+```ts
+builder.recommendedAlarms(false);
+// or
+builder.recommendedAlarms({ enabled: false });
+```
+
+Disable individual alarms:
+
+```ts
+builder.recommendedAlarms({ approximateNumberOfMessagesNotVisible: false });
+```
+
+### Custom alarms
+
+Add custom alarms alongside the recommended ones via `addAlarm`. The callback receives an `AlarmDefinitionBuilder` typed to `IQueue`, so the metric factory has access to the queue's properties.
+
+```ts
+import { Duration } from "aws-cdk-lib";
+
+const queue = createQueueBuilder()
+  .queueName("orders")
+  .addAlarm("highEmptyReceiveRate", (alarm) =>
+    alarm
+      .metric((queue) => queue.metricNumberOfEmptyReceives({ period: Duration.minutes(1) }))
+      .threshold(1000)
+      .greaterThan()
+      .description("Queue receiving an unusually high number of empty receives."),
+  );
+```
+
+### Applying alarm actions
+
+Alarms are returned in the build result as `Record<string, Alarm>`:
+
+```ts
+const result = createQueueBuilder().queueName("orders").build(stack, "Orders");
+
+const alertTopic = new Topic(stack, "AlertTopic");
+for (const alarm of Object.values(result.alarms)) {
+  alarm.addAlarmAction(new SnsAction(alertTopic));
+}
+```
+
+For composing the alarm-actions wiring across multiple builders in a single `compose` system, see [`alarmActionsPolicy`](../cloudwatch/README.md) in `@composurecdk/cloudwatch`.
+
+## Examples
+
+- [OrderProcessorStack](../examples/src/order-processor-app.ts) — Primary SQS queue with recommended alarms routed to a sibling SNS alert topic.

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@composurecdk/sqs",
+  "version": "0.7.0",
+  "description": "Composable SQS queue builder with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/sqs"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.7.0",
+    "@composurecdk/core": "^0.7.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.2",
+    "aws-cdk-lib": "^2.253.1",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/sqs/src/defaults.ts
+++ b/packages/sqs/src/defaults.ts
@@ -1,0 +1,37 @@
+import { Duration } from "aws-cdk-lib";
+import { QueueEncryption, type QueueProps } from "aws-cdk-lib/aws-sqs";
+
+/**
+ * Secure, AWS-recommended defaults applied to every SQS queue built
+ * with {@link createQueueBuilder}. Each property can be individually
+ * overridden via the builder's fluent API.
+ */
+export const QUEUE_DEFAULTS: Partial<QueueProps> = {
+  /**
+   * Reject any request that does not use TLS. Adds a resource policy
+   * `Deny` on `aws:SecureTransport: false`, the same control applied to
+   * SNS topics by {@link createTopicBuilder}.
+   * @see https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-security-best-practices.html
+   */
+  enforceSSL: true,
+
+  /**
+   * Encrypt messages at rest with the SQS-managed key (SSE-SQS). This
+   * is the safe baseline; bring-your-own KMS encryption is opt-in via
+   * `.encryptionMasterKey(...)` paired with `.encryption(QueueEncryption.KMS)`.
+   * CDK already defaults newly-created queues to SSE-SQS — making it
+   * explicit here keeps the default discoverable and stable across CDK
+   * versions.
+   * @see https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-data-protection.html
+   */
+  encryption: QueueEncryption.SQS_MANAGED,
+
+  /**
+   * Enable long polling. Holds `ReceiveMessage` connections open for up
+   * to 20 seconds while waiting for messages, which cuts both the cost
+   * of empty receives and the perceived delivery latency of low-traffic
+   * queues. The 20s value is the SQS maximum.
+   * @see https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
+   */
+  receiveMessageWaitTime: Duration.seconds(20),
+};

--- a/packages/sqs/src/index.ts
+++ b/packages/sqs/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  createQueueBuilder,
+  type IQueueBuilder,
+  type QueueBuilderProps,
+  type QueueBuilderResult,
+} from "./queue-builder.js";
+export { QUEUE_DEFAULTS } from "./defaults.js";
+export { type QueueAlarmConfig } from "./queue-alarm-config.js";
+export { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";

--- a/packages/sqs/src/queue-alarm-config.ts
+++ b/packages/sqs/src/queue-alarm-config.ts
@@ -1,0 +1,48 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for an SQS queue.
+ * All applicable alarms are enabled by default with AWS-recommended thresholds.
+ * Set individual alarms to `false` to disable them, or provide an
+ * {@link AlarmConfig} to tune thresholds.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+ */
+export interface QueueAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the oldest unprocessed message in the queue has been
+   * waiting longer than the configured threshold. Primary signal that
+   * consumers are falling behind.
+   *
+   * Metric: `AWS/SQS ApproximateAgeOfOldestMessage`, statistic Maximum,
+   * period 1 minute.
+   * Default threshold: > 300 seconds (5 minutes).
+   *
+   * The default is conservative and should be tuned to the queue's
+   * SLA and `retentionPeriod`.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  approximateAgeOfOldestMessage?: AlarmConfig | false;
+
+  /**
+   * Alarm when the number of in-flight (received but not yet deleted)
+   * messages approaches the SQS quota of 120,000 per queue. A breach
+   * means new messages will start being rejected.
+   *
+   * Metric: `AWS/SQS ApproximateNumberOfMessagesNotVisible`, statistic
+   * Maximum, period 1 minute.
+   * Default threshold: > 90,000 (75% of the in-flight quota).
+   *
+   * @see https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  approximateNumberOfMessagesNotVisible?: AlarmConfig | false;
+}

--- a/packages/sqs/src/queue-alarm-defaults.ts
+++ b/packages/sqs/src/queue-alarm-defaults.ts
@@ -1,0 +1,46 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+
+interface QueueAlarmDefaults {
+  enabled: true;
+  approximateAgeOfOldestMessage: AlarmConfigDefaults;
+  approximateNumberOfMessagesNotVisible: AlarmConfigDefaults;
+}
+
+/**
+ * AWS-recommended default alarm configuration for SQS queues.
+ *
+ * Tuned for primary (consumer-fed) queues. Dead-letter queues need
+ * different thresholds — any message on a DLQ is itself an alert,
+ * whereas a primary queue with messages is normal.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+ */
+export const QUEUE_ALARM_DEFAULTS: QueueAlarmDefaults = {
+  enabled: true,
+
+  /**
+   * 5 minutes. Conservative starting point for a "consumer falling
+   * behind" alarm. The right value depends on the workload's SLA and
+   * `retentionPeriod`; tune via `recommendedAlarms`.
+   */
+  approximateAgeOfOldestMessage: {
+    threshold: 300,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /**
+   * 90,000 — 75% of the SQS 120,000 in-flight message quota. Proactive
+   * guardrail; a breach means the queue is approaching the point where
+   * new messages will be rejected.
+   * @see https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight
+   */
+  approximateNumberOfMessagesNotVisible: {
+    threshold: 90_000,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};

--- a/packages/sqs/src/queue-alarms.ts
+++ b/packages/sqs/src/queue-alarms.ts
@@ -1,0 +1,98 @@
+import { Duration } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
+import type { IQueue } from "aws-cdk-lib/aws-sqs";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { QueueAlarmConfig } from "./queue-alarm-config.js";
+import { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.minutes(1);
+const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+
+/**
+ * Resolves the recommended alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s for an SQS queue.
+ */
+export function resolveQueueAlarmDefinitions(
+  queue: IQueue,
+  config: QueueAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.approximateAgeOfOldestMessage !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.approximateAgeOfOldestMessage,
+      QUEUE_ALARM_DEFAULTS.approximateAgeOfOldestMessage,
+    );
+    definitions.push({
+      key: "approximateAgeOfOldestMessage",
+      alarmName: cfg.alarmName,
+      metric: queue.metricApproximateAgeOfOldestMessage({ period: METRIC_PERIOD }),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `SQS queue's oldest message has been waiting longer than the threshold, ` +
+        `indicating consumers are falling behind. Threshold: > ${String(cfg.threshold)} seconds in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.approximateNumberOfMessagesNotVisible !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.approximateNumberOfMessagesNotVisible,
+      QUEUE_ALARM_DEFAULTS.approximateNumberOfMessagesNotVisible,
+    );
+    definitions.push({
+      key: "approximateNumberOfMessagesNotVisible",
+      alarmName: cfg.alarmName,
+      metric: queue.metricApproximateNumberOfMessagesNotVisible({ period: METRIC_PERIOD }),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `SQS queue's in-flight messages are approaching the 120,000 per-queue quota; ` +
+        `further receives will be rejected once the quota is hit. ` +
+        `Threshold: > ${String(cfg.threshold)} in-flight in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates AWS-recommended CloudWatch alarms for an SQS queue, merging
+ * recommended definitions with any custom alarm builders.
+ *
+ * @param scope - CDK construct scope for creating alarm constructs.
+ * @param id - Base identifier for alarm construct ids.
+ * @param queue - The SQS queue to create alarms for.
+ * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @returns A record mapping alarm keys to their created Alarm constructs.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+ */
+export function createQueueAlarms(
+  scope: IConstruct,
+  id: string,
+  queue: IQueue,
+  config: QueueAlarmConfig | false | undefined,
+  customAlarms: AlarmDefinitionBuilder<IQueue>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? QUEUE_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveQueueAlarmDefinitions(queue, config);
+  const custom = customAlarms.map((b) => b.resolve(queue));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/sqs/src/queue-builder.ts
+++ b/packages/sqs/src/queue-builder.ts
@@ -1,0 +1,143 @@
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { type IQueue, Queue, type QueueProps } from "aws-cdk-lib/aws-sqs";
+import { type IConstruct } from "constructs";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { QueueAlarmConfig } from "./queue-alarm-config.js";
+import { createQueueAlarms } from "./queue-alarms.js";
+import { QUEUE_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the SQS queue builder.
+ *
+ * Extends the CDK {@link QueueProps} with additional builder-specific options.
+ */
+export interface QueueBuilderProps extends QueueProps {
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates recommended alarms with sensible
+   * thresholds for every applicable metric. Individual alarms can be
+   * customized or disabled. Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification
+   * methods are user-specific. Access alarms from the build result
+   * or use an `afterBuild` hook to apply actions.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  recommendedAlarms?: QueueAlarmConfig | false;
+}
+
+/**
+ * The build output of an {@link IQueueBuilder}. Contains the CDK constructs
+ * created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface QueueBuilderResult {
+  /** The SQS queue construct created by the builder. */
+  queue: Queue;
+
+  /**
+   * CloudWatch alarms created for the queue, keyed by alarm name.
+   *
+   * Includes both AWS-recommended alarms and any custom alarms added
+   * via {@link IQueueBuilder.addAlarm}. Access individual alarms
+   * by key (e.g., `result.alarms.approximateAgeOfOldestMessage`).
+   *
+   * No alarm actions are configured — apply them via the result or an
+   * `afterBuild` hook.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS SQS queue.
+ *
+ * Each configuration property from the CDK {@link QueueProps} is exposed
+ * as an overloaded method: call with a value to set it (returns the builder
+ * for chaining), or call with no arguments to read the current value.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates
+ * an SQS queue with the configured properties and returns a
+ * {@link QueueBuilderResult}.
+ *
+ * The builder also creates AWS-recommended CloudWatch alarms by default.
+ * Alarms can be customized or disabled via the `recommendedAlarms` property.
+ * Custom alarms can be added via the {@link addAlarm} method.
+ *
+ * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.Queue.html
+ *
+ * @example
+ * ```ts
+ * const orders = createQueueBuilder()
+ *   .queueName("orders")
+ *   .visibilityTimeout(Duration.seconds(60));
+ * ```
+ */
+export type IQueueBuilder = ITaggedBuilder<QueueBuilderProps, QueueBuilder>;
+
+class QueueBuilder implements Lifecycle<QueueBuilderResult> {
+  props: Partial<QueueBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<IQueue>[] = [];
+
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<IQueue>) => AlarmDefinitionBuilder<IQueue>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IQueue>(key)));
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: QueueBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
+  }
+
+  build(scope: IConstruct, id: string): QueueBuilderResult {
+    const { recommendedAlarms: alarmConfig, ...queueProps } = this.props;
+
+    const mergedProps = {
+      ...QUEUE_DEFAULTS,
+      ...queueProps,
+    } as QueueBuilderProps;
+
+    const queue = new Queue(scope, id, mergedProps);
+
+    const alarms = createQueueAlarms(scope, id, queue, alarmConfig, this.#customAlarms);
+
+    return { queue, alarms };
+  }
+}
+
+/**
+ * Creates a new {@link IQueueBuilder} for configuring an AWS SQS queue.
+ *
+ * This is the entry point for defining an SQS queue component. The returned
+ * builder exposes every {@link QueueBuilderProps} property as a fluent setter/getter
+ * and implements {@link Lifecycle} for use with {@link compose}.
+ *
+ * @returns A fluent builder for an AWS SQS queue.
+ *
+ * @example
+ * ```ts
+ * const orders = createQueueBuilder()
+ *   .queueName("orders")
+ *   .visibilityTimeout(Duration.seconds(60));
+ *
+ * // Use standalone:
+ * const result = orders.build(stack, "Orders");
+ *
+ * // Or compose into a system:
+ * const system = compose(
+ *   { orders, alerts: createTopicBuilder() },
+ *   { orders: [], alerts: [] },
+ * );
+ * ```
+ */
+export function createQueueBuilder(): IQueueBuilder {
+  return taggedBuilder<QueueBuilderProps, QueueBuilder>(QueueBuilder);
+}

--- a/packages/sqs/test/queue-alarms.test.ts
+++ b/packages/sqs/test/queue-alarms.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { createQueueBuilder } from "../src/queue-builder.js";
+
+function buildResult(configureFn?: (builder: ReturnType<typeof createQueueBuilder>) => void) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createQueueBuilder();
+  configureFn?.(builder);
+  const result = builder.build(stack, "TestQueue");
+  return { result, template: Template.fromStack(stack) };
+}
+
+describe("recommended alarms", () => {
+  describe("defaults", () => {
+    it("creates both recommended alarms by default", () => {
+      const { result, template } = buildResult();
+
+      expect(result.alarms.approximateAgeOfOldestMessage).toBeDefined();
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeDefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+
+    it("creates approximateAgeOfOldestMessage alarm with threshold > 300 seconds", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        Namespace: "AWS/SQS",
+        Threshold: 300,
+        ComparisonOperator: "GreaterThanThreshold",
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        TreatMissingData: "notBreaching",
+        Statistic: "Maximum",
+        Period: 60,
+        Dimensions: Match.arrayWith([Match.objectLike({ Name: "QueueName" })]),
+      });
+    });
+
+    it("creates approximateNumberOfMessagesNotVisible alarm with threshold > 90000", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesNotVisible",
+        Namespace: "AWS/SQS",
+        Threshold: 90_000,
+        ComparisonOperator: "GreaterThanThreshold",
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        TreatMissingData: "notBreaching",
+        Statistic: "Maximum",
+        Period: 60,
+      });
+    });
+  });
+
+  describe("customisation", () => {
+    it("allows overriding the approximateAgeOfOldestMessage threshold", () => {
+      const { template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateAgeOfOldestMessage: { threshold: 60 } }),
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        Threshold: 60,
+      });
+    });
+
+    it("allows overriding evaluationPeriods and treatMissingData", () => {
+      const { template } = buildResult((b) =>
+        b.recommendedAlarms({
+          approximateAgeOfOldestMessage: {
+            evaluationPeriods: 3,
+            treatMissingData: TreatMissingData.MISSING,
+          },
+        }),
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        EvaluationPeriods: 3,
+        TreatMissingData: "missing",
+      });
+    });
+
+    it("disables an individual alarm when set to false", () => {
+      const { result, template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateNumberOfMessagesNotVisible: false }),
+      );
+
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("disables all recommended alarms when recommendedAlarms is false", () => {
+      const { result, template } = buildResult((b) => b.recommendedAlarms(false));
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all recommended alarms when enabled is false", () => {
+      const { result, template } = buildResult((b) => b.recommendedAlarms({ enabled: false }));
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("no default actions", () => {
+    it("creates recommended alarms with no AlarmActions configured", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        AlarmActions: Match.absent(),
+      });
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesNotVisible",
+        AlarmActions: Match.absent(),
+      });
+    });
+  });
+});
+
+describe("addAlarm duplicate-key safety", () => {
+  it("throws when a custom alarm reuses a recommended-alarm key", () => {
+    expect(() =>
+      buildResult((b) => {
+        b.addAlarm("approximateAgeOfOldestMessage", (alarm) =>
+          alarm
+            .metric((queue) => queue.metricApproximateAgeOfOldestMessage())
+            .threshold(1)
+            .greaterThan()
+            .description("Duplicate"),
+        );
+      }),
+    ).toThrow(/Duplicate alarm key "approximateAgeOfOldestMessage"/);
+  });
+});

--- a/packages/sqs/test/queue-builder.test.ts
+++ b/packages/sqs/test/queue-builder.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { type IQueue, QueueEncryption } from "aws-cdk-lib/aws-sqs";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import { createQueueBuilder } from "../src/queue-builder.js";
+
+function synthTemplate(
+  configureFn?: (builder: ReturnType<typeof createQueueBuilder>) => void,
+): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createQueueBuilder();
+  configureFn?.(builder);
+  builder.build(stack, "TestQueue");
+  return Template.fromStack(stack);
+}
+
+describe("QueueBuilder", () => {
+  describe("build", () => {
+    it("returns a QueueBuilderResult with a queue property", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createQueueBuilder().build(stack, "TestQueue");
+
+      expect(result).toBeDefined();
+      expect(result.queue).toBeDefined();
+    });
+
+    it("creates exactly one SQS queue", () => {
+      const template = synthTemplate();
+
+      template.resourceCountIs("AWS::SQS::Queue", 1);
+    });
+
+    it("exposes the alarms record in the result", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createQueueBuilder().build(stack, "TestQueue");
+
+      expect(result.alarms).toBeDefined();
+      expect(typeof result.alarms).toBe("object");
+    });
+  });
+
+  describe("secure defaults", () => {
+    it("enables enforceSSL by default — deny on aws:SecureTransport=false", () => {
+      const template = synthTemplate();
+
+      template.hasResourceProperties("AWS::SQS::QueuePolicy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Deny",
+              Action: "sqs:*",
+              Condition: { Bool: { "aws:SecureTransport": "false" } },
+            }),
+          ]),
+        }),
+      });
+    });
+
+    it("encrypts at rest with SQS_MANAGED by default", () => {
+      const template = synthTemplate();
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        SqsManagedSseEnabled: true,
+      });
+    });
+
+    it("enables long polling with a 20 second receive wait time by default", () => {
+      const template = synthTemplate();
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        ReceiveMessageWaitTimeSeconds: 20,
+      });
+    });
+
+    it("allows enforceSSL to be disabled via the fluent API", () => {
+      const template = synthTemplate((b) => b.enforceSSL(false));
+
+      template.resourceCountIs("AWS::SQS::QueuePolicy", 0);
+    });
+
+    it("allows receiveMessageWaitTime to be overridden", () => {
+      const template = synthTemplate((b) => b.receiveMessageWaitTime(Duration.seconds(0)));
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        ReceiveMessageWaitTimeSeconds: 0,
+      });
+    });
+
+    it("allows the encryption mode to be overridden to a customer-managed KMS key", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const key = new Key(stack, "Key");
+
+      createQueueBuilder()
+        .encryption(QueueEncryption.KMS)
+        .encryptionMasterKey(key)
+        .build(stack, "TestQueue");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        KmsMasterKeyId: Match.anyValue(),
+      });
+    });
+  });
+
+  describe("synthesised output", () => {
+    it("creates a queue with the specified queue name", () => {
+      const template = synthTemplate((b) => b.queueName("orders"));
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        QueueName: "orders",
+      });
+    });
+
+    it("creates a FIFO queue when configured", () => {
+      const template = synthTemplate((b) => b.fifo(true).queueName("orders.fifo"));
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        FifoQueue: true,
+        QueueName: "orders.fifo",
+      });
+    });
+
+    it("forwards the visibility timeout to the underlying CDK construct", () => {
+      const template = synthTemplate((b) => b.visibilityTimeout(Duration.seconds(120)));
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        VisibilityTimeout: 120,
+      });
+    });
+  });
+
+  describe("copy", () => {
+    it("preserves custom alarms across .copy()", () => {
+      const emptyReceives = (queue: IQueue): Metric =>
+        new Metric({
+          namespace: "AWS/SQS",
+          metricName: "NumberOfEmptyReceives",
+          dimensionsMap: { QueueName: queue.queueName },
+          statistic: "Sum",
+          period: Duration.minutes(1),
+        });
+
+      assertCopyPreservesState({
+        factory: () => createQueueBuilder(),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) => a.metric(emptyReceives).threshold(1).greaterThan());
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) => a.metric(emptyReceives).threshold(5).greaterThan());
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Queue"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
+    });
+  });
+
+  describe("addAlarm", () => {
+    it("creates a custom alarm using the supplied metric and threshold", () => {
+      const { result, template } = (() => {
+        const app = new App();
+        const stack = new Stack(app, "TestStack");
+        const result = createQueueBuilder()
+          .queueName("orders")
+          .addAlarm("highEmptyReceiveRate", (a) =>
+            a
+              .metric(
+                (queue) =>
+                  new Metric({
+                    namespace: "AWS/SQS",
+                    metricName: "NumberOfEmptyReceives",
+                    dimensionsMap: { QueueName: queue.queueName },
+                    statistic: "Sum",
+                    period: Duration.minutes(1),
+                  }),
+              )
+              .threshold(1000)
+              .greaterThan()
+              .description("Queue receiving an unusually high number of empty receives."),
+          )
+          .build(stack, "TestQueue");
+        return { result, template: Template.fromStack(stack) };
+      })();
+
+      expect(result.alarms.highEmptyReceiveRate).toBeDefined();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "NumberOfEmptyReceives",
+        Namespace: "AWS/SQS",
+        Threshold: 1000,
+        ComparisonOperator: "GreaterThanThreshold",
+      });
+    });
+  });
+});

--- a/packages/sqs/tsconfig.build.json
+++ b/packages/sqs/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sqs/tsconfig.json
+++ b/packages/sqs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Closes #112. First cut of `@composurecdk/sqs` — a fluent SQS queue builder with secure Well-Architected defaults and two AWS-recommended CloudWatch alarms. Mirrors the structure of `@composurecdk/sns` (`TopicBuilder`, `TopicAlarmConfig`, `TOPIC_ALARM_DEFAULTS`, `createTopicAlarms`).

Plan posted to the issue: https://github.com/laazyj/composureCDK/issues/112#issuecomment-4438621025

## What's in this PR

### Package

- `@composurecdk/sqs`, version `0.7.0`, peerDeps on `core` + `cloudformation` + `cloudwatch` + `aws-cdk-lib`.
- `createQueueBuilder()` — fluent builder, `taggedBuilder`-wrapped (Queue supports Tags), exposes every `QueueProps` field plus `recommendedAlarms` and `addAlarm`.
- `QueueBuilderResult = { queue: Queue, alarms: Record<string, Alarm> }`.
- `[COPY_STATE]` hook so `.copy()` preserves custom alarms (verified via `assertCopyPreservesState`).

### Secure defaults (`QUEUE_DEFAULTS`)

| Property                 | Default                       | Source                                                                                                                                                                                                                                                            |
| ------------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `enforceSSL`             | `true`                        | [SNS/SQS security best practices](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-security-best-practices.html) — deny on `aws:SecureTransport: false`. Mirrors `TopicBuilder`.                                                                |
| `encryption`             | `QueueEncryption.SQS_MANAGED` | [SQS data protection](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-data-protection.html). KMS opt-in via `.encryption(QueueEncryption.KMS)` + `.encryptionMasterKey(key)`.                                                                  |
| `receiveMessageWaitTime` | `Duration.seconds(20)`        | [Long polling](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling) — fewer empty receives, lower cost, lower latency. 20s is the SQS maximum.                                                        |

### Recommended alarms (`QUEUE_ALARM_DEFAULTS`)

| Alarm                                   | Metric (CDK built-in)                                | Default threshold | Rationale                                                                                                                                                |
| --------------------------------------- | ---------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `approximateAgeOfOldestMessage`         | `metricApproximateAgeOfOldestMessage` (Max, 1 min)   | > 300s (5 min)    | Conservative starting point for a "consumer falling behind" signal; tune to your SLA and `retentionPeriod`.                                              |
| `approximateNumberOfMessagesNotVisible` | `metricApproximateNumberOfMessagesNotVisible` (Max, 1 min) | > 90,000   | 75% of the [120k per-queue in-flight quota](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight) — proactive guardrail. |

### Example

`packages/examples/src/order-processor-app.ts` — `ComposureCDK-OrderProcessorStack`. Primary queue with custom retention and a tuned `approximateAgeOfOldestMessage` alarm (60s, 2-of-2), plus a custom `highEmptyReceiveRate` alarm via `addAlarm`. The queue feeds a `createFunctionBuilder` consumer wired as an SQS event source, paired with a sibling `createTopicBuilder` alert topic. `alarmActionsPolicy` wires every alarm in the stack to publish to the topic — the same pattern used by `DualFunctionStack`. Synth assertions live alongside in `test/order-processor-app.test.ts`.

Registered in `bin/app.ts`, added to `examples/README.md`. Ships a post-deploy smoke test (`test/smoke/order-processor.smoke.mjs`): sends a message and polls the consumer's log group to prove the event source and execution-role permissions are wired correctly. The shared Lambda log-group resolution is extracted into a `resolveLambdaLogGroup` helper in `test/smoke/_helpers.mjs` (also adopted by `dual-function.smoke.mjs`).

**Event-source escape hatch:** ComposureCDK has no Lambda event-source helper, so the queue-to-Lambda wiring uses raw `processor.function.addEventSource(new SqsEventSource(...))` on the built function. This is the first example to reach outside the builder API — it's deliberate, commented, and tracked by #118.

## Decisions worth flagging

The plan I posted to #112 had three open questions; I made calls and noted each in the README + JSDoc.

**1. `ApproximateNumberOfMessagesVisible` is omitted from `QUEUE_ALARM_DEFAULTS`.**
The third AWS-recommended SQS alarm, but its useful threshold depends entirely on consumer throughput — any generic default would be noise or silence. Documented in README under "Recommended Alarms"; users add it via `.addAlarm(...)` for workloads where they know the right number. This keeps the `QueueAlarmConfig` shape identical in spirit to `TopicAlarmConfig` (no "off by default" knobs).

Alternative considered: ship it with `enabled: false` per-alarm. Rejected because the SNS analog doesn't have that pattern and inverting the `!== false` check would have introduced an asymmetry. Easy to add later if the consensus shifts.

**2. `retentionPeriod` left at CDK's 4-day default.**
Bumping to 14 days would suit some workloads ("resilient by default" stance) but ships a non-CDK default just to override CDK's. The example app demonstrates `.retentionPeriod(Duration.days(14))` for callers who want longer replay windows.

**3. FIFO is passthrough only.**
`fifo`, `contentBasedDeduplication`, `fifoThroughputLimit`, `deduplicationScope` all work fluently. No FIFO-specific defaults — they're workload-dependent. Tested via `b.fifo(true).queueName("orders.fifo")`. Building FIFO ergonomics out — and fixing the FIFO in-flight alarm-threshold gap (the `90_000` default assumes the 120k standard quota; FIFO's is 20k) — is tracked in #117.

## Out of scope

- `createDlqQueueBuilder` and SNS subscription auto-DLQ wiring — that's #34. Now that this PR establishes `createQueueBuilder`, the DLQ-variant design options (separate builder vs. mode flag vs. preset) are written up in [a comment on #34](https://github.com/laazyj/composureCDK/issues/34#issuecomment-4448537437).
- FIFO ergonomics — #117.
- A composure helper for Lambda event sources — #118 (the order-processor example exercises this gap via the raw-CDK escape hatch above).
- Cross-account queue policy helpers.
- `CHANGELOG.md` — generated by the release tooling.

## ADR

None. The package introduces no new architectural pattern — it's the same `Builder + Lifecycle + recommended alarms + COPY_STATE` shape as `TopicBuilder`.

## Test plan

- [x] `npx nx test sqs` — 24/24 pass
- [x] `npx nx run-many -t test` — full suite, 137 tests across all packages
- [x] `npx nx test examples` — 85/85 pass, including the new `order-processor-app` synth assertions
- [x] `npm run lint`, `npm run format:check`
- [x] `npx nx synth examples -- ComposureCDK-OrderProcessorStack` synthesises cleanly _(implicit — covered by the synth test above)_
- [x] Deployed `ComposureCDK-OrderProcessorStack` to a sandbox account: smoke test passes (message sent → consumed → logged), stack tears down cleanly with no retained resources (queue, function, and Lambda log group all confirmed deleted — the existing `cleanDeskPolicy` log-group injector already covers the Lambda log group, so no clean-desk change needed).