### PR TITLE
fix(release): break nx git-config deadlock between CI and local preview

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -44,10 +44,10 @@ Scopes are optional and do not affect the bump.
 1. **Preview locally.**
 
    ```sh
-   npx nx release --dry-run
+   npm run release:dryrun
    ```
 
-   Prints the planned version, changelog, and per-package bumps. Safe any time. `nx.json` sets `commit/tag/push` to `false` under `release.git`, so a non-`--dry-run` local invocation modifies files but does not commit, tag, or push — `git restore` undoes it.
+   Prints the planned version, changelog, and per-package bumps. Safe any time. The script calls `releaseVersion` then `releaseChangelog` via nx's programmatic API — the same path the CI workflow uses as subcommands. `nx release --dry-run` (the top-level command) is intentionally not used; see the comment in [`scripts/release-dryrun.mjs`](../scripts/release-dryrun.mjs) for the nx@22 config-shape constraint that forces this. `nx.json` sets `commit/tag/push` to `false` under both `release.version.git` and `release.changelog.git`, so a non-dry-run local invocation modifies files but does not commit, tag, or push — `git restore` undoes it.
 
 2. **Open the release PR.** Trigger **Actions → Release Prepare → Run workflow**:
    - Leave inputs blank for a normal conventional-commits-driven release.

--- a/nx.json
+++ b/nx.json
@@ -30,21 +30,26 @@
   "release": {
     "projectsRelationship": "fixed",
     "projects": ["packages/*"],
-    "git": {
-      "commit": false,
-      "tag": false,
-      "push": false
-    },
     "version": {
       "conventionalCommits": true,
       "fallbackCurrentVersionResolver": "disk",
-      "preVersionCommand": "npm run verify"
+      "preVersionCommand": "npm run verify",
+      "git": {
+        "commit": false,
+        "tag": false,
+        "push": false
+      }
     },
     "releaseTagPattern": "v{version}",
     "changelog": {
       "automaticFromRef": true,
       "projectChangelogs": false,
-      "workspaceChangelog": true
+      "workspaceChangelog": true,
+      "git": {
+        "commit": false,
+        "tag": false,
+        "push": false
+      }
     }
   },
   "analytics": false

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",
     "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run test",
+    "release:dryrun": "node scripts/release-dryrun.mjs",
     "prepare": "husky"
   },
   "repository": {

--- a/scripts/release-dryrun.mjs
+++ b/scripts/release-dryrun.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Local dry-run preview of `nx release`.
+//
+// We do NOT use `nx release --dry-run` (the top-level command) because nx@22
+// rejects the top-level command when git options are configured granularly
+// under `release.version.git` / `release.changelog.git` — and they must be,
+// because the CI workflow (.github/workflows/release-prepare.yml) calls
+// `nx release version` and `nx release changelog` as separate subcommands,
+// which in turn reject a top-level `release.git`. Granular config is the only
+// shape that satisfies both CI and the programmatic API used here. See the
+// PR that introduced this script for the full history.
+
+import { releaseChangelog, releaseVersion } from "nx/release";
+
+const { workspaceVersion } = await releaseVersion({ dryRun: true, verbose: false });
+
+if (!workspaceVersion) {
+  console.log("\nNo version bump detected from conventional commits. Nothing to preview.");
+  process.exit(0);
+}
+
+await releaseChangelog({ version: workspaceVersion, dryRun: true, verbose: false });


### PR DESCRIPTION
## Summary

The Release Prepare workflow has been failing intermittently for months because of a contradiction in nx@22's config validation. This PR breaks the deadlock instead of moving it.

### The deadlock

nx@22 enforces **mutually exclusive** placement of git config:

| Invocation | Required placement | Rejection if mis-placed |
|---|---|---|
| `nx release` (top-level) | `release.git` | _\"top level command cannot be used with granular git configuration\"_ |
| `nx release version` / `nx release changelog` (subcommands) | `release.version.git` + `release.changelog.git` | _\"release.git property may not be used with the nx release version subcommand\"_ |

No single placement satisfies both. The CI workflow (`release-prepare.yml`) must use subcommands — it interpolates the resolved version between the two calls. So it pins us to granular config; the top-level local-preview command becomes unusable.

### History of oscillation

- f1125d5 (#71): moved to granular → fixed CI, broke `nx release --dry-run` locally.
- 91dc0ae: hoisted back to top-level → fixed local, broke CI.
- This PR: commits to granular config and replaces the top-level local-preview command with a script that uses nx's programmatic API (same constraint as subcommands).

The latest CI failure is [run 26465158097](https://github.com/laazyj/composureCDK/actions/runs/26465158097/job/77923333454).

### Changes

- `nx.json` — git config back under `release.version.git` + `release.changelog.git`.
- `scripts/release-dryrun.mjs` — drives dry-run via `releaseVersion` → `releaseChangelog`. In-file comment documents the constraint so the next maintainer doesn't \"fix\" it back.
- `package.json` — exposes as `npm run release:dryrun`.
- `docs/ci.md` — replaces the documented `npx nx release --dry-run` with `npm run release:dryrun` and explains why.

### What this does NOT fix

The dry-run still hits nx's `preserveMatchingDependencyRanges` guard when previewing a 0.x minor bump (e.g. 0.8.x → 0.9.0). That's the pre-existing constraint documented at `docs/ci.md` §_Bumping the minor version in 0.x_ — `nx release --dry-run` would have hit the same error before, once it got past the config-validation step it's currently failing on. Out of scope here.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run verify` clean (pre-push hook)
- [x] `npx nx release version --dry-run` — CI's invocation — passes config validation
- [x] `npx nx release changelog 0.9.0 --dry-run` — CI's invocation — passes config validation and renders changelog preview
- [x] `npm run release:dryrun` — local preview path — passes config validation
- [ ] Trigger **Actions → Release Prepare → Run workflow** once merged, with no specifier, and confirm it gets past the `Version packages` step that's been failing