### PR TITLE
feat(eslint-plugin): ban CJS-incompatible syntax in library src

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -27,6 +27,7 @@ File-level overrides (e.g. disabling a rule on a specific file) belong in the co
 | `composurecdk/builder-must-be-tagged`            | `Builder` / `IBuilder` from `@composurecdk/core` in library builders (use `taggedBuilder`). |
 | `composurecdk/builder-must-implement-copy-state` | Builder classes with private fields but no `[COPY_STATE]` hook (see ADR-0005).              |
 | `composurecdk/lifecycle-build-context-required`  | `Lifecycle.build()` missing the `context` param when the class uses `Resolvable<…>`.        |
+| `composurecdk/no-cjs-incompatible-syntax`        | `import.meta` / top-level `await` in library `src/` — neither emits to CommonJS (ADR-0007). |
 
 The `recommended` preset also bans the TypeScript `private` modifier via `no-restricted-syntax` (use ECMAScript `#field` instead — TS `private` leaks through `keyof T` into emitted `.d.ts`, producing TS4094 downstream).
 

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -12,6 +12,7 @@ export const recommended: Linter.Config = {
     "composurecdk/builder-must-be-tagged": "error",
     "composurecdk/builder-must-implement-copy-state": "error",
     "composurecdk/lifecycle-build-context-required": "error",
+    "composurecdk/no-cjs-incompatible-syntax": "error",
     // Bans the TypeScript `private` modifier in favour of ECMAScript private
     // fields (#field). TS `private` members appear in `keyof T` and leak into
     // emitted .d.ts files via mapped types (builder types), producing TS4094

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,9 +1,11 @@
 import { rule as builderMustBeTagged } from "./builder-must-be-tagged.js";
 import { rule as builderMustImplementCopyState } from "./builder-must-implement-copy-state.js";
 import { rule as lifecycleBuildContextRequired } from "./lifecycle-build-context-required.js";
+import { rule as noCjsIncompatibleSyntax } from "./no-cjs-incompatible-syntax.js";
 
 export const rules = {
   "builder-must-be-tagged": builderMustBeTagged,
   "builder-must-implement-copy-state": builderMustImplementCopyState,
   "lifecycle-build-context-required": lifecycleBuildContextRequired,
+  "no-cjs-incompatible-syntax": noCjsIncompatibleSyntax,
 };

--- a/packages/eslint-plugin/src/rules/no-cjs-incompatible-syntax.ts
+++ b/packages/eslint-plugin/src/rules/no-cjs-incompatible-syntax.ts
@@ -1,0 +1,59 @@
+import type { Rule } from "eslint";
+import type { AwaitExpression, ForOfStatement, MetaProperty, Node } from "estree";
+
+const FUNCTION_TYPES = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+]);
+
+/**
+ * Flags syntax in library `src/` that cannot be emitted to CommonJS:
+ * `import.meta`, top-level `await`, and top-level `for await…of`. All are
+ * valid ESM but have no CJS equivalent, so `tsc` (and tshy's CommonJS
+ * dialect) errors on them.
+ *
+ * Every `@composurecdk/*` package is dual-published (ESM + CJS) — see
+ * ADR-0007. Catching these at lint time gives an in-editor error before any
+ * build runs, rather than waiting for the per-dialect compile to fail.
+ */
+export const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Ban ESM-only syntax (import.meta, top-level await) that cannot emit to CommonJS",
+    },
+    schema: [],
+    messages: {
+      importMeta:
+        "`import.meta` cannot be emitted to CommonJS. Every package is dual-published (ADR-0007) — " +
+        "avoid `import.meta` in library `src/`.",
+      topLevelAwait:
+        "Top-level `await` cannot be emitted to CommonJS. Every package is dual-published (ADR-0007) — " +
+        "move the `await` inside an async function.",
+    },
+  },
+  create(ctx) {
+    const isTopLevel = (node: Node): boolean =>
+      !ctx.sourceCode.getAncestors(node).some((ancestor) => FUNCTION_TYPES.has(ancestor.type));
+
+    return {
+      MetaProperty(node: MetaProperty) {
+        if (node.meta.name === "import" && node.property.name === "meta") {
+          ctx.report({ node, messageId: "importMeta" });
+        }
+      },
+      AwaitExpression(node: AwaitExpression) {
+        if (isTopLevel(node)) {
+          ctx.report({ node, messageId: "topLevelAwait" });
+        }
+      },
+      "ForOfStatement[await=true]"(node: ForOfStatement) {
+        if (isTopLevel(node)) {
+          ctx.report({ node, messageId: "topLevelAwait" });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/test/rules/no-cjs-incompatible-syntax.test.ts
+++ b/packages/eslint-plugin/test/rules/no-cjs-incompatible-syntax.test.ts
@@ -1,0 +1,78 @@
+import { rule } from "../../src/rules/no-cjs-incompatible-syntax.js";
+import { ruleTester } from "../rule-tester.js";
+
+ruleTester.run("no-cjs-incompatible-syntax", rule, {
+  valid: [
+    {
+      name: "await inside an async function",
+      code: `
+        async function load() {
+          return await Promise.resolve(1);
+        }
+      `,
+    },
+    {
+      name: "await inside an async arrow function",
+      code: `
+        const load = async () => await Promise.resolve(1);
+      `,
+    },
+    {
+      name: "await inside a nested arrow passed to a top-level call",
+      code: `
+        const results = [1].map(async (x) => await Promise.resolve(x));
+      `,
+    },
+    {
+      name: "for await...of inside an async function",
+      code: `
+        async function drain(source) {
+          for await (const item of source) {
+            console.log(item);
+          }
+        }
+      `,
+    },
+    {
+      name: "no import.meta or await at all",
+      code: `
+        export const value = 42;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "import.meta usage",
+      code: `
+        export const dir = import.meta.url;
+      `,
+      errors: [{ messageId: "importMeta" }],
+    },
+    {
+      name: "top-level await",
+      code: `
+        export const value = await Promise.resolve(1);
+      `,
+      errors: [{ messageId: "topLevelAwait" }],
+    },
+    {
+      name: "top-level await is flagged even when an async function exists elsewhere",
+      code: `
+        async function unrelated() {
+          return 1;
+        }
+        export const value = await Promise.resolve(1);
+      `,
+      errors: [{ messageId: "topLevelAwait" }],
+    },
+    {
+      name: "top-level for await...of",
+      code: `
+        for await (const item of source) {
+          console.log(item);
+        }
+      `,
+      errors: [{ messageId: "topLevelAwait" }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Adds `composurecdk/no-cjs-incompatible-syntax`, flagging `import.meta`, top-level `await`, and top-level `for await…of` in `packages/*/src` — all valid ESM but with no CommonJS equivalent, so they break the CJS dialect once packages are dual-published (ADR-0007).
- Runs at lint time, so a maintainer sees the error in-editor before any build runs — the fastest possible feedback loop. Registered in the `recommended` preset as `error`.

Extracted from #126 so it can land independently of the broader dual ESM/CJS rollout.

Refs #119.

## Test plan

- [ ] `npx nx test eslint-plugin`
- [ ] `npm run lint`
- [ ] `npm run format:check`