### PR TITLE
feat(ci): per-package floor enforcement (ADR-0008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,36 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  cdk-floors-enforce:
+    # Real-install per-package floor guard: packs the @composurecdk graph,
+    # installs each package at its own declared aws-cdk-lib floor, and asserts
+    # every package imports. The runtime complement to `cdk-floors:check` —
+    # see ADR-0008. Kept as a separate job because it does network installs
+    # per floor (~7 today) and has different failure-mode logs.
+    name: CDK floors enforce
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NX_DAEMON: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Packs from each package's dist, so the build must run first.
+      - name: Build
+        run: npm run build
+
+      - name: Enforce per-package floors
+        run: npm run cdk-floors:enforce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Cheap gate: each package's peerDependencies.aws-cdk-lib must match the
+      # cdk-floors.json manifest (ADR-0008).
+      - name: Check CDK floor ranges in sync
+        run: npm run cdk-floors:check
+
       - name: Test
         run: npm run test

--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -1,0 +1,38 @@
+{
+  "$comment": "Per-package aws-cdk-lib floors — the source of truth for each package's peerDependencies.aws-cdk-lib range. `node scripts/cdk-floors.mjs establish` discovers these (ladder-granular); the values here are refined to the exact introducing release and validated by loading each package against real installs. `apply` writes them to package.json; `check` asserts package.json matches. To grandfather older support, drop the requiring API, re-run establish to prove the lower floor, then apply.",
+  "floors": {
+    "cloudformation": { "floor": "2.0.0", "gatedBy": "imports only the aws-cdk-lib root entry" },
+    "cloudwatch": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch)"
+    },
+    "sns": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sns)" },
+    "sqs": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sqs)" },
+    "iam": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-iam)" },
+    "logs": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs)"
+    },
+    "events": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-events)"
+    },
+    "budgets": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-budgets)"
+    },
+    "apigateway": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "ec2": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "s3": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "cloudfront": {
+      "floor": "2.118.0",
+      "gatedBy": "aws-cloudfront.FunctionRuntime (introduced 2.118.0)"
+    },
+    "acm": {
+      "floor": "2.119.0",
+      "gatedBy": "aws-certificatemanager.KeyAlgorithm (introduced 2.119.0)"
+    },
+    "lambda": { "floor": "2.168.0", "gatedBy": "aws-lambda.MetricType (introduced 2.168.0)" },
+    "route53": { "floor": "2.216.0", "gatedBy": "aws-route53.HttpsRecord (introduced 2.216.0)" }
+  }
+}

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -1,0 +1,89 @@
+# ADR 0008: Per-package aws-cdk-lib version floors
+
+- **Status:** Accepted
+- **Date:** 2026-05-26
+
+## Context
+
+Every publishable `@composurecdk/*` package declared `peerDependencies.aws-cdk-lib`
+as `^2.0.0`. That was an untested claim: the packages were only ever built and
+tested against the latest CDK. Issue #146 made the gap concrete — the CloudWatch
+alarm policies called `CfnAlarm.isCfnAlarm`, a static introduced in aws-cdk-lib
+2.231.0, so every consumer on 2.0.0–2.230.x hit a `TypeError` at synth despite
+the `^2.0.0` promise.
+
+Measuring real installs showed the packages have **widely different** actual
+floors, because each pulls different named exports from aws-cdk-lib:
+
+| floor   | packages                                         | gated by                                              |
+| ------- | ------------------------------------------------ | ----------------------------------------------------- |
+| 2.0.0   | cloudformation                                   | imports only the aws-cdk-lib root entry               |
+| 2.1.0   | cloudwatch, sns, sqs, iam, logs, events, budgets | aws-cdk-lib ESM subpath exports (`aws-cdk-lib/aws-*`) |
+| 2.54.0  | apigateway, ec2, s3                              | `aws-cloudwatch.Stats`                                |
+| 2.118.0 | cloudfront                                       | `aws-cloudfront.FunctionRuntime`                      |
+| 2.119.0 | acm                                              | `aws-certificatemanager.KeyAlgorithm`                 |
+| 2.168.0 | lambda                                           | `aws-lambda.MetricType`                               |
+| 2.216.0 | route53                                          | `aws-route53.HttpsRecord`                             |
+
+(`core` depends on `constructs` only, not aws-cdk-lib, so it has no floor.)
+
+A single library-wide floor would force every consumer up to route53's 2.216.0,
+penalising the many packages that work far lower. The packages are published and
+consumed independently, so the floor belongs per package.
+
+## Decision
+
+**Each publishable package declares its own measured `peerDependencies.aws-cdk-lib`
+floor. `cdk-floors.json` is the source of truth; tooling establishes, applies,
+and enforces it.** Floors are monotonic with the peer graph — a package's floor
+is the max of its own aws-cdk-lib usage and its `@composurecdk` peers' floors,
+which holds automatically because a package can only load once its peers do.
+
+`scripts/cdk-floors.mjs` provides four modes (npm scripts `cdk-floors:*`),
+landing across a small sequence of PRs:
+
+- **`apply`** — writes each package's `peerDependencies.aws-cdk-lib` from the
+  manifest. _(This PR.)_
+- **`check`** — asserts package.json ranges match the manifest. Cheap; runs in
+  the main CI job and `verify`. _(This PR.)_
+- **`enforce`** — loads each package against a real install of its own declared
+  floor and fails if any doesn't. The "don't breach the floor" PR gate.
+  _(Follow-up PR.)_
+- **`establish`** — packs the graph and loads every package against a
+  descending ladder of real aws-cdk-lib releases, recording the lowest each
+  loads on and the gating export. Writes a ladder-granular draft
+  (`cdk-floors.discovered.json`) to be refined into `cdk-floors.json`. Re-run
+  it to **prove a new, lower floor** when deliberately grandfathering older
+  support. _(Follow-up PR — discovery / floor-research tool.)_
+
+Floor values are measured at the **import-time** boundary (named exports a
+package pulls from aws-cdk-lib), where every constraint observed so far lives.
+The per-package unit suites — run on every commit against the latest CDK —
+catch runtime regressions in the supported range. A separate on-demand
+diagnostic synth tool exists for ad-hoc validation at any chosen aws-cdk-lib
+version (bug repro, candidate-floor validation, release prep); it is not a PR
+gate, because no single fixed CDK version is the right one to test against
+continuously.
+
+This complements the static guard already in place: the
+`composurecdk/no-cdk-api-above-floor` ESLint rule (`@composurecdk/eslint-plugin`)
+blocks known version-gated APIs at lint time, so they can't be written into
+`src/` in the first place.
+
+## Consequences
+
+- Consumers get honest, per-package ranges; low-floor packages stay broadly
+  installable.
+- The ranges become regression-proof in two layers: `check` (this PR) stops
+  package.json drifting from the manifest, and `enforce` (follow-up PR) stops
+  a package quietly requiring a newer CDK than its declared floor.
+- Lowering a floor is a deliberate, evidenced act: remove the requiring API,
+  re-run `establish` against the candidate floor, validate the composed synth
+  against it, refine the manifest, `apply`.
+- The import probe is a lower bound; a runtime-only requirement could push a
+  floor above the measured value. The per-package unit suites at latest CDK
+  catch new regressions; the diagnostic synth tool validates candidate floors
+  before they're applied.
+- Floors are pinned to the exact introducing release. They will rise over time
+  as packages adopt newer CDK features — that is expected and intentional, and
+  the tooling makes each change measured rather than assumed.

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -39,22 +39,20 @@ and enforces it.** Floors are monotonic with the peer graph — a package's floo
 is the max of its own aws-cdk-lib usage and its `@composurecdk` peers' floors,
 which holds automatically because a package can only load once its peers do.
 
