### PR TITLE
feat: aws-cdk-lib floor diagnostics (ADR-0008)

### DIFF
--- a/.github/workflows/cdk-floor-validate.yml
+++ b/.github/workflows/cdk-floor-validate.yml
@@ -1,0 +1,49 @@
+name: CDK floor validate
+
+# On-demand diagnostic that synthesises a representative compose() system
+# against a real install of any chosen aws-cdk-lib version. Run by hand from
+# the Actions tab; useful for bug repro, candidate-floor validation before
+# editing cdk-floors.json, and release prep. NOT a PR gate — no single fixed
+# version is the right one to test against continuously. See ADR-0008.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cdk-version:
+        description: >-
+          aws-cdk-lib version to synth against. Leave blank to use the default
+          (max of declared floors in cdk-floors.json — the composed-system floor).
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate synth on aws-cdk-lib ${{ inputs.cdk-version || '(manifest default)' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NX_DAEMON: false
+      CDK_FLOOR: ${{ inputs.cdk-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Synth against the chosen aws-cdk-lib version
+        run: npm run cdk-floor:validate

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ dist
 .nx
 .tshy
 .tshy-build
+# tshy writes packages/*/src/package.json (a CJS-mode shim) during `npm pack`.
+packages/*/src/package.json
 cdk.out
 .vscode/
 .claude/
+
+# cdk-floors establish draft (curated values live in cdk-floors.json)
+cdk-floors.discovered.json

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -83,10 +83,14 @@ at the latest CDK.
   and policies via partial-matcher assertions, so this catches both import-time
   (missing named export) and runtime (a too-new method call, e.g. the #146
   `CfnAlarm.isCfnAlarm` inside an Aspect) version-gated APIs.
-- **`establish`** _(planned)_ — discovery tool: probes every package against a
-  descending ladder of real aws-cdk-lib releases to record the lowest each
-  loads on and the gating export, as a draft to refine into `cdk-floors.json`.
-  Used when establishing or **deliberately lowering** a floor.
+- **`establish`** — discovery tool: packs every publishable `@composurecdk/*`
+  package and probes each against a descending ladder of real aws-cdk-lib
+  releases (default 13 rungs from 2.230 down to 2.1; override via
+  `CDK_FLOOR_LADDER`). Records the lowest version each package loads on and the
+  gating export, writing a ladder-granular draft (`cdk-floors.discovered.json`)
+  to be refined into `cdk-floors.json`. Manual; used when establishing initial
+  floors or **deliberately lowering** an existing one (drop the requiring API,
+  re-establish to prove the lower floor, refine, `apply`).
 
 Why `overrides` + a from-scratch install: every package also carries
 `aws-cdk-lib` as a `devDependency` at the latest version, so simply downgrading
@@ -95,6 +99,15 @@ resolve instead — `enforce` would then silently pass against the wrong version
 An `overrides` entry forces the floor across the whole tree, but npm only honours
 it on a clean install; hence the from-scratch reinstall and the post-install
 resolution assertion that fails loudly if the floor did not actually bind.
+
+A complementary `scripts/cdk-floor-validate.mjs` (`npm run cdk-floor:validate`,
+also a `workflow_dispatch` workflow) synthesises a representative `compose()`
+system against any chosen aws-cdk-lib version. On-demand only — for bug repro,
+candidate-floor validation before editing the manifest, and release prep.
+**Not a PR gate**, because no single fixed CDK version is the right one to
+test against continuously; `enforce` (per-package, per-floor) is the gate.
+Defaults to `max(declared floors)` from the manifest — the composed-system
+floor — when no version is supplied.
 
 This complements the static guard already in place: the
 `composurecdk/no-cdk-api-above-floor` ESLint rule (`@composurecdk/eslint-plugin`)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig(
           allowDefaultProject: [
             "eslint.config.mjs",
             "scripts/*.mjs",
+            "scripts/cdk-floor/*.mjs",
             "packages/examples/test/smoke/*.mjs",
           ],
         },
@@ -38,7 +39,7 @@ export default defineConfig(
     extends: [tseslint.configs.disableTypeChecked],
   },
   {
-    files: ["scripts/*.mjs", "packages/examples/test/smoke/*.mjs"],
+    files: ["scripts/*.mjs", "scripts/cdk-floor/*.mjs", "packages/examples/test/smoke/*.mjs"],
     extends: [tseslint.configs.disableTypeChecked],
     languageOptions: {
       globals: {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "cdk-floors:apply": "node scripts/cdk-floors.mjs apply",
     "cdk-floors:check": "node scripts/cdk-floors.mjs check",
     "cdk-floors:enforce": "node scripts/cdk-floors.mjs enforce",
+    "cdk-floors:establish": "node scripts/cdk-floors.mjs establish",
+    "cdk-floor:validate": "node scripts/cdk-floor-validate.mjs",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean && npx nx reset && rm -rf node_modules",

--- a/scripts/cdk-floor-validate.mjs
+++ b/scripts/cdk-floor-validate.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * `cdk-floor-validate` — on-demand diagnostic that synthesises a representative
+ * composed system against a real install of any chosen aws-cdk-lib version.
+ *
+ * Three use cases:
+ *
+ * 1. **Bug repro / triage.** A consumer reports a synth failure on
+ *    aws-cdk-lib X.Y.Z; re-run this with `--cdk-version=X.Y.Z` and observe.
+ * 2. **Candidate-floor validation.** Before lowering a package's floor in
+ *    `cdk-floors.json`, run this against the candidate floor to confirm the
+ *    composed system still synthesises end-to-end (`cdk-floors:enforce`
+ *    proves *imports* per package; this proves the *synth path*).
+ * 3. **Release prep.** Spot-check the integrated `compose(...).build()` story
+ *    on the floor before announcing support.
+ *
+ * It is intentionally **not** a PR gate — no single fixed aws-cdk-lib version
+ * is the right one to test against on every commit. The always-on gates are
+ * `cdk-floors:check` (manifest <-> package.json) and `cdk-floors:enforce`
+ * (per-package real-install import probe). See ADR-0008.
+ *
+ * Run `npm run build` first (this packs from each package's dist).
+ *
+ * Usage:
+ *   node scripts/cdk-floor-validate.mjs                       # default: max(declared floors)
+ *   node scripts/cdk-floor-validate.mjs --cdk-version=2.46.0
+ *   CDK_FLOOR=2.46.0 node scripts/cdk-floor-validate.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { packPublishablePackages } from "./cdk-floor/packages.mjs";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const MANIFEST = join(REPO_ROOT, "cdk-floors.json");
+const CONSTRUCTS_RANGE = "^10.0.0";
+
+/** SemVer compare (assumes plain `MAJOR.MINOR.PATCH`, no pre-release tags). */
+function compareSemver(a, b) {
+  const [a0, a1, a2] = a.split(".").map(Number);
+  const [b0, b1, b2] = b.split(".").map(Number);
+  return a0 - b0 || a1 - b1 || a2 - b2;
+}
+
+/**
+ * Picks the version under test. Precedence: `--cdk-version=…` arg > CDK_FLOOR
+ * env > `max(declared floors)` from the manifest. The manifest-derived default
+ * means the composed-system floor is "the highest version any package
+ * promises", i.e. the de-facto floor for an integrated app.
+ */
+function resolveVersion() {
+  const flag = process.argv.find((arg) => arg.startsWith("--cdk-version="));
+  if (flag !== undefined) return flag.slice("--cdk-version=".length);
+  if (process.env.CDK_FLOOR !== undefined && process.env.CDK_FLOOR !== "") {
+    return process.env.CDK_FLOOR;
+  }
+  const floors = JSON.parse(readFileSync(MANIFEST, "utf8")).floors;
+  return Object.values(floors)
+    .map((entry) => entry.floor)
+    .sort(compareSemver)
+    .at(-1);
+}
+
+const version = resolveVersion();
+const rig = mkdtempSync(join(tmpdir(), `composurecdk-validate-${version.replace(/\./g, "-")}-`));
+try {
+  const dependencies = { "aws-cdk-lib": version, constructs: CONSTRUCTS_RANGE };
+  const tarballs = packPublishablePackages(rig);
+  for (const [name, tarball] of Object.entries(tarballs)) {
+    dependencies[name] = `file:./${tarball}`;
+  }
+
+  writeFileSync(
+    join(rig, "package.json"),
+    `${JSON.stringify(
+      { name: "cdk-floor-validate-rig", private: true, type: "module", dependencies },
+      null,
+      2,
+    )}\n`,
+  );
+  copyFileSync(join(SCRIPT_DIR, "cdk-floor", "synth.mjs"), join(rig, "synth.mjs"));
+
+  console.log(
+    `Installing aws-cdk-lib@${version} + ${Object.keys(tarballs).length} packed packages …`,
+  );
+  // --legacy-peer-deps so versions below some package's declared floor still
+  // install — this is a *diagnostic* probe at an arbitrary version, not an
+  // assertion of the peer ranges.
+  execFileSync("npm", ["install", "--no-audit", "--no-fund", "--legacy-peer-deps"], {
+    cwd: rig,
+    stdio: "inherit",
+  });
+
+  console.log(`Synthesising the composed system against aws-cdk-lib@${version} …`);
+  execFileSync(process.execPath, ["synth.mjs"], { cwd: rig, stdio: "inherit" });
+
+  console.log(`\n✓ cdk-floor-validate passed on aws-cdk-lib ${version}`);
+} catch (error) {
+  console.error(`\n✗ cdk-floor-validate failed: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  rmSync(rig, { recursive: true, force: true });
+}

--- a/scripts/cdk-floor/packages.mjs
+++ b/scripts/cdk-floor/packages.mjs
@@ -1,0 +1,41 @@
+// Shared helper for the cdk-floor diagnostic scripts. Used by both
+// `cdk-floors.mjs` (the `establish` mode) and `cdk-floor-validate.mjs`.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "packages");
+
+/**
+ * `npm pack`s every publishable `@composurecdk/*` package into `destination`
+ * and returns `{ packageName: tarballFilename }`, so probes install the actual
+ * publishable artefact rather than the in-tree source.
+ */
+export function packPublishablePackages(destination) {
+  const tarballs = {};
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(join(PACKAGES_DIR, entry.name, "package.json"), "utf8"));
+    } catch {
+      continue; // not a package directory
+    }
+    if (!pkg.name?.startsWith("@composurecdk/") || pkg.private === true) continue;
+    const output = execFileSync("npm", ["pack", "--pack-destination", destination], {
+      cwd: join(PACKAGES_DIR, entry.name),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const tarball = output
+      .split("\n")
+      .map((line) => line.trim())
+      .reverse()
+      .find((line) => line.endsWith(".tgz"));
+    if (tarball === undefined) throw new Error(`npm pack for ${entry.name} produced no .tgz`);
+    tarballs[pkg.name] = tarball;
+  }
+  return tarballs;
+}

--- a/scripts/cdk-floor/synth.mjs
+++ b/scripts/cdk-floor/synth.mjs
@@ -1,0 +1,76 @@
+// Composed-system synth fixture for the cdk-floor-validate diagnostic tool
+// (scripts/cdk-floor-validate.mjs copies this into a throwaway project that
+// has a pinned aws-cdk-lib + the packed @composurecdk packages installed,
+// then runs it with `node`).
+//
+// It drives a representative `compose(...).build()` system across several
+// builders through a real `Template.fromStack` synth and asserts invariants
+// (resources exist, alarms wired) — never exact CFN output, which drifts
+// across CDK versions. A failure at a specific aws-cdk-lib version tells you
+// the composed system doesn't work on that release. Assertions are
+// version-agnostic so the same fixture works at any version.
+
+import { createRequire } from "node:module";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Template } from "aws-cdk-lib/assertions";
+import { compose, ref } from "@composurecdk/core";
+import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
+import { createFunctionBuilder, sqsEventSource } from "@composurecdk/lambda";
+import { createTopicBuilder } from "@composurecdk/sns";
+import { createQueueBuilder } from "@composurecdk/sqs";
+
+const require = createRequire(import.meta.url);
+const version = require("aws-cdk-lib/package.json").version;
+console.log(`aws-cdk-lib ${version}`);
+
+const app = new App();
+const stack = new Stack(app, "FloorStack");
+
+// A queue → Lambda consumer plus an SNS alert topic, with all alarms routed to
+// the topic. Exercises core (compose/ref), sqs, lambda (event source + role),
+// sns, and cloudwatch (recommended + custom alarms, actions policy) — and their
+// peers (cloudformation, iam, logs) transitively.
+const { alerts } = compose(
+  {
+    alerts: createTopicBuilder().displayName("Floor Alerts"),
+
+    orders: createQueueBuilder()
+      .queueName("orders")
+      .visibilityTimeout(Duration.minutes(2))
+      .addAlarm("highEmptyReceiveRate", (alarm) =>
+        alarm
+          .metric((queue) => queue.metricNumberOfEmptyReceives({ period: Duration.minutes(5) }))
+          .threshold(500)
+          .greaterThan()
+          .description("empty-receive rate"),
+      ),
+
+    processor: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_20_X)
+      .handler("index.handler")
+      .code(Code.fromInline("exports.handler = async () => {};"))
+      .addEventSource("orders", sqsEventSource(ref("orders", (r) => r.queue))),
+  },
+  { alerts: [], orders: [], processor: ["orders"] },
+).build(stack, "OrderProcessor");
+
+alarmActionsPolicy(stack, { defaults: { alarmActions: [new SnsAction(alerts.topic)] } });
+
+const template = Template.fromStack(stack);
+template.resourceCountIs("AWS::SNS::Topic", 1);
+template.resourceCountIs("AWS::SQS::Queue", 1);
+template.resourceCountIs("AWS::Lambda::Function", 1);
+
+const alarms = Object.values(template.findResources("AWS::CloudWatch::Alarm"));
+if (alarms.length === 0) throw new Error("expected the composed system to produce alarms");
+const unwired = alarms.filter((a) => !Array.isArray(a.Properties.AlarmActions));
+if (unwired.length > 0) {
+  throw new Error(`alarmActionsPolicy left ${unwired.length}/${alarms.length} alarm(s) unwired`);
+}
+
+console.log(
+  `PASS: composed system synthesised on aws-cdk-lib ${version} ` +
+    `(${alarms.length} alarms, all wired to the alert topic)`,
+);

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -20,6 +20,11 @@
  *   CI runs it as a matrix, one floor per shard. Locally it requires `--force`
  *   and restores package.json / package-lock.json / node_modules when done
  *   (and on Ctrl-C). See ADR-0008.
+ * - `establish` is the discovery side: packs the graph and probes every package
+ *   against a descending ladder of real aws-cdk-lib releases, recording the
+ *   lowest each loads on and the gating export. Writes a ladder-granular
+ *   draft (`cdk-floors.discovered.json`) to be refined into `cdk-floors.json`.
+ *   Manual; used when establishing or deliberately lowering a floor.
  *
  * Usage:
  *   node scripts/cdk-floors.mjs apply
@@ -28,16 +33,33 @@
  *   node scripts/cdk-floors.mjs enforce 2.118.0      # one floor (CI matrix shard)
  *   CDK_FLOORS_FLOOR=2.118.0 node scripts/cdk-floors.mjs enforce
  *   node scripts/cdk-floors.mjs enforce --force      # local: also restores after
+ *   node scripts/cdk-floors.mjs establish            # write cdk-floors.discovered.json
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { packPublishablePackages } from "./cdk-floor/packages.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const PACKAGES_DIR = join(REPO_ROOT, "packages");
 const MANIFEST = join(REPO_ROOT, "cdk-floors.json");
+// `establish` writes its raw discovery here; cdk-floors.json is the curated,
+// refined source of truth that the other modes consume — so re-running
+// `establish` never clobbers hand-refined floors.
+const DISCOVERED = join(REPO_ROOT, "cdk-floors.discovered.json");
+const CONSTRUCTS_RANGE = "^10.0.0";
+
+// Descending ladder of real aws-cdk-lib releases that `establish` probes.
+// Floors land on a rung; refine by adding rungs around a boundary. Override
+// with CDK_FLOOR_LADDER="2.230.0,2.200.0,…".
+const LADDER = (
+  process.env.CDK_FLOOR_LADDER ??
+  "2.230.0,2.200.0,2.180.0,2.160.0,2.140.0,2.131.0,2.120.0,2.100.0,2.80.0,2.60.0,2.46.0,2.20.0,2.1.0"
+).split(",");
 
 function pkgJsonPath(pkg) {
   return join(PACKAGES_DIR, pkg, "package.json");
@@ -238,13 +260,121 @@ function enforce() {
   process.exit(exitCode);
 }
 
+/**
+ * Probes whether every packed package can be loaded against aws-cdk-lib at the
+ * given version. Creates a throwaway rig with the pinned aws-cdk-lib plus the
+ * packed tarballs, npm-installs (`--legacy-peer-deps` so packages whose
+ * declared floor exceeds the probed version still install), then dynamically
+ * imports each. Returns `[{ name, ok, error? }]` -- one row per package.
+ */
+function probeAtVersion(version, tarballs, cacheDir) {
+  const rig = mkdtempSync(join(cacheDir, `probe-${version.replace(/\./g, "-")}-`));
+  const dependencies = { "aws-cdk-lib": version, constructs: CONSTRUCTS_RANGE };
+  for (const [name, tarball] of Object.entries(tarballs)) {
+    dependencies[name] = `file:${join(cacheDir, tarball)}`;
+  }
+  writeFileSync(
+    join(rig, "package.json"),
+    `${JSON.stringify(
+      { name: `probe-${version}`, private: true, type: "module", dependencies },
+      null,
+      2,
+    )}\n`,
+  );
+  try {
+    execFileSync("npm", ["install", "--no-audit", "--no-fund", "--legacy-peer-deps"], {
+      cwd: rig,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+  } catch (e) {
+    const msg = `npm install failed: ${e.message.split("\n")[0]}`;
+    return Object.keys(tarballs).map((name) => ({ name, ok: false, error: msg }));
+  }
+  return Object.keys(tarballs).map((name) => {
+    try {
+      const probe = `import(${JSON.stringify(name)}).then(() => process.stdout.write("OK"), (e) => process.stdout.write("FAIL:" + (e.message ?? String(e))));`;
+      const out = execFileSync(process.execPath, ["--input-type=module", "-e", probe], {
+        cwd: rig,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      return out.startsWith("OK") ? { name, ok: true } : { name, ok: false, error: out.slice(5) };
+    } catch (e) {
+      return { name, ok: false, error: e.message.split("\n")[0] };
+    }
+  });
+}
+
+/**
+ * Discovers per-package floors by probing each publishable package against a
+ * descending ladder of real aws-cdk-lib releases. Writes a ladder-granular
+ * draft to `cdk-floors.discovered.json`; refine and copy into
+ * `cdk-floors.json` (the curated source of truth) — re-running `establish`
+ * never clobbers the curated manifest.
+ */
+function establish() {
+  const cacheDir = mkdtempSync(join(tmpdir(), "composurecdk-floor-tarballs-"));
+  try {
+    console.log("Packing publishable packages …");
+    const tarballs = packPublishablePackages(cacheDir);
+    const names = Object.keys(tarballs);
+
+    // results[name] = ordered (high -> low) list of { version, ok, error }
+    const results = Object.fromEntries(names.map((n) => [n, []]));
+    for (const version of LADDER) {
+      process.stdout.write(`Probing aws-cdk-lib@${version} … `);
+      const probed = probeAtVersion(version, tarballs, cacheDir);
+      for (const { name, ok, error } of probed) results[name].push({ version, ok, error });
+      console.log(`${probed.filter((r) => r.ok).length}/${names.length} packages load`);
+    }
+
+    const floors = {};
+    for (const name of names) {
+      const rungs = results[name]; // high -> low
+      let floor;
+      let gatedBy;
+      for (const [i, rung] of rungs.entries()) {
+        if (!rung.ok) break;
+        floor = rung.version;
+        gatedBy = rungs[i + 1]?.error; // why the next rung down fails
+      }
+      floors[name.replace("@composurecdk/", "")] =
+        floor === undefined
+          ? { floor: `>${LADDER[0]}`, gatedBy: rungs[0]?.error }
+          : { floor, gatedBy: gatedBy ?? `<=${LADDER[LADDER.length - 1]} (no lower rung probed)` };
+    }
+
+    writeFileSync(
+      DISCOVERED,
+      `${JSON.stringify(
+        {
+          $comment:
+            "Raw discovery from `node scripts/cdk-floors.mjs establish` — ladder-granular. " +
+            "Refine the floors to the exact introducing release and copy into cdk-floors.json (the curated source of truth).",
+          ladder: LADDER,
+          floors,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    console.log(`\nWrote ${DISCOVERED} (draft — refine into cdk-floors.json)\n`);
+    for (const [pkg, { floor, gatedBy }] of Object.entries(floors)) {
+      console.log(`  ${pkg.padEnd(16)} >= ${floor.padEnd(10)} ${gatedBy ?? ""}`);
+    }
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
 const mode = process.argv[2];
-const modes = { apply, check, enforce };
+const modes = { apply, check, enforce, establish };
 if (modes[mode] !== undefined) {
   modes[mode]();
 } else {
   console.error(
-    `Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check|enforce>`,
+    `Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check|enforce|establish>`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
The two on-demand diagnostic tools that complete ADR-0008's toolkit. **Not PR gates** — neither runs on every commit; the per-package `enforce` matrix (#170, now merged) is the gate. These cover the "off-by-one investigation" workflows that gate alone can't.

## What

### `cdk-floors:establish` (fourth mode in `scripts/cdk-floors.mjs`)

Packs every publishable `@composurecdk/*` package, then probes each against a **descending ladder** of real aws-cdk-lib releases (default 13 rungs from 2.230 down to 2.1; override via `CDK_FLOOR_LADDER="…"`). Records the lowest version each package loads on and the gating import error, writing a ladder-granular draft to `cdk-floors.discovered.json` (gitignored) to be refined into `cdk-floors.json`.

Used when **establishing initial floors** or **deliberately lowering** an existing one: drop the requiring API → re-establish to prove the lower floor → refine the manifest → `apply`. (Most of the per-floor PRs in this series were hand-pinned via temp-dir probes; this automates that.)

### `cdk-floor:validate` (new `scripts/cdk-floor-validate.mjs`)

Synthesises a representative `compose(...).build()` system against a real install of any chosen aws-cdk-lib version. Default version: `max(declared floors)` from the manifest — the **composed-system floor** — so `npm run cdk-floor:validate` with no args is meaningful out of the box. Override with `--cdk-version=X.Y.Z` or `CDK_FLOOR=X.Y.Z`.

The composed fixture (`scripts/cdk-floor/synth.mjs`) drives a queue → lambda system with SNS alerts and `alarmActionsPolicy`, asserting invariants (resource counts, alarms wired) — never exact CFN output, which drifts across versions.

Use cases:

1. **Bug repro / triage** — re-run a reported synth failure with the consumer's pinned aws-cdk-lib.
2. **Candidate-floor validation** — before lowering a floor, confirm the composed system still synthesises. `enforce` proves per-package suites at the floor; this proves the composed synth path end-to-end.
3. **Release prep** — spot-check the integration story at the floor.

Also dispatchable from CI via a new `cdk-floor-validate` `workflow_dispatch` workflow (no schedule, no PR trigger — manual only).

## Mechanics

Both tools share a `packPublishablePackages` helper in `scripts/cdk-floor/packages.mjs` (the `npm pack`-each-package logic was otherwise duplicated). They each spin up a throwaway rig dir (`mkdtemp`), assemble a `package.json` with the pinned `aws-cdk-lib` + `file:` references to the packed tarballs, `npm install --legacy-peer-deps`, then either dynamically import each package (`establish`) or run the composed synth fixture (`cdk-floor:validate`).

## ADR

ADR-0008 updated to describe the steady-state toolkit, and the `establish` paragraph promoted from _(planned)_ to live. Adds the `cdk-floor:validate` paragraph noting it's intentionally not a PR gate.

## Validation

`format:check`, `lint`, `cdk-floors:check` all clean. Both tools smoke-validated end-to-end:

- `cdk-floor:validate` at the manifest-derived default (currently 2.216.0): composed system synthesises, 11 alarms wired to the alert topic.
- `cdk-floors:establish` with a 2-rung ladder (`CDK_FLOOR_LADDER="2.257.0,2.230.0"`): all 16 publishable packages load at both rungs; draft written.

## Notes from the rebase

This PR was originally stacked on **#159** (the rejected import-probe `enforce`). #159 was superseded by **#170**'s suite-based `enforce`, which is now merged. Rebasing onto current main required:

- Resolving conflicts in `scripts/cdk-floors.mjs` (kept #170's accurate `enforce` description; slotted `establish` alongside) and `docs/adr/0008-aws-cdk-lib-version-floors.md` (kept the "What a floor guarantees" / functional-vs-cosmetic sections from the floor-correction PRs; folded the `establish`/`validate` paragraphs in).
- Reimplementing `packAll` / `probeAtVersion` in this PR — they originally lived on #159's branch which never landed. They've since been refactored into the shared helper.
- Adding `packages/*/src/package.json` to `.gitignore` — `npm pack` runs each package's `tshy` prepack, which writes a CJS-mode shim into `src/`. The gitignore rule keeps those artefacts from leaking into commits when developers run the smoke tools locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)