### PR TITLE
feat(lambda): SQS event source wiring with contextual alarms

### DIFF
--- a/packages/examples/src/order-processor-app.ts
+++ b/packages/examples/src/order-processor-app.ts
@@ -1,12 +1,11 @@
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
-import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
-import { compose } from "@composurecdk/core";
+import { compose, ref } from "@composurecdk/core";
 import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
-import { createFunctionBuilder } from "@composurecdk/lambda";
+import { createFunctionBuilder, sqsEventSource } from "@composurecdk/lambda";
 import { createTopicBuilder } from "@composurecdk/sns";
-import { createQueueBuilder } from "@composurecdk/sqs";
+import { createQueueBuilder, type QueueBuilderResult } from "@composurecdk/sqs";
 
 /**
  * A primary SQS work queue feeding a Lambda consumer, paired with an SNS
@@ -14,25 +13,26 @@ import { createQueueBuilder } from "@composurecdk/sqs";
  * default (oldest-message age, in-flight near-quota); the processor gets
  * the recommended Lambda alarms (errors, throttles — the duration alarm
  * is timeout-relative and the processor leaves timeout at the CDK
- * default, so it is not emitted); a custom alarm watches empty-receive
- * rate as a low-traffic signal. `alarmActionsPolicy` wires every alarm in
- * the stack to publish to the alert topic, so adding more alarms later is
- * automatic.
+ * default, so it is not emitted) plus the event-source contextual alarms
+ * (failed-invocation, dropped-event) once the queue is wired in; a custom
+ * alarm watches empty-receive rate as a low-traffic signal.
+ * `alarmActionsPolicy` wires every alarm in the stack to publish to the
+ * alert topic, so adding more alarms later is automatic.
  *
  * Demonstrates:
  * - `createQueueBuilder` with secure defaults (enforceSSL, SSE-SQS, long polling)
  * - Custom retention via `.retentionPeriod`
  * - Tuning a recommended alarm threshold via `recommendedAlarms`
  * - Adding a workload-specific alarm via `addAlarm`
- * - Wiring the queue to a `createFunctionBuilder` consumer as an SQS event
- *   source (see the wiring note below)
+ * - Wiring the queue to a `createFunctionBuilder` consumer via
+ *   `sqsEventSource` and a `ref` to the sibling queue
  * - Composing the queue alongside `createTopicBuilder` and routing all
  *   alarm actions through `alarmActionsPolicy`
  */
 export function createOrderProcessorApp(app = new App()) {
   const stack = new Stack(app, "ComposureCDK-OrderProcessorStack");
 
-  const { alerts, orders, processor } = compose(
+  const { alerts } = compose(
     {
       alerts: createTopicBuilder().displayName("Order Processor Alerts"),
 
@@ -77,16 +77,17 @@ export function createOrderProcessorApp(app = new App()) {
           ),
         )
         .memorySize(256)
-        .description("Order processor — consumes and processes order messages"),
+        .description("Order processor — consumes and processes order messages")
+        // The event source is declared as data: `sqsEventSource` resolves
+        // the sibling queue `ref` at build time and `addEventSource` grants
+        // the consume permission onto the function's least-privilege role.
+        .addEventSource(
+          "orders",
+          sqsEventSource(ref("orders", (r: QueueBuilderResult) => r.queue)),
+        ),
     },
-    { alerts: [], orders: [], processor: [] },
+    { alerts: [], orders: [], processor: ["orders"] },
   ).build(stack, "OrderProcessor");
-
-  // SQS-to-Lambda wiring. ComposureCDK has no event-source helper yet
-  // (see https://github.com/laazyj/composureCDK/issues/118), so the event
-  // source is attached directly to the built function. `SqsEventSource`
-  // also grants the execution role permission to consume the queue.
-  processor.function.addEventSource(new SqsEventSource(orders.queue));
 
   alarmActionsPolicy(stack, {
     defaults: { alarmActions: [new SnsAction(alerts.topic)] },

--- a/packages/examples/test/order-processor-app.test.ts
+++ b/packages/examples/test/order-processor-app.test.ts
@@ -85,14 +85,17 @@ describe("order-processor-app", () => {
   });
 
   it("creates the recommended Lambda alarms for the consumer", () => {
-    // errors + throttles. The duration alarm is timeout-relative and the
-    // consumer leaves timeout at the CDK default, so it is not emitted.
-    template.resourcePropertiesCountIs("AWS::CloudWatch::Alarm", { Namespace: "AWS/Lambda" }, 2);
+    // errors + throttles, plus the two event-source contextual alarms
+    // (ordersFailedInvocations, ordersDroppedEvents) emitted because an SQS
+    // event source is attached. The duration alarm is timeout-relative and
+    // the consumer leaves timeout at the CDK default, so it is not emitted.
+    template.resourcePropertiesCountIs("AWS::CloudWatch::Alarm", { Namespace: "AWS/Lambda" }, 4);
   });
 
   it("creates the topic, queue, and consumer recommended alarms", () => {
-    // Topic ships 4 recommended; queue ships 2 recommended + 1 custom;
-    // the Lambda consumer ships 2 recommended (errors, throttles).
-    template.resourceCountIs("AWS::CloudWatch::Alarm", 9);
+    // Topic ships 4 recommended; queue ships 2 recommended + 1 custom; the
+    // Lambda consumer ships 2 recommended (errors, throttles) + 2 contextual
+    // event-source alarms.
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 11);
   });
 });

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -125,12 +125,16 @@ Opt back into CDK's auto-created role attached to `AWSLambdaBasicExecutionRole`.
 
 The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda) by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.
 