-`scripts/cdk-floors.mjs` provides four modes (npm scripts `cdk-floors:*`),
-landing across a small sequence of PRs:
+`scripts/cdk-floors.mjs` provides the modes (npm scripts `cdk-floors:*`):
 
 - **`apply`** — writes each package's `peerDependencies.aws-cdk-lib` from the
-  manifest. _(This PR.)_
+  manifest.
 - **`check`** — asserts package.json ranges match the manifest. Cheap; runs in
-  the main CI job and `verify`. _(This PR.)_
-- **`enforce`** — loads each package against a real install of its own declared
-  floor and fails if any doesn't. The "don't breach the floor" PR gate.
-  _(Follow-up PR.)_
-- **`establish`** — packs the graph and loads every package against a
-  descending ladder of real aws-cdk-lib releases, recording the lowest each
-  loads on and the gating export. Writes a ladder-granular draft
-  (`cdk-floors.discovered.json`) to be refined into `cdk-floors.json`. Re-run
-  it to **prove a new, lower floor** when deliberately grandfathering older
-  support. _(Follow-up PR — discovery / floor-research tool.)_
+  the main CI job and `verify`.
+- **`enforce`** — loads each package against a real install of its own
+  declared floor and fails if any doesn't. The "don't breach the floor" PR
+  gate, in its own CI job (network installs per floor).
+- **`establish`** _(follow-up tool)_ — packs the graph and loads every
+  package against a descending ladder of real aws-cdk-lib releases, recording
+  the lowest each loads on and the gating export. Writes a ladder-granular
+  draft to be refined into `cdk-floors.json`. Re-run it to **prove a new,
+  lower floor** when deliberately grandfathering older support.
 
 Floor values are measured at the **import-time** boundary (named exports a
 package pulls from aws-cdk-lib), where every constraint observed so far lives.
