### PR TITLE
build: per-package aws-cdk-lib version floors

### DIFF
--- a/.github/workflows/cdk-floor-suites.yml
+++ b/.github/workflows/cdk-floor-suites.yml
@@ -1,0 +1,44 @@
+name: CDK floor suites
+
+# Floor-finding tool: runs every package's unit suite against a pinned
+# aws-cdk-lib version to discover the lowest the library still supports. Run it
+# by hand from the Actions tab with a version; lower the version and re-run as
+# you narrow the floor. Not a PR gate — the always-on gate is the drift-robust
+# composed synth in the `cdk-floor` job of ci.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cdk-version:
+        description: aws-cdk-lib version to test the suites against
+        required: true
+        default: 2.230.0
+
+permissions:
+  contents: read
+
+jobs:
+  suites:
+    name: Suites against aws-cdk-lib ${{ inputs.cdk-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NX_DAEMON: false
+      CDK_FLOOR: ${{ inputs.cdk-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run the unit suites against the floor
+        run: npm run test:cdk-floor-suites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,33 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  cdk-floor:
+    name: CDK floor compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NX_DAEMON: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Packs from each package's dist, so the build must run first.
+      - name: Build
+        run: npm run build
+
+      # Installs a real, pinned aws-cdk-lib floor and synthesises against it,
+      # catching published packages that reach for a too-new CDK API (#146).
+      - name: Synth against the aws-cdk-lib floor
+        run: npm run test:cdk-floor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Cheap gate: each package's peerDependencies.aws-cdk-lib must match the
+      # cdk-floors.json manifest.
+      - name: Check CDK floor ranges in sync
+        run: npm run cdk-floors:check
+
       - name: Test
         run: npm run test
 
@@ -90,3 +95,8 @@ jobs:
       # catching published packages that reach for a too-new CDK API (#146).
       - name: Synth against the aws-cdk-lib floor
         run: npm run test:cdk-floor
+
+      # Loads each package at its own declared per-package floor — fails if a
+      # change reaches for an API newer than the package promises.
+      - name: Enforce per-package floors
+        run: npm run cdk-floors:enforce

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 cdk.out
 .vscode/
 .claude/
+
+# cdk-floors establish draft (curated values live in cdk-floors.json)
+cdk-floors.discovered.json

--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -1,0 +1,84 @@
+{
+  "$comment": "Per-package aws-cdk-lib import-time floors, from `node scripts/cdk-floors.mjs establish`. Ladder-granular; floor is the lowest probed release that loads, gatedBy is the API missing one rung lower.",
+  "ladder": [
+    "2.230.0",
+    "2.200.0",
+    "2.180.0",
+    "2.160.0",
+    "2.140.0",
+    "2.131.0",
+    "2.120.0",
+    "2.100.0",
+    "2.80.0",
+    "2.60.0",
+    "2.46.0",
+    "2.20.0",
+    "2.1.0"
+  ],
+  "floors": {
+    "acm": {
+      "floor": "2.120.0",
+      "gatedBy": "The requested module 'aws-cdk-lib/aws-certificatemanager' does not provide an export named 'KeyAlgorithm'"
+    },
+    "apigateway": {
+      "floor": "2.60.0",
+      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudwatch' does not provide an export named 'Stats'"
+    },
+    "budgets": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "cloudformation": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "cloudfront": {
+      "floor": "2.120.0",
+      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudfront' does not provide an export named 'FunctionRuntime'"
+    },
+    "cloudwatch": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "core": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "ec2": {
+      "floor": "2.60.0",
+      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudwatch' does not provide an export named 'Stats'"
+    },
+    "events": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "iam": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "lambda": {
+      "floor": "2.180.0",
+      "gatedBy": "The requested module 'aws-cdk-lib/aws-lambda' does not provide an export named 'MetricType'"
+    },
+    "logs": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "route53": {
+      "floor": "2.230.0",
+      "gatedBy": "The requested module 'aws-cdk-lib/aws-route53' does not provide an export named 'HttpsRecord'"
+    },
+    "s3": {
+      "floor": "2.60.0",
+      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudwatch' does not provide an export named 'Stats'"
+    },
+    "sns": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    },
+    "sqs": {
+      "floor": "2.1.0",
+      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    }
+  }
+}

--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -1,84 +1,38 @@
 {
-  "$comment": "Per-package aws-cdk-lib import-time floors, from `node scripts/cdk-floors.mjs establish`. Ladder-granular; floor is the lowest probed release that loads, gatedBy is the API missing one rung lower.",
-  "ladder": [
-    "2.230.0",
-    "2.200.0",
-    "2.180.0",
-    "2.160.0",
-    "2.140.0",
-    "2.131.0",
-    "2.120.0",
-    "2.100.0",
-    "2.80.0",
-    "2.60.0",
-    "2.46.0",
-    "2.20.0",
-    "2.1.0"
-  ],
+  "$comment": "Per-package aws-cdk-lib floors — the source of truth for each package's peerDependencies.aws-cdk-lib range. `node scripts/cdk-floors.mjs establish` discovers these (ladder-granular); the values here are refined to the exact introducing release and validated by loading each package against real installs. `apply` writes them to package.json; `check` asserts package.json matches. To grandfather older support, drop the requiring API, re-run establish to prove the lower floor, then apply.",
   "floors": {
-    "acm": {
-      "floor": "2.120.0",
-      "gatedBy": "The requested module 'aws-cdk-lib/aws-certificatemanager' does not provide an export named 'KeyAlgorithm'"
-    },
-    "apigateway": {
-      "floor": "2.60.0",
-      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudwatch' does not provide an export named 'Stats'"
-    },
-    "budgets": {
-      "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
-    },
-    "cloudformation": {
-      "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
-    },
-    "cloudfront": {
-      "floor": "2.120.0",
-      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudfront' does not provide an export named 'FunctionRuntime'"
-    },
+    "cloudformation": { "floor": "2.0.0", "gatedBy": "imports only the aws-cdk-lib root entry" },
     "cloudwatch": {
       "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch)"
     },
-    "core": {
+    "sns": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sns)" },
+    "sqs": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sqs)" },
+    "iam": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-iam)" },
+    "logs": {
       "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
-    },
-    "ec2": {
-      "floor": "2.60.0",
-      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudwatch' does not provide an export named 'Stats'"
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs)"
     },
     "events": {
       "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-events)"
     },
-    "iam": {
+    "budgets": {
       "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-budgets)"
     },
-    "lambda": {
-      "floor": "2.180.0",
-      "gatedBy": "The requested module 'aws-cdk-lib/aws-lambda' does not provide an export named 'MetricType'"
+    "apigateway": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "ec2": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "s3": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "cloudfront": {
+      "floor": "2.118.0",
+      "gatedBy": "aws-cloudfront.FunctionRuntime (introduced 2.118.0)"
     },
-    "logs": {
-      "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
+    "acm": {
+      "floor": "2.119.0",
+      "gatedBy": "aws-certificatemanager.KeyAlgorithm (introduced 2.119.0)"
     },
-    "route53": {
-      "floor": "2.230.0",
-      "gatedBy": "The requested module 'aws-cdk-lib/aws-route53' does not provide an export named 'HttpsRecord'"
-    },
-    "s3": {
-      "floor": "2.60.0",
-      "gatedBy": "The requested module 'aws-cdk-lib/aws-cloudwatch' does not provide an export named 'Stats'"
-    },
-    "sns": {
-      "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
-    },
-    "sqs": {
-      "floor": "2.1.0",
-      "gatedBy": "<=2.1.0 (no lower rung probed)"
-    }
+    "lambda": { "floor": "2.168.0", "gatedBy": "aws-lambda.MetricType (introduced 2.168.0)" },
+    "route53": { "floor": "2.216.0", "gatedBy": "aws-route53.HttpsRecord (introduced 2.216.0)" }
   }
 }

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -1,0 +1,79 @@
+# ADR 0008: Per-package aws-cdk-lib version floors
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+
+## Context
+
+Every publishable `@composurecdk/*` package declared `peerDependencies.aws-cdk-lib`
+as `^2.0.0`. That was an untested claim: the packages were only ever built and
+tested against the latest CDK. Issue #146 made the gap concrete — the CloudWatch
+alarm policies called `CfnAlarm.isCfnAlarm`, a static introduced in aws-cdk-lib
+2.231.0, so every consumer on 2.0.0–2.230.x hit a `TypeError` at synth despite
+the `^2.0.0` promise.
+
+Measuring real installs showed the packages have **widely different** actual
+floors, because each pulls different named exports from aws-cdk-lib:
+
+| floor   | packages                                         | gated by                                              |
+| ------- | ------------------------------------------------ | ----------------------------------------------------- |
+| 2.0.0   | cloudformation                                   | imports only the aws-cdk-lib root entry               |
+| 2.1.0   | cloudwatch, sns, sqs, iam, logs, events, budgets | aws-cdk-lib ESM subpath exports (`aws-cdk-lib/aws-*`) |
+| 2.54.0  | apigateway, ec2, s3                              | `aws-cloudwatch.Stats`                                |
+| 2.118.0 | cloudfront                                       | `aws-cloudfront.FunctionRuntime`                      |
+| 2.119.0 | acm                                              | `aws-certificatemanager.KeyAlgorithm`                 |
+| 2.168.0 | lambda                                           | `aws-lambda.MetricType`                               |
+| 2.216.0 | route53                                          | `aws-route53.HttpsRecord`                             |
+
+(`core` depends on `constructs` only, not aws-cdk-lib, so it has no floor.)
+
+A single library-wide floor would force every consumer up to route53's 2.216.0,
+penalising the many packages that work far lower. The packages are published and
+consumed independently, so the floor belongs per package.
+
+## Decision
+
+**Each publishable package declares its own measured `peerDependencies.aws-cdk-lib`
+floor. `cdk-floors.json` is the source of truth; tooling establishes, applies,
+and enforces it.** Floors are monotonic with the peer graph — a package's floor
+is the max of its own aws-cdk-lib usage and its `@composurecdk` peers' floors,
+which holds automatically because a package can only load once its peers do.
+
+`scripts/cdk-floors.mjs` provides four modes (npm scripts `cdk-floors:*`):
+
+- **`establish`** — packs the graph and loads every package against a descending
+  ladder of real aws-cdk-lib releases, recording the lowest each loads on and
+  the gating export. Writes a ladder-granular draft (`cdk-floors.discovered.json`)
+  to be refined into `cdk-floors.json`. Re-run it (optionally with a denser
+  `CDK_FLOOR_LADDER`) to **prove a new, lower floor** when deliberately
+  grandfathering older support.
+- **`apply`** — writes each package's `peerDependencies.aws-cdk-lib` from the
+  manifest.
+- **`check`** — asserts package.json ranges match the manifest. Cheap; runs in
+  the main CI job and `verify`.
+- **`enforce`** — loads each package against a real install of its own declared
+  floor and fails if any doesn't. This is the "don't breach the floor" guard;
+  it runs in the `cdk-floor` CI job.
+
+Establishment measures the **import-time** floor (named exports), where every
+constraint observed so far lives. The composed-synth harness (`test:cdk-floor`)
+and the per-package suites additionally exercise runtime behaviour; a
+runtime-only gap would surface there and raise the floor.
+
+This complements the existing guards: the `composurecdk/no-cdk-api-above-floor`
+ESLint rule blocks known version-gated APIs statically, and the `cdk-floor`
+harness synthesises against a real old CDK.
+
+## Consequences
+
+- Consumers get honest, per-package ranges; low-floor packages stay broadly
+  installable.
+- Floors are regression-proof: `check` stops the ranges drifting from the
+  manifest, `enforce` stops a package quietly requiring a newer CDK.
+- Lowering a floor is a deliberate, evidenced act: remove the requiring API,
+  re-run `establish` to prove the lower floor, refine the manifest, `apply`.
+- The import probe is a lower bound; a runtime-only requirement could push a
+  floor above the established value, caught by the synth/suite layers.
+- Floors are pinned to the exact introducing release. They will rise over time
+  as packages adopt newer CDK features — that is expected and intentional, and
+  the tooling makes each change measured rather than assumed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0005: `.copy()` on Builder for variant authoring and strategy hand-off](0005-builder-copy.md)
 - [ADR-0006: Decorator pattern for cross-cutting builder features](0006-decorator-builder-pattern.md)
 - [ADR-0007: Dual ESM/CJS publishing as an enforced standard](0007-dual-esm-cjs-publishing.md)
+- [ADR-0008: Per-package aws-cdk-lib version floors](0008-aws-cdk-lib-version-floors.md)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ export default defineConfig(
       // Hand-written ESM/CJS consumption fixtures — each is deliberately a
       // specific module system and is exercised by spawning `node`, not linted.
       "packages/module-compat/test/fixtures/",
+      // cdk-floor harness fixture — imports rig-only deps and runs inside a
+      // throwaway project (scripts/cdk-floor-test.mjs), not linted here.
+      "scripts/cdk-floor/",
     ],
   },
   eslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "npx nx run-many -t test",
     "test:cdk-floor": "node scripts/cdk-floor-test.mjs",
     "test:cdk-floor-suites": "node scripts/cdk-floor-suites.mjs",
+    "cdk-floors:establish": "node scripts/cdk-floors.mjs establish",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "format:check": "prettier --check .",
     "typecheck": "npx nx run-many -t typecheck",
     "test": "npx nx run-many -t test",
+    "test:cdk-floor": "node scripts/cdk-floor-test.mjs",
+    "test:cdk-floor-suites": "node scripts/cdk-floor-suites.mjs",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
     "test:cdk-floor": "node scripts/cdk-floor-test.mjs",
     "test:cdk-floor-suites": "node scripts/cdk-floor-suites.mjs",
     "cdk-floors:establish": "node scripts/cdk-floors.mjs establish",
+    "cdk-floors:apply": "node scripts/cdk-floors.mjs apply",
+    "cdk-floors:check": "node scripts/cdk-floors.mjs check",
+    "cdk-floors:enforce": "node scripts/cdk-floors.mjs enforce",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",
-    "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run test",
+    "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run cdk-floors:check && npm run test",
     "prepare": "husky"
   },
   "repository": {

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.119.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/s3": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.118.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -37,7 +37,7 @@
     }
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudwatch/src/policies/alarm-actions-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-actions-policy.ts
@@ -1,13 +1,13 @@
 import { Aspects, Stack } from "aws-cdk-lib";
