### PR TITLE
fix(release): hoist nx release git config to release.git

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -47,7 +47,7 @@ Scopes are optional and do not affect the bump.
    npx nx release --dry-run
    ```
 
-   Prints the planned version, changelog, and per-package bumps. Safe any time. `nx.json` sets `commit/tag/push` to `false` under both `release.version.git` and `release.changelog.git`, so a non-`--dry-run` local invocation modifies files but does not commit, tag, or push — `git restore` undoes it.
+   Prints the planned version, changelog, and per-package bumps. Safe any time. `nx.json` sets `commit/tag/push` to `false` under `release.git`, so a non-`--dry-run` local invocation modifies files but does not commit, tag, or push — `git restore` undoes it.
 
 2. **Open the release PR.** Trigger **Actions → Release Prepare → Run workflow**:
    - Leave inputs blank for a normal conventional-commits-driven release.

--- a/nx.json
+++ b/nx.json
@@ -30,26 +30,21 @@
   "release": {
     "projectsRelationship": "fixed",
     "projects": ["packages/*"],
+    "git": {
+      "commit": false,
+      "tag": false,
+      "push": false
+    },
     "version": {
       "conventionalCommits": true,
       "fallbackCurrentVersionResolver": "disk",
-      "preVersionCommand": "npm run verify",
-      "git": {
-        "commit": false,
-        "tag": false,
-        "push": false
-      }
+      "preVersionCommand": "npm run verify"
     },
     "releaseTagPattern": "v{version}",
     "changelog": {
       "automaticFromRef": true,
       "projectChangelogs": false,
-      "workspaceChangelog": true,
-      "git": {
-        "commit": false,
-        "tag": false,
-        "push": false
-      }
+      "workspaceChangelog": true
     }
   },
   "analytics": false


### PR DESCRIPTION
## Summary

- nx@22 rejects the top-level `nx release` command when `git` options are configured granularly under `release.version.git` and `release.changelog.git`, breaking the `npx nx release --dry-run` local-preview step documented in `docs/ci.md`.
- The two granular blocks in `nx.json` were identical (`commit/tag/push = false`), so collapse them into a single top-level `release.git`. The subcommand calls (`nx release version`, `nx release changelog`) in `release-prepare.yml` keep working unchanged because they inherit from the top-level config.
- Updated the matching sentence in `docs/ci.md` to reference `release.git` instead of the now-removed granular paths.

## Repro of the original failure

```
❯ npx nx release --dry-run
 NX   The "release" top level command cannot be used with granular git configuration. Instead, configure git options in the "release.git" property in nx.json, or use the version, changelog, and publish subcommands or programmatic API directly.
```

After this change, `npx nx release --dry-run` runs through and prints the planned bumps.

## Test plan

- [ ] `npx nx release --dry-run` exits 0 and shows the planned version + changelog
- [ ] `npm run verify` is green
- [ ] CI (ci.yml on Node 20 + 24) is green