### PR TITLE
feat(sqs): warn when redrive maxReceiveCount is below 5

### DIFF
--- a/packages/sqs/src/queue-builder.ts
+++ b/packages/sqs/src/queue-builder.ts
@@ -1,3 +1,4 @@
+import { Annotations, Token } from "aws-cdk-lib";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IQueue, Queue, type QueueProps } from "aws-cdk-lib/aws-sqs";
 import { type IConstruct } from "constructs";
@@ -7,6 +8,17 @@ import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { QueueAlarmConfig } from "./queue-alarm-config.js";
 import { createQueueAlarms } from "./queue-alarms.js";
 import { QUEUE_DEFAULTS } from "./defaults.js";
+
+/**
+ * AWS-recommended minimum for `maxReceiveCount` on an SQS redrive
+ * policy. A consumer needs a few retries before SQS gives up and
+ * forwards the message to the dead-letter queue; anything below this
+ * tends to surface as a flood of "poison" messages from transient
+ * errors that would have succeeded on retry.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+ */
+const RECOMMENDED_MIN_MAX_RECEIVE_COUNT = 5;
 
 /**
  * Configuration properties for the SQS queue builder.
@@ -105,6 +117,8 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
       ...queueProps,
     } as QueueBuilderProps;
 
+    warnIfLowMaxReceiveCount(scope, id, mergedProps);
+
     const queue = new Queue(scope, id, mergedProps);
 
     const alarms = createQueueAlarms(scope, id, queue, alarmConfig, this.#customAlarms);
@@ -140,4 +154,33 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
  */
 export function createQueueBuilder(): IQueueBuilder {
   return taggedBuilder<QueueBuilderProps, QueueBuilder>(QueueBuilder);
+}
+
+/**
+ * Annotates `scope` with a non-fatal warning when a redrive policy is
+ * configured with `maxReceiveCount` below the AWS-recommended floor
+ * of {@link RECOMMENDED_MIN_MAX_RECEIVE_COUNT}.
+ *
+ * The builder owns the redrive policy directly, so this is a true
+ * check rather than a contextual reminder — the actual configured
+ * value is compared. Short-circuits on unresolved tokens so stacks
+ * that thread `maxReceiveCount` through CFN parameters aren't spammed.
+ */
+function warnIfLowMaxReceiveCount(
+  scope: IConstruct,
+  id: string,
+  props: Partial<QueueBuilderProps>,
+): void {
+  const dlq = props.deadLetterQueue;
+  if (!dlq) return;
+  const maxReceiveCount = dlq.maxReceiveCount;
+  if (Token.isUnresolved(maxReceiveCount)) return;
+  if (maxReceiveCount >= RECOMMENDED_MIN_MAX_RECEIVE_COUNT) return;
+  Annotations.of(scope).addWarningV2(
+    "@composurecdk/sqs:redrive-low-max-receive-count",
+    `QueueBuilder "${id}": redrive policy maxReceiveCount is ${String(maxReceiveCount)}; ` +
+      `AWS recommends >= ${String(RECOMMENDED_MIN_MAX_RECEIVE_COUNT)} so the consumer ` +
+      `has room to retry before messages hit the dead-letter queue. ` +
+      `See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html`,
+  );
 }

--- a/packages/sqs/test/queue-builder.test.ts
+++ b/packages/sqs/test/queue-builder.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { App, Duration, Stack } from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
+import { App, CfnParameter, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
-import { type IQueue, QueueEncryption } from "aws-cdk-lib/aws-sqs";
+import { type IQueue, Queue, QueueEncryption } from "aws-cdk-lib/aws-sqs";
 import { Key } from "aws-cdk-lib/aws-kms";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createQueueBuilder } from "../src/queue-builder.js";
@@ -158,6 +158,61 @@ describe("QueueBuilder", () => {
         build: (b) => b.build(new Stack(new App(), "S"), "Queue"),
         inspect: (r) => Object.keys(r.alarms).sort(),
       });
+    });
+  });
+
+  describe("redrive policy maxReceiveCount warning", () => {
+    function buildWithDlq(maxReceiveCount: number, id = "Orders"): Stack {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const dlq = new Queue(stack, "Dlq");
+      createQueueBuilder().deadLetterQueue({ queue: dlq, maxReceiveCount }).build(stack, id);
+      return stack;
+    }
+
+    it.each([1, 2, 3, 4])(
+      "warns when maxReceiveCount is %i (below the AWS-recommended minimum of 5)",
+      (maxReceiveCount) => {
+        const stack = buildWithDlq(maxReceiveCount);
+
+        // The ack tag is what callers use to suppress the warning via
+        // `Annotations.of(scope).acknowledgeWarning(...)`, so the ID is part of
+        // the public surface — guard against accidental rename.
+        Annotations.fromStack(stack).hasWarning(
+          "/TestStack",
+          Match.stringLikeRegexp(
+            `QueueBuilder "Orders": redrive policy maxReceiveCount is ${String(maxReceiveCount)}.*` +
+              "\\[ack: @composurecdk/sqs:redrive-low-max-receive-count\\]",
+          ),
+        );
+      },
+    );
+
+    it.each([5, 10, 100])("does not warn when maxReceiveCount is %i (at or above 5)", (n) => {
+      const stack = buildWithDlq(n);
+
+      expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+    });
+
+    it("does not warn when no dead-letter queue is configured", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      createQueueBuilder().build(stack, "TestQueue");
+
+      expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+    });
+
+    it("does not warn when maxReceiveCount is an unresolved token", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const dlq = new Queue(stack, "Dlq");
+      const param = new CfnParameter(stack, "MaxReceives", { type: "Number", default: 3 });
+
+      createQueueBuilder()
+        .deadLetterQueue({ queue: dlq, maxReceiveCount: param.valueAsNumber })
+        .build(stack, "TestQueue");
+
+      expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary
- `QueueBuilder` now emits a CDK warning (`Annotations.addWarningV2`) when a redrive policy is configured with `maxReceiveCount < 5`, the AWS-recommended minimum.
- Stable ack id `@composurecdk/sqs:redrive-low-max-receive-count` lets users suppress the warning when intentional.
- Short-circuits on `Token.isUnresolved` so env-agnostic stacks aren't spammed when `maxReceiveCount` is threaded through a CFN parameter.

Closes #124.

## Test plan
- [x] `npx nx test @composurecdk/sqs` — 33 tests pass (existing 25 + 8 new)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Manual check: warns at 1/2/3/4, silent at 5/10/100, silent without DLQ, silent for unresolved tokens