### PR TITLE
chore(deps): bump aws-cdk-lib floor to ^2.254.0 for fast-uri fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,9 +112,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.20.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.20.0.tgz",
-      "integrity": "sha512-4kLAUO+I8b4nlk1Z2P4n3Ye8UtqCiXk0kJMLUThBnyHLbdz06rwAb+qlb9WZOie7NtPluemVS243ifcBh/NVsQ==",
+      "version": "53.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.24.0.tgz",
+      "integrity": "sha512-rCwsd0Y9z4CUmV5FhzjbO2MprXjKG0rxCACuLEY40lD+wInvgcHer0lSDo7Xq9Sxe/IoNe/Wxb2YP3GgxvT3GA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -122,7 +122,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -137,7 +137,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -3564,9 +3564,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.253.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
-      "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
+      "version": "2.254.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
+      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -3585,8 +3585,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.2",
-        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.3",
+        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -3607,11 +3607,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.2",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3622,7 +3618,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -3729,7 +3725,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -7673,7 +7669,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8755,7 +8750,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -8777,7 +8772,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -8800,7 +8795,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -8822,7 +8817,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -8842,7 +8837,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -8865,7 +8860,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -8903,7 +8898,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"
@@ -8941,7 +8936,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -8961,7 +8956,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
@@ -8991,7 +8986,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -9013,7 +9008,7 @@
       "devDependencies": {
         "@composurecdk/iam": "^0.8.0",
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -9037,7 +9032,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -9058,7 +9053,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -9091,7 +9086,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -9114,7 +9109,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -9137,7 +9132,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -9159,7 +9154,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.2",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.6.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0"
   },
   "peerDependencies": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@composurecdk/iam": "^0.8.0",
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"


### PR DESCRIPTION
## Summary
- Bumps `devDependencies: aws-cdk-lib` across all 17 workspace packages from `^2.253.1` → `^2.254.0`.
- Resolves [Dependabot alert #18](https://github.com/laazyj/composureCDK/security/dependabot/18) — two high-severity `fast-uri` advisories ([GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6), [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc)) that reached the workspace through `aws-cdk-lib`'s bundled dep tree (`aws-cdk-lib > table > ajv > fast-uri@3.1.0`).
- `aws-cdk-lib@2.254.0` rebundles `fast-uri@3.1.2`, which is the patched release. After the bump, `npm ls fast-uri` reports `3.1.2` and the advisories are gone from `npm audit`.
- Public `peerDependencies: aws-cdk-lib` remains `^2.0.0` — only the internal floor moves, so the supported consumer range is unchanged.

## Test plan
- [x] `npm install` — lockfile resolves `aws-cdk-lib@2.254.0` and `fast-uri@3.1.2` across all packages.
- [x] `npm audit` — both fast-uri advisories cleared.
- [x] `npm run lint` / `npm run format:check`.
- [x] Husky pre-push `npm run verify` (build + `check:exports` + lint + 85 tests across 19 projects) passed.
- [ ] CI green on the Node 20 + 24 matrix.