### PR TITLE
test(module-compat): cover the aws-cdk-lib floor

### DIFF
--- a/packages/module-compat/README.md
+++ b/packages/module-compat/README.md
@@ -1,16 +1,19 @@
 # @composurecdk/module-compat
 
-Executable consumption tests for the dual ESM/CJS publishing standard ([ADR-0007](../../docs/adr/0007-dual-esm-cjs-publishing.md)).
-
-Every `@composurecdk/*` package ships both an ESM and a CommonJS build. These
-tests guard that contract from the consumer's side, by spawning a fresh `node`
-process per case:
+Executable consumption tests that guard the published `@composurecdk/*`
+packages from the consumer's side — both the dual ESM/CJS publishing standard
+([ADR-0007](../../docs/adr/0007-dual-esm-cjs-publishing.md)) and the declared
+`aws-cdk-lib` peer range.
 
 - **Resolution** — each package is loaded under both `require()` (CommonJS) and
-  `import` (ESM), asserting it resolves and its exports are present.
+  `import` (ESM) in a fresh `node`, asserting it resolves and its exports are
+  present.
 - **`cdk synth`** — a tiny CDK app runs `compose(...).build(app, id)` +
   `app.synth()` under both a `"type": "commonjs"` and a `"type": "module"`
   package, exercising the real `cdk synth` path from issue #119.
+- **aws-cdk-lib floor** — exercises the built package against the runtime
+  surface of the oldest supported CDK (CI installs only the latest), so APIs
+  newer than the declared peer floor can't slip in unnoticed (issue #146).
 
 This is a private, unpublished workspace package — it exists only to run in CI
 and `npm run verify`.
@@ -24,6 +27,8 @@ and `npm run verify`.
 - `test/synth.test.ts` — spawns `node` on each `cdk synth` fixture.
 - `test/fixtures/{cjs,esm}/` — the CommonJS and ESM CDK-app fixtures, each in a
   directory with its own `package.json` `type` marker.
+- `test/cdk-floor-compat.test.ts` — synthesises a built package against a
+  simulated pre-2.250 aws-cdk-lib (the version-gated statics removed).
 
 ## Running
 

--- a/packages/module-compat/test/cdk-floor-compat.test.ts
+++ b/packages/module-compat/test/cdk-floor-compat.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import {
+  Alarm,
+  CfnAlarm,
+  CfnCompositeAlarm,
+  ComparisonOperator,
+  Metric,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Template } from "aws-cdk-lib/assertions";
+import { alarmActionsPolicy, alarmNamePolicy } from "@composurecdk/cloudwatch";
+
+/**
+ * `CfnAlarm.isCfnAlarm` / `CfnCompositeAlarm.isCfnCompositeAlarm` only exist in
+ * aws-cdk-lib >= ~2.250. Deleting them reproduces the runtime surface of every
+ * older version inside @composurecdk/cloudwatch's `^2.0.0` peer range, so `fn`
+ * runs as it would on the supported floor (issue #146). Restored afterwards.
+ *
+ * CI installs only the latest aws-cdk-lib, so without this the floor is never
+ * exercised — exactly how the #146 regression shipped undetected.
+ */
+function onCdkFloor(fn: () => void): void {
+  const alarm = CfnAlarm as { isCfnAlarm?: unknown };
+  const composite = CfnCompositeAlarm as { isCfnCompositeAlarm?: unknown };
+  const savedAlarm = alarm.isCfnAlarm;
+  const savedComposite = composite.isCfnCompositeAlarm;
+  delete alarm.isCfnAlarm;
+  delete composite.isCfnCompositeAlarm;
+  try {
+    fn();
+  } finally {
+    alarm.isCfnAlarm = savedAlarm;
+    composite.isCfnCompositeAlarm = savedComposite;
+  }
+}
+
+/**
+ * Consumption test: drives the *built* `@composurecdk/cloudwatch` package
+ * through a real `Template.fromStack` synth, so it also catches build/export
+ * regressions the package's own src-level unit tests would miss.
+ */
+describe("@composurecdk/cloudwatch on the aws-cdk-lib floor (#146)", () => {
+  it("alarm policies apply when the isCfn* L1 statics are absent", () => {
+    onCdkFloor(() => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const topic = new Topic(stack, "Topic");
+      new Alarm(stack, "Errors", {
+        alarmName: "Errors",
+        metric: new Metric({ namespace: "Test", metricName: "Count", period: Duration.minutes(1) }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      });
+
+      alarmNamePolicy(app, { defaults: { prefix: "prod" } });
+      alarmActionsPolicy(app, { defaults: { alarmActions: [new SnsAction(topic)] } });
+
+      // Both aspects run during synth; on the floor the unfixed package threw
+      // "TypeError: CfnAlarm.isCfnAlarm is not a function" right here.
+      const alarms = Object.values(
+        Template.fromStack(stack).findResources("AWS::CloudWatch::Alarm"),
+      );
+      expect(alarms).toHaveLength(1);
+      const props = (alarms[0] as { Properties: { AlarmName?: string; AlarmActions?: unknown[] } })
+        .Properties;
+      expect(props.AlarmName).toBe("prod-Errors");
+      expect(props.AlarmActions).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
> **Stacked on #148** — review/merge that first. The base of this PR is the `fix/cloudwatch-alarm-iscfn-compat` branch, so the diff shown here is only the test; it will rebase onto `main` once #148 merges.

## Why

#148 fixes a regression (#146) where `@composurecdk/cloudwatch` called `CfnAlarm.isCfnAlarm`, a static that only exists in aws-cdk-lib **>= ~2.250**, despite a `^2.0.0` peer range. It shipped undetected because **CI only installs the latest aws-cdk-lib** — nothing ever exercises the older end of the supported range.

This is the "extra credit" guard so the *class* of bug can't recur.

## What

A consumption test in `@composurecdk/module-compat` (whose job is to test the **built/published** packages from a consumer's perspective). It deletes the version-gated `isCfn*` L1 statics to reproduce the runtime surface of any pre-2.250 CDK, then synthesises a stack using `alarmNamePolicy` + `alarmActionsPolicy` imported from the built `@composurecdk/cloudwatch`, asserting both aspects still apply (prefixed `AlarmName`, one alarm action attached).

- Driving the **published entry** (not `src`) also catches build/export regressions the package's own unit tests would miss.
- On the unfixed package this test throws the exact `TypeError: CfnAlarm.isCfnAlarm is not a function` from #146.
- Broadens module-compat's remit from "dual ESM/CJS resolution" to "consumption compatibility" generally; README updated to match.

### Note on approach

This simulates the floor by stripping the new statics in-process — deterministic, fast, no network — rather than installing an ancient aws-cdk-lib (awkward in a hoisted workspace, and 2.0.0-era deps don't install cleanly on modern Node). A real pinned-version install job is a reasonable future CI addition; see the discussion on #146. A companion improvement worth considering separately: an ESLint rule flagging `isCfn<Resource>` (and similar version-gated statics) in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)