### PR TITLE
test(ci): aws-cdk-lib floor compatibility harness

### DIFF
--- a/.github/workflows/cdk-floor-suites.yml
+++ b/.github/workflows/cdk-floor-suites.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/cdk-floor-suites.yml
+++ b/.github/workflows/cdk-floor-suites.yml
@@ -1,0 +1,44 @@
+name: CDK floor suites
+
+# Floor-finding tool: runs every package's unit suite against a pinned
+# aws-cdk-lib version to discover the lowest the library still supports. Run it
+# by hand from the Actions tab with a version; lower the version and re-run as
+# you narrow the floor. Not a PR gate — the always-on gate is the drift-robust
+# composed synth in the `cdk-floor` job of ci.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cdk-version:
+        description: aws-cdk-lib version to test the suites against
+        required: true
+        default: 2.230.0
+
+permissions:
+  contents: read
+
+jobs:
+  suites:
+    name: Suites against aws-cdk-lib ${{ inputs.cdk-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NX_DAEMON: false
+      CDK_FLOOR: ${{ inputs.cdk-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run the unit suites against the floor
+        run: npm run test:cdk-floor-suites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,33 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  cdk-floor:
+    name: CDK floor compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NX_DAEMON: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Packs from each package's dist, so the build must run first.
+      - name: Build
+        run: npm run build
+
+      # Installs a real, pinned aws-cdk-lib floor and synthesises against it,
+      # catching published packages that reach for a too-new CDK API (#146).
+      - name: Synth against the aws-cdk-lib floor
+        run: npm run test:cdk-floor

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ export default defineConfig(
       // Hand-written ESM/CJS consumption fixtures — each is deliberately a
       // specific module system and is exercised by spawning `node`, not linted.
       "packages/module-compat/test/fixtures/",
+      // cdk-floor harness fixture — imports rig-only deps and runs inside a
+      // throwaway project (scripts/cdk-floor-test.mjs), not linted here.
+      "scripts/cdk-floor/",
     ],
   },
   eslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "format:check": "prettier --check .",
     "typecheck": "npx nx run-many -t typecheck",
     "test": "npx nx run-many -t test",
+    "test:cdk-floor": "node scripts/cdk-floor-test.mjs",
+    "test:cdk-floor-suites": "node scripts/cdk-floor-suites.mjs",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",

--- a/scripts/cdk-floor-suites.mjs
+++ b/scripts/cdk-floor-suites.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * aws-cdk-lib floor compatibility harness (exhaustive-suites half).
+ *
+ * Pins a real aws-cdk-lib floor across the workspace and runs every package's
+ * own unit suite against it, so a too-new CDK API in *any* package surfaces —
+ * not just the composed smoke that `cdk-floor-test.mjs` exercises.
+ *
+ * This is a floor-*finding* tool, run manually (the `cdk-floor-suites` workflow,
+ * dispatched with a version). It is NOT a PR gate: the per-package suites use
+ * partial matchers and mostly hold across versions, but exact-output assertions
+ * drift, so a failure means "investigate", not necessarily "broken". The
+ * always-on PR gate is the drift-robust composed synth in `cdk-floor-test.mjs`.
+ *
+ * MUTATES the workspace (installs the floor over node_modules; the example
+ * suites rewrite their snapshots). Intended for ephemeral CI — run `npm ci`
+ * (and `git checkout packages/examples/test/__snapshots__`) to restore locally.
+ */
+
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const FLOOR = process.env.CDK_FLOOR ?? "2.230.0";
+
+if (process.env.CI === undefined && !process.argv.includes("--force")) {
+  console.error(
+    "cdk-floor-suites mutates node_modules and rewrites example snapshots — it is meant for CI.\n" +
+      "Run with --force to proceed locally, then restore with `npm ci` and " +
+      "`git checkout packages/examples/test/__snapshots__`.",
+  );
+  process.exit(1);
+}
+
+function run(cmd, args, extraEnv) {
+  execFileSync(cmd, args, {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+    env: extraEnv ? { ...process.env, ...extraEnv } : process.env,
+  });
+}
+
+console.log(`Pinning aws-cdk-lib@${FLOOR} across the workspace …`);
+run("npm", ["install", "--no-save", "--no-audit", "--no-fund", `aws-cdk-lib@${FLOOR}`]);
+
+// Builder/core suites use partial matchers, so they assert against the floor
+// directly. Exclude examples here — they assert exact CFN snapshots that drift
+// across versions — and run them separately in synth-only (snapshot-rewriting)
+// mode below.
+console.log("Running per-package unit suites against the floor …");
+run(
+  "npx",
+  ["nx", "run-many", "-t", "test", "--exclude", "@composurecdk/examples", "--skip-nx-cache"],
+  {
+    NX_DAEMON: "false",
+  },
+);
+
+// `--update` makes the example suites regenerate their snapshots, so they
+// exercise a full synth of every example stack (the broadest integration
+// surface) without failing on benign cross-version output drift.
+console.log("Synthesising every example stack against the floor …");
+run("npm", ["run", "--workspace", "@composurecdk/examples", "test:update"]);
+
+console.log(`\n✓ cdk-floor-suites passed on aws-cdk-lib ${FLOOR}`);

--- a/scripts/cdk-floor-test.mjs
+++ b/scripts/cdk-floor-test.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * aws-cdk-lib floor compatibility harness (composed-synth half).
+ *
+ * CI installs only the latest aws-cdk-lib, so nothing exercises the older end
+ * of the `^2` peer range — which is how the #146 regression (a call to the
+ * 2.231-only `CfnAlarm.isCfnAlarm`) shipped undetected.
+ *
+ * This packs every publishable @composurecdk package, installs them into a
+ * throwaway project alongside a *real* pinned aws-cdk-lib, and runs a
+ * representative `compose(...).build()` synth against it
+ * (scripts/cdk-floor/synth.mjs). A non-zero exit means a published package
+ * reaches for a CDK API the floor doesn't have. The companion
+ * `cdk-floor-suites.mjs` runs every package's own unit suite at the floor for
+ * exhaustive per-package coverage; this half is the always-on integration smoke.
+ *
+ * Run `npm run build` first (the harness packs from each package's dist).
+ * Override the version under test with `CDK_FLOOR=<version> node
+ * scripts/cdk-floor-test.mjs`.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const PACKAGES_DIR = join(REPO_ROOT, "packages");
+
+// The aws-cdk-lib version under test — the highest release that predates the
+// `isCfn<Resource>` guards, so it exercises the #146 condition. Lower this as
+// the supported floor is established; CDK_FLOOR overrides it ad hoc.
+const FLOOR = process.env.CDK_FLOOR ?? "2.230.0";
+const CONSTRUCTS_RANGE = "^10.0.0";
+
+/** Every publishable @composurecdk package, so the fixture can import any of them. */
+function discoverPublishablePackages() {
+  const names = [];
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(join(PACKAGES_DIR, entry.name, "package.json"), "utf8"));
+      if (pkg.name?.startsWith("@composurecdk/") && pkg.private !== true) {
+        names.push({ name: pkg.name, dir: entry.name });
+      }
+    } catch {
+      // Not a package directory — skip.
+    }
+  }
+  return names;
+}
+
+function packTarball(dir, destination) {
+  const output = execFileSync("npm", ["pack", "--pack-destination", destination], {
+    cwd: join(PACKAGES_DIR, dir),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"], // capture the tarball name; drop npm's notices
+  });
+  const tarball = output
+    .split("\n")
+    .map((line) => line.trim())
+    .reverse()
+    .find((line) => line.endsWith(".tgz"));
+  if (tarball === undefined)
+    throw new Error(`npm pack for ${dir} did not report a .tgz:\n${output}`);
+  return tarball;
+}
+
+const rig = mkdtempSync(join(tmpdir(), "composurecdk-cdk-floor-"));
+try {
+  const dependencies = { "aws-cdk-lib": FLOOR, constructs: CONSTRUCTS_RANGE };
+  const packed = discoverPublishablePackages();
+  for (const { name, dir } of packed) {
+    dependencies[name] = `file:./${packTarball(dir, rig)}`;
+  }
+
+  writeFileSync(
+    join(rig, "package.json"),
+    `${JSON.stringify({ name: "cdk-floor-rig", private: true, type: "module", dependencies }, null, 2)}\n`,
+  );
+  copyFileSync(join(SCRIPT_DIR, "cdk-floor", "synth.mjs"), join(rig, "synth.mjs"));
+
+  console.log(`Installing aws-cdk-lib@${FLOOR} + ${packed.length} packed packages …`);
+  execFileSync("npm", ["install", "--no-audit", "--no-fund"], { cwd: rig, stdio: "inherit" });
+
+  console.log("Synthesising the composed system against the floor …");
+  execFileSync(process.execPath, ["synth.mjs"], { cwd: rig, stdio: "inherit" });
+
+  console.log("\n✓ cdk-floor-test passed");
+} catch (error) {
+  // npm install / synth stream their own output via stdio: "inherit"; surface
+  // anything else (e.g. a pack failure captured as a string).
+  console.error(`\n✗ cdk-floor-test failed: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  rmSync(rig, { recursive: true, force: true });
+}

--- a/scripts/cdk-floor/synth.mjs
+++ b/scripts/cdk-floor/synth.mjs
@@ -1,0 +1,76 @@
+// Composed-system synth fixture for the cdk-floor harness
+// (scripts/cdk-floor-test.mjs copies this into a throwaway project that has a
+// pinned aws-cdk-lib + the packed @composurecdk packages installed, then runs
+// it with `node`).
+//
+// It drives a representative `compose(...).build()` system across several
+// builders through a real `Template.fromStack` synth and asserts invariants
+// (resources exist, alarms wired) — never exact CFN output, which drifts
+// across CDK versions. A failure means a published package reached for a CDK
+// API the pinned floor doesn't have (the #146 class of bug). Assertions are
+// version-agnostic so the same fixture works at any floor.
+
+import { createRequire } from "node:module";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Template } from "aws-cdk-lib/assertions";
+import { compose, ref } from "@composurecdk/core";
+import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
+import { createFunctionBuilder, sqsEventSource } from "@composurecdk/lambda";
+import { createTopicBuilder } from "@composurecdk/sns";
+import { createQueueBuilder } from "@composurecdk/sqs";
+
+const require = createRequire(import.meta.url);
+const version = require("aws-cdk-lib/package.json").version;
+console.log(`aws-cdk-lib ${version}`);
+
+const app = new App();
+const stack = new Stack(app, "FloorStack");
+
+// A queue → Lambda consumer plus an SNS alert topic, with all alarms routed to
+// the topic. Exercises core (compose/ref), sqs, lambda (event source + role),
+// sns, and cloudwatch (recommended + custom alarms, actions policy) — and their
+// peers (cloudformation, iam, logs) transitively.
+const { alerts } = compose(
+  {
+    alerts: createTopicBuilder().displayName("Floor Alerts"),
+
+    orders: createQueueBuilder()
+      .queueName("orders")
+      .visibilityTimeout(Duration.minutes(2))
+      .addAlarm("highEmptyReceiveRate", (alarm) =>
+        alarm
+          .metric((queue) => queue.metricNumberOfEmptyReceives({ period: Duration.minutes(5) }))
+          .threshold(500)
+          .greaterThan()
+          .description("empty-receive rate"),
+      ),
+
+    processor: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_20_X)
+      .handler("index.handler")
+      .code(Code.fromInline("exports.handler = async () => {};"))
+      .addEventSource("orders", sqsEventSource(ref("orders", (r) => r.queue))),
+  },
+  { alerts: [], orders: [], processor: ["orders"] },
+).build(stack, "OrderProcessor");
+
+alarmActionsPolicy(stack, { defaults: { alarmActions: [new SnsAction(alerts.topic)] } });
+
+const template = Template.fromStack(stack);
+template.resourceCountIs("AWS::SNS::Topic", 1);
+template.resourceCountIs("AWS::SQS::Queue", 1);
+template.resourceCountIs("AWS::Lambda::Function", 1);
+
+const alarms = Object.values(template.findResources("AWS::CloudWatch::Alarm"));
+if (alarms.length === 0) throw new Error("expected the composed system to produce alarms");
+const unwired = alarms.filter((a) => !Array.isArray(a.Properties.AlarmActions));
+if (unwired.length > 0) {
+  throw new Error(`alarmActionsPolicy left ${unwired.length}/${alarms.length} alarm(s) unwired`);
+}
+
+console.log(
+  `PASS: composed system synthesised on aws-cdk-lib ${version} ` +
+    `(${alarms.length} alarms, all wired to the alert topic)`,
+);


### PR DESCRIPTION
> **Stacked on #148** (base is `fix/cloudwatch-alarm-iscfn-compat`). Diff shown is only the harness; retargets to `main` once #148 merges. Depends on #148 — the synth would fail against the *unfixed* package, which is the point.

Steps 2–3 of the cross-version compatibility plan (follow-up to #146 / #148 / #151). A real-install harness — no simulation — in two complementary halves.

## 1. Composed-synth smoke (always-on PR gate)

`scripts/cdk-floor-test.mjs` → the `cdk-floor` job in `ci.yml`, and `npm run test:cdk-floor`:

- Discovers and `npm pack`s **every publishable `@composurecdk` package** (16).
- Installs them into a throwaway project with a **real pinned `aws-cdk-lib`** + constructs.
- Synthesises a representative `compose(...).build()` system — core + sqs + lambda + sns + cloudwatch (and their peers: cloudformation, iam, logs) — and asserts **invariants** (resource counts, every alarm wired by `alarmActionsPolicy`), never exact CFN output. Drift-robust, so it's a reliable gate.

Verified locally on real `aws-cdk-lib@2.230.0`: 11 alarms, all wired, ✓.

## 2. Suites-at-floor (manual floor-finding)

`scripts/cdk-floor-suites.mjs` → the `cdk-floor-suites` **`workflow_dispatch`** workflow (takes a version input), and `npm run test:cdk-floor-suites`:

- Pins the chosen `aws-cdk-lib` across the workspace and runs **every package's own unit suite** (partial matchers — drift-robust) + an example-stack synth (`test:update`, the broadest integration surface).
- **Not a PR gate** — exact-output assertions drift across versions, so a failure means "investigate", not "broken". It mutates the workspace, so it's gated behind `CI`/`--force`.

## Why both

The static lint rule (#151) stops a too-new API being *written*; the composed smoke proves the published packages *synth* on the floor; the suites sweep finds *where* the floor actually is, per package.

## Moving the floor (step 3)

One `CDK_FLOOR` constant / env var drives both, e.g. `CDK_FLOOR=2.46.0 npm run test:cdk-floor`. Empirically so far: cloudwatch alone synths down to **2.1.0**; the composed system's floor is gated by the newest CDK feature any builder uses (e.g. the example processor's Lambda runtime enum). Lowering `CDK_FLOOR` and re-running the suites workflow is how we'll pin the real supported floor — which should then drive `peerDependencies` bumps + an ADR before 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)