-import {
-  CfnAlarm,
-  CfnCompositeAlarm,
-  type IAlarm,
-  type IAlarmAction,
-} from "aws-cdk-lib/aws-cloudwatch";
+import type { CfnAlarm, CfnCompositeAlarm, IAlarm, IAlarmAction } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
-import { type AlarmRuleScope, ruleMatches } from "./policy-matcher.js";
-import type { AlarmMatchContext } from "./policy-matcher.js";
+import {
+  type AlarmMatchContext,
+  type AlarmRuleScope,
+  isCfnAlarm,
+  isCfnCompositeAlarm,
+  ruleMatches,
+} from "./policy-matcher.js";
 
 export type { AlarmMatchContext, AlarmMatcher } from "./policy-matcher.js";
 
@@ -82,8 +82,8 @@ type AlarmVisitor = (
 function visitAlarms(scope: IConstruct, visit: AlarmVisitor): void {
   Aspects.of(scope).add({
     visit(node: IConstruct): void {
-      const isAlarm = CfnAlarm.isCfnAlarm(node);
-      const isComposite = CfnCompositeAlarm.isCfnCompositeAlarm(node);
+      const isAlarm = isCfnAlarm(node);
+      const isComposite = isCfnCompositeAlarm(node);
       if (!isAlarm && !isComposite) return;
       const parent = node.node.scope;
       const l2 = isL2AlarmLike(parent) ? parent : undefined;
@@ -105,9 +105,10 @@ function visitAlarms(scope: IConstruct, visit: AlarmVisitor): void {
  * any `IAlarmAction` instances in `config` (e.g. `new SnsAction(topic)`)
  * must reference constructs that already exist when the policy is called.
  *
- * Detection uses the jsii type guards `CfnAlarm.isCfnAlarm` /
- * `CfnCompositeAlarm.isCfnCompositeAlarm` on the L1 resource; the L2 parent
- * is found via duck-typing on `addAlarmAction`. Actions are attached through
+ * Detection uses the version-portable `isCfnAlarm` / `isCfnCompositeAlarm`
+ * guards (`CfnResource.isCfnResource` + `cfnResourceType`, so they work below
+ * aws-cdk-lib 2.231.0) on the L1 resource; the L2 parent is found via
+ * duck-typing on `addAlarmAction`. Actions are attached through
  * the L2 so that `IAlarmAction.bind()` runs and permissions are wired
  * correctly. Bare `CfnAlarm` nodes (created without an L2 wrapper) are
  * detected but silently skipped.

--- a/packages/cloudwatch/src/policies/alarm-name-policy.ts
+++ b/packages/cloudwatch/src/policies/alarm-name-policy.ts
@@ -1,8 +1,14 @@
 import { Aspects, Stack } from "aws-cdk-lib";
-import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import type { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IConstruct } from "constructs";
 import { type AlarmName, alarmName as brandAlarmName } from "../alarm-name.js";
-import { type AlarmMatchContext, type AlarmRuleScope, ruleMatches } from "./policy-matcher.js";
+import {
+  type AlarmMatchContext,
+  type AlarmRuleScope,
+  isCfnAlarm,
+  isCfnCompositeAlarm,
+  ruleMatches,
+} from "./policy-matcher.js";
 
 /** Context passed to {@link AlarmNameRule.transform}. */
 export interface AlarmNameTransformContext extends AlarmMatchContext {
@@ -105,8 +111,8 @@ export function alarmNamePolicy(scope: IConstruct, config: AlarmNamePolicyConfig
 
   Aspects.of(scope).add({
     visit(node: IConstruct): void {
-      const isAlarm = CfnAlarm.isCfnAlarm(node);
-      const isComposite = CfnCompositeAlarm.isCfnCompositeAlarm(node);
+      const isAlarm = isCfnAlarm(node);
+      const isComposite = isCfnCompositeAlarm(node);
       if (!isAlarm && !isComposite) return;
       const cfn = node;
       if (processed.has(cfn)) return;

--- a/packages/cloudwatch/src/policies/policy-matcher.ts
+++ b/packages/cloudwatch/src/policies/policy-matcher.ts
@@ -1,4 +1,27 @@
-import type { CfnAlarm, CfnCompositeAlarm, IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnResource } from "aws-cdk-lib";
+import { CfnAlarm, CfnCompositeAlarm, type IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import type { IConstruct } from "constructs";
+
+/**
+ * Version-portable replacement for `CfnAlarm.isCfnAlarm`, which only exists in
+ * aws-cdk-lib >= 2.231.0 and throws `TypeError` on older versions inside our
+ * declared `^2.0.0` peer range (issue #146). Checks the foundational
+ * `CfnResource.isCfnResource` guard plus a `cfnResourceType` compare — exactly
+ * what the modern static does internally — so it works across the full range.
+ */
+export function isCfnAlarm(x: IConstruct): x is CfnAlarm {
+  return CfnResource.isCfnResource(x) && x.cfnResourceType === CfnAlarm.CFN_RESOURCE_TYPE_NAME;
+}
+
+/**
+ * Version-portable replacement for `CfnCompositeAlarm.isCfnCompositeAlarm`.
+ * See {@link isCfnAlarm} for why this exists.
+ */
+export function isCfnCompositeAlarm(x: IConstruct): x is CfnCompositeAlarm {
+  return (
+    CfnResource.isCfnResource(x) && x.cfnResourceType === CfnCompositeAlarm.CFN_RESOURCE_TYPE_NAME
+  );
+}
 
 /**
  * Selects which alarms a rule applies to.

--- a/packages/cloudwatch/test/_simulate-old-cdk.ts
+++ b/packages/cloudwatch/test/_simulate-old-cdk.ts
@@ -1,0 +1,23 @@
+import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
+
+/**
+ * Runs `fn` with `CfnAlarm.isCfnAlarm` / `CfnCompositeAlarm.isCfnCompositeAlarm`
+ * removed, reproducing aws-cdk-lib < 2.231.0 where those statics don't exist
+ * (issue #146). Restores them afterwards so other tests are unaffected.
+ *
+ * Not a `*.test.ts` file, so vitest does not collect it as a suite.
+ */
+export function withoutIsCfnStatics(fn: () => void): void {
+  const alarm = CfnAlarm as { isCfnAlarm?: unknown };
+  const composite = CfnCompositeAlarm as { isCfnCompositeAlarm?: unknown };
+  const savedAlarm = alarm.isCfnAlarm;
+  const savedComposite = composite.isCfnCompositeAlarm;
+  delete alarm.isCfnAlarm;
+  delete composite.isCfnCompositeAlarm;
+  try {
+    fn();
+  } finally {
+    alarm.isCfnAlarm = savedAlarm;
+    composite.isCfnCompositeAlarm = savedComposite;
+  }
+}

--- a/packages/cloudwatch/test/alarm-actions-policy.test.ts
+++ b/packages/cloudwatch/test/alarm-actions-policy.test.ts
@@ -15,6 +15,7 @@ import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { Template } from "aws-cdk-lib/assertions";
 import { alarmActionsPolicy } from "../src/policies/alarm-actions-policy.js";
+import { withoutIsCfnStatics } from "./_simulate-old-cdk.js";
 
 function makeMetric(): Metric {
   return new Metric({ namespace: "Test", metricName: "Count", period: Duration.minutes(1) });
@@ -107,6 +108,20 @@ describe("alarmActionsPolicy", () => {
       const resources = template.findResources("AWS::CloudWatch::Alarm");
       const bare = Object.values(resources)[0] as { Properties: { AlarmActions?: unknown[] } };
       expect(bare.Properties.AlarmActions).toBeUndefined();
+    });
+
+    it("applies on aws-cdk-lib < 2.231.0, where isCfn* statics are absent (#146)", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const topic = new Topic(stack, "Topic");
+      makeAlarm(stack, "Errors");
+
+      withoutIsCfnStatics(() => {
+        alarmActionsPolicy(app, { defaults: { alarmActions: [new SnsAction(topic)] } });
+        // The aspect runs during synth; on the old code this threw
+        // "TypeError: CfnAlarm.isCfnAlarm is not a function".
+        expect(getAlarmActions(Template.fromStack(stack), "Errors")).toHaveLength(1);
+      });
     });
 
     it("does not affect non-alarm constructs", () => {

--- a/packages/cloudwatch/test/alarm-name-policy.test.ts
+++ b/packages/cloudwatch/test/alarm-name-policy.test.ts
@@ -4,6 +4,7 @@ import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib
 import { Template } from "aws-cdk-lib/assertions";
 import { alarmName } from "../src/alarm-name.js";
 import { alarmNamePolicy } from "../src/policies/alarm-name-policy.js";
+import { withoutIsCfnStatics } from "./_simulate-old-cdk.js";
 
 function makeMetric(): Metric {
   return new Metric({ namespace: "Test", metricName: "Count", period: Duration.minutes(1) });
@@ -44,6 +45,20 @@ describe("alarmNamePolicy", () => {
     for (const name of Object.values(names)) {
       expect(name.startsWith("prod-")).toBe(true);
     }
+  });
+
+  it("applies on aws-cdk-lib < 2.231.0, where isCfn* statics are absent (#146)", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    makeAlarm(stack, "Errors", "stack/svc/errors");
+
+    withoutIsCfnStatics(() => {
+      alarmNamePolicy(app, { defaults: { prefix: "prod" } });
+      // The aspect runs during synth; on the old code this threw
+      // "TypeError: CfnAlarm.isCfnAlarm is not a function".
+      const names = alarmNamesByLogicalId(Template.fromStack(stack));
+      expect(Object.values(names)).toContain("prod-stack/svc/errors");
+    });
   });
 
   it("applies defaults.suffix", () => {

--- a/packages/cloudwatch/test/policy-matcher.test.ts
+++ b/packages/cloudwatch/test/policy-matcher.test.ts
@@ -1,11 +1,60 @@
 import { describe, it, expect } from "vitest";
-import type { CfnAlarm, CfnCompositeAlarm, IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { App, Stack } from "aws-cdk-lib";
+import { CfnAlarm, CfnCompositeAlarm, type IAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
 import {
   type AlarmMatchContext,
   type AlarmRuleScope,
+  isCfnAlarm,
+  isCfnCompositeAlarm,
   matchesOne,
   ruleMatches,
 } from "../src/policies/policy-matcher.js";
+import { withoutIsCfnStatics } from "./_simulate-old-cdk.js";
+
+function makeCfnAlarm(scope: Stack, id: string): CfnAlarm {
+  return new CfnAlarm(scope, id, {
+    comparisonOperator: "GreaterThanThreshold",
+    evaluationPeriods: 1,
+    metricName: "Count",
+    namespace: "Test",
+    period: 60,
+    statistic: "Sum",
+    threshold: 1,
+  });
+}
+
+describe("isCfnAlarm / isCfnCompositeAlarm", () => {
+  it("identifies each L1 alarm kind and rejects the other", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const alarm = makeCfnAlarm(stack, "Alarm");
+    const composite = new CfnCompositeAlarm(stack, "Composite", { alarmRule: "ALARM(x)" });
+
+    expect(isCfnAlarm(alarm)).toBe(true);
+    expect(isCfnCompositeAlarm(alarm)).toBe(false);
+    expect(isCfnCompositeAlarm(composite)).toBe(true);
+    expect(isCfnAlarm(composite)).toBe(false);
+  });
+
+  it("rejects non-alarm resources", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const bucket = new CfnBucket(stack, "Bucket");
+
+    expect(isCfnAlarm(bucket)).toBe(false);
+    expect(isCfnCompositeAlarm(bucket)).toBe(false);
+  });
+
+  it("works on aws-cdk-lib < 2.231.0 (no isCfn* statics)", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const alarm = makeCfnAlarm(stack, "Alarm");
+    const composite = new CfnCompositeAlarm(stack, "Composite", { alarmRule: "ALARM(x)" });
+
+    withoutIsCfnStatics(() => {
+      expect(isCfnAlarm(alarm)).toBe(true);
+      expect(isCfnCompositeAlarm(composite)).toBe(true);
+    });
+  });
+});
 
 function ctx(overrides: Partial<AlarmMatchContext> = {}): AlarmMatchContext {
   return {

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -42,7 +42,7 @@
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/iam": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -42,7 +42,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.216.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/scripts/cdk-floor-suites.mjs
+++ b/scripts/cdk-floor-suites.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * aws-cdk-lib floor compatibility harness (exhaustive-suites half).
+ *
+ * Pins a real aws-cdk-lib floor across the workspace and runs every package's
+ * own unit suite against it, so a too-new CDK API in *any* package surfaces —
+ * not just the composed smoke that `cdk-floor-test.mjs` exercises.
+ *
+ * This is a floor-*finding* tool, run manually (the `cdk-floor-suites` workflow,
+ * dispatched with a version). It is NOT a PR gate: the per-package suites use
+ * partial matchers and mostly hold across versions, but exact-output assertions
+ * drift, so a failure means "investigate", not necessarily "broken". The
+ * always-on PR gate is the drift-robust composed synth in `cdk-floor-test.mjs`.
+ *
+ * MUTATES the workspace (installs the floor over node_modules; the example
+ * suites rewrite their snapshots). Intended for ephemeral CI — run `npm ci`
+ * (and `git checkout packages/examples/test/__snapshots__`) to restore locally.
+ */
+
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const FLOOR = process.env.CDK_FLOOR ?? "2.230.0";
+
+if (process.env.CI === undefined && !process.argv.includes("--force")) {
+  console.error(
+    "cdk-floor-suites mutates node_modules and rewrites example snapshots — it is meant for CI.\n" +
+      "Run with --force to proceed locally, then restore with `npm ci` and " +
+      "`git checkout packages/examples/test/__snapshots__`.",
+  );
+  process.exit(1);
+}
+
+function run(cmd, args, extraEnv) {
+  execFileSync(cmd, args, {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+    env: extraEnv ? { ...process.env, ...extraEnv } : process.env,
+  });
+}
+
+console.log(`Pinning aws-cdk-lib@${FLOOR} across the workspace …`);
+run("npm", ["install", "--no-save", "--no-audit", "--no-fund", `aws-cdk-lib@${FLOOR}`]);
+
+// Builder/core suites use partial matchers, so they assert against the floor
+// directly. Exclude examples here — they assert exact CFN snapshots that drift
+// across versions — and run them separately in synth-only (snapshot-rewriting)
+// mode below.
+console.log("Running per-package unit suites against the floor …");
+run(
+  "npx",
+  ["nx", "run-many", "-t", "test", "--exclude", "@composurecdk/examples", "--skip-nx-cache"],
+  {
+    NX_DAEMON: "false",
+  },
+);
+
+// `--update` makes the example suites regenerate their snapshots, so they
+// exercise a full synth of every example stack (the broadest integration
+// surface) without failing on benign cross-version output drift.
+console.log("Synthesising every example stack against the floor …");
+run("npm", ["run", "--workspace", "@composurecdk/examples", "test:update"]);
+
+console.log(`\n✓ cdk-floor-suites passed on aws-cdk-lib ${FLOOR}`);

--- a/scripts/cdk-floor-test.mjs
+++ b/scripts/cdk-floor-test.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * aws-cdk-lib floor compatibility harness (composed-synth half).
+ *
+ * CI installs only the latest aws-cdk-lib, so nothing exercises the older end
+ * of the `^2` peer range — which is how the #146 regression (a call to the
+ * 2.231-only `CfnAlarm.isCfnAlarm`) shipped undetected.
+ *
+ * This packs every publishable @composurecdk package, installs them into a
+ * throwaway project alongside a *real* pinned aws-cdk-lib, and runs a
+ * representative `compose(...).build()` synth against it
+ * (scripts/cdk-floor/synth.mjs). A non-zero exit means a published package
+ * reaches for a CDK API the floor doesn't have. The companion
+ * `cdk-floor-suites.mjs` runs every package's own unit suite at the floor for
+ * exhaustive per-package coverage; this half is the always-on integration smoke.
+ *
+ * Run `npm run build` first (the harness packs from each package's dist).
+ * Override the version under test with `CDK_FLOOR=<version> node
+ * scripts/cdk-floor-test.mjs`.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const PACKAGES_DIR = join(REPO_ROOT, "packages");
+
+// The aws-cdk-lib version under test — the highest release that predates the
+// `isCfn<Resource>` guards, so it exercises the #146 condition. Lower this as
+// the supported floor is established; CDK_FLOOR overrides it ad hoc.
+const FLOOR = process.env.CDK_FLOOR ?? "2.230.0";
+const CONSTRUCTS_RANGE = "^10.0.0";
+
+/** Every publishable @composurecdk package, so the fixture can import any of them. */
+function discoverPublishablePackages() {
+  const names = [];
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(join(PACKAGES_DIR, entry.name, "package.json"), "utf8"));
+      if (pkg.name?.startsWith("@composurecdk/") && pkg.private !== true) {
+        names.push({ name: pkg.name, dir: entry.name });
+      }
+    } catch {
+      // Not a package directory — skip.
+    }
+  }
+  return names;
+}
+
+function packTarball(dir, destination) {
+  const output = execFileSync("npm", ["pack", "--pack-destination", destination], {
+    cwd: join(PACKAGES_DIR, dir),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"], // capture the tarball name; drop npm's notices
+  });
+  const tarball = output
+    .split("\n")
+    .map((line) => line.trim())
+    .reverse()
+    .find((line) => line.endsWith(".tgz"));
+  if (tarball === undefined)
+    throw new Error(`npm pack for ${dir} did not report a .tgz:\n${output}`);
+  return tarball;
+}
+
+const rig = mkdtempSync(join(tmpdir(), "composurecdk-cdk-floor-"));
+try {
+  const dependencies = { "aws-cdk-lib": FLOOR, constructs: CONSTRUCTS_RANGE };
+  const packed = discoverPublishablePackages();
+  for (const { name, dir } of packed) {
+    dependencies[name] = `file:./${packTarball(dir, rig)}`;
+  }
+
+  writeFileSync(
+    join(rig, "package.json"),
+    `${JSON.stringify({ name: "cdk-floor-rig", private: true, type: "module", dependencies }, null, 2)}\n`,
+  );
+  copyFileSync(join(SCRIPT_DIR, "cdk-floor", "synth.mjs"), join(rig, "synth.mjs"));
+
+  console.log(`Installing aws-cdk-lib@${FLOOR} + ${packed.length} packed packages …`);
+  execFileSync("npm", ["install", "--no-audit", "--no-fund"], { cwd: rig, stdio: "inherit" });
+
+  console.log("Synthesising the composed system against the floor …");
+  execFileSync(process.execPath, ["synth.mjs"], { cwd: rig, stdio: "inherit" });
+
+  console.log("\n✓ cdk-floor-test passed");
+} catch (error) {
+  // npm install / synth stream their own output via stdio: "inherit"; surface
+  // anything else (e.g. a pack failure captured as a string).
+  console.error(`\n✗ cdk-floor-test failed: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  rmSync(rig, { recursive: true, force: true });
+}

--- a/scripts/cdk-floor-test.mjs
+++ b/scripts/cdk-floor-test.mjs
@@ -91,7 +91,12 @@ try {
   copyFileSync(join(SCRIPT_DIR, "cdk-floor", "synth.mjs"), join(rig, "synth.mjs"));
 
   console.log(`Installing aws-cdk-lib@${FLOOR} + ${packed.length} packed packages …`);
-  execFileSync("npm", ["install", "--no-audit", "--no-fund"], { cwd: rig, stdio: "inherit" });
+  // --legacy-peer-deps so a CDK_FLOOR below some package's declared floor still
+  // installs (we want to test whether the synth resolves, not the peer ranges).
+  execFileSync("npm", ["install", "--no-audit", "--no-fund", "--legacy-peer-deps"], {
+    cwd: rig,
+    stdio: "inherit",
+  });
 
   console.log("Synthesising the composed system against the floor …");
   execFileSync(process.execPath, ["synth.mjs"], { cwd: rig, stdio: "inherit" });

--- a/scripts/cdk-floor/probe.mjs
+++ b/scripts/cdk-floor/probe.mjs
@@ -1,0 +1,20 @@
+// Import probe for the cdk-floors `establish` sweep. Runs inside a rig that has
+// a pinned aws-cdk-lib + the packed @composurecdk packages installed. Attempts
+// to load each package (which executes its top-level aws-cdk-lib imports) and
+// reports, as JSON on stdout, whether it loaded and — if not — the first error.
+//
+// Package names come in via the CDK_FLOOR_PACKAGES env var (JSON array).
+
+const packages = JSON.parse(process.env.CDK_FLOOR_PACKAGES ?? "[]");
+const results = [];
+
+for (const name of packages) {
+  try {
+    await import(name);
+    results.push({ name, ok: true });
+  } catch (error) {
+    results.push({ name, ok: false, error: error.message.split("\n")[0] });
+  }
+}
+
+process.stdout.write(JSON.stringify(results));

--- a/scripts/cdk-floor/synth.mjs
+++ b/scripts/cdk-floor/synth.mjs
@@ -1,0 +1,76 @@
+// Composed-system synth fixture for the cdk-floor harness
+// (scripts/cdk-floor-test.mjs copies this into a throwaway project that has a
+// pinned aws-cdk-lib + the packed @composurecdk packages installed, then runs
+// it with `node`).
+//
+// It drives a representative `compose(...).build()` system across several
+// builders through a real `Template.fromStack` synth and asserts invariants
+// (resources exist, alarms wired) — never exact CFN output, which drifts
+// across CDK versions. A failure means a published package reached for a CDK
+// API the pinned floor doesn't have (the #146 class of bug). Assertions are
+// version-agnostic so the same fixture works at any floor.
+
+import { createRequire } from "node:module";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Template } from "aws-cdk-lib/assertions";
+import { compose, ref } from "@composurecdk/core";
+import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
+import { createFunctionBuilder, sqsEventSource } from "@composurecdk/lambda";
+import { createTopicBuilder } from "@composurecdk/sns";
+import { createQueueBuilder } from "@composurecdk/sqs";
+
+const require = createRequire(import.meta.url);
+const version = require("aws-cdk-lib/package.json").version;
+console.log(`aws-cdk-lib ${version}`);
+
+const app = new App();
+const stack = new Stack(app, "FloorStack");
+
+// A queue → Lambda consumer plus an SNS alert topic, with all alarms routed to
+// the topic. Exercises core (compose/ref), sqs, lambda (event source + role),
+// sns, and cloudwatch (recommended + custom alarms, actions policy) — and their
+// peers (cloudformation, iam, logs) transitively.
+const { alerts } = compose(
+  {
+    alerts: createTopicBuilder().displayName("Floor Alerts"),
+
+    orders: createQueueBuilder()
+      .queueName("orders")
+      .visibilityTimeout(Duration.minutes(2))
+      .addAlarm("highEmptyReceiveRate", (alarm) =>
+        alarm
+          .metric((queue) => queue.metricNumberOfEmptyReceives({ period: Duration.minutes(5) }))
+          .threshold(500)
+          .greaterThan()
+          .description("empty-receive rate"),
+      ),
+
+    processor: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_20_X)
+      .handler("index.handler")
+      .code(Code.fromInline("exports.handler = async () => {};"))
+      .addEventSource("orders", sqsEventSource(ref("orders", (r) => r.queue))),
+  },
+  { alerts: [], orders: [], processor: ["orders"] },
+).build(stack, "OrderProcessor");
+
+alarmActionsPolicy(stack, { defaults: { alarmActions: [new SnsAction(alerts.topic)] } });
+
+const template = Template.fromStack(stack);
+template.resourceCountIs("AWS::SNS::Topic", 1);
+template.resourceCountIs("AWS::SQS::Queue", 1);
+template.resourceCountIs("AWS::Lambda::Function", 1);
+
+const alarms = Object.values(template.findResources("AWS::CloudWatch::Alarm"));
+if (alarms.length === 0) throw new Error("expected the composed system to produce alarms");
+const unwired = alarms.filter((a) => !Array.isArray(a.Properties.AlarmActions));
+if (unwired.length > 0) {
+  throw new Error(`alarmActionsPolicy left ${unwired.length}/${alarms.length} alarm(s) unwired`);
+}
+
+console.log(
+  `PASS: composed system synthesised on aws-cdk-lib ${version} ` +
+    `(${alarms.length} alarms, all wired to the alert topic)`,
+);

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+/**
+ * Per-package aws-cdk-lib floor tooling.
+ *
+ * `establish` sweeps a descending ladder of real aws-cdk-lib versions and, for
+ * each publishable @composurecdk package, records the lowest version it still
+ * loads on plus the API that gates it (the named export missing one rung
+ * lower). It writes that to cdk-floors.json — the source of truth from which
+ * per-package `peerDependencies` are set and enforced.
+ *
+ * This measures the import-time floor (named exports a package pulls from
+ * aws-cdk-lib), which is where every floor constraint we have hit lives. The
+ * runtime-complete guard is `enforce` (runs each package's suite at its
+ * declared floor); a runtime-only gap there raises the floor above what
+ * `establish` found.
+ *
+ * Usage: node scripts/cdk-floors.mjs establish
+ * Run `npm run build` first (it packs from each package's dist).
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const PACKAGES_DIR = join(REPO_ROOT, "packages");
+const MANIFEST = join(REPO_ROOT, "cdk-floors.json");
+const CONSTRUCTS_RANGE = "^10.0.0";
+
+// Descending ladder of real aws-cdk-lib releases to probe. Floors land on a
+// rung; refine by adding rungs around a boundary. Override with
+// CDK_FLOOR_LADDER="2.230.0,2.200.0,…".
+const LADDER = (
+  process.env.CDK_FLOOR_LADDER ??
+  "2.230.0,2.200.0,2.180.0,2.160.0,2.140.0,2.131.0,2.120.0,2.100.0,2.80.0,2.60.0,2.46.0,2.20.0,2.1.0"
+).split(",");
+
+const minorOf = (version) => Number(version.split(".")[1]);
+
+function discoverPublishablePackages() {
+  const names = [];
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(join(PACKAGES_DIR, entry.name, "package.json"), "utf8"));
+      if (pkg.name?.startsWith("@composurecdk/") && pkg.private !== true) {
+        names.push({ name: pkg.name, dir: entry.name });
+      }
+    } catch {
+      // Not a package directory — skip.
+    }
+  }
+  return names;
+}
+
+function packAll(destination) {
+  const tarballs = {};
+  for (const { name, dir } of discoverPublishablePackages()) {
+    const output = execFileSync("npm", ["pack", "--pack-destination", destination], {
+      cwd: join(PACKAGES_DIR, dir),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const tarball = output
+      .split("\n")
+      .map((line) => line.trim())
+      .reverse()
+      .find((line) => line.endsWith(".tgz"));
+    if (tarball === undefined) throw new Error(`npm pack for ${dir} produced no .tgz`);
+    tarballs[name] = tarball;
+  }
+  return tarballs;
+}
+
+/** Install the packed packages + aws-cdk-lib@version into a rig, probe each import. */
+function probeAtVersion(version, tarballs, cacheDir) {
+  const rig = mkdtempSync(join(tmpdir(), `composurecdk-floor-${minorOf(version)}-`));
+  try {
+    const dependencies = { "aws-cdk-lib": version, constructs: CONSTRUCTS_RANGE };
+    for (const [name, tarball] of Object.entries(tarballs)) {
+      dependencies[name] = `file:${join(cacheDir, tarball)}`;
+    }
+    writeFileSync(
+      join(rig, "package.json"),
+      `${JSON.stringify({ name: "cdk-floor-probe", private: true, type: "module", dependencies }, null, 2)}\n`,
+    );
+    copyFileSync(join(SCRIPT_DIR, "cdk-floor", "probe.mjs"), join(rig, "probe.mjs"));
+    execFileSync("npm", ["install", "--no-audit", "--no-fund"], {
+      cwd: rig,
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    const out = execFileSync(process.execPath, ["probe.mjs"], {
+      cwd: rig,
+      encoding: "utf8",
+      env: { ...process.env, CDK_FLOOR_PACKAGES: JSON.stringify(Object.keys(tarballs)) },
+    });
+    return JSON.parse(out);
+  } finally {
+    rmSync(rig, { recursive: true, force: true });
+  }
+}
+
+function establish() {
+  const cacheDir = mkdtempSync(join(tmpdir(), "composurecdk-floor-tarballs-"));
+  try {
+    console.log("Packing publishable packages …");
+    const tarballs = packAll(cacheDir);
+    const names = Object.keys(tarballs);
+
+    // results[name] = ordered (high→low) list of { version, ok, error }
+    const results = Object.fromEntries(names.map((n) => [n, []]));
+    for (const version of LADDER) {
+      process.stdout.write(`Probing aws-cdk-lib@${version} … `);
+      const probed = probeAtVersion(version, tarballs, cacheDir);
+      for (const { name, ok, error } of probed) results[name].push({ version, ok, error });
+      console.log(`${probed.filter((r) => r.ok).length}/${names.length} packages load`);
+    }
+
+    const floors = {};
+    for (const name of names) {
+      const rungs = results[name]; // high → low
+      let floor;
+      let gatedBy;
+      for (let i = 0; i < rungs.length; i++) {
+        if (rungs[i].ok) {
+          floor = rungs[i].version;
+          gatedBy = rungs[i + 1]?.error; // why the next rung down fails
+        } else break;
+      }
+      floors[name.replace("@composurecdk/", "")] =
+        floor === undefined
+          ? { floor: `>${LADDER[0]}`, gatedBy: rungs[0]?.error }
+          : { floor, gatedBy: gatedBy ?? `<=${LADDER[LADDER.length - 1]} (no lower rung probed)` };
+    }
+
+    writeFileSync(
+      MANIFEST,
+      `${JSON.stringify(
+        {
+          $comment:
+            "Per-package aws-cdk-lib import-time floors, from `node scripts/cdk-floors.mjs establish`. " +
+            "Ladder-granular; floor is the lowest probed release that loads, gatedBy is the API missing one rung lower.",
+          ladder: LADDER,
+          floors,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    console.log(`\nWrote ${MANIFEST}\n`);
+    for (const [pkg, { floor, gatedBy }] of Object.entries(floors)) {
+      console.log(`  ${pkg.padEnd(16)} >= ${floor.padEnd(10)} ${gatedBy ?? ""}`);
+    }
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
+const mode = process.argv[2];
+if (mode === "establish") {
+  establish();
+} else {
+  console.error(`Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs establish`);
+  process.exit(1);
+}

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -1,22 +1,25 @@
 #!/usr/bin/env node
 
 /**
- * Per-package aws-cdk-lib floor tooling.
+ * Per-package aws-cdk-lib floor tooling. cdk-floors.json is the curated source
+ * of truth (package -> { floor, gatedBy }); four modes feed, apply and guard it:
  *
- * `establish` sweeps a descending ladder of real aws-cdk-lib versions and, for
- * each publishable @composurecdk package, records the lowest version it still
- * loads on plus the API that gates it (the named export missing one rung
- * lower). It writes that to cdk-floors.json — the source of truth from which
- * per-package `peerDependencies` are set and enforced.
+ * - `establish` sweeps a descending ladder of real aws-cdk-lib versions and,
+ *   for each publishable @composurecdk package, records the lowest version it
+ *   still loads on plus the API that gates it (the named export missing one
+ *   rung lower). It writes a ladder-granular draft to cdk-floors.discovered.json
+ *   to be refined into cdk-floors.json — re-running it never clobbers curation.
+ * - `apply` writes each package's peerDependencies.aws-cdk-lib from the manifest.
+ * - `check` asserts package.json ranges match the manifest (a cheap CI gate).
+ * - `enforce` loads each package at its own declared floor and fails if any
+ *   doesn't — the "don't breach the floor" guard.
  *
- * This measures the import-time floor (named exports a package pulls from
- * aws-cdk-lib), which is where every floor constraint we have hit lives. The
- * runtime-complete guard is `enforce` (runs each package's suite at its
- * declared floor); a runtime-only gap there raises the floor above what
- * `establish` found.
+ * `establish`/`enforce` measure the import-time floor (named exports a package
+ * pulls from aws-cdk-lib), which is where every floor constraint we have hit
+ * lives. A runtime-only gap would surface in a package's suite run at its floor.
  *
- * Usage: node scripts/cdk-floors.mjs establish
- * Run `npm run build` first (it packs from each package's dist).
+ * Usage: node scripts/cdk-floors.mjs <establish|apply|check|enforce>
+ * `establish`/`enforce` need `npm run build` first (they pack from each dist).
  */
 
 import { execFileSync } from "node:child_process";
@@ -36,6 +39,10 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const PACKAGES_DIR = join(REPO_ROOT, "packages");
 const MANIFEST = join(REPO_ROOT, "cdk-floors.json");
+// `establish` writes its raw discovery here; cdk-floors.json is the curated,
+// refined source of truth that `apply`/`check` consume — so re-running
+// `establish` never clobbers hand-refined floors.
+const DISCOVERED = join(REPO_ROOT, "cdk-floors.discovered.json");
 const CONSTRUCTS_RANGE = "^10.0.0";
 
 // Descending ladder of real aws-cdk-lib releases to probe. Floors land on a
@@ -96,7 +103,10 @@ function probeAtVersion(version, tarballs, cacheDir) {
       `${JSON.stringify({ name: "cdk-floor-probe", private: true, type: "module", dependencies }, null, 2)}\n`,
     );
     copyFileSync(join(SCRIPT_DIR, "cdk-floor", "probe.mjs"), join(rig, "probe.mjs"));
-    execFileSync("npm", ["install", "--no-audit", "--no-fund"], {
+    // --legacy-peer-deps: we deliberately install at versions that violate the
+    // packages' own declared peer floors — the point is to test whether the
+    // imports resolve at `version`, not whether the declared ranges agree.
+    execFileSync("npm", ["install", "--no-audit", "--no-fund", "--legacy-peer-deps"], {
       cwd: rig,
       stdio: ["ignore", "ignore", "inherit"],
     });
@@ -145,12 +155,12 @@ function establish() {
     }
 
     writeFileSync(
-      MANIFEST,
+      DISCOVERED,
       `${JSON.stringify(
         {
           $comment:
-            "Per-package aws-cdk-lib import-time floors, from `node scripts/cdk-floors.mjs establish`. " +
-            "Ladder-granular; floor is the lowest probed release that loads, gatedBy is the API missing one rung lower.",
+            "Raw discovery from `node scripts/cdk-floors.mjs establish` — ladder-granular. " +
+            "Refine the floors to the exact introducing release and copy into cdk-floors.json (the curated source of truth).",
           ladder: LADDER,
           floors,
         },
@@ -159,7 +169,7 @@ function establish() {
       )}\n`,
     );
 
-    console.log(`\nWrote ${MANIFEST}\n`);
+    console.log(`\nWrote ${DISCOVERED} (draft — refine into cdk-floors.json)\n`);
     for (const [pkg, { floor, gatedBy }] of Object.entries(floors)) {
       console.log(`  ${pkg.padEnd(16)} >= ${floor.padEnd(10)} ${gatedBy ?? ""}`);
     }
@@ -168,10 +178,100 @@ function establish() {
   }
 }
 
+function pkgJsonPath(pkg) {
+  return join(PACKAGES_DIR, pkg, "package.json");
+}
+
+function readFloors() {
+  return JSON.parse(readFileSync(MANIFEST, "utf8")).floors;
+}
+
+/** Writes each package's peerDependencies.aws-cdk-lib from the curated manifest. */
+function apply() {
+  for (const [pkg, { floor }] of Object.entries(readFloors())) {
+    const path = pkgJsonPath(pkg);
+    const json = JSON.parse(readFileSync(path, "utf8"));
+    if (json.peerDependencies?.["aws-cdk-lib"] === undefined) {
+      console.log(`  ${pkg.padEnd(16)} skipped (no aws-cdk-lib peer — constructs only)`);
+      continue;
+    }
+    json.peerDependencies["aws-cdk-lib"] = `^${floor}`;
+    writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
+    console.log(`  ${pkg.padEnd(16)} aws-cdk-lib ^${floor}`);
+  }
+  console.log("\nApplied to package.json files (run `npm run format` to normalise).");
+}
+
+/** Asserts each package.json peer range matches the manifest; non-zero on drift. */
+function check() {
+  const floors = readFloors();
+  const mismatches = [];
+  for (const [pkg, { floor }] of Object.entries(floors)) {
+    const actual = JSON.parse(readFileSync(pkgJsonPath(pkg), "utf8")).peerDependencies?.[
+      "aws-cdk-lib"
+    ];
+    if (actual !== `^${floor}`) {
+      mismatches.push(
+        `  ${pkg}: package.json has "${actual ?? "(unset)"}", manifest expects "^${floor}"`,
+      );
+    }
+  }
+  if (mismatches.length > 0) {
+    console.error(
+      `cdk-floors check failed — run \`npm run cdk-floors:apply\`:\n${mismatches.join("\n")}`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `cdk-floors check passed (${Object.keys(floors).length} packages match the manifest)`,
+  );
+}
+
+/**
+ * Loads each package against a real install of its *own* declared floor and
+ * fails if any doesn't — the "don't breach the floor" guard. Catches a change
+ * that reaches for an aws-cdk-lib API newer than the package promises.
+ */
+function enforce() {
+  const byFloor = new Map();
+  for (const [pkg, { floor }] of Object.entries(readFloors())) {
+    if (!byFloor.has(floor)) byFloor.set(floor, []);
+    byFloor.get(floor).push(`@composurecdk/${pkg}`);
+  }
+  const cacheDir = mkdtempSync(join(tmpdir(), "composurecdk-floor-tarballs-"));
+  try {
+    console.log("Packing publishable packages …");
+    const tarballs = packAll(cacheDir);
+    const failures = [];
+    for (const [floor, group] of [...byFloor].sort()) {
+      process.stdout.write(`Enforcing aws-cdk-lib@${floor} for ${group.length} package(s) … `);
+      const loaded = probeAtVersion(floor, tarballs, cacheDir).filter((r) =>
+        group.includes(r.name),
+      );
+      const failed = loaded.filter((r) => !r.ok);
+      console.log(failed.length === 0 ? "ok" : `${failed.length} FAILED`);
+      for (const r of failed) failures.push(`  ${r.name} @ ${floor}: ${r.error}`);
+    }
+    if (failures.length > 0) {
+      console.error(
+        `\ncdk-floors enforce failed — a package needs a newer aws-cdk-lib than its declared floor:\n${failures.join("\n")}\n\n` +
+          "Either avoid the newer API, or raise the floor (update cdk-floors.json, run `npm run cdk-floors:apply`).",
+      );
+      process.exit(1);
+    }
+    console.log("\ncdk-floors enforce passed (every package loads at its declared floor)");
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
 const mode = process.argv[2];
-if (mode === "establish") {
-  establish();
+const modes = { establish, apply, check, enforce };
+if (modes[mode] !== undefined) {
+  modes[mode]();
 } else {
-  console.error(`Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs establish`);
+  console.error(
+    `Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <establish|apply|check|enforce>`,
+  );
   process.exit(1);
 }


### PR DESCRIPTION
> **Stacked on #155 → #148.** Diff shown is only this branch's work; retargets down the stack as each merges.

Step 3 of the cross-version plan: establish each package's real aws-cdk-lib floor, document *why*, and make it redrivable + enforced. Per ADR-0008.

## The floors (measured against real installs, pinned to the introducing release)

| floor | packages | gated by |
|---|---|---|
| 2.0.0 | cloudformation | root-only imports |
| 2.1.0 | cloudwatch, sns, sqs, iam, logs, events, budgets | aws-cdk-lib ESM subpath exports (`aws-cdk-lib/aws-*`) |
| 2.54.0 | apigateway, ec2, s3 | `aws-cloudwatch.Stats` |
| 2.118.0 | cloudfront | `aws-cloudfront.FunctionRuntime` |
| 2.119.0 | acm | `aws-certificatemanager.KeyAlgorithm` |
| 2.168.0 | lambda | `aws-lambda.MetricType` |
| 2.216.0 | route53 | `aws-route53.HttpsRecord` |

(`core` is constructs-only — no aws-cdk-lib peer.) The old blanket `^2.0.0` was an untested claim; these replace it. A notable finding: most packages can't reach 2.0.0 at all because aws-cdk-lib only added **ESM subpath exports** around 2.1.0.

## Mechanism (`scripts/cdk-floors.mjs`, `cdk-floors.json` = source of truth)

- **`establish`** — probes the graph across a real version ladder, finds each package's lowest-loading version + the gating export; writes a draft to refine.
- **`apply`** — writes each `peerDependencies.aws-cdk-lib` from the manifest.
- **`check`** — asserts package.json matches the manifest (cheap; main CI job + `verify`).
- **`enforce`** — loads each package against a real install of *its own* floor; fails if a change needs something newer (`cdk-floor` CI job).

Grandfathering a lower floor is a deliberate, evidenced act: drop the requiring API, re-run `establish` to prove it, refine, `apply`.

## Checks
`cdk-floors:check` and `cdk-floors:enforce` both pass; lint/format clean; build green across all 18 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)