### PR TITLE
feat(ec2): SecurityGroup builder with closed-egress default

### DIFF
--- a/packages/ec2/README.md
+++ b/packages/ec2/README.md
@@ -220,6 +220,74 @@ createVpcBuilder().flowLogs(false);
 
 For multiple flow logs against the same VPC, omit this config and create additional `FlowLog` constructs directly against the returned `vpc`.
 
+## Security Group Builder
+
+```ts
+import { createSecurityGroupBuilder } from "@composurecdk/ec2";
+import { Peer, Port } from "aws-cdk-lib/aws-ec2";
+
+const web = createSecurityGroupBuilder()
+  .vpc(vpc)
+  .description("Public web tier")
+  .addIngressRule(Peer.anyIpv4(), Port.tcp(443), "Public HTTPS")
+  .addEgressRule(Peer.anyIpv4(), Port.tcp(443), "HTTPS to origin")
+  .build(stack, "WebSg");
+```
+
+Every [SecurityGroupProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.SecurityGroupProps.html) property is available as a fluent setter on the builder, except `vpc` which is set via the dedicated `.vpc()` method to support cross-component wiring with `ref<T>(...)`.
+
+Ingress and egress rules are accumulated via `addIngressRule`, `addEgressRule`, and `addSelfIngress` (for the intra-SG "allow within the cluster" pattern). Each peer is a `Resolvable<IPeer>`, so it can be a concrete `IPeer` (a CIDR via `Peer.ipv4(...)`, another `ISecurityGroup`, a prefix list, …) or a `Ref` to a sibling component's output.
+
+### Security Group Defaults
+
+| Property           | Default | Rationale                                                                                                                                                |
+| ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowAllOutbound` | `false` | Closes the implicit `0.0.0.0/0` egress rule CDK ships by default. Every outbound flow becomes an explicit `addEgressRule` — the least-privilege default. |
+
+Two properties intentionally have no default — they are application-specific and must be supplied explicitly:
+
+- `vpc` (via the `.vpc()` method)
+- `description` (a short, human-readable summary of the SG's purpose; whitespace-only values are rejected)
+
+The defaults are exported as `SECURITY_GROUP_DEFAULTS` for visibility and testing:
+
+```ts
+import { SECURITY_GROUP_DEFAULTS } from "@composurecdk/ec2";
+```
+
+### Wiring two SGs via `ref`
+
+The canonical cross-component pattern — a bastion SG and a database SG that talks to it — declares the dependency in `compose()` and resolves the peer at build time:
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createSecurityGroupBuilder, createVpcBuilder } from "@composurecdk/ec2";
+import type { SecurityGroupBuilderResult, VpcBuilderResult } from "@composurecdk/ec2";
+import { Port } from "aws-cdk-lib/aws-ec2";
+
+compose(
+  {
+    network: createVpcBuilder(),
+    bastion: createSecurityGroupBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .description("Bastion host"),
+    database: createSecurityGroupBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .description("Database")
+      .addIngressRule(
+        ref<SecurityGroupBuilderResult>("bastion").get("securityGroup"),
+        Port.tcp(5432),
+        "Bastion to Postgres",
+      ),
+  },
+  { network: [], bastion: ["network"], database: ["network", "bastion"] },
+).build(stack, "App");
+```
+
+### Recommended Alarms
+
+The Security Group builder does **not** create CloudWatch alarms. Security groups do not emit CloudWatch metrics — the [AWS recommended-alarms reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html) has no SG entry. Operational visibility for SGs comes from adjacent signals (VPC Flow Logs, GuardDuty findings, CloudTrail `AuthorizeSecurityGroupIngress`/`Egress` events), none of which belong on the builder result.
+
 ## Volume Builder
 
 ```ts

--- a/packages/ec2/src/index.ts
+++ b/packages/ec2/src/index.ts
@@ -29,3 +29,11 @@ export {
   type VpcBuilderResult,
 } from "./vpc-builder.js";
 export { VPC_DEFAULTS } from "./vpc-defaults.js";
+
+export {
+  createSecurityGroupBuilder,
+  type ISecurityGroupBuilder,
+  type SecurityGroupBuilderProps,
+  type SecurityGroupBuilderResult,
+} from "./security-group-builder.js";
+export { SECURITY_GROUP_DEFAULTS } from "./security-group-defaults.js";

--- a/packages/ec2/src/security-group-builder.ts
+++ b/packages/ec2/src/security-group-builder.ts
@@ -1,0 +1,261 @@
+import {
+  type IPeer,
+  type IVpc,
+  type Port,
+  SecurityGroup,
+  type SecurityGroupProps,
+} from "aws-cdk-lib/aws-ec2";
+import { type IConstruct } from "constructs";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { SECURITY_GROUP_DEFAULTS } from "./security-group-defaults.js";
+
+/**
+ * Configuration properties for the security group builder.
+ *
+ * Extends the CDK {@link SecurityGroupProps} but lifts `vpc` off the props
+ * object — it is supplied via the dedicated
+ * {@link ISecurityGroupBuilder.vpc | .vpc()} method so it can accept a
+ * {@link Resolvable} for cross-component wiring (e.g. a sibling
+ * `VpcBuilder`).
+ *
+ * Ingress and egress rules are added imperatively via
+ * {@link ISecurityGroupBuilder.addIngressRule | .addIngressRule()},
+ * {@link ISecurityGroupBuilder.addEgressRule | .addEgressRule()}, and
+ * {@link ISecurityGroupBuilder.addSelfIngress | .addSelfIngress()} so each
+ * peer can also be a {@link Resolvable}.
+ */
+export type SecurityGroupBuilderProps = Omit<SecurityGroupProps, "vpc">;
+
+/**
+ * The build output of an {@link ISecurityGroupBuilder}. Contains the CDK
+ * constructs created during {@link Lifecycle.build}, keyed by role.
+ *
+ * The `securityGroup` is itself an `IConnectable` and `IPeer`, so consumers
+ * compose against it directly — there is no separate `connections` field on
+ * the result.
+ *
+ * The builder creates no CloudWatch alarms. Security groups do not emit
+ * CloudWatch metrics, so the
+ * [recommended-alarms reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html)
+ * has no SG entry. Operational visibility comes from adjacent signals —
+ * VPC Flow Logs, GuardDuty findings, CloudTrail authorize-events.
+ */
+export interface SecurityGroupBuilderResult {
+  securityGroup: SecurityGroup;
+}
+
+interface PeerRuleSpec {
+  readonly direction: "ingress" | "egress";
+  readonly peer: Resolvable<IPeer>;
+  readonly port: Port;
+  readonly description?: string;
+}
+
+interface SelfIngressSpec {
+  readonly port: Port;
+  readonly description?: string;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS EC2 security group.
+ *
+ * Each configuration property from the CDK {@link SecurityGroupProps} (other
+ * than `vpc`) is exposed as an overloaded method: call with a value to set
+ * it, or with no arguments to read it. The `vpc` is set via the dedicated
+ * {@link ISecurityGroupBuilder.vpc | .vpc()} method that accepts a
+ * {@link Resolvable} for cross-component wiring with sibling builders.
+ *
+ * Ingress and egress rules are accumulated via
+ * {@link ISecurityGroupBuilder.addIngressRule | .addIngressRule()},
+ * {@link ISecurityGroupBuilder.addEgressRule | .addEgressRule()}, and
+ * {@link ISecurityGroupBuilder.addSelfIngress | .addSelfIngress()} and
+ * applied when {@link Lifecycle.build | build()} runs. Each peer is a
+ * {@link Resolvable} so it can be a concrete `IPeer` (including another
+ * `ISecurityGroup`) or a {@link ref | Ref} to a sibling component's output.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}.
+ *
+ * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.SecurityGroup.html
+ *
+ * @example
+ * ```ts
+ * compose(
+ *   {
+ *     network: createVpcBuilder(),
+ *     bastion: createSecurityGroupBuilder()
+ *       .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+ *       .description("Bastion host"),
+ *     database: createSecurityGroupBuilder()
+ *       .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+ *       .description("Database")
+ *       .addIngressRule(
+ *         ref<SecurityGroupBuilderResult>("bastion").get("securityGroup"),
+ *         Port.tcp(5432),
+ *         "Bastion to Postgres",
+ *       ),
+ *   },
+ *   { network: [], bastion: ["network"], database: ["network", "bastion"] },
+ * );
+ * ```
+ */
+export type ISecurityGroupBuilder = ITaggedBuilder<SecurityGroupBuilderProps, SecurityGroupBuilder>;
+
+class SecurityGroupBuilder implements Lifecycle<SecurityGroupBuilderResult> {
+  props: Partial<SecurityGroupBuilderProps> = {};
+  readonly #peerRules: PeerRuleSpec[] = [];
+  readonly #selfIngress: SelfIngressSpec[] = [];
+  #vpc?: Resolvable<IVpc>;
+
+  /**
+   * Sets the VPC the security group is created in.
+   *
+   * Accepts a concrete {@link IVpc} or a {@link Ref} that resolves to one
+   * at build time — e.g. a sibling {@link IVpcBuilder} in the same
+   * composed system.
+   *
+   * @param vpc - The VPC or a Ref to one.
+   * @returns This builder for chaining.
+   */
+  vpc(vpc: Resolvable<IVpc>): this {
+    this.#vpc = vpc;
+    return this;
+  }
+
+  /**
+   * Adds an ingress rule. The peer accepts any {@link IPeer} — a concrete
+   * `Peer.ipv4(...)`, another `ISecurityGroup`, a prefix list — or a
+   * {@link Ref} that resolves to one.
+   *
+   * @param peer - The source of the allowed traffic.
+   * @param port - The port or port range.
+   * @param description - Optional human-readable description of the rule.
+   * @returns This builder for chaining.
+   */
+  addIngressRule(peer: Resolvable<IPeer>, port: Port, description?: string): this {
+    this.#peerRules.push({
+      direction: "ingress",
+      peer,
+      port,
+      ...(description !== undefined ? { description } : {}),
+    });
+    return this;
+  }
+
+  /**
+   * Adds an egress rule. Required when `allowAllOutbound` is `false`
+   * (the builder default — see {@link SECURITY_GROUP_DEFAULTS}). The peer
+   * accepts any {@link IPeer} or a {@link Ref} that resolves to one.
+   *
+   * @param peer - The destination of the allowed traffic.
+   * @param port - The port or port range.
+   * @param description - Optional human-readable description of the rule.
+   * @returns This builder for chaining.
+   */
+  addEgressRule(peer: Resolvable<IPeer>, port: Port, description?: string): this {
+    this.#peerRules.push({
+      direction: "egress",
+      peer,
+      port,
+      ...(description !== undefined ? { description } : {}),
+    });
+    return this;
+  }
+
+  /**
+   * Adds an ingress rule whose peer is the security group itself —
+   * the canonical "allow intra-SG traffic on port N" pattern. The peer
+   * cannot be expressed at configuration time because the security group
+   * identity does not exist yet; the builder wires it after the SG is
+   * constructed.
+   *
+   * @param port - The port or port range.
+   * @param description - Optional human-readable description of the rule.
+   * @returns This builder for chaining.
+   */
+  addSelfIngress(port: Port, description?: string): this {
+    this.#selfIngress.push({
+      port,
+      ...(description !== undefined ? { description } : {}),
+    });
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: SecurityGroupBuilder): void {
+    target.#vpc = this.#vpc;
+    target.#peerRules.push(...this.#peerRules);
+    target.#selfIngress.push(...this.#selfIngress);
+  }
+
+  build(
+    scope: IConstruct,
+    id: string,
+    context?: Record<string, object>,
+  ): SecurityGroupBuilderResult {
+    const resolvedVpc = this.#vpc ? resolve(this.#vpc, context) : undefined;
+    if (!resolvedVpc) {
+      throw new Error(
+        `SecurityGroupBuilder "${id}" requires a VPC. ` +
+          "Call .vpc() with an IVpc or a Ref to one.",
+      );
+    }
+    if (this.props.description === undefined || this.props.description.trim() === "") {
+      throw new Error(
+        `SecurityGroupBuilder "${id}" requires a description. ` +
+          "Call .description() with a short summary of the SG's purpose.",
+      );
+    }
+
+    // Drop keys whose value is `undefined` so a fluent call like
+    // `.allowAllOutbound(undefined)` (common in "optional override" code:
+    // `b.allowAllOutbound(cfg?.allowAllOutbound)`) does not clobber the
+    // closed-egress default with explicit `undefined`.
+    const userProps: Partial<SecurityGroupBuilderProps> = {};
+    for (const key of Object.keys(this.props) as (keyof SecurityGroupBuilderProps)[]) {
+      const value = this.props[key];
+      if (value !== undefined) {
+        (userProps as Record<string, unknown>)[key] = value;
+      }
+    }
+
+    const mergedProps = {
+      ...SECURITY_GROUP_DEFAULTS,
+      ...userProps,
+      vpc: resolvedVpc,
+    } as SecurityGroupProps;
+
+    const securityGroup = new SecurityGroup(scope, id, mergedProps);
+
+    for (const rule of this.#peerRules) {
+      const peer = resolve(rule.peer, context);
+      if (rule.direction === "ingress") {
+        securityGroup.addIngressRule(peer, rule.port, rule.description);
+      } else {
+        securityGroup.addEgressRule(peer, rule.port, rule.description);
+      }
+    }
+    for (const rule of this.#selfIngress) {
+      securityGroup.addIngressRule(securityGroup, rule.port, rule.description);
+    }
+
+    return { securityGroup };
+  }
+}
+
+/**
+ * Creates a new {@link ISecurityGroupBuilder} for configuring an AWS EC2
+ * security group.
+ *
+ * The returned builder exposes every {@link SecurityGroupBuilderProps}
+ * property as a fluent setter/getter, plus
+ * {@link ISecurityGroupBuilder.vpc | .vpc()} for cross-component VPC wiring
+ * and the `addIngressRule` / `addEgressRule` / `addSelfIngress` accumulators.
+ * It implements {@link Lifecycle} for use with {@link compose}.
+ *
+ * @returns A fluent builder for an AWS EC2 security group.
+ */
+export function createSecurityGroupBuilder(): ISecurityGroupBuilder {
+  return taggedBuilder<SecurityGroupBuilderProps, SecurityGroupBuilder>(SecurityGroupBuilder);
+}

--- a/packages/ec2/src/security-group-defaults.ts
+++ b/packages/ec2/src/security-group-defaults.ts
@@ -1,0 +1,25 @@
+import type { SecurityGroupProps } from "aws-cdk-lib/aws-ec2";
+
+/**
+ * Secure, AWS-recommended defaults applied to every security group built
+ * with {@link createSecurityGroupBuilder}. Each property can be individually
+ * overridden via the builder's fluent API.
+ *
+ * Two properties intentionally have no default — they are application-
+ * specific and must be supplied explicitly:
+ *   - `vpc` (via the builder's `.vpc()` method)
+ *   - `description` (a short, human-readable summary of the SG's purpose)
+ */
+export const SECURITY_GROUP_DEFAULTS: Partial<SecurityGroupProps> = {
+  /**
+   * Closed-by-default egress. CDK's stock default is `true`, which creates
+   * an implicit `0.0.0.0/0` outbound rule on every SG — flagged by
+   * compliance scanners and incompatible with the project's least-privilege
+   * stance. Closing egress forces every outbound flow to be expressed as
+   * an explicit `addEgressRule` (or `.allowAllOutbound(true)` to opt back
+   * into the CDK default).
+   *
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_network_protection_layered.html
+   */
+  allowAllOutbound: false,
+};

--- a/packages/ec2/test/security-group-builder.test.ts
+++ b/packages/ec2/test/security-group-builder.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Peer, Port, type IVpc, Vpc } from "aws-cdk-lib/aws-ec2";
+import { compose, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import {
+  createSecurityGroupBuilder,
+  type SecurityGroupBuilderResult,
+} from "../src/security-group-builder.js";
+import { createVpcBuilder, type VpcBuilderResult } from "../src/vpc-builder.js";
+
+function freshScope(): { stack: Stack; vpc: Vpc } {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const vpc = new Vpc(stack, "TestVpc", { maxAzs: 2, natGateways: 0 });
+  return { stack, vpc };
+}
+
+describe("SecurityGroupBuilder", () => {
+  describe("build", () => {
+    it("returns a SecurityGroupBuilderResult with a securityGroup property", () => {
+      const { stack, vpc } = freshScope();
+      const result = createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Test SG")
+        .build(stack, "Sg");
+
+      expect(result).toBeDefined();
+      expect(result.securityGroup).toBeDefined();
+    });
+
+    it("creates exactly one security group construct", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder().vpc(vpc).description("Test SG").build(stack, "Sg");
+
+      // VPC test fixture has restrictDefaultSecurityGroup off, so the only
+      // SG resource is the one the builder created.
+      Template.fromStack(stack).resourceCountIs("AWS::EC2::SecurityGroup", 1);
+    });
+
+    it("passes through description", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder().vpc(vpc).description("My API tier").build(stack, "Sg");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+        GroupDescription: "My API tier",
+      });
+    });
+
+    it("throws a clear error when vpc is not provided", () => {
+      const { stack } = freshScope();
+      const builder = createSecurityGroupBuilder().description("Test SG");
+
+      expect(() => builder.build(stack, "Sg")).toThrow(/requires a VPC/);
+    });
+
+    it("throws a clear error when description is missing", () => {
+      const { stack, vpc } = freshScope();
+      const builder = createSecurityGroupBuilder().vpc(vpc);
+
+      expect(() => builder.build(stack, "Sg")).toThrow(/requires a description/);
+    });
+
+    it("throws a clear error when description is an empty string", () => {
+      const { stack, vpc } = freshScope();
+      const builder = createSecurityGroupBuilder().vpc(vpc).description("");
+
+      expect(() => builder.build(stack, "Sg")).toThrow(/requires a description/);
+    });
+
+    it("throws a clear error when description is whitespace only", () => {
+      const { stack, vpc } = freshScope();
+      const builder = createSecurityGroupBuilder().vpc(vpc).description("   ");
+
+      expect(() => builder.build(stack, "Sg")).toThrow(/requires a description/);
+    });
+  });
+
+  describe("well-architected defaults", () => {
+    it("closes all egress by default (allowAllOutbound: false)", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder().vpc(vpc).description("Test SG").build(stack, "Sg");
+
+      // CDK emits a placeholder 255.255.255.255/32 ICMP type 252 rule when
+      // allowAllOutbound is false. The diagnostic invariant is the absence
+      // of the unrestricted 0.0.0.0/0 ALL-traffic rule that CDK ships when
+      // allowAllOutbound is true.
+      const sgs = Template.fromStack(stack).findResources("AWS::EC2::SecurityGroup");
+      const props = Object.values(sgs)[0]?.Properties as {
+        SecurityGroupEgress?: Record<string, unknown>[];
+      };
+      const unrestrictedAll = props.SecurityGroupEgress?.find(
+        (rule) => rule.CidrIp === "0.0.0.0/0" && rule.IpProtocol === "-1",
+      );
+      expect(unrestrictedAll).toBeUndefined();
+    });
+
+    it("preserves the closed-egress default when allowAllOutbound is set to undefined", () => {
+      // Defensive: `.allowAllOutbound(cfg?.allowAllOutbound)` with an
+      // undefined config value would otherwise write `undefined` into props
+      // and the merge would silently override the secure default.
+      const { stack, vpc } = freshScope();
+      const builder = createSecurityGroupBuilder().vpc(vpc).description("Test SG");
+      (
+        builder as unknown as { allowAllOutbound: (v: boolean | undefined) => unknown }
+      ).allowAllOutbound(undefined);
+      builder.build(stack, "Sg");
+
+      const sgs = Template.fromStack(stack).findResources("AWS::EC2::SecurityGroup");
+      const props = Object.values(sgs)[0]?.Properties as {
+        SecurityGroupEgress?: Record<string, unknown>[];
+      };
+      const unrestrictedAll = props.SecurityGroupEgress?.find(
+        (rule) => rule.CidrIp === "0.0.0.0/0" && rule.IpProtocol === "-1",
+      );
+      expect(unrestrictedAll).toBeUndefined();
+    });
+
+    it("re-opens egress when allowAllOutbound(true) is set explicitly", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Test SG")
+        .allowAllOutbound(true)
+        .build(stack, "Sg");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+        SecurityGroupEgress: Match.arrayWith([
+          Match.objectLike({ CidrIp: "0.0.0.0/0", IpProtocol: "-1" }),
+        ]),
+      });
+    });
+  });
+
+  describe("rule accumulators", () => {
+    it("adds an ingress rule from a CIDR peer", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Public web")
+        .addIngressRule(Peer.anyIpv4(), Port.tcp(443), "Public HTTPS")
+        .build(stack, "WebSg");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+        SecurityGroupIngress: Match.arrayWith([
+          Match.objectLike({
+            CidrIp: "0.0.0.0/0",
+            FromPort: 443,
+            ToPort: 443,
+            IpProtocol: "tcp",
+            Description: "Public HTTPS",
+          }),
+        ]),
+      });
+    });
+
+    it("adds an explicit egress rule", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Service tier")
+        .addEgressRule(Peer.anyIpv4(), Port.tcp(443), "HTTPS to internet")
+        .build(stack, "ServiceSg");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+        SecurityGroupEgress: Match.arrayWith([
+          Match.objectLike({
+            CidrIp: "0.0.0.0/0",
+            FromPort: 443,
+            ToPort: 443,
+            IpProtocol: "tcp",
+            Description: "HTTPS to internet",
+          }),
+        ]),
+      });
+    });
+
+    it("accepts a port range", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Range SG")
+        .addIngressRule(Peer.ipv4("10.0.0.0/8"), Port.tcpRange(8000, 8100))
+        .build(stack, "Sg");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+        SecurityGroupIngress: Match.arrayWith([
+          Match.objectLike({
+            CidrIp: "10.0.0.0/8",
+            FromPort: 8000,
+            ToPort: 8100,
+            IpProtocol: "tcp",
+          }),
+        ]),
+      });
+    });
+
+    it("accepts a prefix-list peer", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Prefix list peer")
+        .addIngressRule(Peer.prefixList("pl-1234abcd"), Port.tcp(443))
+        .build(stack, "Sg");
+
+      // Prefix-list peers emit as a standalone SecurityGroupIngress resource
+      // because the rule references an external prefix-list id rather than
+      // an inline CIDR.
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+        SourcePrefixListId: "pl-1234abcd",
+        FromPort: 443,
+        ToPort: 443,
+        IpProtocol: "tcp",
+      });
+    });
+
+    it("wires a self-ingress rule against the SG's own group id", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Intra-cluster traffic")
+        .addSelfIngress(Port.allTcp(), "All TCP within cluster")
+        .build(stack, "ClusterSg");
+
+      // Self-references emit as a separate SecurityGroupIngress resource so
+      // the SG can refer to its own GroupId without a circular dependency.
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+        IpProtocol: "tcp",
+        FromPort: 0,
+        ToPort: 65535,
+        Description: "All TCP within cluster",
+        GroupId: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["GroupId"]) }),
+        SourceSecurityGroupId: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["GroupId"]) }),
+      });
+    });
+
+    it("resolves a Ref-based peer SG at build time (the canonical two-SG case)", () => {
+      const { stack, vpc } = freshScope();
+
+      // Bastion SG is constructed first and supplied to the database SG via
+      // a Ref. The database SG resolves the peer at build time and emits an
+      // ingress rule referencing the bastion's GroupId.
+      const bastion = createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Bastion")
+        .build(stack, "BastionSg");
+
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Database")
+        .addIngressRule(
+          ref<SecurityGroupBuilderResult>("bastion").get("securityGroup"),
+          Port.tcp(5432),
+          "Bastion to Postgres",
+        )
+        .build(stack, "DatabaseSg", { bastion });
+
+      // The database SG ingress references the bastion SG's GroupId (not a
+      // raw CIDR), which is the well-architected peer-SG-by-identity shape.
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+        IpProtocol: "tcp",
+        FromPort: 5432,
+        ToPort: 5432,
+        SourceSecurityGroupId: Match.objectLike({
+          "Fn::GetAtt": Match.arrayWith(["GroupId"]),
+        }),
+      });
+    });
+  });
+
+  describe("compose integration", () => {
+    it("orders SG and VPC builds correctly through compose()", () => {
+      const app = new App();
+      const stack = new Stack(app, "ComposedStack");
+
+      const system = compose(
+        {
+          network: createVpcBuilder().maxAzs(2).natGateways(0),
+          web: createSecurityGroupBuilder()
+            .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+            .description("Public web")
+            .addIngressRule(Peer.anyIpv4(), Port.tcp(443), "HTTPS"),
+        },
+        { network: [], web: ["network"] },
+      );
+
+      const result = system.build(stack, "App");
+      expect(result.web.securityGroup).toBeDefined();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroup", {
+        GroupDescription: "Public web",
+      });
+    });
+  });
+
+  describe("tag propagation", () => {
+    it("applies builder tags to the resulting security group", () => {
+      const { stack, vpc } = freshScope();
+      createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Tagged SG")
+        .tag("Project", "rig")
+        .tags({ Owner: "platform" })
+        .build(stack, "Sg");
+
+      // CDK sorts tags alphabetically by key. Assert both tags are present
+      // by checking each independently — Match.arrayWith requires patterns
+      // in array order, which is brittle to the sort.
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::EC2::SecurityGroup", {
+        Tags: Match.arrayWith([Match.objectLike({ Key: "Project", Value: "rig" })]),
+      });
+      template.hasResourceProperties("AWS::EC2::SecurityGroup", {
+        Tags: Match.arrayWith([Match.objectLike({ Key: "Owner", Value: "platform" })]),
+      });
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #vpc, #peerRules, and #selfIngress across .copy()", () => {
+      const vpcRef = ref<{ vpc: IVpc }>("infra").get("vpc");
+
+      assertCopyPreservesState({
+        factory: () => createSecurityGroupBuilder().vpc(vpcRef).description("Variant SG"),
+        configure: (b) => {
+          b.addIngressRule(Peer.anyIpv4(), Port.tcp(443), "first");
+          b.addSelfIngress(Port.tcp(9000), "first-self");
+        },
+        mutate: (b) => {
+          b.addEgressRule(Peer.anyIpv4(), Port.tcp(80), "second");
+          b.addSelfIngress(Port.tcp(9001), "second-self");
+        },
+        build: (b) => {
+          const stack = new Stack(new App(), "S");
+          const vpc = new Vpc(stack, "Vpc", { maxAzs: 2, natGateways: 0 });
+          return b.build(stack, "Sg", { infra: { vpc } });
+        },
+        // Inspect every rule-bearing resource so any leak of #peerRules or
+        // #selfIngress through .copy() shows up in the snapshot. Pin the
+        // SG resource by its logical id prefix so future CDK changes that
+        // introduce additional SGs in the same stack do not cause the
+        // helper to compare the wrong resource.
+        inspect: (r) => {
+          const template = Template.fromStack(Stack.of(r.securityGroup));
+          const sgEntries = Object.entries(template.findResources("AWS::EC2::SecurityGroup"));
+          const builderSg = sgEntries.find(([id]) => id.startsWith("Sg"))?.[1].Properties as {
+            SecurityGroupIngress?: { Description?: string }[];
+            SecurityGroupEgress?: { Description?: string }[];
+          };
+          const ingressInline = builderSg.SecurityGroupIngress?.map(
+            (rule) => rule.Description ?? "",
+          ).sort();
+          const egressInline = builderSg.SecurityGroupEgress?.map(
+            (rule) => rule.Description ?? "",
+          ).sort();
+          const standaloneIngress = Object.values(
+            template.findResources("AWS::EC2::SecurityGroupIngress"),
+          )
+            .map((res) => (res.Properties as { Description?: string }).Description ?? "")
+            .sort();
+          return { ingressInline, egressInline, standaloneIngress };
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `createSecurityGroupBuilder()` to `@composurecdk/ec2`, completing the EC2 trio of `Vpc` + `Instance` + `SecurityGroup` builders. Sibling components can now wire SGs via `Ref<ISecurityGroup>` at config time instead of imperatively in `afterBuild` hooks.
- Defaults `allowAllOutbound: false` per [SEC05-BP02](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_network_protection_layered.html). Documented and individually overridable via `.allowAllOutbound(true)`.
- Explicitly creates no CloudWatch alarms — security groups emit no metrics and have no entry in the [AWS recommended-alarms reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html). The absence is intentional and called out in the README.
- Includes `addSelfIngress()` for the intra-SG case (the peer reference cannot be expressed at config time because the SG identity does not yet exist).

Closes #152. See the [research comment on the issue](https://github.com/laazyj/composureCDK/issues/152#issuecomment-4548608666) for the design rationale, alternatives, and well-architected sources.

## Design decisions worth a second look

- **`allowAllOutbound` defaults to `false`.** A deviation from raw CDK; matches `VPC_DEFAULTS.restrictDefaultSecurityGroup: true` and the README's stance that secure defaults should be the path of least friction.
- **No `connections` field on the result.** `result.securityGroup` is itself an `IConnectable`/`IPeer`, so the connections API is already one property access away.
- **Description is required** (whitespace-only is rejected). Diverges slightly from CDK's auto-generated fallback but enforces a meaningful operational description at the console.
- **Defensive `undefined` filtering in the merge.** Prevents `.allowAllOutbound(cfg?.allowAllOutbound)` with undefined config from silently reopening egress.

## In scope vs deferred

In scope (cheap synth-time tests, included here):

- Closed-egress default + the `undefined` regression guard
- Explicit `.allowAllOutbound(true)` override
- Public CIDR ingress, peer-SG-via-`Ref` (the bastion+db canonical case), port ranges, prefix-list peers, self-ingress
- `compose()` integration with `Ref<VpcBuilderResult>`
- `taggedBuilder` tag propagation onto the SG construct
- Required-field validation (vpc, description, whitespace-only description)
- ADR-0005 `.copy()` isolation via `assertCopyPreservesState`

Deferred to follow-up PRs (these are more likely to need iteration, and bundling them here would slow merge):

- **Cross-stack peer SGs** via `compose().withStacks()` — needs the SG builder to work alongside the stack-routing machinery and may require exposing CDK's `remoteRule` boolean. Separate PR with its own multi-stack test fixtures.
- **Integration example in `packages/examples/`** — a `ComposureCDK-SecurityGroupTier` stack demonstrating ALB → ECS → RDS-style three-tier wiring, plus a smoke test under `packages/examples/test/smoke/`. Separate PR per AGENTS.md's "Adding a new example" guidance.

## Test plan

- [x] `npx nx test ec2` — 108/108 tests pass (19 new for the SG builder)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run verify` chain via pre-push hook — green
- [x] `attw` + `publint` via `check:exports` — clean
- [ ] Manual `cdk synth` of an example stack composing VPC + SG + Instance (deferred to the `packages/examples/` follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
