### PR TITLE
docs(cloudwatch): lead alarmActionsPolicy docs with Aspect/timing contract

### DIFF
--- a/packages/cloudwatch/README.md
+++ b/packages/cloudwatch/README.md
@@ -123,6 +123,8 @@ alarmActionsPolicy(app, {
 });
 ```
 
+The policy is implemented as a CDK [Aspect](https://docs.aws.amazon.com/cdk/v2/guide/aspects.html) — it has no dependency on `@composurecdk/core` and works in any CDK app. Because aspects fire during synth, the policy can be registered before or after the alarms it targets, and there is **no need to wrap the call in `afterBuild`** — calling `alarmActionsPolicy(app, …)` at app scope outside any `compose()` chain is the recommended shape. The only constraint is that any `IAlarmAction` instances in the config (e.g. `new SnsAction(topic)`) must reference constructs that already exist when the policy is called.
+
 Per-alarm routing is expressed as rules. Matchers can be a substring (tested against both the alarm's `id` and `path`), a `RegExp` (tested against `path`), or a predicate receiving the full match context. Rules append actions on top of `defaults`; set `replaceDefaults: true` on a rule to suppress defaults for its matched alarms.
 
 ```ts
@@ -137,7 +139,30 @@ alarmActionsPolicy(app, {
 
 All three action states are supported: `alarmActions`, `okActions`, and `insufficientDataActions`.
 
-The policy is implemented as a CDK [Aspect](https://docs.aws.amazon.com/cdk/v2/guide/aspects.html) — it has no dependency on `@composurecdk/core` and works in any CDK app. Because aspects fire during synth, the policy can be registered before or after the alarms it targets. The only constraint is that any `IAlarmAction` instances in the config (e.g. `new SnsAction(topic)`) must reference constructs that already exist when the policy is called.
+### Per-scope routing: different topics for different stacks
+
+Rules route by _alarm identity_ (id, path, predicate). When you instead need to route by _scope_ — e.g. one SNS topic for everything in `us-east-1` and another for the primary region — call `alarmActionsPolicy` multiple times, once per target scope. If the topics are themselves built by the composed system, this is the case where wrapping in [`afterBuild`](../core/README.md) is load-bearing: the closure captures the build `results` so each call can reference its topic.
+
+```ts
+compose(
+  { usEast1Alerts: createTopicBuilder(), siteAlerts: createTopicBuilder() },
+  {
+    /* … */
+  },
+)
+  .withStacks({ usEast1Alerts: usEast1AlertsStack, siteAlerts: siteStack })
+  .afterBuild((_scope, _id, results) => {
+    alarmActionsPolicy(usEast1AlertsStack, {
+      defaults: { alarmActions: [new SnsAction(results.usEast1Alerts.topic)] },
+    });
+    alarmActionsPolicy(siteStack, {
+      defaults: { alarmActions: [new SnsAction(results.siteAlerts.topic)] },
+    });
+  })
+  .build(app, "MySystem");
+```
+
+If a _single_ topic covers the whole app, prefer the top-level form above — `afterBuild` adds nothing in that case.
 
 ### Limitation: L2 alarms only
 

--- a/packages/cloudwatch/src/policies/alarm-actions-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-actions-policy.ts
@@ -93,17 +93,24 @@ function visitAlarms(scope: IConstruct, visit: AlarmVisitor): void {
 }
 
 /**
- * Attaches CloudWatch alarm actions to every `Alarm` and `CompositeAlarm`
- * (L2) construct in the subtree under `scope`.
+ * Registers a CDK {@link https://docs.aws.amazon.com/cdk/v2/guide/aspects.html | Aspect}
+ * on `scope` that attaches CloudWatch alarm actions to every `Alarm` and
+ * `CompositeAlarm` (L2) construct in the subtree at synth time. Call once
+ * with any scope — an `App`, a `Stack`, or the scope passed to `.build()`
+ * for a composed system; alarms added after the call still pick up the
+ * policy, so call ordering is irrelevant as
+ * long as it happens before `app.synth()`. In particular, there is no need
+ * to wrap this call in `afterBuild` — the Aspect runs after the construct
+ * tree is finalised, not at call time. The only temporal constraint is that
+ * any `IAlarmAction` instances in `config` (e.g. `new SnsAction(topic)`)
+ * must reference constructs that already exist when the policy is called.
  *
- * The policy installs a CDK {@link https://docs.aws.amazon.com/cdk/v2/guide/aspects.html | Aspect}
- * that fires during the synth prepare phase, so late-added alarms are also
- * covered. Detection uses the jsii type guards
- * `CfnAlarm.isCfnAlarm` / `CfnCompositeAlarm.isCfnCompositeAlarm` on the L1
- * resource; the L2 parent is found via duck-typing on `addAlarmAction`.
- * Actions are attached through the L2 so that `IAlarmAction.bind()` runs and
- * permissions are wired correctly. Bare `CfnAlarm` nodes (created without an
- * L2 wrapper) are detected but silently skipped.
+ * Detection uses the jsii type guards `CfnAlarm.isCfnAlarm` /
+ * `CfnCompositeAlarm.isCfnCompositeAlarm` on the L1 resource; the L2 parent
+ * is found via duck-typing on `addAlarmAction`. Actions are attached through
+ * the L2 so that `IAlarmAction.bind()` runs and permissions are wired
+ * correctly. Bare `CfnAlarm` nodes (created without an L2 wrapper) are
+ * detected but silently skipped.
  *
  * `defaults` apply to every matched alarm; `rules` append additional actions.
  * A rule matches if any of its `match` entries matches. Set


### PR DESCRIPTION
## Summary

- Lift the Aspect-based timing guarantee to the lead of both the `alarmActionsPolicy` docstring and the README section, so the first thing a reader sees is *"this is a CDK Aspect; call ordering doesn't matter; no `afterBuild` wrapper needed."*
- Add a new README subsection — *Per-scope routing: different topics for different stacks* — that frames `afterBuild`-wrapped usage as the **exception case** (you need closure over composed-system build `results` to route different scopes to different topics), with a worked example.
- Replace the docstring's previous "(`App`, `Stack`, or a composed-system root)" parenthetical, since "composed-system root" wasn't terminology used elsewhere — now reads "an `App`, a `Stack`, or the scope passed to `.build()` for a composed system."

No code changes. Decided against shipping the `alarmActionsHook(...)` helper sketched in the issue: unlike `outputs()`, it would be a one-line closure over `alarmActionsPolicy` with no real temporal coupling to plumb, and codifying a typed entry point for the `afterBuild` form would undercut the docs change that's trying to steer people away from it for the common case. Reassess if doc fix doesn't move the needle.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npx nx test cloudwatch` — 80/80 pass
- [x] Husky `pre-push` (full `verify`) passed on push

Closes #65