### PR TITLE
refactor(core): brand Ref with Symbol.for instead of instanceof

### DIFF
--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -1,4 +1,14 @@
 /**
+ * @internal Brands every {@link Ref} instance so {@link isRef} can recognise
+ * one without `instanceof`. `instanceof` is realm-bound: when `@composurecdk/core`
+ * is loaded as both ESM and CommonJS in the same process (the dual-package
+ * hazard), each copy has its own `Ref` class and `instanceof` fails across the
+ * boundary. A `Symbol.for(...)` brand is registered in the global symbol
+ * registry, so a `Ref` minted by either copy is still recognised by either.
+ */
+export const REF_BRAND = Symbol.for("composurecdk.ref");
+
+/**
  * A lazy reference to a value produced by another component at build time.
  *
  * `Ref` enables declarative cross-component wiring: a builder can capture a
@@ -26,6 +36,9 @@
  * ```
  */
 export class Ref<T> {
+  /** @internal Realm-agnostic brand — see {@link REF_BRAND}. */
+  readonly [REF_BRAND] = true;
+
   readonly #resolver: (context: Record<string, object>) => T;
 
   private constructor(resolver: (context: Record<string, object>) => T) {
@@ -134,9 +147,14 @@ export type Resolvable<T> = T | Ref<T>;
 
 /**
  * Type guard that checks whether a value is a {@link Ref}.
+ *
+ * Recognises a `Ref` by its {@link REF_BRAND} symbol rather than `instanceof`,
+ * so it works across the dual-package boundary — a `Ref` produced by the ESM
+ * copy of `@composurecdk/core` is still recognised by the CommonJS copy and
+ * vice versa.
  */
 export function isRef<T>(value: Resolvable<T>): value is Ref<T> {
-  return value instanceof Ref;
+  return typeof value === "object" && value !== null && REF_BRAND in value;
 }
 
 /**

--- a/packages/core/test/ref.test.ts
+++ b/packages/core/test/ref.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ref, resolve, isRef, type Resolvable } from "../src/ref.js";
+import { ref, resolve, isRef, REF_BRAND, type Resolvable } from "../src/ref.js";
 
 interface FakeResult {
   value: string;
@@ -109,6 +109,14 @@ describe("Resolvable utilities", () => {
       const value: Resolvable<FakeResult> = { value: "hello", nested: { id: 1 } };
 
       expect(isRef(value)).toBe(false);
+    });
+
+    it("recognises a Ref by its shared brand, not by instanceof", () => {
+      // Simulates a Ref minted by a different realm's copy of the module (the
+      // dual-package hazard): same Symbol.for brand, different class identity.
+      const foreignRef = { [REF_BRAND]: true };
+
+      expect(isRef(foreignRef as unknown as Resolvable<FakeResult>)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- `isRef` used `value instanceof Ref`, which is realm-bound. Once `@composurecdk/core` ships dual ESM/CJS and both copies load in one process (the dual-package hazard), each copy has its own `Ref` class and `instanceof` fails across the boundary.
- Brand every `Ref` instance with `Symbol.for("composurecdk.ref")` — a global-registry symbol shared across realms — and recognise it by that brand. Mirrors the existing `COPY_STATE` and `ComposureEventSource` brand patterns.

Extracted from #126 so it can land independently of the broader dual ESM/CJS rollout.

Refs #119.

## Test plan

- [ ] `npx nx test core`
- [ ] `npm run lint`
- [ ] `npm run format:check`