-| Alarm                  | Metric                            | Default threshold           | Created when                          |
-| ---------------------- | --------------------------------- | --------------------------- | ------------------------------------- |
-| `errors`               | Errors (Sum, 1 min)               | > 0                         | Always                                |
-| `throttles`            | Throttles (Sum, 1 min)            | > 0                         | Always                                |
-| `duration`             | Duration (p99, 1 min)             | > 90% of configured timeout | `timeout` is set                      |
-| `concurrentExecutions` | ConcurrentExecutions (Max, 1 min) | >= 80% of reserved limit    | `reservedConcurrentExecutions` is set |
+| Alarm                    | Metric                            | Default threshold           | Created when                          |
+| ------------------------ | --------------------------------- | --------------------------- | ------------------------------------- |
+| `errors`                 | Errors (Sum, 1 min)               | > 0                         | Always                                |
+| `throttles`              | Throttles (Sum, 1 min)            | > 0                         | Always                                |
+| `duration`               | Duration (p99, 1 min)             | > 90% of configured timeout | `timeout` is set                      |
+| `concurrentExecutions`   | ConcurrentExecutions (Max, 1 min) | >= 80% of reserved limit    | `reservedConcurrentExecutions` is set |
+| `<key>FailedInvocations` | FailedInvokeEventCount (Sum)      | > 0                         | An SQS event source is attached       |
+| `<key>DroppedEvents`     | DroppedEventCount (Sum)           | > 0                         | An SQS event source is attached       |
+
+The event-source alarms are contextual: one pair is created per event source attached via `addEventSource` (see [Event sources](#event-sources)) whose kind emits per-mapping ESM metrics. Each alarm's key is the event source's key suffixed with `FailedInvocations` / `DroppedEvents` — e.g. an event source added as `"orders"` produces `ordersFailedInvocations` and `ordersDroppedEvents`. The `eventSourceFailedInvocations` / `eventSourceDroppedEvents` fields on `recommendedAlarms` tune every such alarm.
 
 The defaults are exported as `FUNCTION_ALARM_DEFAULTS` for visibility and testing:
 
@@ -216,7 +220,63 @@ for (const alarm of Object.values(result.alarms)) {
 }
 ```
 
+## Event sources
+
+`addEventSource(key, source)` wires a queue or stream to the function. A Lambda
+function can have many event sources of mixed types, so the hook is repeatable
+and keyed — the resolved sources are exposed on `result.eventSources`.
+
+Pass a `ComposureEventSource` from a factory (`sqsEventSource`), which carries
+its own `Resolvable` so the source queue can be a `ref()` to a sibling
+component, or a bare CDK `IEventSource` as an escape hatch.
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createFunctionBuilder, sqsEventSource } from "@composurecdk/lambda";
+import { createQueueBuilder } from "@composurecdk/sqs";
+
+const system = compose(
+  {
+    orders: createQueueBuilder().queueName("orders"),
+    processor: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_22_X)
+      .handler("index.handler")
+      .code(Code.fromAsset("lambda"))
+      .addEventSource("orders", sqsEventSource(ref("orders", (r) => r.queue))),
+  },
+  { orders: [], processor: ["orders"] },
+);
+```
+
+The source is attached _after_ the function and its least-privilege execution
+role exist, so the `source.bind(fn)` that `addEventSource` performs grants the
+queue-consume permission onto the builder's role rather than CDK's auto-role.
+
+### Secure defaults
+
+`sqsEventSource` applies AWS-recommended defaults, each overridable via the
+second `props` argument and exported as `DEFAULT_SQS_EVENT_SOURCE_PROPS`:
+
+| Property                  | Default                     | Rationale                                                                                          |
+| ------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------- |
+| `reportBatchItemFailures` | `true`                      | A single poison message fails only its own record, not the whole batch. CDK defaults this `false`. |
+| `metricsConfig`           | `{ metrics: [EventCount] }` | Enables the per-mapping ESM metrics that back the event-source contextual alarms.                  |
+
+### Cross-component invariants
+
+AWS Well-Architected guidance spans the queue and the function — the source
+queue's visibility timeout should be ≥ 6× the function timeout, and its redrive
+`maxReceiveCount` should be ≥ 5 before the DLQ. These are **not** enforced
+today (the queue often arrives as an unresolved `ref()`); they are tracked in
+[#123](https://github.com/laazyj/composureCDK/issues/123) and
+[#124](https://github.com/laazyj/composureCDK/issues/124).
+
+`kinesisEventSource` / `dynamoEventSource` and the stream-only `IteratorAge`
+alarm are deferred — see [#120](https://github.com/laazyj/composureCDK/issues/120)
+and [#121](https://github.com/laazyj/composureCDK/issues/121).
+
 ## Examples
 
 - [DualFunctionStack](../examples/src/dual-function-app.ts) — Two Lambda functions with recommended alarms, custom alarms, and SNS alarm actions
 - [MultiStackApp](../examples/src/multi-stack-app.ts) — Lambda split across stacks via `.withStacks()`, wired with `ref`
+- [OrderProcessorStack](../examples/src/order-processor-app.ts) — SQS queue wired to a Lambda consumer via `sqsEventSource`

--- a/packages/lambda/src/alarm-config.ts
+++ b/packages/lambda/src/alarm-config.ts
@@ -87,4 +87,36 @@ export interface FunctionAlarmConfig {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda
    */
   concurrentExecutions?: PercentageAlarmConfig | false;
+
+  /**
+   * Alarm when an event source fails to invoke the function.
+   *
+   * Contextual: one alarm is created per event source attached via
+   * {@link IFunctionBuilder.addEventSource} whose kind emits per-mapping ESM
+   * metrics (currently SQS). The created alarm's key is the event source's
+   * key suffixed with `FailedInvocations` (e.g. `ordersFailedInvocations`);
+   * this config tunes every such alarm.
+   *
+   * Metric: `AWS/Lambda FailedInvokeEventCount`, statistic Sum, period 1
+   * minute, dimensioned on the event source mapping. Default threshold: > 0.
+   *
+   * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
+   */
+  eventSourceFailedInvocations?: AlarmConfig | false;
+
+  /**
+   * Alarm when an event source drops events after exhausting retries or TTL.
+   *
+   * Contextual: one alarm is created per event source attached via
+   * {@link IFunctionBuilder.addEventSource} whose kind emits per-mapping ESM
+   * metrics (currently SQS). The created alarm's key is the event source's
+   * key suffixed with `DroppedEvents` (e.g. `ordersDroppedEvents`); this
+   * config tunes every such alarm.
+   *
+   * Metric: `AWS/Lambda DroppedEventCount`, statistic Sum, period 1 minute,
+   * dimensioned on the event source mapping. Default threshold: > 0.
+   *
+   * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
+   */
+  eventSourceDroppedEvents?: AlarmConfig | false;
 }

--- a/packages/lambda/src/alarm-defaults.ts
+++ b/packages/lambda/src/alarm-defaults.ts
@@ -8,6 +8,8 @@ interface FunctionAlarmDefaults {
   throttles: AlarmConfigDefaults;
   duration: PercentageAlarmConfigDefaults;
   concurrentExecutions: PercentageAlarmConfigDefaults;
+  eventSourceFailedInvocations: AlarmConfigDefaults;
+  eventSourceDroppedEvents: AlarmConfigDefaults;
 }
 
 /**
@@ -53,6 +55,22 @@ export const FUNCTION_ALARM_DEFAULTS: FunctionAlarmDefaults = {
     thresholdPercent: 0.8,
     evaluationPeriods: 3,
     datapointsToAlarm: 3,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any failed invocation from an event source is worth investigating; threshold 0. */
+  eventSourceFailedInvocations: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** Any dropped event is lost work; threshold 0. */
+  eventSourceDroppedEvents: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
     treatMissingData: TreatMissingData.NOT_BREACHING,
   },
 };

--- a/packages/lambda/src/event-sources/composure-event-source.ts
+++ b/packages/lambda/src/event-sources/composure-event-source.ts
@@ -1,0 +1,93 @@
+import type { IEventSource } from "aws-cdk-lib/aws-lambda";
+import type { Resolvable } from "@composurecdk/core";
+
+/**
+ * Discriminator for the kind of event source a {@link ComposureEventSource}
+ * wraps. `FunctionBuilder` keys its contextual alarms and invariant checks
+ * off this value so it never has to `instanceof` CDK internals.
+ *
+ * `"unknown"` is the kind assigned to a bare {@link IEventSource} passed
+ * straight to {@link IFunctionBuilder.addEventSource} as an escape hatch —
+ * the builder still attaches it, but cannot reason about it.
+ */
+export type EventSourceKind = "sqs" | "unknown";
+
+/** @internal — brands {@link ComposureEventSource} so the guard is unambiguous. */
+const COMPOSURE_EVENT_SOURCE = Symbol.for("composurecdk.lambda.eventSource");
+
+/**
+ * A `Resolvable`-aware event source produced by a ComposureCDK factory
+ * (e.g. {@link sqsEventSource}).
+ *
+ * Follows the `events/targets` factory shape — the factory wraps the
+ * underlying CDK event source and resolves any `ref()` to a sibling
+ * component at build time — and additionally tags it with a
+ * {@link EventSourceKind} discriminator (plus an optional mapping-id reader)
+ * so `FunctionBuilder` can pick the right contextual alarms without
+ * inspecting CDK internals.
+ *
+ * Construct one via a factory rather than by hand; the brand is private.
+ */
+export interface ComposureEventSource {
+  /** @internal */
+  readonly [COMPOSURE_EVENT_SOURCE]: true;
+
+  /** The kind of source, used to dispatch contextual alarms and checks. */
+  readonly kind: EventSourceKind;
+
+  /**
+   * The wrapped CDK event source, deferred behind a {@link Resolvable} when
+   * the factory was handed a `ref()` to a sibling component's output.
+   */
+  readonly source: Resolvable<IEventSource>;
+
+  /**
+   * Reads the event source mapping UUID off the source once it has been
+   * bound to a function. Defined only for kinds whose per-mapping ESM
+   * metrics back contextual alarms (currently SQS); the builder invokes it
+   * after `addEventSource` so the binding exists. Keeping it here lets the
+   * builder stay kind-agnostic — no `instanceof` of CDK source classes.
+   */
+  readonly readMappingId?: (bound: IEventSource) => string;
+}
+
+/** @internal — assembles a branded {@link ComposureEventSource}. */
+export function composureEventSource(
+  kind: EventSourceKind,
+  source: Resolvable<IEventSource>,
+  readMappingId?: (bound: IEventSource) => string,
+): ComposureEventSource {
+  return { [COMPOSURE_EVENT_SOURCE]: true, kind, source, readMappingId };
+}
+
+/**
+ * Type guard distinguishing a {@link ComposureEventSource} from a bare
+ * {@link IEventSource} escape-hatch value.
+ */
+export function isComposureEventSource(
+  value: ComposureEventSource | IEventSource,
+): value is ComposureEventSource {
+  return COMPOSURE_EVENT_SOURCE in value;
+}
+
+/**
+ * An event source resolved and attached to a function during build, carrying
+ * the metadata the alarm machinery needs to emit contextual alarms.
+ *
+ * @internal — the contract between `FunctionBuilder.build()` and the
+ *   event-source alarm machinery in `function-alarms.ts`.
+ */
+export interface AttachedEventSource {
+  /** The key the source was registered under via `addEventSource`. */
+  key: string;
+
+  /** The kind of source, used to dispatch contextual alarms. */
+  kind: EventSourceKind;
+
+  /**
+   * The event source mapping UUID, populated for kinds whose per-mapping
+   * ESM metrics back contextual alarms (currently SQS only). The contextual
+   * alarms key off this dimension.
+   */
+  eventSourceMappingId?: string;
+}

--- a/packages/lambda/src/event-sources/composure-event-source.ts
+++ b/packages/lambda/src/event-sources/composure-event-source.ts
@@ -1,4 +1,5 @@
 import type { IEventSource } from "aws-cdk-lib/aws-lambda";
+import type { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import type { Resolvable } from "@composurecdk/core";
 
 /**
@@ -22,9 +23,8 @@ const COMPOSURE_EVENT_SOURCE = Symbol.for("composurecdk.lambda.eventSource");
  * Follows the `events/targets` factory shape — the factory wraps the
  * underlying CDK event source and resolves any `ref()` to a sibling
  * component at build time — and additionally tags it with a
- * {@link EventSourceKind} discriminator (plus an optional mapping-id reader)
- * so `FunctionBuilder` can pick the right contextual alarms without
- * inspecting CDK internals.
+ * {@link EventSourceKind} discriminator so `FunctionBuilder` can pick the
+ * right contextual alarms without inspecting CDK internals.
  *
  * Construct one via a factory rather than by hand; the brand is private.
  */
@@ -40,25 +40,36 @@ export interface ComposureEventSource {
    * the factory was handed a `ref()` to a sibling component's output.
    */
   readonly source: Resolvable<IEventSource>;
-
-  /**
-   * Reads the event source mapping UUID off the source once it has been
-   * bound to a function. Defined only for kinds whose per-mapping ESM
-   * metrics back contextual alarms (currently SQS); the builder invokes it
-   * after `addEventSource` so the binding exists. Keeping it here lets the
-   * builder stay kind-agnostic — no `instanceof` of CDK source classes.
-   */
-  readonly readMappingId?: (bound: IEventSource) => string;
 }
 
 /** @internal — assembles a branded {@link ComposureEventSource}. */
 export function composureEventSource(
   kind: EventSourceKind,
   source: Resolvable<IEventSource>,
-  readMappingId?: (bound: IEventSource) => string,
 ): ComposureEventSource {
-  return { [COMPOSURE_EVENT_SOURCE]: true, kind, source, readMappingId };
+  return { [COMPOSURE_EVENT_SOURCE]: true, kind, source };
 }
+
+/**
+ * Reads the event source mapping UUID off a bound CDK source, keyed by
+ * {@link EventSourceKind}. Defined only for kinds whose per-mapping ESM
+ * metrics back contextual alarms (currently SQS); `FunctionBuilder` invokes
+ * the reader after `addEventSource` so the binding exists. Keying off `kind`
+ * — like {@link EVENT_SOURCE_ALARM_SPECS} — keeps the builder from
+ * `instanceof`-ing CDK source classes.
+ *
+ * @internal
+ */
+export const EVENT_SOURCE_MAPPING_ID_READERS: Record<
+  EventSourceKind,
+  ((bound: IEventSource) => string) | undefined
+> = {
+  // Safe: the `"sqs"` kind is only ever assigned by `sqsEventSource()`, which
+  // constructs the `SqsEventSource` in the same call — kind and concrete class
+  // move in lockstep.
+  sqs: (bound) => (bound as SqsEventSource).eventSourceMappingId,
+  unknown: undefined,
+};
 
 /**
  * Type guard distinguishing a {@link ComposureEventSource} from a bare

--- a/packages/lambda/src/event-sources/sqs-event-source.ts
+++ b/packages/lambda/src/event-sources/sqs-event-source.ts
@@ -1,0 +1,90 @@
+import type { IEventSource } from "aws-cdk-lib/aws-lambda";
+import { MetricType } from "aws-cdk-lib/aws-lambda";
+import { SqsEventSource, type SqsEventSourceProps } from "aws-cdk-lib/aws-lambda-event-sources";
+import type { IQueue } from "aws-cdk-lib/aws-sqs";
+import { isRef, type Resolvable } from "@composurecdk/core";
+import { type ComposureEventSource, composureEventSource } from "./composure-event-source.js";
+
+/**
+ * Secure, AWS-recommended defaults applied to every SQS event source built
+ * with {@link sqsEventSource}. Each property can be overridden via the
+ * factory's `props` argument.
+ */
+export const DEFAULT_SQS_EVENT_SOURCE_PROPS: Pick<
+  SqsEventSourceProps,
+  "reportBatchItemFailures" | "metricsConfig"
+> = {
+  /**
+   * Report partial batch failures so a single poison message does not fail
+   * the whole batch and force redelivery of already-processed records. CDK
+   * defaults this to `false`.
+   * @see https://aws.amazon.com/blogs/compute/implementing-aws-well-architected-best-practices-for-amazon-sqs-part-3/
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+   */
+  reportBatchItemFailures: true,
+
+  /**
+   * Enable the per-mapping `EventCount` ESM metrics (`FailedInvokeEventCount`,
+   * `DroppedEventCount`, …). They emit only when opted in, and the
+   * event-source contextual alarms on {@link IFunctionBuilder} depend on them.
+   * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
+   */
+  metricsConfig: { metrics: [MetricType.EVENT_COUNT] },
+};
+
+/**
+ * Wraps an SQS queue as a Lambda {@link IEventSource}, deferring resolution
+ * when the queue is a `ref()` to a sibling component's output.
+ *
+ * Follows the `events/targets` factory shape: register the result with
+ * {@link IFunctionBuilder.addEventSource} and the builder resolves the
+ * `ref()`, attaches the source, and (because `addEventSource` calls
+ * `source.bind(fn)`) grants the function's least-privilege execution role
+ * permission to consume the queue.
+ *
+ * Applies {@link DEFAULT_SQS_EVENT_SOURCE_PROPS}; pass `props` to override.
+ *
+ * ## Cross-component invariants (not enforced)
+ *
+ * AWS Well-Architected guidance spans the queue and the function:
+ * - the source queue's visibility timeout should be ≥ 6× the function
+ *   timeout, leaving room for Lambda to retry a throttled batch;
+ * - the source queue's redrive `maxReceiveCount` should be ≥ 5 before the DLQ.
+ *
+ * These are not validated here — the queue often arrives as a `ref()` that is
+ * not resolvable at configuration time. Tracked in laazyj/composureCDK#123
+ * and #124.
+ *
+ * @param queue - The source queue, concrete or a `ref()` to a sibling.
+ * @param props - Overrides for {@link DEFAULT_SQS_EVENT_SOURCE_PROPS} and any
+ *   other {@link SqsEventSourceProps}.
+ *
+ * @example
+ * ```ts
+ * compose(
+ *   {
+ *     orders: createQueueBuilder().queueName("orders"),
+ *     processor: createFunctionBuilder()
+ *       .runtime(Runtime.NODEJS_22_X)
+ *       .handler("index.handler")
+ *       .code(Code.fromAsset("lambda"))
+ *       .addEventSource("orders", sqsEventSource(ref("orders", (r) => r.queue))),
+ *   },
+ *   { orders: [], processor: ["orders"] },
+ * );
+ * ```
+ */
+export function sqsEventSource(
+  queue: Resolvable<IQueue>,
+  props?: SqsEventSourceProps,
+): ComposureEventSource {
+  const merged: SqsEventSourceProps = { ...DEFAULT_SQS_EVENT_SOURCE_PROPS, ...props };
+  const source: Resolvable<IEventSource> = isRef(queue)
+    ? queue.map((resolved) => new SqsEventSource(resolved, merged))
+    : new SqsEventSource(queue, merged);
+  return composureEventSource(
+    "sqs",
+    source,
+    (bound) => (bound as SqsEventSource).eventSourceMappingId,
+  );
+}

--- a/packages/lambda/src/event-sources/sqs-event-source.ts
+++ b/packages/lambda/src/event-sources/sqs-event-source.ts
@@ -82,9 +82,5 @@ export function sqsEventSource(
   const source: Resolvable<IEventSource> = isRef(queue)
     ? queue.map((resolved) => new SqsEventSource(resolved, merged))
     : new SqsEventSource(queue, merged);
-  return composureEventSource(
-    "sqs",
-    source,
-    (bound) => (bound as SqsEventSource).eventSourceMappingId,
-  );
+  return composureEventSource("sqs", source);
 }

--- a/packages/lambda/src/function-alarms.ts
+++ b/packages/lambda/src/function-alarms.ts
@@ -21,13 +21,7 @@ import type { AttachedEventSource } from "./event-sources/composure-event-source
 const METRIC_PERIOD = Duration.minutes(1);
 const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
 
-/**
- * Per-event-source contextual alarms, keyed by source kind. Each entry
- * derives an `AWS/Lambda` ESM metric dimensioned on the event source
- * mapping.
- *
- * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
- */
+/** One contextual alarm derived from a per-mapping ESM metric. */
 interface EventSourceAlarmSpec {
   /** Suffix appended to the event source key to form the alarm key. */
   keySuffix: string;
@@ -37,6 +31,12 @@ interface EventSourceAlarmSpec {
   describe: (eventSourceKey: string, threshold: number) => string;
 }
 
+/**
+ * Contextual alarm specs keyed by source kind: each attached event source
+ * of a kind contributes one alarm per spec, dimensioned on its mapping UUID.
+ *
+ * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
+ */
 const EVENT_SOURCE_ALARM_SPECS: Record<AttachedEventSource["kind"], EventSourceAlarmSpec[]> = {
   sqs: [
     {

--- a/packages/lambda/src/function-alarms.ts
+++ b/packages/lambda/src/function-alarms.ts
@@ -2,6 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import {
   type Alarm,
   ComparisonOperator,
+  Metric,
   Stats,
   TreatMissingData,
 } from "aws-cdk-lib/aws-cloudwatch";
@@ -15,9 +16,48 @@ import type {
   PercentageAlarmConfigDefaults,
 } from "./alarm-config.js";
 import { FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
+import type { AttachedEventSource } from "./event-sources/composure-event-source.js";
 
 const METRIC_PERIOD = Duration.minutes(1);
 const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+
+/**
+ * Per-event-source contextual alarms, keyed by source kind. Each entry
+ * derives an `AWS/Lambda` ESM metric dimensioned on the event source
+ * mapping.
+ *
+ * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
+ */
+interface EventSourceAlarmSpec {
+  /** Suffix appended to the event source key to form the alarm key. */
+  keySuffix: string;
+  /** `FunctionAlarmConfig` field tuning this alarm. */
+  configKey: "eventSourceFailedInvocations" | "eventSourceDroppedEvents";
+  metricName: string;
+  describe: (eventSourceKey: string, threshold: number) => string;
+}
+
+const EVENT_SOURCE_ALARM_SPECS: Record<AttachedEventSource["kind"], EventSourceAlarmSpec[]> = {
+  sqs: [
+    {
+      keySuffix: "FailedInvocations",
+      configKey: "eventSourceFailedInvocations",
+      metricName: "FailedInvokeEventCount",
+      describe: (key, threshold) =>
+        `Lambda event source "${key}" is failing to invoke the function. ` +
+        `Threshold: > ${String(threshold)} failed invocations in ${METRIC_PERIOD_LABEL}.`,
+    },
+    {
+      keySuffix: "DroppedEvents",
+      configKey: "eventSourceDroppedEvents",
+      metricName: "DroppedEventCount",
+      describe: (key, threshold) =>
+        `Lambda event source "${key}" is dropping events after exhausting retries or TTL. ` +
+        `Threshold: > ${String(threshold)} dropped events in ${METRIC_PERIOD_LABEL}.`,
+    },
+  ],
+  unknown: [],
+};
 
 /**
  * Resolves the recommended alarm configuration into fully-resolved
@@ -28,6 +68,7 @@ export function resolveFunctionAlarmDefinitions(
   fn: LambdaFunction,
   config: FunctionAlarmConfig | undefined,
   props: Pick<FunctionProps, "timeout" | "reservedConcurrentExecutions">,
+  eventSources: AttachedEventSource[] = [],
 ): AlarmDefinition[] {
   if (config?.enabled === false) return [];
 
@@ -103,7 +144,47 @@ export function resolveFunctionAlarmDefinitions(
     });
   }
 
+  for (const eventSource of eventSources) {
+    // The ESM metrics that back these alarms are dimensioned on the mapping
+    // UUID; without it (e.g. a bare escape-hatch source) there is nothing to
+    // alarm on.
+    if (eventSource.eventSourceMappingId === undefined) continue;
+
+    for (const spec of EVENT_SOURCE_ALARM_SPECS[eventSource.kind]) {
+      const userConfig = config?.[spec.configKey];
+      if (userConfig === false) continue;
+
+      const cfg = resolveAlarmConfig(userConfig, FUNCTION_ALARM_DEFAULTS[spec.configKey]);
+      definitions.push({
+        key: `${eventSource.key}${spec.keySuffix}`,
+        alarmName: cfg.alarmName,
+        metric: eventSourceMetric(eventSource.eventSourceMappingId, spec.metricName),
+        threshold: cfg.threshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: cfg.evaluationPeriods,
+        datapointsToAlarm: cfg.datapointsToAlarm,
+        treatMissingData: cfg.treatMissingData,
+        description: spec.describe(eventSource.key, cfg.threshold),
+      });
+    }
+  }
+
   return definitions;
+}
+
+/**
+ * Builds an `AWS/Lambda` event source mapping metric. These per-mapping ESM
+ * metrics are dimensioned on `EventSourceMappingUUID` rather than
+ * `FunctionName`, so they cannot use the function's built-in metric helpers.
+ */
+function eventSourceMetric(eventSourceMappingId: string, metricName: string): Metric {
+  return new Metric({
+    namespace: "AWS/Lambda",
+    metricName,
+    dimensionsMap: { EventSourceMappingUUID: eventSourceMappingId },
+    statistic: Stats.SUM,
+    period: METRIC_PERIOD,
+  });
 }
 
 /**
@@ -115,6 +196,8 @@ export function resolveFunctionAlarmDefinitions(
  * @param fn - The Lambda function to create alarms for.
  * @param config - User-provided alarm configuration, or `false` to disable all.
  * @param props - The merged function props, used for contextual alarm thresholds.
+ * @param eventSources - Event sources attached to the function, used for
+ *   per-event-source contextual alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
@@ -126,6 +209,7 @@ export function createFunctionAlarms(
   fn: LambdaFunction,
   config: FunctionAlarmConfig | false | undefined,
   props: Pick<FunctionProps, "timeout" | "reservedConcurrentExecutions">,
+  eventSources: AttachedEventSource[] = [],
   customAlarms: AlarmDefinitionBuilder<LambdaFunction>[] = [],
 ): Record<string, Alarm> {
   if (config === false) return {};
@@ -133,7 +217,7 @@ export function createFunctionAlarms(
   const enabled = config?.enabled ?? FUNCTION_ALARM_DEFAULTS.enabled;
   if (!enabled) return {};
 
-  const recommended = resolveFunctionAlarmDefinitions(fn, config, props);
+  const recommended = resolveFunctionAlarmDefinitions(fn, config, props, eventSources);
   const custom = customAlarms.map((b) => b.resolve(fn));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -1,6 +1,10 @@
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IRole, ManagedPolicy } from "aws-cdk-lib/aws-iam";
-import { Function as LambdaFunction, type FunctionProps } from "aws-cdk-lib/aws-lambda";
+import {
+  Function as LambdaFunction,
+  type FunctionProps,
+  type IEventSource,
+} from "aws-cdk-lib/aws-lambda";
 import type { ILogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
 import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
@@ -15,6 +19,11 @@ import { createLogGroupBuilder } from "@composurecdk/logs";
 import type { FunctionAlarmConfig } from "./alarm-config.js";
 import { createFunctionAlarms } from "./function-alarms.js";
 import { FUNCTION_DEFAULTS } from "./defaults.js";
+import {
+  type AttachedEventSource,
+  type ComposureEventSource,
+  isComposureEventSource,
+} from "./event-sources/composure-event-source.js";
 
 const LOGS_WRITER_POLICY_NAME = "LogsWriter";
 
@@ -51,8 +60,12 @@ export interface FunctionBuilderProps extends Omit<FunctionProps, "role"> {
    * methods are user-specific. Access alarms from the build result
    * or use an `afterBuild` hook to apply actions.
    *
-   * Contextual alarms (duration, concurrentExecutions) are only created
-   * when the corresponding function configuration is present.
+   * Contextual alarms are only created when the corresponding function
+   * configuration is present: `duration` when `timeout` is set,
+   * `concurrentExecutions` when `reservedConcurrentExecutions` is set, and
+   * the event-source alarms (`eventSourceFailedInvocations`,
+   * `eventSourceDroppedEvents`) once an event source is attached via
+   * {@link IFunctionBuilder.addEventSource}.
    *
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda
    */
@@ -107,6 +120,18 @@ export interface FunctionBuilderResult {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda
    */
   alarms: Record<string, Alarm>;
+
+  /**
+   * Event sources attached to the function via
+   * {@link IFunctionBuilder.addEventSource}, keyed by the key passed to that
+   * call. Each value is the resolved CDK {@link IEventSource} — for sources
+   * built by a ComposureCDK factory (e.g. {@link sqsEventSource}) the
+   * concrete type is preserved, so callers can read back post-`bind()` state
+   * such as `eventSourceMappingId`.
+   *
+   * Always present — `{}` when no event sources were added.
+   */
+  eventSources: Record<string, IEventSource>;
 }
 
 /**
@@ -166,9 +191,15 @@ export interface FunctionBuilderResult {
  */
 export type IFunctionBuilder = ITaggedBuilder<FunctionBuilderProps, FunctionBuilder>;
 
+interface EventSourceEntry {
+  key: string;
+  source: Resolvable<ComposureEventSource | IEventSource>;
+}
+
 class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
   props: Partial<FunctionBuilderProps> = {};
   readonly #customAlarms: AlarmDefinitionBuilder<LambdaFunction>[] = [];
+  readonly #eventSources: EventSourceEntry[] = [];
   #configureRole?: (rb: IRoleBuilder) => unknown;
   #useCdkAutoRole = false;
 
@@ -179,6 +210,35 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
     ) => AlarmDefinitionBuilder<LambdaFunction>,
   ): this {
     this.#customAlarms.push(configure(new AlarmDefinitionBuilder<LambdaFunction>(key)));
+    return this;
+  }
+
+  /**
+   * Register an event source to be attached to the function at build time.
+   *
+   * A Lambda function can have many event sources of mixed types, so this
+   * hook is repeatable and typed to the common {@link IEventSource}. Pass a
+   * {@link ComposureEventSource} from a ComposureCDK factory (e.g. {@link sqsEventSource})
+   * or a bare concrete {@link IEventSource}.
+   *
+   * At build time the source is resolved and attached *after* the function
+   * (and its least-privilege execution role) exist, so the `source.bind(fn)`
+   * that `addEventSource` performs grants the consume permission onto the
+   * builder's role. The resolved source is exposed on
+   * {@link FunctionBuilderResult.eventSources} under `key`.
+   *
+   * Sources built by a recognised factory also enable contextual alarms —
+   * see {@link FunctionBuilderProps.recommendedAlarms}.
+   *
+   * @throws If `key` was already used by a previous `addEventSource` call.
+   */
+  addEventSource(key: string, source: Resolvable<ComposureEventSource | IEventSource>): this {
+    if (this.#eventSources.some((e) => e.key === key)) {
+      throw new Error(
+        `FunctionBuilder.addEventSource: duplicate key "${key}". Each event source must use a unique key.`,
+      );
+    }
+    this.#eventSources.push({ key, source });
     return this;
   }
 
@@ -220,6 +280,7 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
   /** @internal — see ADR-0005. */
   [COPY_STATE](target: FunctionBuilder): void {
     target.#customAlarms.push(...this.#customAlarms);
+    target.#eventSources.push(...this.#eventSources);
     target.#configureRole = this.#configureRole;
     target.#useCdkAutoRole = this.#useCdkAutoRole;
   }
@@ -270,12 +331,42 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
 
     const fn = new LambdaFunction(scope, id, mergedProps);
 
+    const eventSources: Record<string, IEventSource> = {};
+    const attachedEventSources: AttachedEventSource[] = [];
+    for (const entry of this.#eventSources) {
+      const outer = resolve(entry.source, context);
+
+      let kind: AttachedEventSource["kind"] = "unknown";
+      let eventSource: IEventSource;
+      let readMappingId: ComposureEventSource["readMappingId"];
+      if (isComposureEventSource(outer)) {
+        kind = outer.kind;
+        eventSource = resolve(outer.source, context);
+        readMappingId = outer.readMappingId;
+      } else {
+        eventSource = outer;
+      }
+
+      // Attach after the function exists so the `source.bind(fn)` that
+      // `addEventSource` performs grants the consume permission onto the
+      // builder's least-privilege role; the mapping UUID is only readable
+      // once bound.
+      fn.addEventSource(eventSource);
+      eventSources[entry.key] = eventSource;
+      attachedEventSources.push({
+        key: entry.key,
+        kind,
+        eventSourceMappingId: readMappingId?.(eventSource),
+      });
+    }
+
     const alarms = createFunctionAlarms(
       scope,
       id,
       fn,
       alarmConfig,
       mergedProps,
+      attachedEventSources,
       this.#customAlarms,
     );
 
@@ -284,7 +375,7 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
       throw new Error(`FunctionBuilder "${id}": Lambda function has no execution role.`);
     }
 
-    return { function: fn, role: resolvedRole, logGroup, alarms };
+    return { function: fn, role: resolvedRole, logGroup, alarms, eventSources };
   }
 
   #buildDefaultRole(

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -22,6 +22,7 @@ import { FUNCTION_DEFAULTS } from "./defaults.js";
 import {
   type AttachedEventSource,
   type ComposureEventSource,
+  EVENT_SOURCE_MAPPING_ID_READERS,
   isComposureEventSource,
 } from "./event-sources/composure-event-source.js";
 
@@ -338,11 +339,9 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
 
       let kind: AttachedEventSource["kind"] = "unknown";
       let eventSource: IEventSource;
-      let readMappingId: ComposureEventSource["readMappingId"];
       if (isComposureEventSource(outer)) {
         kind = outer.kind;
         eventSource = resolve(outer.source, context);
-        readMappingId = outer.readMappingId;
       } else {
         eventSource = outer;
       }
@@ -356,7 +355,7 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
       attachedEventSources.push({
         key: entry.key,
         kind,
-        eventSourceMappingId: readMappingId?.(eventSource),
+        eventSourceMappingId: EVENT_SOURCE_MAPPING_ID_READERS[kind]?.(eventSource),
       });
     }
 

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -7,3 +7,11 @@ export {
 export { FUNCTION_DEFAULTS } from "./defaults.js";
 export { type FunctionAlarmConfig, type PercentageAlarmConfig } from "./alarm-config.js";
 export { FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
+export {
+  type ComposureEventSource,
+  type EventSourceKind,
+} from "./event-sources/composure-event-source.js";
+export {
+  sqsEventSource,
+  DEFAULT_SQS_EVENT_SOURCE_PROPS,
+} from "./event-sources/sqs-event-source.js";

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Code, type IEventSource, Runtime } from "aws-cdk-lib/aws-lambda";
+import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { isRef, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import { createFunctionBuilder } from "../src/function-builder.js";
+import {
+  DEFAULT_SQS_EVENT_SOURCE_PROPS,
+  sqsEventSource,
+} from "../src/event-sources/sqs-event-source.js";
+
+function baseBuilder(): ReturnType<typeof createFunctionBuilder> {
+  return createFunctionBuilder()
+    .runtime(Runtime.NODEJS_22_X)
+    .handler("index.handler")
+    .code(Code.fromInline("exports.handler = async () => {}"));
+}
+
+describe("sqsEventSource", () => {
+  it("returns a ComposureEventSource of kind 'sqs'", () => {
+    const stack = new Stack(new App(), "S");
+    const source = sqsEventSource(new Queue(stack, "Q"));
+
+    expect(source.kind).toBe("sqs");
+  });
+
+  it("holds a concrete source for a concrete queue", () => {
+    const stack = new Stack(new App(), "S");
+    const source = sqsEventSource(new Queue(stack, "Q"));
+
+    expect(isRef(source.source)).toBe(false);
+  });
+
+  it("holds a Ref source for a Ref queue", () => {
+    const source = sqsEventSource(ref("orders", (r: { queue: Queue }) => r.queue));
+
+    expect(isRef(source.source)).toBe(true);
+  });
+
+  it("exposes its secure defaults for visibility", () => {
+    expect(DEFAULT_SQS_EVENT_SOURCE_PROPS.reportBatchItemFailures).toBe(true);
+    expect(DEFAULT_SQS_EVENT_SOURCE_PROPS.metricsConfig).toEqual({ metrics: ["EventCount"] });
+  });
+});
+
+describe("FunctionBuilder.addEventSource", () => {
+  it("throws on a duplicate key", () => {
+    const stack = new Stack(new App(), "S");
+    const builder = baseBuilder().addEventSource("orders", sqsEventSource(new Queue(stack, "Q")));
+
+    expect(() => builder.addEventSource("orders", sqsEventSource(new Queue(stack, "Q2")))).toThrow(
+      /duplicate key "orders"/,
+    );
+  });
+
+  it("returns an empty eventSources record when none are added", () => {
+    const result = baseBuilder().build(new Stack(new App(), "S"), "Fn");
+
+    expect(result.eventSources).toEqual({});
+  });
+
+  it("exposes the resolved event source on the build result, keyed by key", () => {
+    const stack = new Stack(new App(), "S");
+    const source = sqsEventSource(new Queue(stack, "Q"));
+    const result = baseBuilder().addEventSource("orders", source).build(stack, "Fn");
+
+    expect(result.eventSources.orders).toBeInstanceOf(SqsEventSource);
+  });
+
+  it("synthesises an event source mapping", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::EventSourceMapping", 1);
+  });
+
+  it("applies the secure SQS defaults to the mapping", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::EventSourceMapping", {
+      FunctionResponseTypes: ["ReportBatchItemFailures"],
+      MetricsConfig: { Metrics: ["EventCount"] },
+    });
+  });
+
+  it("lets props override the secure defaults", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource(
+        "orders",
+        sqsEventSource(new Queue(stack, "Q"), { reportBatchItemFailures: false }),
+      )
+      .build(stack, "Fn");
+
+    const mappings = Template.fromStack(stack).findResources("AWS::Lambda::EventSourceMapping");
+    const [mapping] = Object.values(mappings) as { Properties: Record<string, unknown> }[];
+    expect(mapping.Properties.FunctionResponseTypes).toBeUndefined();
+  });
+
+  it("grants the builder's least-privilege role permission to consume the queue", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(["sqs:ReceiveMessage"]),
+            Effect: "Allow",
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("resolves a Ref event source against the build context", () => {
+    const stack = new Stack(new App(), "S");
+    const queue = new Queue(stack, "Q");
+
+    const result = baseBuilder()
+      .addEventSource("orders", sqsEventSource(ref("orders", (r: { queue: Queue }) => r.queue)))
+      .build(stack, "Fn", { orders: { queue } });
+
+    expect(result.eventSources.orders).toBeInstanceOf(SqsEventSource);
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::EventSourceMapping", 1);
+  });
+
+  it("accepts a bare IEventSource as an escape hatch", () => {
+    const stack = new Stack(new App(), "S");
+    const bare: IEventSource = new SqsEventSource(new Queue(stack, "Q"));
+
+    const result = baseBuilder().addEventSource("orders", bare).build(stack, "Fn");
+
+    expect(result.eventSources.orders).toBe(bare);
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::EventSourceMapping", 1);
+  });
+
+  it("preserves #eventSources across .copy()", () => {
+    assertCopyPreservesState({
+      factory: baseBuilder,
+      configure: (b) =>
+        b.addEventSource("first", sqsEventSource(ref("q1", (r: { queue: Queue }) => r.queue))),
+      mutate: (b) =>
+        b.addEventSource("second", sqsEventSource(ref("q2", (r: { queue: Queue }) => r.queue))),
+      build: (b) => {
+        const stack = new Stack(new App(), "S");
+        return b.build(stack, "Fn", {
+          q1: { queue: new Queue(stack, "Q1") },
+          q2: { queue: new Queue(stack, "Q2") },
+        });
+      },
+      inspect: (r) => Object.keys(r.eventSources).sort(),
+    });
+  });
+});
+
+describe("event-source contextual alarms", () => {
+  it("creates failed-invocation and dropped-event alarms when an SQS source is attached", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    expect(result.alarms).toHaveProperty("ordersFailedInvocations");
+    expect(result.alarms).toHaveProperty("ordersDroppedEvents");
+  });
+
+  it("dimensions the alarm metric on the event source mapping", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/Lambda",
+      MetricName: "FailedInvokeEventCount",
+      Dimensions: [{ Name: "EventSourceMappingUUID", Value: Match.anyValue() }],
+      Threshold: 0,
+      ComparisonOperator: "GreaterThanThreshold",
+    });
+  });
+
+  it("does not create event-source alarms when no event source is attached", () => {
+    const result = baseBuilder().build(new Stack(new App(), "S"), "Fn");
+
+    expect(result.alarms).not.toHaveProperty("ordersFailedInvocations");
+    expect(result.alarms).not.toHaveProperty("ordersDroppedEvents");
+  });
+
+  it("does not create event-source alarms for a bare escape-hatch source", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", new SqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    expect(result.alarms).not.toHaveProperty("ordersFailedInvocations");
+    expect(result.alarms).not.toHaveProperty("ordersDroppedEvents");
+  });
+
+  it("creates one set of alarms per attached SQS source", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Orders")))
+      .addEventSource("refunds", sqsEventSource(new Queue(stack, "Refunds")))
+      .build(stack, "Fn");
+
+    expect(Object.keys(result.alarms).sort()).toEqual(
+      expect.arrayContaining([
+        "ordersFailedInvocations",
+        "ordersDroppedEvents",
+        "refundsFailedInvocations",
+        "refundsDroppedEvents",
+      ]),
+    );
+  });
+
+  it("tunes the alarm threshold via recommendedAlarms", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .recommendedAlarms({ eventSourceFailedInvocations: { threshold: 10 } })
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "FailedInvokeEventCount",
+      Threshold: 10,
+    });
+  });
+
+  it("disables a single event-source alarm via recommendedAlarms", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .recommendedAlarms({ eventSourceFailedInvocations: false })
+      .build(stack, "Fn");
+
+    expect(result.alarms).not.toHaveProperty("ordersFailedInvocations");
+    expect(result.alarms).toHaveProperty("ordersDroppedEvents");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap from #118 — ComposureCDK had no ergonomic, `ref()`-aware wrapper for Lambda event sources. Implements the hybrid A+B design from the consolidated plan in the issue.

- **`sqsEventSource(queue, props?)`** — a `Resolvable`-aware factory (shape follows `events/targets`) that wraps `SqsEventSource`, resolves a `ref()` to a sibling queue at build time, and applies AWS-recommended secure defaults via `DEFAULT_SQS_EVENT_SOURCE_PROPS` (`reportBatchItemFailures: true`, `metricsConfig` enabling the EventCount ESM metrics).
- **`FunctionBuilder.addEventSource(key, source)`** — repeatable, keyed hook (mirrors `RuleBuilder.addTarget`). Sources resolve and attach *after* the function and its least-privilege role exist, so the `source.bind(fn)` consume-grant lands on the builder's role. Resolved sources are exposed on `FunctionBuilderResult.eventSources`.
- **Contextual alarms** — when an SQS source is attached, `FunctionBuilder` emits `<key>FailedInvocations` and `<key>DroppedEvents` per source, keyed off the per-mapping ESM metrics, tunable/disable-able via `recommendedAlarms`.
- **`ComposureEventSource`** carries a `kind` discriminator so the builder dispatches alarms without `instanceof`-ing CDK source classes. The mapping-UUID read is an internal `EVENT_SOURCE_MAPPING_ID_READERS` table keyed off the same discriminator (mirroring `EVENT_SOURCE_ALARM_SPECS`), so `ComposureEventSource` stays pure data — adding `kinesisEventSource`/`dynamoEventSource` later (#120/#121) is purely additive.
- **order-processor example** — replaces the raw-CDK escape hatch (`processor.function.addEventSource(new SqsEventSource(orders.queue))` applied post-build) with the declarative `.addEventSource("orders", sqsEventSource(ref("orders", …)))` inside `compose`.

Three logical commits: the lambda package, the example rewire, then a refactor dropping the per-instance `readMappingId` callback in favour of the kind-keyed reader table.

## Verification

- `nx test` for `lambda` (90) and `examples` (85) pass; lint + format clean.
- Deployed `ComposureCDK-OrderProcessorStack` to the sandbox account and ran the smoke test: stack `CREATE_COMPLETE`, a message sent to the queue was consumed and logged by the Lambda — proving the `sqsEventSource` wiring and the execution-role consume-grant work end-to-end. Stack torn down afterwards.

## Open questions for review

1. **No ADR.** The consolidated plan explicitly decided against one. Worth a sanity check: `ComposureEventSource` is a slightly heavier pattern than the bare `Resolvable<IRuleTarget>` that `events/targets` returns — it adds a symbol brand and a `kind` discriminator. The extra surface is genuinely needed (the builder needs `kind` to dispatch contextual alarms without `instanceof`), but if you'd rather capture the rationale in an ADR, happy to add one. (The earlier `readMappingId` callback that reviewers flagged as a new-pattern extension has since been removed — see commit 3.)
2. **Alarm-key naming.** The plan named the `FunctionAlarmConfig` *config* fields `eventSourceFailedInvocations` / `eventSourceDroppedEvents` but didn't specify the *per-source alarm* key. I went with `<eventSourceKey>FailedInvocations` / `<eventSourceKey>DroppedEvents` (e.g. `ordersFailedInvocations`) so multiple attached sources don't collide. The config fields tune every such alarm. Shout if you'd prefer a different convention.
3. **`EventSourceMappingUUID` dimension.** Used as specified in the issue's research comment. The deploy confirmed the alarms synthesize, but I haven't independently re-verified the CloudWatch dimension name against live ESM metrics — flagging in case you want to double-check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)