### PR TITLE
feat(eslint-plugin): ban CDK APIs above the floor

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -22,12 +22,13 @@ File-level overrides (e.g. disabling a rule on a specific file) belong in the co
 
 ## Rules
 
-| Rule                                             | What it flags                                                                               |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `composurecdk/builder-must-be-tagged`            | `Builder` / `IBuilder` from `@composurecdk/core` in library builders (use `taggedBuilder`). |
-| `composurecdk/builder-must-implement-copy-state` | Builder classes with private fields but no `[COPY_STATE]` hook (see ADR-0005).              |
-| `composurecdk/lifecycle-build-context-required`  | `Lifecycle.build()` missing the `context` param when the class uses `Resolvable<…>`.        |
-| `composurecdk/no-cjs-incompatible-syntax`        | `import.meta` / top-level `await` in library `src/` — neither emits to CommonJS (ADR-0007). |
+| Rule                                             | What it flags                                                                                                                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `composurecdk/builder-must-be-tagged`            | `Builder` / `IBuilder` from `@composurecdk/core` in library builders (use `taggedBuilder`).                                                                         |
+| `composurecdk/builder-must-implement-copy-state` | Builder classes with private fields but no `[COPY_STATE]` hook (see ADR-0005).                                                                                      |
+| `composurecdk/lifecycle-build-context-required`  | `Lifecycle.build()` missing the `context` param when the class uses `Resolvable<…>`.                                                                                |
+| `composurecdk/no-cdk-api-above-floor`            | `aws-cdk-lib` APIs newer than the supported peer floor (e.g. the per-resource `isCfn<Resource>` L1 static guards) — they throw on older versions in the peer range. |
+| `composurecdk/no-cjs-incompatible-syntax`        | `import.meta` / top-level `await` in library `src/` — neither emits to CommonJS (ADR-0007).                                                                         |
 
 The `recommended` preset also bans the TypeScript `private` modifier via `no-restricted-syntax` (use ECMAScript `#field` instead — TS `private` leaks through `keyof T` into emitted `.d.ts`, producing TS4094 downstream).
 

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -12,6 +12,7 @@ export const recommended: Linter.Config = {
     "composurecdk/builder-must-be-tagged": "error",
     "composurecdk/builder-must-implement-copy-state": "error",
     "composurecdk/lifecycle-build-context-required": "error",
+    "composurecdk/no-cdk-api-above-floor": "error",
     "composurecdk/no-cjs-incompatible-syntax": "error",
     // Bans the TypeScript `private` modifier in favour of ECMAScript private
     // fields (#field). TS `private` members appear in `keyof T` and leak into

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,11 +1,13 @@
 import { rule as builderMustBeTagged } from "./builder-must-be-tagged.js";
 import { rule as builderMustImplementCopyState } from "./builder-must-implement-copy-state.js";
 import { rule as lifecycleBuildContextRequired } from "./lifecycle-build-context-required.js";
+import { rule as noCdkApiAboveFloor } from "./no-cdk-api-above-floor.js";
 import { rule as noCjsIncompatibleSyntax } from "./no-cjs-incompatible-syntax.js";
 
 export const rules = {
   "builder-must-be-tagged": builderMustBeTagged,
   "builder-must-implement-copy-state": builderMustImplementCopyState,
   "lifecycle-build-context-required": lifecycleBuildContextRequired,
+  "no-cdk-api-above-floor": noCdkApiAboveFloor,
   "no-cjs-incompatible-syntax": noCjsIncompatibleSyntax,
 };

--- a/packages/eslint-plugin/src/rules/no-cdk-api-above-floor.ts
+++ b/packages/eslint-plugin/src/rules/no-cdk-api-above-floor.ts
@@ -1,0 +1,89 @@
+import type { Rule } from "eslint";
+import type { MemberExpression } from "estree";
+
+/**
+ * An `aws-cdk-lib` API that postdates @composurecdk's supported peer-dependency
+ * floor, and so must not be used in library `src/`: calling it throws on older
+ * (but still supported) CDK versions.
+ *
+ * Matched by the accessed member name rather than the owning class identifier,
+ * so it holds up regardless of how the class is imported or aliased.
+ */
+interface ForbiddenMember {
+  /** True when an accessed property name is the banned member. */
+  matches: (propertyName: string) => boolean;
+  /** Short description of the banned API for the diagnostic. */
+  label: string;
+  /** The `aws-cdk-lib` version that introduced it. */
+  since: string;
+  /** What to use instead. */
+  use: string;
+}
+
+/**
+ * Foundational `isCfn*` guards that predate the floor (core, since v2.0) and
+ * are therefore allowed — `isCfnResource` is in fact the portable replacement
+ * for the banned per-resource guards.
+ */
+const ALLOWED_CFN_GUARDS = new Set(["isCfnResource", "isCfnElement"]);
+
+/**
+ * The ban list. Add an entry whenever an `aws-cdk-lib` API we reach for turns
+ * out to postdate the supported floor — this list is expected to grow as the
+ * floor is pinned and lowered ahead of 1.0.0.
+ *
+ * Seeded with the per-resource `isCfn<Resource>` static type guards, which
+ * aws-cdk-lib first shipped on every generated L1 in 2.231.0 (verified by
+ * installing real versions: 2.230.0 lacks them, 2.231.0 has them). Calling
+ * them (e.g. `CfnAlarm.isCfnAlarm(node)`) throws `TypeError` on the older
+ * versions in our `^2` peer range — see issue #146.
+ */
+const FORBIDDEN: ForbiddenMember[] = [
+  {
+    matches: (name) => /^isCfn[A-Z]/.test(name) && !ALLOWED_CFN_GUARDS.has(name),
+    label: "the per-resource `Cfn<Resource>.isCfn<Resource>` L1 static type guards",
+    since: "2.231.0",
+    use:
+      "`CfnResource.isCfnResource(x) && x.cfnResourceType === Cfn<Resource>.CFN_RESOURCE_TYPE_NAME` " +
+      "(what the static does internally, but valid across the whole peer range), e.g. the " +
+      "`isCfnAlarm` helper in @composurecdk/cloudwatch",
+  },
+];
+
+/**
+ * Flags use of `aws-cdk-lib` APIs newer than the supported peer-dependency
+ * floor. Such calls compile fine (devDeps track the latest CDK) but throw at
+ * runtime for consumers on an older, still-supported CDK version.
+ *
+ * The check is name-based and only fires on member access (`Class.method`), so
+ * the portable bare-call helpers we ship (`isCfnAlarm(node)`) are unaffected.
+ */
+export const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Ban aws-cdk-lib APIs newer than the supported peer-dependency floor",
+    },
+    schema: [],
+    messages: {
+      aboveFloor:
+        "{{label}} were added in aws-cdk-lib {{since}}, above the supported floor — they throw on " +
+        "older versions in the peer range. Use {{use}}.",
+    },
+  },
+  create(ctx) {
+    return {
+      MemberExpression(node: MemberExpression) {
+        if (node.property.type !== "Identifier") return;
+        const { name } = node.property;
+        const forbidden = FORBIDDEN.find((entry) => entry.matches(name));
+        if (forbidden === undefined) return;
+        ctx.report({
+          node: node.property,
+          messageId: "aboveFloor",
+          data: { label: forbidden.label, since: forbidden.since, use: forbidden.use },
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/src/rules/no-cdk-api-above-floor.ts
+++ b/packages/eslint-plugin/src/rules/no-cdk-api-above-floor.ts
@@ -1,5 +1,5 @@
-import type { Rule } from "eslint";
-import type { MemberExpression } from "estree";
+import type { Rule, Scope } from "eslint";
+import type { Identifier, MemberExpression } from "estree";
 
 /**
  * An `aws-cdk-lib` API that postdates @composurecdk's supported peer-dependency
@@ -38,6 +38,18 @@ const ALLOWED_CFN_GUARDS = new Set(["isCfnResource", "isCfnElement"]);
  * them (e.g. `CfnAlarm.isCfnAlarm(node)`) throws `TypeError` on the older
  * versions in our `^2` peer range — see issue #146.
  */
+/**
+ * Loose shape used by `chainRoot` to walk MemberExpression + TS-wrapper nodes
+ * uniformly. estree's static types don't model the typescript-eslint-specific
+ * wrappers (`TSAsExpression`, `TSNonNullExpression`, `TSSatisfiesExpression`,
+ * `TSTypeAssertion`) or `ChainExpression`, so the walk checks `.type` at runtime.
+ */
+interface WalkNode {
+  type: string;
+  object?: unknown;
+  expression?: unknown;
+}
+
 const FORBIDDEN: ForbiddenMember[] = [
   {
     matches: (name) => /^isCfn[A-Z]/.test(name) && !ALLOWED_CFN_GUARDS.has(name),
@@ -55,8 +67,18 @@ const FORBIDDEN: ForbiddenMember[] = [
  * floor. Such calls compile fine (devDeps track the latest CDK) but throw at
  * runtime for consumers on an older, still-supported CDK version.
  *
- * The check is name-based and only fires on member access (`Class.method`), so
- * the portable bare-call helpers we ship (`isCfnAlarm(node)`) are unaffected.
+ * It fires only when the member chain is rooted at an aws-cdk-lib import —
+ * `CfnAlarm.isCfnAlarm`, `cw.CfnAlarm.isCfnAlarm` (named or `* as` submodule),
+ * `cdk.aws_cloudwatch.CfnAlarm.isCfnAlarm` — resolved through ESLint's scope
+ * manager, so a local that shadows the import name (e.g. a parameter named
+ * `CfnAlarm`) is correctly treated as a non-cdk binding. `chainRoot` also
+ * unwraps the TS-only wrappers a developer might use to silence types
+ * (`as`, `satisfies`, `!`, angle-bracket assertion) so they can't smuggle the
+ * call past the rule. A call in the chain (e.g. `Stack.of(x).isCfnY()`) still
+ * breaks the root link, since that reads a runtime value, not the import.
+ *
+ * Known gaps: computed bracket access (`CfnAlarm["isCfnAlarm"](x)`) and
+ * `import = require()` are not tracked — both are uncommon in our ESM src.
  */
 export const rule: Rule.RuleModule = {
   meta: {
@@ -72,14 +94,68 @@ export const rule: Rule.RuleModule = {
     },
   },
   create(ctx) {
+    // The leftmost identifier a member chain reads from, peeling MemberExpression
+    // and the TS-only wrappers typescript-eslint produces (`as`, `!`, `satisfies`,
+    // angle-bracket assertion, `?.` ChainExpression). Returns undefined if a call
+    // or other expression breaks the chain — `f().isCfnX` reads a runtime value
+    // rather than the imported class.
+    const TS_WRAPPERS = new Set([
+      "ChainExpression",
+      "TSAsExpression",
+      "TSNonNullExpression",
+      "TSSatisfiesExpression",
+      "TSTypeAssertion",
+    ]);
+    const chainRoot = (expr: MemberExpression["object"]): Identifier | undefined => {
+      let current = expr as unknown as WalkNode;
+      while (current.type === "MemberExpression" || TS_WRAPPERS.has(current.type)) {
+        current = (
+          current.type === "MemberExpression" ? current.object : current.expression
+        ) as WalkNode;
+      }
+      return current.type === "Identifier" ? (current as unknown as Identifier) : undefined;
+    };
+
+    // True when `name` resolves, in the current scope chain, to a binding from
+    // an `aws-cdk-lib` ImportDeclaration. This is scope-aware: a local that
+    // shadows the import name (e.g. a function parameter named `CfnAlarm`)
+    // resolves to its own binding and is NOT treated as the cdk class.
+    const rootIsCdkImport = (scope: Scope.Scope, name: string): boolean => {
+      for (let current: Scope.Scope | null = scope; current !== null; current = current.upper) {
+        const variable = current.set.get(name);
+        if (variable === undefined) continue;
+        // `.at(0)` (not `[0]`) — defs can be empty at runtime for predefined
+        // globals (e.g. `console`), even though `Variable.defs: Definition[]`
+        // says otherwise; `.at` gives us the honest `Definition | undefined`.
+        const def = variable.defs.at(0);
+        if (def?.type !== "ImportBinding") return false;
+        // `def.parent` is typed as `ImportDeclaration` but at runtime
+        // typescript-eslint also reports `ImportBinding` for `import x =
+        // require(...)`, whose parent is a `TSImportEqualsDeclaration` with no
+        // `.source`. Widen and check the discriminator before reading `source`.
+        const parent = def.parent as { type: string; source?: { value?: unknown } };
+        if (parent.type !== "ImportDeclaration") return false;
+        const source = parent.source?.value;
+        return (
+          source === "aws-cdk-lib" ||
+          (typeof source === "string" && source.startsWith("aws-cdk-lib/"))
+        );
+      }
+      return false;
+    };
+
     return {
       MemberExpression(node: MemberExpression) {
         if (node.property.type !== "Identifier") return;
-        const { name } = node.property;
-        const forbidden = FORBIDDEN.find((entry) => entry.matches(name));
+        const property = node.property;
+        const root = chainRoot(node.object);
+        if (root === undefined) return;
+        if (!rootIsCdkImport(ctx.sourceCode.getScope(node), root.name)) return;
+
+        const forbidden = FORBIDDEN.find((entry) => entry.matches(property.name));
         if (forbidden === undefined) return;
         ctx.report({
-          node: node.property,
+          node: property,
           messageId: "aboveFloor",
           data: { label: forbidden.label, since: forbidden.since, use: forbidden.use },
         });

--- a/packages/eslint-plugin/test/rules/no-cdk-api-above-floor.test.ts
+++ b/packages/eslint-plugin/test/rules/no-cdk-api-above-floor.test.ts
@@ -1,0 +1,68 @@
+import { rule } from "../../src/rules/no-cdk-api-above-floor.js";
+import { ruleTester } from "../rule-tester.js";
+
+ruleTester.run("no-cdk-api-above-floor", rule, {
+  valid: [
+    {
+      name: "the portable bare-call helper (not member access)",
+      code: `
+        if (isCfnAlarm(node)) attach(node);
+      `,
+    },
+    {
+      name: "the foundational CfnResource.isCfnResource guard",
+      code: `
+        const ok = CfnResource.isCfnResource(node) && node.cfnResourceType === T;
+      `,
+    },
+    {
+      name: "the foundational CfnElement.isCfnElement guard",
+      code: `
+        const ok = CfnElement.isCfnElement(node);
+      `,
+    },
+    {
+      name: "an unrelated method that merely starts with 'is'",
+      code: `
+        const ok = thing.isReady();
+      `,
+    },
+    {
+      name: "accessing CFN_RESOURCE_TYPE_NAME",
+      code: `
+        const t = CfnAlarm.CFN_RESOURCE_TYPE_NAME;
+      `,
+    },
+    {
+      name: "defining our own isCfnAlarm helper",
+      code: `
+        export function isCfnAlarm(x) {
+          return CfnResource.isCfnResource(x) && x.cfnResourceType === CfnAlarm.CFN_RESOURCE_TYPE_NAME;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "CfnAlarm.isCfnAlarm (added in 2.231.0)",
+      code: `
+        if (CfnAlarm.isCfnAlarm(node)) attach(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "CfnCompositeAlarm.isCfnCompositeAlarm",
+      code: `
+        const composite = CfnCompositeAlarm.isCfnCompositeAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "the family generalises to any generated L1 guard",
+      code: `
+        const b = CfnBucket.isCfnBucket(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/test/rules/no-cdk-api-above-floor.test.ts
+++ b/packages/eslint-plugin/test/rules/no-cdk-api-above-floor.test.ts
@@ -6,18 +6,21 @@ ruleTester.run("no-cdk-api-above-floor", rule, {
     {
       name: "the portable bare-call helper (not member access)",
       code: `
+        import { isCfnAlarm } from "./policy-matcher.js";
         if (isCfnAlarm(node)) attach(node);
       `,
     },
     {
       name: "the foundational CfnResource.isCfnResource guard",
       code: `
+        import { CfnResource } from "aws-cdk-lib";
         const ok = CfnResource.isCfnResource(node) && node.cfnResourceType === T;
       `,
     },
     {
       name: "the foundational CfnElement.isCfnElement guard",
       code: `
+        import { CfnElement } from "aws-cdk-lib";
         const ok = CfnElement.isCfnElement(node);
       `,
     },
@@ -30,15 +33,63 @@ ruleTester.run("no-cdk-api-above-floor", rule, {
     {
       name: "accessing CFN_RESOURCE_TYPE_NAME",
       code: `
+        import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
         const t = CfnAlarm.CFN_RESOURCE_TYPE_NAME;
       `,
     },
     {
-      name: "defining our own isCfnAlarm helper",
+      // The reviewer's case: a same-named member on something that is NOT an
+      // aws-cdk-lib import must not be flagged.
+      name: "isCfn* on a non-aws-cdk-lib import",
       code: `
-        export function isCfnAlarm(x) {
-          return CfnResource.isCfnResource(x) && x.cfnResourceType === CfnAlarm.CFN_RESOURCE_TYPE_NAME;
+        import { CfnAlarm } from "./my-local-cfn.js";
+        const ok = CfnAlarm.isCfnAlarm(node);
+      `,
+    },
+    {
+      name: "isCfn* on a plain local value",
+      code: `
+        const widget = makeWidget();
+        const ok = widget.isCfnWhatever(node);
+      `,
+    },
+    {
+      // A call breaks the chain root: the receiver is a runtime value, not the
+      // imported class, so this isn't the version-gated static.
+      name: "a call breaks the chain to the cdk import",
+      code: `
+        import { Stack } from "aws-cdk-lib";
+        const ok = Stack.of(scope).isCfnWhatever(node);
+      `,
+    },
+    {
+      // Scope-aware resolution: a local that shadows the import name is not
+      // the cdk class, so the rule must not fire on it.
+      name: "a local that shadows a cdk import is not flagged",
+      code: `
+        import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
+        function check(scope) {
+          const CfnAlarm = { isCfnAlarm: () => true };
+          return CfnAlarm.isCfnAlarm(scope);
         }
+      `,
+    },
+    {
+      // The allow-list still gates members reached on a cdk-rooted chain.
+      name: "an allow-listed guard on a cdk import",
+      code: `
+        import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
+        const ok = CfnAlarm.isCfnResource(node);
+      `,
+    },
+    {
+      // `import = require` produces an `ImportBinding` def whose parent is a
+      // `TSImportEqualsDeclaration`, not an `ImportDeclaration`. The rule must
+      // skip those (and not crash on the missing `.source`).
+      name: "import = require (untracked, must not crash)",
+      code: `
+        import CfnAlarm = require("aws-cdk-lib/aws-cloudwatch");
+        const ok = CfnAlarm.isCfnAlarm(node);
       `,
     },
   ],
@@ -46,6 +97,7 @@ ruleTester.run("no-cdk-api-above-floor", rule, {
     {
       name: "CfnAlarm.isCfnAlarm (added in 2.231.0)",
       code: `
+        import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
         if (CfnAlarm.isCfnAlarm(node)) attach(node);
       `,
       errors: [{ messageId: "aboveFloor" }],
@@ -53,6 +105,7 @@ ruleTester.run("no-cdk-api-above-floor", rule, {
     {
       name: "CfnCompositeAlarm.isCfnCompositeAlarm",
       code: `
+        import { CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
         const composite = CfnCompositeAlarm.isCfnCompositeAlarm(node);
       `,
       errors: [{ messageId: "aboveFloor" }],
@@ -60,7 +113,74 @@ ruleTester.run("no-cdk-api-above-floor", rule, {
     {
       name: "the family generalises to any generated L1 guard",
       code: `
+        import { CfnBucket } from "aws-cdk-lib/aws-s3";
         const b = CfnBucket.isCfnBucket(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "an aliased aws-cdk-lib import",
+      code: `
+        import { CfnAlarm as Alarm } from "aws-cdk-lib/aws-cloudwatch";
+        const ok = Alarm.isCfnAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "a `* as` submodule namespace import",
+      code: `
+        import * as cw from "aws-cdk-lib/aws-cloudwatch";
+        const ok = cw.CfnAlarm.isCfnAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "a named submodule import used as a namespace",
+      code: `
+        import { aws_cloudwatch as cw } from "aws-cdk-lib";
+        const ok = cw.CfnAlarm.isCfnAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "a deep chain off the whole-library namespace import",
+      code: `
+        import * as cdk from "aws-cdk-lib";
+        const ok = cdk.aws_cloudwatch.CfnAlarm.isCfnAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      // A TS `as` cast must not smuggle the call past the rule.
+      name: "a TS `as` cast at the chain root",
+      code: `
+        import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
+        const ok = (CfnAlarm as typeof CfnAlarm).isCfnAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "a TS non-null assertion at the chain root",
+      code: `
+        import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
+        const ok = CfnAlarm!.isCfnAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      name: "a TS `satisfies` at the chain root",
+      code: `
+        import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
+        const ok = (CfnAlarm satisfies object).isCfnAlarm(node);
+      `,
+      errors: [{ messageId: "aboveFloor" }],
+    },
+    {
+      // Optional chaining must not defeat the rule either.
+      name: "an optional chain off the namespace import",
+      code: `
+        import * as cdk from "aws-cdk-lib";
+        const ok = cdk?.aws_cloudwatch.CfnAlarm.isCfnAlarm(node);
       `,
       errors: [{ messageId: "aboveFloor" }],
     },


### PR DESCRIPTION
> **Stacked on #148** (base is `fix/cloudwatch-alarm-iscfn-compat`). The diff shown is only the new rule; it retargets to `main` once #148 merges. Depends on #148 because the rule would otherwise flag the pre-fix cloudwatch code on `main`.

Step 1 of the cross-version compatibility plan (follow-up to #146 / #148).

## What

A new internal lint rule, `composurecdk/no-cdk-api-above-floor`, that flags use of `aws-cdk-lib` APIs newer than the supported peer-dependency floor. These compile fine — devDeps track the latest CDK — but throw at runtime for consumers on an older, still-supported version. That's exactly how #146 shipped undetected.

Seeded with the per-resource `isCfn<Resource>` L1 static type guards (e.g. `CfnAlarm.isCfnAlarm`), which aws-cdk-lib first shipped in **2.231.0** (verified by installing real versions — 2.230.0 lacks them, 2.231.0 has them):

- Matched by **member name** (`/^isCfn[A-Z]/`), so it holds regardless of how the class is imported/aliased.
- Allowlists the foundational `isCfnResource` / `isCfnElement` (core since v2.0 — `isCfnResource` is in fact the portable replacement).
- Only fires on **member access** (`Class.method`), so the bare-call helpers we ship (`isCfnAlarm(node)`) are unaffected.

The `FORBIDDEN` list is deliberately a growable array — more entries land as we pin and lower the floor toward 1.0.0 (steps 2–3).

## Why a lint rule

A static rule prevents the call from ever being *written* in `src/`, in-editor, before any build — strictly better than a runtime check for "don't call this". The complementary runtime guarantee (synth against a *real* old CDK) is the next PR.

## Tests / checks

- `RuleTester` cases: bare-call helper, `CfnResource.isCfnResource`, `CFN_RESOURCE_TYPE_NAME`, and a helper *definition* are all valid; `CfnAlarm.isCfnAlarm`, `CfnCompositeAlarm.isCfnCompositeAlarm`, and `CfnBucket.isCfnBucket` are flagged.
- Plugin build + tests green; **repo-wide `npm run lint` passes with the rule active** (confirms no `src/` still reaches for a version-gated API after #148); format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)