### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## 0.8.0 (2026-05-16)
+
+### 🚀 Features
+
+- dual ESM/CJS publishing as an enforced project-wide standard ([#126](https://github.com/laazyj/composureCDK/pull/126), [#119](https://github.com/laazyj/composureCDK/issues/119))
+- **eslint-plugin:** ban CJS-incompatible syntax in library src ([#119](https://github.com/laazyj/composureCDK/issues/119))
+- ⚠️ **lambda:** scope execution-role logs permissions to the function's own log group ([#105](https://github.com/laazyj/composureCDK/pull/105), [#41](https://github.com/laazyj/composureCDK/issues/41))
+- **lambda:** SQS event source wiring with contextual alarms ([#125](https://github.com/laazyj/composureCDK/pull/125), [#118](https://github.com/laazyj/composureCDK/issues/118))
+- **route53:** default-on DNS query logging with shared resource policy ([#101](https://github.com/laazyj/composureCDK/pull/101), [#44](https://github.com/laazyj/composureCDK/issues/44))
+- **sns:** protocol-specific subscription defaults ([#116](https://github.com/laazyj/composureCDK/pull/116), [#35](https://github.com/laazyj/composureCDK/issues/35))
+- **sqs:** add @composurecdk/sqs with QueueBuilder ([#115](https://github.com/laazyj/composureCDK/pull/115), [#112](https://github.com/laazyj/composureCDK/issues/112))
+
+### 🩹 Fixes
+
+- **ci:** trigger release.yml via tag push instead of workflow_call ([7a6eeb4](https://github.com/laazyj/composureCDK/commit/7a6eeb4))
+- ⚠️ **sns:** route SubscriptionBuilder through ITopicSubscription.bind() ([#39](https://github.com/laazyj/composureCDK/issues/39), [#38](https://github.com/laazyj/composureCDK/issues/38))
+
+### ⚠️ Breaking Changes
+
+- **sns:** route SubscriptionBuilder through ITopicSubscription.bind() ([#39](https://github.com/laazyj/composureCDK/issues/39), [#38](https://github.com/laazyj/composureCDK/issues/38))
+- **lambda:** scope execution-role logs permissions to the function's own log group ([#105](https://github.com/laazyj/composureCDK/pull/105), [#41](https://github.com/laazyj/composureCDK/issues/41))
+  the IAM role's CloudFormation logical id changes from
+  "<id>ServiceRole<hash>" (nested under the function) to
+  "<id>ExecutionRole<hash>" (sibling). Existing stacks will replace the
+  role on upgrade. Use .useCdkAutoRole() to opt back into CDK's prior
+  behaviour during a phased migration.
+  BREAKING CHANGE: FunctionBuilderProps.role is widened from IRole to
+  Resolvable<IRole>; the .role() setter is mutually exclusive with
+  .configureRole() and .useCdkAutoRole().
+  Closes #41
+
+### ❤️ Thank You
+
+- Claude (laazyj)
+- Claude Opus 4.7 (1M context)
+- Jason Duffett
+
 ## 0.7.0 (2026-05-08)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -8764,7 +8764,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8777,16 +8777,16 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8799,17 +8799,17 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/logs": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/logs": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8822,16 +8822,16 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8844,14 +8844,14 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8864,17 +8864,17 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/s3": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/s3": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8893,7 +8893,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -8912,7 +8912,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8925,17 +8925,17 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/logs": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/logs": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8950,7 +8950,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -8963,15 +8963,15 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.253.1",
@@ -8984,23 +8984,23 @@
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
-        "@composurecdk/apigateway": "^0.7.0",
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudfront": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/ec2": "^0.7.0",
-        "@composurecdk/events": "^0.7.0",
-        "@composurecdk/lambda": "^0.7.0",
-        "@composurecdk/route53": "^0.7.0",
-        "@composurecdk/s3": "^0.7.0",
-        "@composurecdk/sns": "^0.7.0",
-        "@composurecdk/sqs": "^0.7.0"
+        "@composurecdk/apigateway": "^0.8.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudfront": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/ec2": "^0.8.0",
+        "@composurecdk/events": "^0.8.0",
+        "@composurecdk/lambda": "^0.8.0",
+        "@composurecdk/route53": "^0.8.0",
+        "@composurecdk/s3": "^0.8.0",
+        "@composurecdk/sns": "^0.8.0",
+        "@composurecdk/sqs": "^0.8.0"
       }
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -9013,18 +9013,18 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
-        "@composurecdk/iam": "^0.7.0",
+        "@composurecdk/iam": "^0.8.0",
         "@types/node": "^25.6.2",
         "aws-cdk-lib": "^2.253.1",
         "constructs": "^10.6.0",
@@ -9035,18 +9035,18 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/iam": "^0.7.0",
-        "@composurecdk/logs": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/iam": "^0.8.0",
+        "@composurecdk/logs": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -9059,15 +9059,15 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -9080,27 +9080,27 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/acm": "^0.7.0",
-        "@composurecdk/apigateway": "^0.7.0",
-        "@composurecdk/budgets": "^0.7.0",
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudfront": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/ec2": "^0.7.0",
-        "@composurecdk/events": "^0.7.0",
-        "@composurecdk/iam": "^0.7.0",
-        "@composurecdk/lambda": "^0.7.0",
-        "@composurecdk/logs": "^0.7.0",
-        "@composurecdk/route53": "^0.7.0",
-        "@composurecdk/s3": "^0.7.0",
-        "@composurecdk/sns": "^0.7.0",
-        "@composurecdk/sqs": "^0.7.0"
+        "@composurecdk/acm": "^0.8.0",
+        "@composurecdk/apigateway": "^0.8.0",
+        "@composurecdk/budgets": "^0.8.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudfront": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/ec2": "^0.8.0",
+        "@composurecdk/events": "^0.8.0",
+        "@composurecdk/iam": "^0.8.0",
+        "@composurecdk/lambda": "^0.8.0",
+        "@composurecdk/logs": "^0.8.0",
+        "@composurecdk/route53": "^0.8.0",
+        "@composurecdk/s3": "^0.8.0",
+        "@composurecdk/sns": "^0.8.0",
+        "@composurecdk/sqs": "^0.8.0"
       }
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -9113,17 +9113,17 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/logs": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/logs": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -9136,17 +9136,17 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
-        "@composurecdk/logs": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "@composurecdk/logs": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -9159,16 +9159,16 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -9181,9 +9181,9 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@composurecdk/cloudformation": "^0.7.0",
-        "@composurecdk/cloudwatch": "^0.7.0",
-        "@composurecdk/core": "^0.7.0",
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
       }

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,9 +37,9 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/logs": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/logs": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",
@@ -37,9 +37,9 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/s3": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/s3": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/logs": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/logs": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,8 +37,8 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {
@@ -22,18 +22,18 @@
     "constructs": "^10.6.0"
   },
   "peerDependencies": {
-    "@composurecdk/apigateway": "^0.7.0",
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/cloudfront": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/ec2": "^0.7.0",
-    "@composurecdk/events": "^0.7.0",
-    "@composurecdk/lambda": "^0.7.0",
-    "@composurecdk/route53": "^0.7.0",
-    "@composurecdk/s3": "^0.7.0",
-    "@composurecdk/sns": "^0.7.0",
-    "@composurecdk/sqs": "^0.7.0"
+    "@composurecdk/apigateway": "^0.8.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/cloudfront": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/ec2": "^0.8.0",
+    "@composurecdk/events": "^0.8.0",
+    "@composurecdk/lambda": "^0.8.0",
+    "@composurecdk/route53": "^0.8.0",
+    "@composurecdk/s3": "^0.8.0",
+    "@composurecdk/sns": "^0.8.0",
+    "@composurecdk/sqs": "^0.8.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,8 +37,8 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,16 +37,16 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/iam": "^0.7.0",
-    "@composurecdk/logs": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/iam": "^0.8.0",
+    "@composurecdk/logs": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "@composurecdk/iam": "^0.7.0",
+    "@composurecdk/iam": "^0.8.0",
     "@types/node": "^25.6.2",
     "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",
@@ -37,8 +37,8 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {
@@ -22,22 +22,22 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@composurecdk/acm": "^0.7.0",
-    "@composurecdk/apigateway": "^0.7.0",
-    "@composurecdk/budgets": "^0.7.0",
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudfront": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/ec2": "^0.7.0",
-    "@composurecdk/events": "^0.7.0",
-    "@composurecdk/iam": "^0.7.0",
-    "@composurecdk/lambda": "^0.7.0",
-    "@composurecdk/logs": "^0.7.0",
-    "@composurecdk/route53": "^0.7.0",
-    "@composurecdk/s3": "^0.7.0",
-    "@composurecdk/sns": "^0.7.0",
-    "@composurecdk/sqs": "^0.7.0"
+    "@composurecdk/acm": "^0.8.0",
+    "@composurecdk/apigateway": "^0.8.0",
+    "@composurecdk/budgets": "^0.8.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudfront": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/ec2": "^0.8.0",
+    "@composurecdk/events": "^0.8.0",
+    "@composurecdk/iam": "^0.8.0",
+    "@composurecdk/lambda": "^0.8.0",
+    "@composurecdk/logs": "^0.8.0",
+    "@composurecdk/route53": "^0.8.0",
+    "@composurecdk/s3": "^0.8.0",
+    "@composurecdk/sns": "^0.8.0",
+    "@composurecdk/sqs": "^0.8.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",
@@ -38,10 +38,10 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/logs": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/logs": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
-    "@composurecdk/logs": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "@composurecdk/logs": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,9 +37,9 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",
@@ -37,9 +37,9 @@
     }
   },
   "peerDependencies": {
-    "@composurecdk/cloudformation": "^0.7.0",
-    "@composurecdk/cloudwatch": "^0.7.0",
-    "@composurecdk/core": "^0.7.0",
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
   },


### PR DESCRIPTION
Release **v0.8.0**.

Generated by `release-prepare` workflow run [#25964193774](https://github.com/laazyj/composureCDK/actions/runs/25964193774).

## Merge checklist

- [ ] CI is green
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.8.0`, which triggers `release.yml` (deploy-test → npm publish).