### PR TITLE
feat(sns): protocol-specific subscription defaults

### DIFF
--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -219,6 +219,39 @@ Attaching a dead-letter queue is the primary reliability control for SNS subscri
 
 The CloudWatch metrics that surface delivery failures (`NumberOfNotificationsRedrivenToDlq`, `NumberOfNotificationsFailedToRedriveToDlq`) are topic-level, so the recommended alarms for them live on the `TopicBuilder` (see [Recommended Alarms](#recommended-alarms) above) and only report data once at least one subscription has a DLQ attached.
 
+## Subscription Defaults
+
+Both `createSubscriptionBuilder` and `TopicBuilder.addSubscription` apply per-protocol defaults to the `TopicSubscriptionConfig` returned by `ITopicSubscription.bind(topic)`. Defaults are gap-filling: anything the `ITopicSubscription` itself configured (via its constructor options) wins; defaults only apply where the bound config left a field unset.
+
+| Protocol   | Default                    | Rationale                                                                                                                                                                                                                                                                   |
+| ---------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SQS`      | `rawMessageDelivery: true` | Removes the SNS envelope so downstream SQS consumers see the publisher's payload as-is — fewer bytes, no parse step. The typical choice for SNS → SQS fan-out.                                                                                                              |
+| `FIREHOSE` | `rawMessageDelivery: true` | Stores records as the publisher sent them rather than wrapped in an SNS envelope.                                                                                                                                                                                           |
+| `HTTP`     | _(no default applied)_     | Emits a synth-time warning instead — plain HTTP delivery means messages and signed-confirmation tokens travel unencrypted. Prefer `SubscriptionProtocol.HTTPS`. ([SNS security best practices](https://docs.aws.amazon.com/sns/latest/dg/sns-security-best-practices.html)) |
+
+`LAMBDA` is intentionally absent — SNS does not support raw delivery to Lambda subscriptions; the handler always receives the SNS envelope. Other protocols (HTTPS, EMAIL, EMAIL_JSON, SMS, APPLICATION) receive no overrides.
+
+These defaults are guided by [SNS raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) and the [AWS SNS security best practices](https://docs.aws.amazon.com/sns/latest/dg/sns-security-best-practices.html).
+
+The map is exported as `SUBSCRIPTION_DEFAULTS` for visibility and testing:
+
+```ts
+import { SUBSCRIPTION_DEFAULTS } from "@composurecdk/sns";
+```
+
+### Overriding a default
+
+Any default is individually overridable through the `ITopicSubscription`'s own constructor options:
+
+```ts
+import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+
+createSubscriptionBuilder()
+  .topic(orders)
+  .subscription(new SqsSubscription(queue, { rawMessageDelivery: false }))
+  .build(stack, "OrdersToQueue");
+```
+
 ## Examples
 
 - [DualFunctionStack](../examples/src/dual-function-app.ts) — Two Lambda functions with TopicBuilder for alarm actions

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -13,3 +13,4 @@ export {
   type SubscriptionBuilderProps,
   type SubscriptionBuilderResult,
 } from "./subscription-builder.js";
+export { SUBSCRIPTION_DEFAULTS, type SubscriptionDefaults } from "./subscription-defaults.js";

--- a/packages/sns/src/subscription-builder.ts
+++ b/packages/sns/src/subscription-builder.ts
@@ -7,6 +7,7 @@ import {
   type Resolvable,
   resolve,
 } from "@composurecdk/core";
+import { applySubscriptionDefaults } from "./subscription-defaults.js";
 
 /**
  * Configuration properties for the SNS subscription builder.
@@ -104,7 +105,11 @@ class SubscriptionBuilder implements Lifecycle<SubscriptionBuilderResult> {
 
     const resolvedTopic = resolve(topic, context);
     const resolvedSubscription = resolve(subscription, context);
-    const subscriptionConfig = resolvedSubscription.bind(resolvedTopic);
+    const subscriptionConfig = applySubscriptionDefaults(
+      scope,
+      id,
+      resolvedSubscription.bind(resolvedTopic),
+    );
 
     const built = new Subscription(scope, id, {
       topic: resolvedTopic,

--- a/packages/sns/src/subscription-defaults.ts
+++ b/packages/sns/src/subscription-defaults.ts
@@ -1,0 +1,98 @@
+import { Annotations } from "aws-cdk-lib";
+import { SubscriptionProtocol, type TopicSubscriptionConfig } from "aws-cdk-lib/aws-sns";
+import type { IConstruct } from "constructs";
+
+/**
+ * Per-protocol overrides applied to a {@link TopicSubscriptionConfig}.
+ *
+ * Only fields relevant to delivery semantics are included; `protocol`,
+ * `endpoint`, `subscriberId`, etc. are determined by the
+ * {@link aws-cdk-lib.aws_sns.ITopicSubscription | ITopicSubscription} and
+ * are never defaulted here.
+ */
+export type SubscriptionDefaults = Pick<TopicSubscriptionConfig, "rawMessageDelivery">;
+
+/**
+ * AWS-recommended defaults applied per `SubscriptionProtocol` when a
+ * subscription is bound through either `createSubscriptionBuilder` or
+ * `TopicBuilder.addSubscription`.
+ *
+ * Defaults are merged into the {@link TopicSubscriptionConfig} returned by
+ * `ITopicSubscription.bind(topic)`: any field the `ITopicSubscription`
+ * itself set to a defined value wins, and the default only fills the gap
+ * when the bound config left the field `undefined`. This keeps every
+ * default individually overridable through the `ITopicSubscription`
+ * constructor options.
+ *
+ * Only the protocols on which SNS actually supports raw message delivery
+ * (SQS and Firehose) receive a default — applying it elsewhere would
+ * trigger CDK's own raw-delivery validation at synth time. Lambda is
+ * intentionally absent: SNS does not support raw delivery to Lambda
+ * subscriptions, and Lambda handlers always receive the SNS envelope.
+ *
+ * @see https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html
+ */
+export const SUBSCRIPTION_DEFAULTS: Partial<Record<SubscriptionProtocol, SubscriptionDefaults>> = {
+  /**
+   * Deliver raw payloads to SQS so downstream consumers don't have to
+   * unwrap the SNS envelope. Halves payload size and removes a parse step
+   * — the typical choice for SNS → SQS fan-out.
+   * @see https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html
+   */
+  [SubscriptionProtocol.SQS]: { rawMessageDelivery: true },
+
+  /**
+   * Deliver raw payloads to Firehose so records are stored as the
+   * publisher sent them rather than wrapped in an SNS envelope.
+   * @see https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html
+   */
+  [SubscriptionProtocol.FIREHOSE]: { rawMessageDelivery: true },
+};
+
+/**
+ * Merge {@link SUBSCRIPTION_DEFAULTS} into the result of
+ * `ITopicSubscription.bind(topic)` and emit transport-security warnings.
+ *
+ * Both `createSubscriptionBuilder` and `TopicBuilder.addSubscription`
+ * route through this helper so SNS subscriptions get the same defaults
+ * regardless of which builder created them.
+ *
+ * - Defaults are gap-filling: any field the `ITopicSubscription`
+ *   explicitly set wins, and the default only applies when the bound
+ *   config left the field `undefined`. Many `ITopicSubscription`
+ *   implementations propagate `undefined` from their props, so a naive
+ *   `{ ...defaults, ...config }` spread would clobber the defaults —
+ *   this helper filters undefined entries before merging.
+ * - Emits a synth-time warning when subscribing over plain `HTTP` to
+ *   nudge callers toward `HTTPS` for transport encryption. Other invalid
+ *   protocol/option combinations (e.g. `rawMessageDelivery` on EMAIL)
+ *   are surfaced by CDK's own `Subscription` validation.
+ *
+ * @param scope - The construct scope used to attach annotations.
+ * @param id - The subscription's logical id, used in warning text.
+ * @param config - The `TopicSubscriptionConfig` returned by
+ *   `ITopicSubscription.bind(topic)`.
+ *
+ * @see https://docs.aws.amazon.com/sns/latest/dg/sns-security-best-practices.html
+ */
+export function applySubscriptionDefaults(
+  scope: IConstruct,
+  id: string,
+  config: TopicSubscriptionConfig,
+): TopicSubscriptionConfig {
+  const protocolDefaults = SUBSCRIPTION_DEFAULTS[config.protocol] ?? {};
+  const definedConfig = Object.fromEntries(
+    Object.entries(config).filter(([, value]) => value !== undefined),
+  );
+  const merged = { ...protocolDefaults, ...definedConfig } as TopicSubscriptionConfig;
+
+  if (merged.protocol === SubscriptionProtocol.HTTP) {
+    Annotations.of(scope).addWarningV2(
+      "@composurecdk/sns:http-subscription-insecure",
+      `SNS subscription "${id}": delivering over plain HTTP — messages and any signed-confirmation tokens travel unencrypted. ` +
+        `Prefer SubscriptionProtocol.HTTPS for transport encryption.`,
+    );
+  }
+
+  return merged;
+}

--- a/packages/sns/src/topic-builder.ts
+++ b/packages/sns/src/topic-builder.ts
@@ -13,6 +13,7 @@ import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { TopicAlarmConfig } from "./topic-alarm-config.js";
 import { createTopicAlarms } from "./topic-alarms.js";
 import { TOPIC_DEFAULTS } from "./defaults.js";
+import { applySubscriptionDefaults } from "./subscription-defaults.js";
 
 /**
  * Configuration properties for the SNS topic builder.
@@ -161,8 +162,12 @@ class TopicBuilder implements Lifecycle<TopicBuilderResult> {
     const subscriptions: Record<string, Subscription> = {};
     for (const entry of this.#subscriptions) {
       const resolvedSub = resolve(entry.subscription, context ?? {});
-      const subscriptionConfig = resolvedSub.bind(topic);
       const subscriptionId = `${id}${entry.key[0].toUpperCase()}${entry.key.slice(1)}Subscription`;
+      const subscriptionConfig = applySubscriptionDefaults(
+        scope,
+        subscriptionId,
+        resolvedSub.bind(topic),
+      );
       subscriptions[entry.key] = new Subscription(scope, subscriptionId, {
         topic,
         ...subscriptionConfig,

--- a/packages/sns/test/subscription-defaults.test.ts
+++ b/packages/sns/test/subscription-defaults.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { SubscriptionProtocol, Topic, type TopicSubscriptionConfig } from "aws-cdk-lib/aws-sns";
+import {
+  EmailSubscription,
+  LambdaSubscription,
+  SqsSubscription,
+  UrlSubscription,
+} from "aws-cdk-lib/aws-sns-subscriptions";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { SUBSCRIPTION_DEFAULTS, applySubscriptionDefaults } from "../src/subscription-defaults.js";
+import { createSubscriptionBuilder } from "../src/subscription-builder.js";
+import { createTopicBuilder } from "../src/topic-builder.js";
+
+function makeHandler(stack: Stack, id = "Handler") {
+  return new LambdaFunction(stack, id, {
+    runtime: Runtime.NODEJS_20_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => {};"),
+  });
+}
+
+function newStack() {
+  const app = new App();
+  return new Stack(app, "TestStack");
+}
+
+describe("SUBSCRIPTION_DEFAULTS", () => {
+  it("opts SQS and Firehose into raw message delivery", () => {
+    expect(SUBSCRIPTION_DEFAULTS[SubscriptionProtocol.SQS]).toEqual({ rawMessageDelivery: true });
+    expect(SUBSCRIPTION_DEFAULTS[SubscriptionProtocol.FIREHOSE]).toEqual({
+      rawMessageDelivery: true,
+    });
+  });
+
+  it.each([
+    SubscriptionProtocol.LAMBDA,
+    SubscriptionProtocol.EMAIL,
+    SubscriptionProtocol.EMAIL_JSON,
+    SubscriptionProtocol.SMS,
+    SubscriptionProtocol.HTTPS,
+    SubscriptionProtocol.HTTP,
+    SubscriptionProtocol.APPLICATION,
+  ])("declares no defaults for %s", (protocol) => {
+    expect(SUBSCRIPTION_DEFAULTS[protocol]).toBeUndefined();
+  });
+});
+
+describe("applySubscriptionDefaults", () => {
+  function baseConfig(
+    protocol: SubscriptionProtocol,
+    overrides: Partial<TopicSubscriptionConfig> = {},
+  ): TopicSubscriptionConfig {
+    return {
+      subscriberId: "Sub",
+      protocol,
+      endpoint: "endpoint-value",
+      ...overrides,
+    };
+  }
+
+  it("fills in rawMessageDelivery when the protocol has a default and the config did not set it", () => {
+    const stack = newStack();
+    const merged = applySubscriptionDefaults(stack, "Sub", baseConfig(SubscriptionProtocol.SQS));
+
+    expect(merged.rawMessageDelivery).toBe(true);
+  });
+
+  it("preserves an explicit rawMessageDelivery=false on a protocol with a default", () => {
+    const stack = newStack();
+    const merged = applySubscriptionDefaults(
+      stack,
+      "Sub",
+      baseConfig(SubscriptionProtocol.SQS, { rawMessageDelivery: false }),
+    );
+
+    expect(merged.rawMessageDelivery).toBe(false);
+  });
+
+  it("treats an explicit undefined as 'not set' so the default still applies", () => {
+    // ITopicSubscription bind() results often propagate undefined from their
+    // props (e.g. SqsSubscription always sets rawMessageDelivery: this.props.rawMessageDelivery).
+    // A naive { ...defaults, ...config } spread would clobber the default with undefined;
+    // this asserts the helper avoids that.
+    const stack = newStack();
+    const merged = applySubscriptionDefaults(
+      stack,
+      "Sub",
+      baseConfig(SubscriptionProtocol.SQS, { rawMessageDelivery: undefined }),
+    );
+
+    expect(merged.rawMessageDelivery).toBe(true);
+  });
+
+  it("leaves protocols without defaults unchanged", () => {
+    const stack = newStack();
+    const merged = applySubscriptionDefaults(stack, "Sub", baseConfig(SubscriptionProtocol.HTTPS));
+
+    expect(merged.rawMessageDelivery).toBeUndefined();
+  });
+
+  it("emits a synth-time warning for HTTP subscriptions, ack-tagged with a stable ID", () => {
+    const stack = newStack();
+    applySubscriptionDefaults(stack, "Sub", baseConfig(SubscriptionProtocol.HTTP));
+
+    // The ack tag is what callers use to suppress the warning via
+    // `Annotations.of(scope).acknowledgeWarning(...)`, so the ID is part of
+    // the public surface — guard against accidental rename.
+    Annotations.fromStack(stack).hasWarning(
+      "/TestStack",
+      Match.stringLikeRegexp(
+        "delivering over plain HTTP.*\\[ack: @composurecdk/sns:http-subscription-insecure\\]",
+      ),
+    );
+  });
+
+  it("does not warn for HTTPS subscriptions", () => {
+    const stack = newStack();
+    applySubscriptionDefaults(stack, "Sub", baseConfig(SubscriptionProtocol.HTTPS));
+
+    expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+  });
+});
+
+describe("integration with createSubscriptionBuilder", () => {
+  it("applies rawMessageDelivery=true for an SqsSubscription bound through the builder", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Topic");
+    const queue = new Queue(stack, "Queue");
+
+    createSubscriptionBuilder()
+      .topic(topic)
+      .subscription(new SqsSubscription(queue))
+      .build(stack, "Sub");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "sqs",
+      RawMessageDelivery: true,
+    });
+  });
+
+  it("lets a caller override the default to rawMessageDelivery=false on the ITopicSubscription", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Topic");
+    const queue = new Queue(stack, "Queue");
+
+    createSubscriptionBuilder()
+      .topic(topic)
+      .subscription(new SqsSubscription(queue, { rawMessageDelivery: false }))
+      .build(stack, "Sub");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "sqs",
+      RawMessageDelivery: false,
+    });
+  });
+
+  it("does not enable raw delivery for Lambda subscriptions", () => {
+    // SNS does not support raw delivery to Lambda — CDK rejects it at synth.
+    // The defaults map omits LAMBDA so this combination synthesises cleanly.
+    const stack = newStack();
+    const topic = new Topic(stack, "Topic");
+    const handler = makeHandler(stack);
+
+    createSubscriptionBuilder()
+      .topic(topic)
+      .subscription(new LambdaSubscription(handler))
+      .build(stack, "Sub");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "lambda",
+      RawMessageDelivery: Match.absent(),
+    });
+  });
+
+  it("does not enable raw delivery for email subscriptions", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Topic");
+
+    createSubscriptionBuilder()
+      .topic(topic)
+      .subscription(new EmailSubscription("ops@example.com"))
+      .build(stack, "Sub");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "email",
+      RawMessageDelivery: Match.absent(),
+    });
+  });
+
+  it("warns when binding an HTTP UrlSubscription", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Topic");
+
+    createSubscriptionBuilder()
+      .topic(topic)
+      .subscription(new UrlSubscription("http://example.com/hook"))
+      .build(stack, "Sub");
+
+    Annotations.fromStack(stack).hasWarning(
+      "/TestStack",
+      Match.stringLikeRegexp("delivering over plain HTTP"),
+    );
+  });
+
+  it("does not warn for an HTTPS UrlSubscription", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Topic");
+
+    createSubscriptionBuilder()
+      .topic(topic)
+      .subscription(new UrlSubscription("https://example.com/hook"))
+      .build(stack, "Sub");
+
+    expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+  });
+});
+
+describe("integration with TopicBuilder.addSubscription", () => {
+  it("applies rawMessageDelivery=true for an SqsSubscription on a topic builder", () => {
+    const stack = newStack();
+    const queue = new Queue(stack, "Queue");
+
+    createTopicBuilder()
+      .topicName("alerts")
+      .recommendedAlarms(false)
+      .addSubscription("queue", new SqsSubscription(queue))
+      .build(stack, "Alerts");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "sqs",
+      RawMessageDelivery: true,
+    });
+  });
+
+  it("warns on HTTP subscriptions added via the topic builder", () => {
+    const stack = newStack();
+
+    createTopicBuilder()
+      .topicName("alerts")
+      .recommendedAlarms(false)
+      .addSubscription("hook", new UrlSubscription("http://example.com/hook"))
+      .build(stack, "Alerts");
+
+    Annotations.fromStack(stack).hasWarning(
+      "/TestStack",
+      Match.stringLikeRegexp("delivering over plain HTTP"),
+    );
+  });
+});


### PR DESCRIPTION
Apply per-`SubscriptionProtocol` defaults to the `TopicSubscriptionConfig`
returned by `ITopicSubscription.bind(topic)`. Defaults are gap-filling
— anything the `ITopicSubscription` set wins; defaults only apply where
the bound config left a field unset. Both `createSubscriptionBuilder`
and `TopicBuilder.addSubscription` route through the same helper so
behaviour is identical.

Initial defaults:
- SQS → `rawMessageDelivery: true` (typical fan-out choice)
- FIREHOSE → `rawMessageDelivery: true`
- HTTP → no value default; emits a synth-time warning steering callers
  toward `HTTPS` for transport encryption.

LAMBDA is intentionally omitted: SNS does not support raw delivery to
Lambda (CDK rejects it at synth). The original issue sketch listed it,
but it was incorrect.

`bind()` results from CDK's subscription classes propagate `undefined`
fields from their props (e.g. `SqsSubscription` always sets
`rawMessageDelivery: this.props.rawMessageDelivery`). A naive
`{ ...defaults, ...config }` spread would let those undefineds clobber
the defaults, so the helper filters them out first — exercised by the
"explicit undefined" test.

Validation of `rawMessageDelivery` against the protocol's allow-list is
left to CDK's own `Subscription` constructor rather than re-implemented
here.

Resolves #35.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
