### PR TITLE
ci: add Node 20 + 24 matrix and check:exports gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,17 @@ concurrency:
 
 jobs:
   ci:
-    name: Lint, Format, Typecheck, Test, Build
+    name: Lint, Format, Typecheck, Test, Build (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       NX_DAEMON: false
+    strategy:
+      fail-fast: false
+      matrix:
+        # Node 20 is the supported floor; 24 is current. Dual-published
+        # packages must resolve on both — see ADR-0007.
+        node-version: [20, 24]
 
     steps:
       - name: Checkout
@@ -31,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
@@ -45,6 +51,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Check exports
+        run: npm run check:exports
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## Summary

- `ci.yml` gains a Node 20 + 24 matrix and a `Check exports` step. The matrix exercises the dual-publishing floor and current Node side-by-side; the `Check exports` step runs the same `attw + publint` gate as `npm run verify` so a regression cannot reach `main`.

## Dependency

**Depends on #126.** The `Check exports` step invokes `npm run check:exports`, which the export-enforcement scaffolding in #126 introduces at the workspace root. Merge #126 first; CI here will fail otherwise.

Refs #119.

## Test plan

- [ ] After #126 merges, rebase this on `main` and confirm the matrix run completes on both Node versions.
- [ ] Confirm the `Check exports` step runs `npm run check:exports` cleanly.