### PR TITLE
fix(cloudwatch): support aws-cdk-lib below 2.250

### DIFF
--- a/packages/cloudwatch/src/policies/alarm-actions-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-actions-policy.ts
@@ -1,13 +1,13 @@
 import { Aspects, Stack } from "aws-cdk-lib";
-import {
-  CfnAlarm,
-  CfnCompositeAlarm,
-  type IAlarm,
-  type IAlarmAction,
-} from "aws-cdk-lib/aws-cloudwatch";
+import type { CfnAlarm, CfnCompositeAlarm, IAlarm, IAlarmAction } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
-import { type AlarmRuleScope, ruleMatches } from "./policy-matcher.js";
-import type { AlarmMatchContext } from "./policy-matcher.js";
+import {
+  type AlarmMatchContext,
+  type AlarmRuleScope,
+  isCfnAlarm,
+  isCfnCompositeAlarm,
+  ruleMatches,
+} from "./policy-matcher.js";
 
 export type { AlarmMatchContext, AlarmMatcher } from "./policy-matcher.js";
 
@@ -82,8 +82,8 @@ type AlarmVisitor = (
 function visitAlarms(scope: IConstruct, visit: AlarmVisitor): void {
   Aspects.of(scope).add({
     visit(node: IConstruct): void {
-      const isAlarm = CfnAlarm.isCfnAlarm(node);
-      const isComposite = CfnCompositeAlarm.isCfnCompositeAlarm(node);
+      const isAlarm = isCfnAlarm(node);
+      const isComposite = isCfnCompositeAlarm(node);
       if (!isAlarm && !isComposite) return;
       const parent = node.node.scope;
       const l2 = isL2AlarmLike(parent) ? parent : undefined;
@@ -105,9 +105,10 @@ function visitAlarms(scope: IConstruct, visit: AlarmVisitor): void {
  * any `IAlarmAction` instances in `config` (e.g. `new SnsAction(topic)`)
  * must reference constructs that already exist when the policy is called.
  *
- * Detection uses the jsii type guards `CfnAlarm.isCfnAlarm` /
- * `CfnCompositeAlarm.isCfnCompositeAlarm` on the L1 resource; the L2 parent
- * is found via duck-typing on `addAlarmAction`. Actions are attached through
+ * Detection uses the version-portable `isCfnAlarm` / `isCfnCompositeAlarm`
+ * guards (`CfnResource.isCfnResource` + `cfnResourceType`, so they work below
+ * aws-cdk-lib 2.231.0) on the L1 resource; the L2 parent is found via
+ * duck-typing on `addAlarmAction`. Actions are attached through
  * the L2 so that `IAlarmAction.bind()` runs and permissions are wired
  * correctly. Bare `CfnAlarm` nodes (created without an L2 wrapper) are
  * detected but silently skipped.

--- a/packages/cloudwatch/src/policies/alarm-name-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-name-policy.ts
@@ -1,8 +1,14 @@
 import { Aspects, Stack } from "aws-cdk-lib";
-import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import type { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
 import { type AlarmName, alarmName as brandAlarmName } from "../alarm-name.js";
-import { type AlarmMatchContext, type AlarmRuleScope, ruleMatches } from "./policy-matcher.js";
+import {
+  type AlarmMatchContext,
+  type AlarmRuleScope,
+  isCfnAlarm,
+  isCfnCompositeAlarm,
+  ruleMatches,
+} from "./policy-matcher.js";
 
 /** Context passed to {@link AlarmNameRule.transform}. */
 export interface AlarmNameTransformContext extends AlarmMatchContext {
@@ -105,8 +111,8 @@ export function alarmNamePolicy(scope: IConstruct, config: AlarmNamePolicyConfig
 
   Aspects.of(scope).add({
     visit(node: IConstruct): void {
-      const isAlarm = CfnAlarm.isCfnAlarm(node);
-      const isComposite = CfnCompositeAlarm.isCfnCompositeAlarm(node);
+      const isAlarm = isCfnAlarm(node);
+      const isComposite = isCfnCompositeAlarm(node);
       if (!isAlarm && !isComposite) return;
       const cfn = node;
       if (processed.has(cfn)) return;

--- a/packages/cloudwatch/src/policies/policy-matcher.ts
+++ b/packages/cloudwatch/src/policies/policy-matcher.ts
@@ -1,4 +1,27 @@
-import type { CfnAlarm, CfnCompositeAlarm, IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnResource } from "aws-cdk-lib";
+import { CfnAlarm, CfnCompositeAlarm, type IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import type { IConstruct } from "constructs";
+
+/**
+ * Version-portable replacement for `CfnAlarm.isCfnAlarm`, which only exists in
+ * aws-cdk-lib >= 2.231.0 and throws `TypeError` on older versions inside our
+ * declared `^2.0.0` peer range (issue #146). Checks the foundational
+ * `CfnResource.isCfnResource` guard plus a `cfnResourceType` compare — exactly
+ * what the modern static does internally — so it works across the full range.
+ */
+export function isCfnAlarm(x: IConstruct): x is CfnAlarm {
+  return CfnResource.isCfnResource(x) && x.cfnResourceType === CfnAlarm.CFN_RESOURCE_TYPE_NAME;
+}
+
+/**
+ * Version-portable replacement for `CfnCompositeAlarm.isCfnCompositeAlarm`.
+ * See {@link isCfnAlarm} for why this exists.
+ */
+export function isCfnCompositeAlarm(x: IConstruct): x is CfnCompositeAlarm {
+  return (
+    CfnResource.isCfnResource(x) && x.cfnResourceType === CfnCompositeAlarm.CFN_RESOURCE_TYPE_NAME
+  );
+}
 
 /**
  * Selects which alarms a rule applies to.

--- a/packages/cloudwatch/test/_simulate-old-cdk.ts
+++ b/packages/cloudwatch/test/_simulate-old-cdk.ts
@@ -1,0 +1,23 @@
+import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
+
+/**
+ * Runs `fn` with `CfnAlarm.isCfnAlarm` / `CfnCompositeAlarm.isCfnCompositeAlarm`
+ * removed, reproducing aws-cdk-lib < 2.231.0 where those statics don't exist
+ * (issue #146). Restores them afterwards so other tests are unaffected.
+ *
+ * Not a `*.test.ts` file, so vitest does not collect it as a suite.
+ */
+export function withoutIsCfnStatics(fn: () => void): void {
+  const alarm = CfnAlarm as { isCfnAlarm?: unknown };
+  const composite = CfnCompositeAlarm as { isCfnCompositeAlarm?: unknown };
+  const savedAlarm = alarm.isCfnAlarm;
+  const savedComposite = composite.isCfnCompositeAlarm;
+  delete alarm.isCfnAlarm;
+  delete composite.isCfnCompositeAlarm;
+  try {
+    fn();
+  } finally {
+    alarm.isCfnAlarm = savedAlarm;
+    composite.isCfnCompositeAlarm = savedComposite;
+  }
+}

--- a/packages/cloudwatch/test/alarm-actions-policy.test.ts
+++ b/packages/cloudwatch/test/alarm-actions-policy.test.ts
@@ -15,6 +15,7 @@ import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { Template } from "aws-cdk-lib/assertions";
 import { alarmActionsPolicy } from "../src/policies/alarm-actions-policy.js";
+import { withoutIsCfnStatics } from "./_simulate-old-cdk.js";
 
 function makeMetric(): Metric {
   return new Metric({ namespace: "Test", metricName: "Count", period: Duration.minutes(1) });
@@ -107,6 +108,20 @@ describe("alarmActionsPolicy", () => {
       const resources = template.findResources("AWS::CloudWatch::Alarm");
       const bare = Object.values(resources)[0] as { Properties: { AlarmActions?: unknown[] } };
       expect(bare.Properties.AlarmActions).toBeUndefined();
+    });
+
+    it("applies on aws-cdk-lib < 2.231.0, where isCfn* statics are absent (#146)", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const topic = new Topic(stack, "Topic");
+      makeAlarm(stack, "Errors");
+
+      withoutIsCfnStatics(() => {
+        alarmActionsPolicy(app, { defaults: { alarmActions: [new SnsAction(topic)] } });
+        // The aspect runs during synth; on the old code this threw
+        // "TypeError: CfnAlarm.isCfnAlarm is not a function".
+        expect(getAlarmActions(Template.fromStack(stack), "Errors")).toHaveLength(1);
+      });
     });
 
     it("does not affect non-alarm constructs", () => {

--- a/packages/cloudwatch/test/alarm-name-policy.test.ts
+++ b/packages/cloudwatch/test/alarm-name-policy.test.ts
@@ -4,6 +4,7 @@ import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib
 import { Template } from "aws-cdk-lib/assertions";
 import { alarmName } from "../src/alarm-name.js";
 import { alarmNamePolicy } from "../src/policies/alarm-name-policy.js";
+import { withoutIsCfnStatics } from "./_simulate-old-cdk.js";
 
 function makeMetric(): Metric {
   return new Metric({ namespace: "Test", metricName: "Count", period: Duration.minutes(1) });
@@ -44,6 +45,20 @@ describe("alarmNamePolicy", () => {
     for (const name of Object.values(names)) {
       expect(name.startsWith("prod-")).toBe(true);
     }
+  });
+
+  it("applies on aws-cdk-lib < 2.231.0, where isCfn* statics are absent (#146)", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+
+    withoutIsCfnStatics(() => {
+      alarmNamePolicy(app, { defaults: { prefix: "prod" } });
+      // The aspect runs during synth; on the old code this threw
+      // "TypeError: CfnAlarm.isCfnAlarm is not a function".
+      const names = alarmNamesByLogicalId(Template.fromStack(stack));
+      expect(Object.values(names)).toContain("prod-stack/svc/errors");
+    });
   });
 
   it("applies defaults.suffix", () => {

--- a/packages/cloudwatch/test/policy-matcher.test.ts
+++ b/packages/cloudwatch/test/policy-matcher.test.ts
@@ -1,11 +1,60 @@
 import { describe, it, expect } from "vitest";
-import type { CfnAlarm, CfnCompositeAlarm, IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { App, Stack } from "aws-cdk-lib";
+import { CfnAlarm, CfnCompositeAlarm, type IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
 import {
   type AlarmMatchContext,
   type AlarmRuleScope,
+  isCfnAlarm,
+  isCfnCompositeAlarm,
   matchesOne,
   ruleMatches,
 } from "../src/policies/policy-matcher.js";
+import { withoutIsCfnStatics } from "./_simulate-old-cdk.js";
+
+function makeCfnAlarm(scope: Stack, id: string): CfnAlarm {
+  return new CfnAlarm(scope, id, {
+    comparisonOperator: "GreaterThanThreshold",
+    evaluationPeriods: 1,
+    metricName: "Count",
+    namespace: "Test",
+    period: 60,
+    statistic: "Sum",
+    threshold: 1,
+  });
+}
+
+describe("isCfnAlarm / isCfnCompositeAlarm", () => {
+  it("identifies each L1 alarm kind and rejects the other", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const alarm = makeCfnAlarm(stack, "Alarm");
+    const composite = new CfnCompositeAlarm(stack, "Composite", { alarmRule: "ALARM(x)" });
+
+    expect(isCfnAlarm(alarm)).toBe(true);
+    expect(isCfnCompositeAlarm(alarm)).toBe(false);
+    expect(isCfnCompositeAlarm(composite)).toBe(true);
+    expect(isCfnAlarm(composite)).toBe(false);
+  });
+
+  it("rejects non-alarm resources", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const bucket = new CfnBucket(stack, "Bucket");
+
+    expect(isCfnAlarm(bucket)).toBe(false);
+    expect(isCfnCompositeAlarm(bucket)).toBe(false);
+  });
+
+  it("works on aws-cdk-lib < 2.231.0 (no isCfn* statics)", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const alarm = makeCfnAlarm(stack, "Alarm");
+    const composite = new CfnCompositeAlarm(stack, "Composite", { alarmRule: "ALARM(x)" });
+
+    withoutIsCfnStatics(() => {
+      expect(isCfnAlarm(alarm)).toBe(true);
+      expect(isCfnCompositeAlarm(composite)).toBe(true);
+    });
+  });
+});
 
 function ctx(overrides: Partial<AlarmMatchContext> = {}): AlarmMatchContext {
   return {


### PR DESCRIPTION
## Problem

`@composurecdk/cloudwatch` declares `aws-cdk-lib` `^2.0.0`, but the `alarmNamePolicy` and `alarmActionsPolicy` aspects detected L1 alarms with `CfnAlarm.isCfnAlarm` / `CfnCompositeAlarm.isCfnCompositeAlarm`. Those static type guards were **added in aws-cdk-lib 2.231.0** (verified empirically by installing real versions: 2.230.0 lacks them, 2.231.0 has them). Every version from 2.0.0 through **2.230.x** in the declared range hits `TypeError: CfnAlarm.isCfnAlarm is not a function` at synth.

Reported in #146. Note: the issue's stated boundary (2.249/2.250) was inaccurate — the real break point is ~20 releases lower, which widens the affected range considerably.

## Fix

Add version-portable `isCfnAlarm` / `isCfnCompositeAlarm` guards in `policy-matcher.ts`, built on `CfnResource.isCfnResource` + a `cfnResourceType` compare against `CFN_RESOURCE_TYPE_NAME`:

```ts
export function isCfnAlarm(x: IConstruct): x is CfnAlarm {
  return CfnResource.isCfnResource(x) && x.cfnResourceType === CfnAlarm.CFN_RESOURCE_TYPE_NAME;
}
```

This is **exactly** what the modern `isCfnAlarm` does internally (confirmed in the compiled `aws-cdk-lib` source), so behaviour is identical on new CDK — but `isCfnResource`, `cfnResourceType`, and `CFN_RESOURCE_TYPE_NAME` are all foundational APIs present since v2.0, so it also works on the older floor. The check is identity-free (no `instanceof`), keeping it cross-realm safe per the dual ESM/CJS rule in AGENTS.md.

No peer-range bump, no public API change beyond two new exported guards. Detection only — matching, precedence, and action wiring are untouched.

## Tests

- Unit tests for the guards (correct kind, rejects non-alarms).
- A shared `test/_simulate-old-cdk.ts` helper strips the new statics to reproduce a pre-2.231 CDK; both aspects get a regression test asserting they still apply.
- **Verified end-to-end against a real `aws-cdk-lib@2.230.0` install** (packed package + pinned CDK + synth) — `prod-Errors` + action applied, no `TypeError`. That real-version harness is the subject of a follow-up PR.

Build + typecheck + tests green; lint and format clean.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)