### PR TITLE
feat(cloudwatch): accept MathExpression in AlarmDefinition metric

### DIFF
--- a/packages/cloudwatch/README.md
+++ b/packages/cloudwatch/README.md
@@ -46,6 +46,40 @@ The `description` method also accepts a factory for contextual descriptions:
 builder.description((def) => `Alert when invocations >= ${def.threshold} per minute`);
 ```
 
+### Rate and ratio alarms
+
+The metric factory may return either a `Metric` or a `MathExpression` (the
+exported `AlarmMetric` union), so rate/ratio alarms share the same definition
+shape:
+
+```ts
+import { MathExpression } from "aws-cdk-lib/aws-cloudwatch";
+
+new AlarmDefinitionBuilder<LambdaFunction>("errorRate")
+  // Guard the denominator: a divide-by-zero data point is dropped, which would
+  // otherwise push the alarm into INSUFFICIENT_DATA when there are no invocations.
+  .metric(
+    (fn) =>
+      new MathExpression({
+        expression: "IF(invocations > 0, errors / invocations, 0)",
+        usingMetrics: {
+          errors: fn.metricErrors(),
+          invocations: fn.metricInvocations(),
+        },
+        // Set the period on the expression — it overrides the period of every
+        // metric in usingMetrics (default 5 minutes otherwise).
+        period: Duration.minutes(1),
+      }),
+  )
+  .threshold(0.05)
+  .greaterThanOrEqual()
+  .treatMissingData(TreatMissingData.NOT_BREACHING);
+```
+
+Only single-time-series expressions can be alarmed: a `MathExpression` whose
+expression uses `SEARCH(...)` (or otherwise returns multiple series) is rejected
+by CloudWatch at deploy time.
+
 ## createAlarms
 
 Factory function that creates CDK [Alarm](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch.Alarm.html) constructs from fully-resolved `AlarmDefinition`s. Returns a `Record<string, Alarm>` keyed by each definition's key.

--- a/packages/cloudwatch/src/alarm-definition-builder.ts
+++ b/packages/cloudwatch/src/alarm-definition-builder.ts
@@ -1,20 +1,20 @@
-import { ComparisonOperator, type Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { AlarmDefinition } from "./alarm-definition.js";
+import { ComparisonOperator, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmDefinition, AlarmMetric } from "./alarm-definition.js";
 import type { AlarmName } from "./alarm-name.js";
 
 /**
  * Fluent builder for constructing deferred {@link AlarmDefinition}s.
  *
- * Stores a metric factory `(construct: T) => Metric` at configuration time.
- * Call {@link resolve} during build to invoke the factory and produce a
- * complete {@link AlarmDefinition}.
+ * Stores a metric factory `(construct: T) => AlarmMetric` at configuration time
+ * (a `Metric` or a `MathExpression`). Call {@link resolve} during build to
+ * invoke the factory and produce a complete {@link AlarmDefinition}.
  *
  * @typeParam TConstruct - The construct type the metric factory receives.
  */
 export class AlarmDefinitionBuilder<TConstruct> {
   readonly #key: string;
   #alarmName?: AlarmName;
-  #metricFactory?: (construct: TConstruct) => Metric;
+  #metricFactory?: (construct: TConstruct) => AlarmMetric;
   #threshold = 0;
   #comparisonOperator = ComparisonOperator.GREATER_THAN_THRESHOLD;
   #evaluationPeriods = 1;
@@ -26,7 +26,7 @@ export class AlarmDefinitionBuilder<TConstruct> {
     this.#key = key;
   }
 
-  metric(factory: (construct: TConstruct) => Metric): this {
+  metric(factory: (construct: TConstruct) => AlarmMetric): this {
     this.#metricFactory = factory;
     return this;
   }

--- a/packages/cloudwatch/src/alarm-definition.ts
+++ b/packages/cloudwatch/src/alarm-definition.ts
@@ -1,5 +1,21 @@
-import type { ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type {
+  ComparisonOperator,
+  MathExpression,
+  Metric,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
 import type { AlarmName } from "./alarm-name.js";
+
+/**
+ * A metric an alarm can be created from: either a single {@link Metric} or a
+ * {@link MathExpression} (e.g. a rate/ratio like `errors / invocations`).
+ *
+ * Both classes carry `createAlarm(...)` — it is declared on the concrete
+ * classes, not on `IMetric` — so this union is exactly what {@link createAlarms}
+ * needs to call. When using a `MathExpression`, set its `period` explicitly:
+ * the expression overrides the period of every metric in `usingMetrics`.
+ */
+export type AlarmMetric = Metric | MathExpression;
 
 /**
  * A fully-resolved alarm descriptor. All fields are required —
@@ -11,7 +27,7 @@ import type { AlarmName } from "./alarm-name.js";
 export interface AlarmDefinition {
   key: string;
   alarmName?: AlarmName;
-  metric: Metric;
+  metric: AlarmMetric;
   threshold: number;
   comparisonOperator: ComparisonOperator;
   evaluationPeriods: number;

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -1,5 +1,5 @@
 export type { AlarmConfig, AlarmConfigDefaults } from "./alarm-config.js";
-export type { AlarmDefinition } from "./alarm-definition.js";
+export type { AlarmDefinition, AlarmMetric } from "./alarm-definition.js";
 export { AlarmDefinitionBuilder } from "./alarm-definition-builder.js";
 export { type AlarmName, alarmName } from "./alarm-name.js";
 export { defaultAlarmName } from "./default-alarm-name.js";

--- a/packages/cloudwatch/test/alarm-definition-builder.test.ts
+++ b/packages/cloudwatch/test/alarm-definition-builder.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { Duration } from "aws-cdk-lib";
-import { ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  ComparisonOperator,
+  MathExpression,
+  Metric,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
 import { AlarmDefinitionBuilder } from "../src/alarm-definition-builder.js";
 import { alarmName } from "../src/alarm-name.js";
 
@@ -32,6 +37,25 @@ describe("AlarmDefinitionBuilder", () => {
       treatMissingData: TreatMissingData.BREACHING,
       description: "Test alarm description",
     });
+  });
+
+  it("accepts a MathExpression from the metric factory", () => {
+    const expression = new MathExpression({
+      expression: "errors / invocations",
+      usingMetrics: {
+        errors: new Metric({ namespace: "Test", metricName: "Errors" }),
+        invocations: new Metric({ namespace: "Test", metricName: "Invocations" }),
+      },
+      period: Duration.minutes(1),
+    });
+
+    const definition = new AlarmDefinitionBuilder<string>("errorRate")
+      .metric(() => expression)
+      .threshold(0.05)
+      .greaterThanOrEqual()
+      .resolve("unused");
+
+    expect(definition.metric).toBe(expression);
   });
 
   it("applies sensible defaults", () => {

--- a/packages/cloudwatch/test/create-alarms.test.ts
+++ b/packages/cloudwatch/test/create-alarms.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
-import { ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import { Template } from "aws-cdk-lib/assertions";
+import {
+  ComparisonOperator,
+  MathExpression,
+  Metric,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { alarmName } from "../src/alarm-name.js";
 import { createAlarms } from "../src/create-alarms.js";
 import type { AlarmDefinition } from "../src/alarm-definition.js";
@@ -83,6 +88,44 @@ describe("createAlarms", () => {
     ]);
     Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
       AlarmName: "custom-name",
+    });
+  });
+
+  it("creates an alarm from a MathExpression metric", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const errors = new Metric({
+      namespace: "Test",
+      metricName: "Errors",
+      period: Duration.minutes(1),
+    });
+    const invocations = new Metric({
+      namespace: "Test",
+      metricName: "Invocations",
+      period: Duration.minutes(1),
+    });
+
+    const result = createAlarms(stack, "Fn", [
+      makeDefinition({
+        key: "errorRate",
+        metric: new MathExpression({
+          expression: "IF(invocations > 0, errors / invocations, 0)",
+          usingMetrics: { errors, invocations },
+          period: Duration.minutes(1),
+        }),
+        threshold: 0.05,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      }),
+    ]);
+
+    expect(result.errorRate).toBeDefined();
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      // Math-expression alarms are emitted as a Metrics array, not the
+      // top-level MetricName/Namespace/Statistic of a single-metric alarm.
+      MetricName: Match.absent(),
+      Statistic: Match.absent(),
+      Metrics: Match.arrayWith([
+        Match.objectLike({ Expression: "IF(invocations > 0, errors / invocations, 0)" }),
+      ]),
     });
   });
 


### PR DESCRIPTION
## Summary

Widens the alarm metric type so rate/ratio alarms expressed as `MathExpression` (e.g. `errors / invocations`) compile against `AlarmDefinition` and the fluent `AlarmDefinitionBuilder` — no casting or vendoring required.

- New exported convenience type `AlarmMetric = Metric | MathExpression`, used by both `AlarmDefinition.metric` and `AlarmDefinitionBuilder.metric()`.
- The union targets the **concrete classes**, not `IMetric`: `createAlarm` is declared on `Metric`/`MathExpression`, not on the `IMetric` interface, and both share an identical `createAlarm` signature — so `createAlarms` needs no change.
- **Pure type widening, no runtime/behaviour change.** Existing recommended-alarm definitions all return `Metric`, which is assignable to the union, so the ~15 resource packages are untouched.

Closes #144.

## MathExpression behaviour (documented, not enforced in code)

Verified against `aws-cdk-lib@2.254.0`:

- **Period lives on the expression.** `MathExpression` overrides the period of every metric in `usingMetrics` to its own `period` (default 5 min) and warns when they differ — so the README example sets `period` on the expression.
- **Ratio/divide-by-zero** drops the data point and can flip a ratio alarm to `INSUFFICIENT_DATA`; the example uses `IF(invocations > 0, errors / invocations, 0)` and notes `treatMissingData`.
- **Single time series only.** `SearchExpression` is a separate class (excluded by the union for free); a `MathExpression` using `SEARCH(...)` that returns multiple series is rejected by CloudWatch at deploy — documented.

## Changes

- `src/alarm-definition.ts` — add `AlarmMetric`, widen `metric` field.
- `src/alarm-definition-builder.ts` — widen `#metricFactory` and `metric()`.
- `src/index.ts` — export `AlarmMetric`.
- `README.md` — document the union and add a rate-alarm example.

## Tests

- `test/create-alarms.test.ts` — alarm from a `MathExpression` synthesizes a `Metrics` array (with top-level `MetricName`/`Statistic` absent).
- `test/alarm-definition-builder.test.ts` — the builder factory accepts and resolves a `MathExpression`.

## Verification

`npm run lint`, `npm run format:check`, `npx nx test cloudwatch` (82 passing), and the full `npm run verify` gate (build + `check:exports` attw/publint confirming the new `AlarmMetric` export emits for both ESM and CJS) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
