### PR TITLE
feat: per-package aws-cdk-lib peer floors (ADR-0008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Cheap gate: each package's peerDependencies.aws-cdk-lib must match the
+      # cdk-floors.json manifest (ADR-0008).
+      - name: Check CDK floor ranges in sync
+        run: npm run cdk-floors:check
+
       - name: Test
         run: npm run test

--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -1,0 +1,38 @@
+{
+  "$comment": "Per-package aws-cdk-lib floors — the source of truth for each package's peerDependencies.aws-cdk-lib range. `node scripts/cdk-floors.mjs establish` discovers these (ladder-granular); the values here are refined to the exact introducing release and validated by loading each package against real installs. `apply` writes them to package.json; `check` asserts package.json matches. To grandfather older support, drop the requiring API, re-run establish to prove the lower floor, then apply.",
+  "floors": {
+    "cloudformation": { "floor": "2.0.0", "gatedBy": "imports only the aws-cdk-lib root entry" },
+    "cloudwatch": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch)"
+    },
+    "sns": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sns)" },
+    "sqs": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sqs)" },
+    "iam": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-iam)" },
+    "logs": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs)"
+    },
+    "events": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-events)"
+    },
+    "budgets": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-budgets)"
+    },
+    "apigateway": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "ec2": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "s3": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "cloudfront": {
+      "floor": "2.118.0",
+      "gatedBy": "aws-cloudfront.FunctionRuntime (introduced 2.118.0)"
+    },
+    "acm": {
+      "floor": "2.119.0",
+      "gatedBy": "aws-certificatemanager.KeyAlgorithm (introduced 2.119.0)"
+    },
+    "lambda": { "floor": "2.168.0", "gatedBy": "aws-lambda.MetricType (introduced 2.168.0)" },
+    "route53": { "floor": "2.216.0", "gatedBy": "aws-route53.HttpsRecord (introduced 2.216.0)" }
+  }
+}

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -1,0 +1,89 @@
+# ADR 0008: Per-package aws-cdk-lib version floors
+
+- **Status:** Accepted
+- **Date:** 2026-05-26
+
+## Context
+
+Every publishable `@composurecdk/*` package declared `peerDependencies.aws-cdk-lib`
+as `^2.0.0`. That was an untested claim: the packages were only ever built and
+tested against the latest CDK. Issue #146 made the gap concrete — the CloudWatch
+alarm policies called `CfnAlarm.isCfnAlarm`, a static introduced in aws-cdk-lib
+2.231.0, so every consumer on 2.0.0–2.230.x hit a `TypeError` at synth despite
+the `^2.0.0` promise.
+
+Measuring real installs showed the packages have **widely different** actual
+floors, because each pulls different named exports from aws-cdk-lib:
+
+| floor   | packages                                         | gated by                                              |
+| ------- | ------------------------------------------------ | ----------------------------------------------------- |
+| 2.0.0   | cloudformation                                   | imports only the aws-cdk-lib root entry               |
+| 2.1.0   | cloudwatch, sns, sqs, iam, logs, events, budgets | aws-cdk-lib ESM subpath exports (`aws-cdk-lib/aws-*`) |
+| 2.54.0  | apigateway, ec2, s3                              | `aws-cloudwatch.Stats`                                |
+| 2.118.0 | cloudfront                                       | `aws-cloudfront.FunctionRuntime`                      |
+| 2.119.0 | acm                                              | `aws-certificatemanager.KeyAlgorithm`                 |
+| 2.168.0 | lambda                                           | `aws-lambda.MetricType`                               |
+| 2.216.0 | route53                                          | `aws-route53.HttpsRecord`                             |
+
+(`core` depends on `constructs` only, not aws-cdk-lib, so it has no floor.)
+
+A single library-wide floor would force every consumer up to route53's 2.216.0,
+penalising the many packages that work far lower. The packages are published and
+consumed independently, so the floor belongs per package.
+
+## Decision
+
+**Each publishable package declares its own measured `peerDependencies.aws-cdk-lib`
+floor. `cdk-floors.json` is the source of truth; tooling establishes, applies,
+and enforces it.** Floors are monotonic with the peer graph — a package's floor
+is the max of its own aws-cdk-lib usage and its `@composurecdk` peers' floors,
+which holds automatically because a package can only load once its peers do.
+
+`scripts/cdk-floors.mjs` provides four modes (npm scripts `cdk-floors:*`),
+landing across a small sequence of PRs:
+
+- **`apply`** — writes each package's `peerDependencies.aws-cdk-lib` from the
+  manifest. _(This PR.)_
+- **`check`** — asserts package.json ranges match the manifest. Cheap; runs in
+  the main CI job and `verify`. _(This PR.)_
+- **`enforce`** — loads each package against a real install of its own declared
+  floor and fails if any doesn't. The "don't breach the floor" PR gate.
+  _(Follow-up PR.)_
+- **`establish`** — packs the graph and loads every package against a
+  descending ladder of real aws-cdk-lib releases, recording the lowest each
+  loads on and the gating export. Writes a ladder-granular draft
+  (`cdk-floors.discovered.json`) to be refined into `cdk-floors.json`. Re-run
+  it to **prove a new, lower floor** when deliberately grandfathering older
+  support. _(Follow-up PR — discovery / floor-research tool.)_
+
+Floor values are measured at the **import-time** boundary (named exports a
+package pulls from aws-cdk-lib), where every constraint observed so far lives.
+The per-package unit suites — run on every commit against the latest CDK —
+catch runtime regressions in the supported range. A separate on-demand
+diagnostic synth tool exists for ad-hoc validation at any chosen aws-cdk-lib
+version (bug repro, candidate-floor validation, release prep); it is not a PR
+gate, because no single fixed CDK version is the right one to test against
+continuously.
+
+This complements the static guard already in place: the
+`composurecdk/no-cdk-api-above-floor` ESLint rule (`@composurecdk/eslint-plugin`)
+blocks known version-gated APIs at lint time, so they can't be written into
+`src/` in the first place.
+
+## Consequences
+
+- Consumers get honest, per-package ranges; low-floor packages stay broadly
+  installable.
+- The ranges become regression-proof in two layers: `check` (this PR) stops
+  package.json drifting from the manifest, and `enforce` (follow-up PR) stops
+  a package quietly requiring a newer CDK than its declared floor.
+- Lowering a floor is a deliberate, evidenced act: remove the requiring API,
+  re-run `establish` against the candidate floor, validate the composed synth
+  against it, refine the manifest, `apply`.
+- The import probe is a lower bound; a runtime-only requirement could push a
+  floor above the measured value. The per-package unit suites at latest CDK
+  catch new regressions; the diagnostic synth tool validates candidate floors
+  before they're applied.
+- Floors are pinned to the exact introducing release. They will rise over time
+  as packages adopt newer CDK features — that is expected and intentional, and
+  the tooling makes each change measured rather than assumed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0005: `.copy()` on Builder for variant authoring and strategy hand-off](0005-builder-copy.md)
 - [ADR-0006: Decorator pattern for cross-cutting builder features](0006-decorator-builder-pattern.md)
 - [ADR-0007: Dual ESM/CJS publishing as an enforced standard](0007-dual-esm-cjs-publishing.md)