@@ -74,9 +72,9 @@ blocks known version-gated APIs at lint time, so they can't be written into
 
 - Consumers get honest, per-package ranges; low-floor packages stay broadly
   installable.
-- The ranges become regression-proof in two layers: `check` (this PR) stops
-  package.json drifting from the manifest, and `enforce` (follow-up PR) stops
-  a package quietly requiring a newer CDK than its declared floor.
+- The ranges become regression-proof in two layers: `check` stops package.json
+  drifting from the manifest, and `enforce` stops a package quietly requiring
+  a newer CDK than its declared floor.
 - Lowering a floor is a deliberate, evidenced act: remove the requiring API,
   re-run `establish` against the candidate floor, validate the composed synth
   against it, refine the manifest, `apply`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0005: `.copy()` on Builder for variant authoring and strategy hand-off](0005-builder-copy.md)
 - [ADR-0006: Decorator pattern for cross-cutting builder features](0006-decorator-builder-pattern.md)
 - [ADR-0007: Dual ESM/CJS publishing as an enforced standard](0007-dual-esm-cjs-publishing.md)
+- [ADR-0008: Per-package aws-cdk-lib version floors](0008-aws-cdk-lib-version-floors.md)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ export default defineConfig(
       // Hand-written ESM/CJS consumption fixtures — each is deliberately a
       // specific module system and is exercised by spawning `node`, not linted.
       "packages/module-compat/test/fixtures/",
+      // cdk-floors rig probe — imports rig-only deps and runs inside a
+      // throwaway project (scripts/cdk-floors.mjs `enforce`), not linted here.
+      "scripts/cdk-floor/",
     ],
   },
   eslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "format:check": "prettier --check .",
     "typecheck": "npx nx run-many -t typecheck",
     "test": "npx nx run-many -t test",
+    "cdk-floors:apply": "node scripts/cdk-floors.mjs apply",
+    "cdk-floors:check": "node scripts/cdk-floors.mjs check",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",
-    "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run test",
+    "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run cdk-floors:check && npm run test",
     "release:dryrun": "node scripts/release-dryrun.mjs",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "npx nx run-many -t test",
     "cdk-floors:apply": "node scripts/cdk-floors.mjs apply",
     "cdk-floors:check": "node scripts/cdk-floors.mjs check",
