### PR TITLE
build: normalize root package.json to "type": "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "composurecdk",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
@@ -21,7 +20,7 @@
   "keywords": [],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "bugs": {
     "url": "https://github.com/laazyj/composureCDK/issues"
   },


### PR DESCRIPTION
## Summary

- The root `"type": "commonjs"` governed nothing — the only root-level JS is `eslint.config.mjs` and `scripts/smoke-test.mjs`, both explicit `.mjs`. Setting it to `"module"` matches every workspace package and the project's ESM-first direction.
- Also drops the dead `"main": "index.js"` field (no such file exists).

Extracted from #126 so it can land independently of the broader dual ESM/CJS rollout.

Refs #119.

## Test plan

- [ ] `npm run lint`
- [ ] `npm run format:check`
- [ ] `npx nx run-many -t build` (sanity — no root-level JS resolution changes expected)