+- [ADR-0008: Per-package aws-cdk-lib version floors](0008-aws-cdk-lib-version-floors.md)

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "format:check": "prettier --check .",
     "typecheck": "npx nx run-many -t typecheck",
     "test": "npx nx run-many -t test",
+    "cdk-floors:apply": "node scripts/cdk-floors.mjs apply",
+    "cdk-floors:check": "node scripts/cdk-floors.mjs check",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",
-    "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run test",
+    "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run cdk-floors:check && npm run test",
     "release:dryrun": "node scripts/release-dryrun.mjs",
     "prepare": "husky"
   },

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.119.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/s3": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.118.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -37,7 +37,7 @@
     }
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -42,7 +42,7 @@
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/iam": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -42,7 +42,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.216.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * Per-package aws-cdk-lib floor tooling. `cdk-floors.json` is the curated
+ * source of truth (package -> { floor, gatedBy }); this script reads it and
+ * keeps each package's `peerDependencies.aws-cdk-lib` in sync.
+ *
+ * - `apply` writes each package's `peerDependencies.aws-cdk-lib` from the
+ *   manifest. Run it after editing `cdk-floors.json`.
+ * - `check` asserts every package.json matches the manifest, exiting non-zero
+ *   on drift. Cheap; wired into the main CI job and `npm run verify`.
+ *
+ * The discovery side (how floor values are arrived at) and the enforcement
+ * side (running each package against a real install of its declared floor)
+ * are separate follow-up tools — see ADR-0008.
+ *
+ * Usage: node scripts/cdk-floors.mjs <apply|check>
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PACKAGES_DIR = join(REPO_ROOT, "packages");
+const MANIFEST = join(REPO_ROOT, "cdk-floors.json");
+
+function pkgJsonPath(pkg) {
+  return join(PACKAGES_DIR, pkg, "package.json");
+}
+
+function readFloors() {
+  return JSON.parse(readFileSync(MANIFEST, "utf8")).floors;
+}
+
+/** Writes each package's peerDependencies.aws-cdk-lib from the curated manifest. */
+function apply() {
+  for (const [pkg, { floor }] of Object.entries(readFloors())) {
+    const path = pkgJsonPath(pkg);
+    const json = JSON.parse(readFileSync(path, "utf8"));
+    if (json.peerDependencies?.["aws-cdk-lib"] === undefined) {
+      console.log(`  ${pkg.padEnd(16)} skipped (no aws-cdk-lib peer — constructs only)`);
+      continue;
+    }
+    json.peerDependencies["aws-cdk-lib"] = `^${floor}`;
+    writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
+    console.log(`  ${pkg.padEnd(16)} aws-cdk-lib ^${floor}`);
+  }
+  console.log("\nApplied to package.json files (run `npm run format` to normalise).");
+}
+
+/** Asserts each package.json peer range matches the manifest; non-zero on drift. */
+function check() {
+  const floors = readFloors();
+  const mismatches = [];
+  for (const [pkg, { floor }] of Object.entries(floors)) {
+    const actual = JSON.parse(readFileSync(pkgJsonPath(pkg), "utf8")).peerDependencies?.[
+      "aws-cdk-lib"
+    ];
+    if (actual !== `^${floor}`) {
+      mismatches.push(
+        `  ${pkg}: package.json has "${actual ?? "(unset)"}", manifest expects "^${floor}"`,
+      );
+    }
+  }
+  if (mismatches.length > 0) {
+    console.error(
+      `cdk-floors check failed — run \`npm run cdk-floors:apply\`:\n${mismatches.join("\n")}`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `cdk-floors check passed (${Object.keys(floors).length} packages match the manifest)`,
+  );
+}
+
+const mode = process.argv[2];
+const modes = { apply, check };
+if (modes[mode] !== undefined) {
+  modes[mode]();
+} else {
+  console.error(`Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check>`);
+  process.exit(1);
+}


### PR DESCRIPTION
First of three small follow-ups to #148 / #151, restructured from the closed #155 / #156. **No stacking** — this lands directly on `main`.

## The change

Replaces the untested `aws-cdk-lib ^2.0.0` peer claim on every publishable package with measured per-package ranges, pinned to the release that introduced each package's binding aws-cdk-lib API.

| floor | packages | gated by |
|---|---|---|
| 2.0.0 | cloudformation | imports only the aws-cdk-lib root entry |
| 2.1.0 | cloudwatch, sns, sqs, iam, logs, events, budgets | aws-cdk-lib ESM subpath exports |
| 2.54.0 | apigateway, ec2, s3 | `aws-cloudwatch.Stats` |
| 2.118.0 | cloudfront | `aws-cloudfront.FunctionRuntime` |
| 2.119.0 | acm | `aws-certificatemanager.KeyAlgorithm` |
| 2.168.0 | lambda | `aws-lambda.MetricType` |
| 2.216.0 | route53 | `aws-route53.HttpsRecord` |

(`core` is constructs-only; no aws-cdk-lib peer.)

`cdk-floors.json` is the source of truth. `cdk-floors:apply` writes from it, `cdk-floors:check` keeps package.json in sync (cheap CI gate from day one; wired into the main `ci` job and `verify`). The redrivable establish + enforce tooling and the on-demand synth diagnostic come in two follow-up PRs, per ADR-0008.

## What landed

- `cdk-floors.json` — curated manifest, each floor pinned to the exact introducing release.
- 14 `packages/*/package.json` peer-range edits (cloudformation's was already `^2.0.0` so unchanged; the manifest still pins it for `check`).
- `scripts/cdk-floors.mjs` — small script with two modes: `apply` and `check`.
- `cdk-floors:apply` + `cdk-floors:check` npm scripts; `cdk-floors:check` added to `verify` and the main `ci.yml` job.
- `docs/adr/0008-aws-cdk-lib-version-floors.md` + index entry.

## Verification

`npm run verify` green (format + build + check:exports + lint + **cdk-floors:check** + test); `cdk-floors:check` reports `15 packages match the manifest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)