+    "cdk-floors:enforce": "node scripts/cdk-floors.mjs enforce",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.119.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/s3": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.118.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -37,7 +37,7 @@
     }
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -42,7 +42,7 @@
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/iam": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.168.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -42,7 +42,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.216.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.54.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/scripts/cdk-floor/probe.mjs
+++ b/scripts/cdk-floor/probe.mjs
@@ -1,0 +1,21 @@
+// Import probe for the cdk-floors `enforce` mode (and the future `establish`
+// sweep). Runs inside a rig that has a pinned aws-cdk-lib + the packed
+// @composurecdk packages installed. Attempts to load each package (which
+// executes its top-level aws-cdk-lib imports) and reports, as JSON on stdout,
+// whether it loaded and — if not — the first error.
+//
+// Package names come in via the CDK_FLOOR_PACKAGES env var (JSON array).
+
+const packages = JSON.parse(process.env.CDK_FLOOR_PACKAGES ?? "[]");
+const results = [];
+
+for (const name of packages) {
+  try {
+    await import(name);
+    results.push({ name, ok: true });
+  } catch (error) {
+    results.push({ name, ok: false, error: error.message.split("\n")[0] });
+  }
+}
+
+process.stdout.write(JSON.stringify(results));

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -2,28 +2,42 @@
 
 /**
  * Per-package aws-cdk-lib floor tooling. `cdk-floors.json` is the curated
- * source of truth (package -> { floor, gatedBy }); this script reads it and
- * keeps each package's `peerDependencies.aws-cdk-lib` in sync.
+ * source of truth (package -> { floor, gatedBy }); this script reads it,
+ * keeps each package's `peerDependencies.aws-cdk-lib` in sync, and verifies
+ * that the declared floors actually hold at runtime.
  *
  * - `apply` writes each package's `peerDependencies.aws-cdk-lib` from the
  *   manifest. Run it after editing `cdk-floors.json`.
  * - `check` asserts every package.json matches the manifest, exiting non-zero
  *   on drift. Cheap; wired into the main CI job and `npm run verify`.
+ * - `enforce` loads each package against a real install of its own declared
+ *   floor and fails if any doesn't — the "don't breach the floor" PR gate.
+ *   Heavier (network installs); runs in its own CI job. See ADR-0008.
  *
- * The discovery side (how floor values are arrived at) and the enforcement
- * side (running each package against a real install of its declared floor)
- * are separate follow-up tools — see ADR-0008.
+ * The discovery side (`establish`, how floor values are arrived at in the
+ * first place) is a separate follow-up tool.
  *
- * Usage: node scripts/cdk-floors.mjs <apply|check>
+ * Usage: node scripts/cdk-floors.mjs <apply|check|enforce>
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const PACKAGES_DIR = join(REPO_ROOT, "packages");
 const MANIFEST = join(REPO_ROOT, "cdk-floors.json");
+const CONSTRUCTS_RANGE = "^10.0.0";
 
 function pkgJsonPath(pkg) {
   return join(PACKAGES_DIR, pkg, "package.json");
@@ -74,11 +88,119 @@ function check() {
   );
 }
 
+function discoverPublishablePackages() {
+  const names = [];
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(join(PACKAGES_DIR, entry.name, "package.json"), "utf8"));
+      if (pkg.name?.startsWith("@composurecdk/") && pkg.private !== true) {
+        names.push({ name: pkg.name, dir: entry.name });
+      }
+    } catch {
+      // Not a package directory — skip.
+    }
+  }
+  return names;
+}
+
+/** `npm pack`s every publishable package into `destination`, returning name -> tarball-filename. */
+function packAll(destination) {
+  const tarballs = {};
+  for (const { name, dir } of discoverPublishablePackages()) {
+    const output = execFileSync("npm", ["pack", "--pack-destination", destination], {
+      cwd: join(PACKAGES_DIR, dir),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const tarball = output
+      .split("\n")
+      .map((line) => line.trim())
+      .reverse()
+      .find((line) => line.endsWith(".tgz"));
+    if (tarball === undefined) throw new Error(`npm pack for ${dir} produced no .tgz`);
+    tarballs[name] = tarball;
+  }
+  return tarballs;
+}
+
+/** Install the packed packages + aws-cdk-lib@version into a rig, probe each import. */
+function probeAtVersion(version, tarballs, cacheDir) {
+  const rig = mkdtempSync(join(tmpdir(), `composurecdk-floor-${version.replace(/\./g, "-")}-`));
+  try {
+    const dependencies = { "aws-cdk-lib": version, constructs: CONSTRUCTS_RANGE };
+    for (const [name, tarball] of Object.entries(tarballs)) {
+      dependencies[name] = `file:${join(cacheDir, tarball)}`;
+    }
+    writeFileSync(
+      join(rig, "package.json"),
+      `${JSON.stringify({ name: "cdk-floors-probe", private: true, type: "module", dependencies }, null, 2)}\n`,
+    );
+    copyFileSync(join(SCRIPT_DIR, "cdk-floor", "probe.mjs"), join(rig, "probe.mjs"));
+    // --legacy-peer-deps: we deliberately install at versions that violate
+    // some packages' declared peer floors — the point is to test whether the
+    // group at *this* floor loads, not whether unrelated packages' ranges are
+    // satisfied at it.
+    execFileSync("npm", ["install", "--no-audit", "--no-fund", "--legacy-peer-deps"], {
+      cwd: rig,
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    const out = execFileSync(process.execPath, ["probe.mjs"], {
+      cwd: rig,
+      encoding: "utf8",
+      env: { ...process.env, CDK_FLOOR_PACKAGES: JSON.stringify(Object.keys(tarballs)) },
+    });
+    return JSON.parse(out);
+  } finally {
+    rmSync(rig, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Loads each package against a real install of its *own* declared floor and
+ * fails if any doesn't. Groups packages by floor so we do one install per
+ * distinct floor (~7 today) rather than per package.
+ */
+function enforce() {
+  const byFloor = new Map();
+  for (const [pkg, { floor }] of Object.entries(readFloors())) {
+    if (!byFloor.has(floor)) byFloor.set(floor, []);
+    byFloor.get(floor).push(`@composurecdk/${pkg}`);
+  }
+  const cacheDir = mkdtempSync(join(tmpdir(), "composurecdk-floor-tarballs-"));
+  try {
+    console.log("Packing publishable packages …");
+    const tarballs = packAll(cacheDir);
+    const failures = [];
+    for (const [floor, group] of [...byFloor].sort()) {
+      process.stdout.write(`Enforcing aws-cdk-lib@${floor} for ${group.length} package(s) … `);
+      const loaded = probeAtVersion(floor, tarballs, cacheDir).filter((r) =>
+        group.includes(r.name),
+      );
+      const failed = loaded.filter((r) => !r.ok);
+      console.log(failed.length === 0 ? "ok" : `${failed.length} FAILED`);
+      for (const r of failed) failures.push(`  ${r.name} @ ${floor}: ${r.error}`);
+    }
+    if (failures.length > 0) {
+      console.error(
+        `\ncdk-floors enforce failed — a package needs a newer aws-cdk-lib than its declared floor:\n${failures.join("\n")}\n\n` +
+          "Either avoid the newer API, or raise the floor (update cdk-floors.json, run `npm run cdk-floors:apply`).",
+      );
+      process.exit(1);
+    }
+    console.log("\ncdk-floors enforce passed (every package loads at its declared floor)");
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
 const mode = process.argv[2];
-const modes = { apply, check };
+const modes = { apply, check, enforce };
 if (modes[mode] !== undefined) {
   modes[mode]();
 } else {
-  console.error(`Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check>`);
+  console.error(
+    `Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check|enforce>`,
+  );
   process.exit(1);
 }

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * Per-package aws-cdk-lib floor tooling. `cdk-floors.json` is the curated
+ * source of truth (package -> { floor, gatedBy }); this script reads it and
+ * keeps each package's `peerDependencies.aws-cdk-lib` in sync.
+ *
+ * - `apply` writes each package's `peerDependencies.aws-cdk-lib` from the
+ *   manifest. Run it after editing `cdk-floors.json`.
+ * - `check` asserts every package.json matches the manifest, exiting non-zero
+ *   on drift. Cheap; wired into the main CI job and `npm run verify`.
+ *
+ * The discovery side (how floor values are arrived at) and the enforcement
+ * side (running each package against a real install of its declared floor)
+ * are separate follow-up tools — see ADR-0008.
+ *
+ * Usage: node scripts/cdk-floors.mjs <apply|check>
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PACKAGES_DIR = join(REPO_ROOT, "packages");
+const MANIFEST = join(REPO_ROOT, "cdk-floors.json");
+
+function pkgJsonPath(pkg) {
+  return join(PACKAGES_DIR, pkg, "package.json");
+}
+
+function readFloors() {
+  return JSON.parse(readFileSync(MANIFEST, "utf8")).floors;
+}
+
+/** Writes each package's peerDependencies.aws-cdk-lib from the curated manifest. */
+function apply() {
+  for (const [pkg, { floor }] of Object.entries(readFloors())) {
+    const path = pkgJsonPath(pkg);
+    const json = JSON.parse(readFileSync(path, "utf8"));
+    if (json.peerDependencies?.["aws-cdk-lib"] === undefined) {
+      console.log(`  ${pkg.padEnd(16)} skipped (no aws-cdk-lib peer — constructs only)`);
+      continue;
+    }
+    json.peerDependencies["aws-cdk-lib"] = `^${floor}`;
+    writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
+    console.log(`  ${pkg.padEnd(16)} aws-cdk-lib ^${floor}`);
+  }
+  console.log("\nApplied to package.json files (run `npm run format` to normalise).");
+}
+
+/** Asserts each package.json peer range matches the manifest; non-zero on drift. */
+function check() {
+  const floors = readFloors();
+  const mismatches = [];
+  for (const [pkg, { floor }] of Object.entries(floors)) {
+    const actual = JSON.parse(readFileSync(pkgJsonPath(pkg), "utf8")).peerDependencies?.[
+      "aws-cdk-lib"
+    ];
+    if (actual !== `^${floor}`) {
+      mismatches.push(
+        `  ${pkg}: package.json has "${actual ?? "(unset)"}", manifest expects "^${floor}"`,
+      );
+    }
+  }
+  if (mismatches.length > 0) {
+    console.error(
+      `cdk-floors check failed — run \`npm run cdk-floors:apply\`:\n${mismatches.join("\n")}`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `cdk-floors check passed (${Object.keys(floors).length} packages match the manifest)`,
+  );
+}
+
+const mode = process.argv[2];
+const modes = { apply, check };
+if (modes[mode] !== undefined) {
+  modes[mode]();
+} else {
+  console.error(`Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check>`);
+  process.exit(1);
+}


### PR DESCRIPTION
> **Stacked on #157.** Diff shown is only this PR's work; retargets to `main` once #157 merges.

PR 2 of 3 in the cross-version compatibility restructure. Adds the runtime complement to #157's `cdk-floors:check`.

## What

`cdk-floors:enforce` (third mode in `scripts/cdk-floors.mjs`) loads each publishable @composurecdk package against a **real install of its own declared aws-cdk-lib floor** and fails if any package doesn't load. This catches a change that reaches for an aws-cdk-lib API newer than its package's declared floor — the runtime gap that `check` (file-only sync) and the `no-cdk-api-above-floor` lint rule (#151, statically named APIs) don't cover.

Wired into a new **`cdk-floors-enforce`** job in `ci.yml`, separate from the main job because it does network installs and has different failure-mode logs.

## How

1. Reads `cdk-floors.json` and groups packages by their declared floor (7 distinct floors today, 15 packages).
2. `npm pack`s the publishable graph once into a tarball cache.
3. For each floor, creates a throwaway rig pinned to `aws-cdk-lib@<floor>` + every packed tarball, installs with `--legacy-peer-deps` (we deliberately install at versions that violate *other* packages' declared peers — only this floor's group is asserted per install), and runs a small child probe (`scripts/cdk-floor/probe.mjs`) that imports each package in the group.
4. Fails non-zero with a per-package `package @ floor: <error>` list if any group has failures.

## Failure surface this catches

The original #146 was a runtime call (`CfnAlarm.isCfnAlarm`) that didn't fail at import — but our packages mostly use named imports, and that's where the binding APIs live. `enforce` catches the dominant class:

- A package starts using a new aws-cdk-lib named export → the rig install at the package's floor fails to import → CI red, named export quoted in the failure list.
- The lint rule (#151) catches it statically for known-banned APIs; `enforce` is the live "we tested it" guarantee for *every* API.

## Verification

`npm run cdk-floors:enforce` locally (real installs, ~7 floors, ~30s):
```
Enforcing aws-cdk-lib@2.0.0 for 1 package(s) … ok
Enforcing aws-cdk-lib@2.1.0 for 7 package(s) … ok
Enforcing aws-cdk-lib@2.118.0 for 1 package(s) … ok
Enforcing aws-cdk-lib@2.119.0 for 1 package(s) … ok
Enforcing aws-cdk-lib@2.168.0 for 1 package(s) … ok
Enforcing aws-cdk-lib@2.216.0 for 1 package(s) … ok
Enforcing aws-cdk-lib@2.54.0 for 3 package(s) … ok
cdk-floors enforce passed (every package loads at its declared floor)
```

## Also in this PR

- `scripts/cdk-floor/probe.mjs` — the child import probe (eslint-ignored as a rig fixture).
- ADR-0008 updated: drop the per-PR staging markers now that `enforce` has landed (`establish` remains a planned follow-up discovery tool, per the restructure).

## Next (PR 3)

The on-demand diagnostic synth tool + `establish`. Smallest of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)