### PR TITLE
feat(examples): exercise SG builder in Ec2Stack (avoid duplicate deploy)

### DIFF
--- a/.github/cloudformation/github-oidc-role.yml
+++ b/.github/cloudformation/github-oidc-role.yml
@@ -138,16 +138,18 @@ Resources:
               - cloudformation:ListStacks
             Resource: "*"
 
-          # EC2 — read-only describes for the smoke test (instance state +
-          # status checks for ComposureCDK-Ec2Stack). EC2 Describe* actions
-          # do not support resource-level permissions, so Resource is "*".
-          # Stack creation/mutation of EC2 resources runs under the CDK
-          # cfn-exec role (not this OIDC role) via AssumeRole below.
+          # EC2 — read-only describes for the smoke test against
+          # ComposureCDK-Ec2Stack: instance state + status, and the live
+          # security-group rules (bastion + database tiers). EC2 Describe*
+          # actions do not support resource-level permissions, so Resource
+          # is "*". Stack creation/mutation of EC2 resources runs under the
+          # CDK cfn-exec role (not this OIDC role) via AssumeRole below.
           - Sid: EC2Read
             Effect: Allow
             Action:
               - ec2:DescribeInstances
               - ec2:DescribeInstanceStatus
+              - ec2:DescribeSecurityGroups
             Resource: "*"
 
           # Lambda — scoped by CloudFormation stack-name tag.

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -4,18 +4,18 @@ Example applications demonstrating ComposureCDK patterns. Each example is a self
 
 All example stacks use the `ComposureCDK-` name prefix. This convention enables the CI deploy-test pipeline to scope IAM permissions and discover stacks automatically — see [CI documentation](../../docs/ci.md#stack-naming-convention) for details. **New examples must follow this prefix.**
 
-| Stack                                                                                               | Description                                                                                                                          |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [`ComposureCDK-DualFunctionStack`](src/dual-function-app.ts)                                        | Two Lambda functions (API handler + async worker) with different configurations; worker on an EventBridge schedule via `RuleBuilder` |
-| [`ComposureCDK-MockApiStack`](src/mock-api-app.ts)                                                  | CRUD REST API with mock integrations and recommended alarms                                                                          |
-| [`ComposureCDK-MultiStackServiceStack` / `ComposureCDK-MultiStackApiStack`](src/multi-stack-app.ts) | REST API + Lambda split across two stacks via `.withStacks()`                                                                        |
-| [`ComposureCDK-StaticWebsiteStack`](src/static-website/app.ts)                                      | S3 + CloudFront static website with OAC, error pages, and content deployment                                                         |
-| [`ComposureCDK-OpenApiPetstoreStack`](src/openapi-petstore-app.ts)                                  | PetStore REST API defined by an inline OpenAPI 3.0 specification                                                                     |
-| [`ComposureCDK-DnsZoneStack`](src/dns-zone-app.ts)                                                  | Public Route 53 zone built with the BIND-style zone DSL, including a CloudFront `ALIAS` at `www`                                     |
-| [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + EC2 instance with well-architected defaults, recommended alarms, and SNS alert wiring                                          |
-| [`ComposureCDK-AgentVolumeStack`](src/agent-volume-app.ts)                                          | VPC + EC2 instance with a persistent EBS data volume attached via `attachVolume` + alarm wiring                                      |
-| [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`                                          |
-| [`ComposureCDK-OrderProcessorStack`](src/order-processor-app.ts)                                    | SQS work queue feeding a Lambda consumer via an SQS event source, with recommended alarms wired to a sibling SNS alert topic         |
+| Stack                                                                                               | Description                                                                                                                                         |
+| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`ComposureCDK-DualFunctionStack`](src/dual-function-app.ts)                                        | Two Lambda functions (API handler + async worker) with different configurations; worker on an EventBridge schedule via `RuleBuilder`                |
+| [`ComposureCDK-MockApiStack`](src/mock-api-app.ts)                                                  | CRUD REST API with mock integrations and recommended alarms                                                                                         |
+| [`ComposureCDK-MultiStackServiceStack` / `ComposureCDK-MultiStackApiStack`](src/multi-stack-app.ts) | REST API + Lambda split across two stacks via `.withStacks()`                                                                                       |
+| [`ComposureCDK-StaticWebsiteStack`](src/static-website/app.ts)                                      | S3 + CloudFront static website with OAC, error pages, and content deployment                                                                        |
+| [`ComposureCDK-OpenApiPetstoreStack`](src/openapi-petstore-app.ts)                                  | PetStore REST API defined by an inline OpenAPI 3.0 specification                                                                                    |
+| [`ComposureCDK-DnsZoneStack`](src/dns-zone-app.ts)                                                  | Public Route 53 zone built with the BIND-style zone DSL, including a CloudFront `ALIAS` at `www`                                                    |
+| [`ComposureCDK-Ec2Stack`](src/ec2-app.ts)                                                           | VPC + bastion/database SGs + EC2 instance demonstrating peer-SG-via-`ref` wiring, closed-egress defaults, recommended alarms, and SNS alert routing |
+| [`ComposureCDK-AgentVolumeStack`](src/agent-volume-app.ts)                                          | VPC + EC2 instance with a persistent EBS data volume attached via `attachVolume` + alarm wiring                                                     |
+| [`ComposureCDK-TaggedSystemStack`](src/tagged-system-app.ts)                                        | Builder-level selector tags via `.tag()` plus system-wide cost-allocation tags via `tags()`                                                         |
+| [`ComposureCDK-OrderProcessorStack`](src/order-processor-app.ts)                                    | SQS work queue feeding a Lambda consumer via an SQS event source, with recommended alarms wired to a sibling SNS alert topic                        |
 
 ## Prerequisites
 
@@ -39,4 +39,4 @@ To skip IAM approval prompts (e.g. in CI): add `--require-approval never` to dep
 
 ## Costs
 
-These examples create minimal resources (Lambda functions, API Gateway endpoints, S3 buckets, CloudFront distributions) and should fall within the [AWS Free Tier](https://aws.amazon.com/free/). Destroy stacks when done to avoid unexpected charges.
+These examples create minimal resources (Lambda functions, API Gateway endpoints, S3 buckets, CloudFront distributions, t3.micro EC2 instances) and should fall within the [AWS Free Tier](https://aws.amazon.com/free/) for the first 12 months. EC2 instances and VPC flow logs (CloudWatch Logs ingestion + storage) accrue charges once the free-tier window closes, so destroy stacks when done to avoid unexpected charges.

--- a/packages/examples/src/ec2-app.ts
+++ b/packages/examples/src/ec2-app.ts
@@ -1,34 +1,61 @@
 import { App, Stack } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import {
+  type ISecurityGroup,
   InstanceClass,
   InstanceSize,
   InstanceType,
   MachineImage,
+  Peer,
+  Port,
   type Vpc,
 } from "aws-cdk-lib/aws-ec2";
 import { compose, ref } from "@composurecdk/core";
 import { alarmActionsPolicy } from "@composurecdk/cloudwatch";
-import { createInstanceBuilder, createVpcBuilder, type VpcBuilderResult } from "@composurecdk/ec2";
+import {
+  createInstanceBuilder,
+  createSecurityGroupBuilder,
+  createVpcBuilder,
+  type SecurityGroupBuilderResult,
+  type VpcBuilderResult,
+} from "@composurecdk/ec2";
 import { createTopicBuilder } from "@composurecdk/sns";
 
 /**
- * A VPC with an EC2 instance launched into its private subnet, composed
- * into a single stack alongside an SNS alert topic.
+ * A VPC + two explicit security groups + an EC2 bastion host + an SNS
+ * alert topic, all composed into a single stack.
  *
  * Demonstrates:
- * - Creating a VPC with well-architected defaults (2 AZs, flow logs)
- * - Creating an EC2 instance with well-architected defaults
- *   (IMDSv2, detailed monitoring, encrypted GP3 root, SSM-managed)
- * - Wiring the instance to the VPC via `ref<VpcBuilderResult>(...)` —
- *   no direct construct passing needed
- * - Recommended alarms (CPU, status check, CPU credit balance for T-family)
- * - Routing every alarm to the alert topic via `alarmActionsPolicy`
+ * - {@link createVpcBuilder} with well-architected defaults (2 AZs, flow
+ *   logs).
+ * - {@link createSecurityGroupBuilder} with its closed-egress default —
+ *   every outbound flow must be an explicit `addEgressRule`, the
+ *   least-privilege stance recommended by AWS Well-Architected
+ *   ([SEC05-BP02](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_network_protection_layered.html)).
+ * - Cross-component peer-SG wiring: the database SG ingresses on Postgres
+ *   from the bastion SG via `ref<SecurityGroupBuilderResult>("bastion")` —
+ *   the relationship is data in the `compose()` graph, not procedural
+ *   `afterBuild` glue.
+ * - Cross-builder wiring: the `InstanceBuilder` consumes the bastion SG's
+ *   output via `.securityGroup(ref<...>)`, so the same Ref machinery that
+ *   wires VPC → instance also wires SG → instance.
+ * - {@link createInstanceBuilder} with well-architected defaults
+ *   (IMDSv2, detailed monitoring, encrypted GP3 root, SSM-managed) and
+ *   recommended alarms (CPU, status check, CPU credit balance for the
+ *   T-family).
+ * - Routing every alarm to the alert topic via `alarmActionsPolicy`.
+ *
+ * No actual database is provisioned — the database SG demonstrates the
+ * canonical peer-SG-by-Ref wiring without the cost of a DB instance.
  *
  * NAT gateways are disabled here to keep deploy/destroy fast and cheap
- * for the example workflow — the instance therefore has no internet
- * egress, so SSM Session Manager will not work without VPC endpoints.
- * Override `natGateways` for a workload that needs egress.
+ * for the example workflow. Because the bastion SG defaults to closed
+ * egress, the instance has no outbound network of any kind — bumping
+ * `natGateways` alone is not enough to make SSM Session Manager work.
+ * For an interactively reachable jump-box, also call `.addEgressRule(...)`
+ * on the bastion SG for the destinations the workload needs (the SSM
+ * service endpoints, or `Peer.anyIpv4()` if you only need internet
+ * egress and accept the wider blast radius).
  */
 export function createEc2App(app = new App()) {
   const stack = new Stack(app, "ComposureCDK-Ec2Stack");
@@ -39,12 +66,45 @@ export function createEc2App(app = new App()) {
 
       network: createVpcBuilder().maxAzs(2).natGateways(0),
 
+      bastion: createSecurityGroupBuilder()
+        .vpc(ref<VpcBuilderResult>("network").map((r: VpcBuilderResult): Vpc => r.vpc))
+        // GroupDescription rejects non-ASCII per the EC2 API
+        // (allowed: a-zA-Z0-9 ._-:/()#,@[]+=&;{}!$*); avoid em-dashes here.
+        .description("Bastion host - operator SSH entry point")
+        // Placeholder operator CIDR (RFC 5737 TEST-NET-1) — replace with your
+        // network's egress IP before deploying. Kept narrow rather than
+        // `Peer.anyIpv4()` so the least-privilege intent is visible.
+        .addIngressRule(Peer.ipv4("192.0.2.10/32"), Port.tcp(22), "Operator SSH"),
+
+      database: createSecurityGroupBuilder()
+        .vpc(ref<VpcBuilderResult>("network").map((r: VpcBuilderResult): Vpc => r.vpc))
+        .description("Database tier - Postgres ingress from bastion only")
+        .addIngressRule(
+          ref<SecurityGroupBuilderResult>("bastion").map(
+            (r: SecurityGroupBuilderResult): ISecurityGroup => r.securityGroup,
+          ),
+          Port.tcp(5432),
+          "Bastion to Postgres",
+        )
+        .addSelfIngress(Port.tcp(5432), "Intra-tier replication"),
+
       server: createInstanceBuilder()
         .vpc(ref<VpcBuilderResult>("network").map((r: VpcBuilderResult): Vpc => r.vpc))
         .instanceType(InstanceType.of(InstanceClass.T3, InstanceSize.MICRO))
-        .machineImage(MachineImage.latestAmazonLinux2023()),
+        .machineImage(MachineImage.latestAmazonLinux2023())
+        .securityGroup(
+          ref<SecurityGroupBuilderResult>("bastion").map(
+            (r: SecurityGroupBuilderResult): ISecurityGroup => r.securityGroup,
+          ),
+        ),
     },
-    { alerts: [], network: [], server: ["network"] },
+    {
+      alerts: [],
+      network: [],
+      bastion: ["network"],
+      database: ["network", "bastion"],
+      server: ["network", "bastion"],
+    },
   ).build(stack, "Ec2App");
 
   alarmActionsPolicy(stack, {

--- a/packages/examples/test/__snapshots__/ec2-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/ec2-app.test.ts.snap
@@ -271,6 +271,93 @@ exports[`ec2-app > matches the expected synthesised template 1`] = `
       },
       "Type": "AWS::SNS::TopicPolicy",
     },
+    "Ec2Appbastion62C411EA": {
+      "Properties": {
+        "GroupDescription": "Bastion host - operator SSH entry point",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "192.0.2.10/32",
+            "Description": "Operator SSH",
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "ToPort": 22,
+          },
+        ],
+        "VpcId": {
+          "Ref": "Ec2Appnetwork88B7C786",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "Ec2Appdatabase802BE9D4": {
+      "Properties": {
+        "GroupDescription": "Database tier - Postgres ingress from bastion only",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "VpcId": {
+          "Ref": "Ec2Appnetwork88B7C786",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "Ec2AppdatabasefromComposureCDKEc2StackEc2AppbastionAC45BA8854328941C525": {
+      "Properties": {
+        "Description": "Bastion to Postgres",
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "Ec2Appdatabase802BE9D4",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "Ec2Appbastion62C411EA",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "Ec2AppdatabasefromComposureCDKEc2StackEc2AppdatabaseF4ED4D895432C6ADDD86": {
+      "Properties": {
+        "Description": "Intra-tier replication",
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "Ec2Appdatabase802BE9D4",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "Ec2Appdatabase802BE9D4",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
     "Ec2Appnetwork88B7C786": {
       "Properties": {
         "CidrBlock": "10.0.0.0/16",
@@ -719,7 +806,7 @@ exports[`ec2-app > matches the expected synthesised template 1`] = `
         "SecurityGroupIds": [
           {
             "Fn::GetAtt": [
-              "Ec2AppserverInstanceSecurityGroup67724A4B",
+              "Ec2Appbastion62C411EA",
               "GroupId",
             ],
           },
@@ -872,28 +959,6 @@ exports[`ec2-app > matches the expected synthesised template 1`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "Ec2AppserverInstanceSecurityGroup67724A4B": {
-      "Properties": {
-        "GroupDescription": "ComposureCDK-Ec2Stack/Ec2App--server/InstanceSecurityGroup",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "ComposureCDK-Ec2Stack/Ec2App--server",
-          },
-        ],
-        "VpcId": {
-          "Ref": "Ec2Appnetwork88B7C786",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "Ec2AppserverLaunchTemplateDDE5D6EF": {
       "Properties": {

--- a/packages/examples/test/ec2-app.test.ts
+++ b/packages/examples/test/ec2-app.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { createEc2App } from "../src/ec2-app.js";
 
 describe("ec2-app", () => {
@@ -12,6 +12,12 @@ describe("ec2-app", () => {
 
   it("creates exactly one EC2 instance", () => {
     template.resourceCountIs("AWS::EC2::Instance", 1);
+  });
+
+  it("creates the bastion and database security groups", () => {
+    // VPC_DEFAULTS sets restrictDefaultSecurityGroup, which adds a
+    // CustomResource (not an SG). The two visible SGs are the builder's.
+    template.resourceCountIs("AWS::EC2::SecurityGroup", 2);
   });
 
   it("creates recommended CloudWatch alarms for the instance (cpu, status, attached EBS, credit balance)", () => {
@@ -40,6 +46,98 @@ describe("ec2-app", () => {
     template.resourceCountIs("AWS::EC2::FlowLog", 1);
     template.hasResourceProperties("AWS::EC2::FlowLog", {
       LogDestinationType: "cloud-watch-logs",
+    });
+  });
+
+  it("closes egress by default on both builder-created SGs", () => {
+    // Neither SG should carry an unrestricted 0.0.0.0/0 ALL-traffic egress
+    // rule — that's the CDK-default-egress signature the builder turns off.
+    const sgs = Object.values(template.findResources("AWS::EC2::SecurityGroup"));
+    for (const sg of sgs) {
+      const egress = (sg.Properties as { SecurityGroupEgress?: Record<string, unknown>[] })
+        .SecurityGroupEgress;
+      const unrestricted = egress?.find(
+        (rule) => rule.CidrIp === "0.0.0.0/0" && rule.IpProtocol === "-1",
+      );
+      expect(unrestricted).toBeUndefined();
+    }
+  });
+
+  it("opens the bastion to operator SSH on the placeholder CIDR", () => {
+    template.hasResourceProperties("AWS::EC2::SecurityGroup", {
+      GroupDescription: "Bastion host - operator SSH entry point",
+      SecurityGroupIngress: Match.arrayWith([
+        Match.objectLike({
+          CidrIp: "192.0.2.10/32",
+          FromPort: 22,
+          ToPort: 22,
+          IpProtocol: "tcp",
+          Description: "Operator SSH",
+        }),
+      ]),
+    });
+  });
+
+  it("emits the bastion→database Postgres ingress as a standalone SG ingress resource", () => {
+    // Peer-SG-by-id rules emit as a standalone AWS::EC2::SecurityGroupIngress
+    // so the source SG's GroupId can be referenced via Fn::GetAtt. This is
+    // the canonical synth signature of well-architected peer-SG wiring.
+    template.hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+      IpProtocol: "tcp",
+      FromPort: 5432,
+      ToPort: 5432,
+      Description: "Bastion to Postgres",
+      SourceSecurityGroupId: Match.objectLike({
+        "Fn::GetAtt": Match.arrayWith(["GroupId"]),
+      }),
+    });
+  });
+
+  it("emits the database self-ingress rule pointing at the database SG on both sides", () => {
+    // Pin the self-ingress to a single SG by capturing the GroupId logical
+    // id from the GroupId field and asserting SourceSecurityGroupId matches
+    // the same id. Without this, a peer-ingress that happened to share the
+    // "Intra-tier replication" description would also satisfy the matcher.
+    const ingressResources = template.findResources("AWS::EC2::SecurityGroupIngress", {
+      Properties: {
+        Description: "Intra-tier replication",
+        IpProtocol: "tcp",
+        FromPort: 5432,
+        ToPort: 5432,
+      },
+    });
+    const entries = Object.values(ingressResources);
+    expect(entries).toHaveLength(1);
+    const props = entries[0]?.Properties as {
+      GroupId: { "Fn::GetAtt": [string, string] };
+      SourceSecurityGroupId: { "Fn::GetAtt": [string, string] };
+    };
+    expect(props.SourceSecurityGroupId["Fn::GetAtt"][0]).toBe(props.GroupId["Fn::GetAtt"][0]);
+    expect(props.GroupId["Fn::GetAtt"][1]).toBe("GroupId");
+  });
+
+  it("attaches the bastion SG (specifically, not the database SG) to the EC2 instance via the cross-builder Ref", () => {
+    // Pin the instance's SG reference to the *bastion* logical id, not just
+    // any Fn::GetAtt-by-GroupId. With two SGs in the template, a regression
+    // that resolved the wrong Ref ("database" instead of "bastion") would
+    // satisfy the loose matcher but break the wiring the test exists to
+    // confirm. Capture the bastion's logical id from the standalone ingress
+    // rule (whose SourceSecurityGroupId is the bastion), then assert the
+    // instance references the same id.
+    const bastionIngressEntries = Object.values(
+      template.findResources("AWS::EC2::SecurityGroupIngress", {
+        Properties: { Description: "Bastion to Postgres" },
+      }),
+    );
+    expect(bastionIngressEntries).toHaveLength(1);
+    const bastionLogicalId = (
+      bastionIngressEntries[0]?.Properties as {
+        SourceSecurityGroupId: { "Fn::GetAtt": [string, string] };
+      }
+    ).SourceSecurityGroupId["Fn::GetAtt"][0];
+
+    template.hasResourceProperties("AWS::EC2::Instance", {
+      SecurityGroupIds: [{ "Fn::GetAtt": [bastionLogicalId, "GroupId"] }],
     });
   });
 

--- a/packages/examples/test/smoke/ec2.smoke.mjs
+++ b/packages/examples/test/smoke/ec2.smoke.mjs
@@ -2,45 +2,186 @@ import { findStackResources } from "./_helpers.mjs";
 
 const STACK = "ComposureCDK-Ec2Stack";
 
+/**
+ * Post-deploy verification for the Ec2 example.
+ *
+ * - Deploy invariant: every EC2 instance reaches `running` state and AWS's
+ *   first round of status checks has not reported `impaired`. The first
+ *   status check often hasn't completed yet when smoke runs immediately
+ *   after deploy — `initializing` is the normal pre-first-check state, so
+ *   only `impaired` (and obviously non-running instance states) are treated
+ *   as failures. Sustained-health monitoring belongs in observability, not
+ *   a post-deploy smoke check.
+ * - Security-group wiring: the bastion SG carries the operator-SSH
+ *   ingress; the database SG carries an ingress sourced from the bastion
+ *   SG's group id; the live EC2 instance is attached to the bastion SG;
+ *   neither SG carries an unrestricted 0.0.0.0/0 egress (the builder's
+ *   closed-egress default must survive deploy).
+ *
+ * SGs are identified by their CFN logical-id substrings ("bastion",
+ * "database") rather than by `GroupDescription` substring — descriptions
+ * carry user-facing UTF-8 (em-dashes) and are fragile to shell/encoding
+ * layers, while logical ids are pinned by the compose key names.
+ */
 export default {
-  name: "EC2 instance checks",
-  run: async ({ aws, pass, fail }) => {
-    const instanceIds = findStackResources(aws, STACK, {
-      type: "AWS::EC2::Instance",
-    }).map((r) => r.PhysicalResourceId);
+  name: "EC2 instance + security group checks",
+  run: ({ aws, pass, fail }) => {
+    checkInstances({ aws, pass, fail });
+    checkSecurityGroups({ aws, pass, fail });
+  },
+};
 
-    if (instanceIds.length === 0) {
-      fail(`${STACK} — no AWS::EC2::Instance resources found`);
-      return;
+function checkInstances({ aws, pass, fail }) {
+  const instanceIds = findStackResources(aws, STACK, {
+    type: "AWS::EC2::Instance",
+  }).map((r) => r.PhysicalResourceId);
+
+  if (instanceIds.length === 0) {
+    fail(`${STACK} — no AWS::EC2::Instance resources found`);
+    return;
+  }
+
+  // describe-instance-status only returns "running" instances by default.
+  // --include-all-instances surfaces stopped/pending so we can report state
+  // explicitly rather than getting an empty result.
+  const { InstanceStatuses: statuses } = aws(
+    "ec2",
+    "describe-instance-status",
+    "--instance-ids",
+    ...instanceIds,
+    "--include-all-instances",
+    "--output",
+    "json",
+  );
+
+  for (const id of instanceIds) {
+    const status = statuses.find((s) => s.InstanceId === id);
+    if (!status) {
+      fail(`${id} — no status returned`);
+      continue;
     }
+    const state = status.InstanceState?.Name;
+    const sys = status.SystemStatus?.Status;
+    const inst = status.InstanceStatus?.Status;
+    // `initializing` is the legitimate pre-first-status-check state for a
+    // freshly-launched instance — accept it. `impaired` (and `not-applicable`,
+    // which only appears on terminated instances) are real failures.
+    const sysOk = sys === "ok" || sys === "initializing";
+    const instOk = inst === "ok" || inst === "initializing";
+    if (state === "running" && sysOk && instOk) {
+      pass(`${id} — running, system=${sys}, instance=${inst}`);
+    } else {
+      fail(`${id} — state=${state}, system=${sys}, instance=${inst}`);
+    }
+  }
+}
 
-    // describe-instance-status only returns "running" instances by default.
-    // --include-all-instances surfaces stopped/pending so we can report state
-    // explicitly rather than getting an empty result.
-    const { InstanceStatuses: statuses } = aws(
+function checkSecurityGroups({ aws, pass, fail }) {
+  const sgResources = findStackResources(aws, STACK, {
+    type: "AWS::EC2::SecurityGroup",
+  });
+
+  const bastionResource = sgResources.find((r) => /bastion/i.test(r.LogicalResourceId));
+  const databaseResource = sgResources.find((r) => /database/i.test(r.LogicalResourceId));
+
+  if (!bastionResource) {
+    fail(`${STACK} — bastion SG not found in stack resources`);
+  }
+  if (!databaseResource) {
+    fail(`${STACK} — database SG not found in stack resources`);
+  }
+  if (!bastionResource || !databaseResource) return;
+
+  const sgIds = [bastionResource.PhysicalResourceId, databaseResource.PhysicalResourceId];
+  const { SecurityGroups: sgs } = aws(
+    "ec2",
+    "describe-security-groups",
+    "--group-ids",
+    ...sgIds,
+    "--output",
+    "json",
+  );
+
+  const bastion = sgs.find((sg) => sg.GroupId === bastionResource.PhysicalResourceId);
+  const database = sgs.find((sg) => sg.GroupId === databaseResource.PhysicalResourceId);
+
+  if (!bastion || !database) {
+    fail(`${STACK} — describe-security-groups did not return both bastion and database SGs`);
+    return;
+  }
+
+  // Cross-builder Ref check: the live EC2 instance must include the
+  // bastion SG in its attached security groups. Without this, drift
+  // (manual console detach, mis-applied CFN update, or a regression in
+  // InstanceBuilder.securityGroup(Resolvable<>)) could leave the SG
+  // rules correct on paper but disconnected from any workload.
+  const instanceResources = findStackResources(aws, STACK, { type: "AWS::EC2::Instance" });
+  if (instanceResources.length > 0) {
+    const { Reservations: reservations } = aws(
       "ec2",
-      "describe-instance-status",
+      "describe-instances",
       "--instance-ids",
-      ...instanceIds,
-      "--include-all-instances",
+      ...instanceResources.map((r) => r.PhysicalResourceId),
       "--output",
       "json",
     );
-
-    for (const id of instanceIds) {
-      const status = statuses.find((s) => s.InstanceId === id);
-      if (!status) {
-        fail(`${id} — no status returned`);
-        continue;
-      }
-      const state = status.InstanceState?.Name;
-      const sys = status.SystemStatus?.Status;
-      const inst = status.InstanceStatus?.Status;
-      if (state === "running" && sys === "ok" && inst === "ok") {
-        pass(`${id} — running, system=ok, instance=ok`);
-      } else {
-        fail(`${id} — state=${state}, system=${sys}, instance=${inst}`);
-      }
+    const attachedSgIds = new Set(
+      (reservations ?? [])
+        .flatMap((res) => res.Instances ?? [])
+        .flatMap((inst) => inst.SecurityGroups ?? [])
+        .map((g) => g.GroupId),
+    );
+    if (attachedSgIds.has(bastion.GroupId)) {
+      pass(`${STACK} — EC2 instance attached to bastion SG (${bastion.GroupId})`);
+    } else {
+      fail(
+        `${STACK} — EC2 instance is NOT attached to bastion SG (${bastion.GroupId}); attached SGs: ${[...attachedSgIds].join(", ") || "(none)"}`,
+      );
     }
-  },
-};
+  }
+
+  // Bastion should carry the operator-SSH ingress on 192.0.2.10/32.
+  const bastionSsh = (bastion.IpPermissions ?? []).find(
+    (p) =>
+      p.IpProtocol === "tcp" &&
+      p.FromPort === 22 &&
+      p.ToPort === 22 &&
+      (p.IpRanges ?? []).some((r) => r.CidrIp === "192.0.2.10/32"),
+  );
+  if (bastionSsh) {
+    pass(`${STACK} — bastion SG has operator SSH ingress on 192.0.2.10/32`);
+  } else {
+    fail(`${STACK} — bastion SG missing the operator SSH ingress rule`);
+  }
+
+  // Database should carry an ingress on 5432 sourced from the bastion SG.
+  const dbBastionIngress = (database.IpPermissions ?? []).find(
+    (p) =>
+      p.IpProtocol === "tcp" &&
+      p.FromPort === 5432 &&
+      p.ToPort === 5432 &&
+      (p.UserIdGroupPairs ?? []).some((pair) => pair.GroupId === bastion.GroupId),
+  );
+  if (dbBastionIngress) {
+    pass(`${STACK} — database SG ingress on 5432 from bastion SG (${bastion.GroupId})`);
+  } else {
+    fail(`${STACK} — database SG missing the bastion-peer ingress rule on 5432`);
+  }
+
+  // Closed-egress default: neither SG should carry the implicit allow-all
+  // egress rule (CIDR 0.0.0.0/0, protocol "-1"). CDK emits a placeholder
+  // 255.255.255.255/32 ICMP rule for the closed state.
+  for (const sg of [bastion, database]) {
+    const allowAll = (sg.IpPermissionsEgress ?? []).find(
+      (p) => p.IpProtocol === "-1" && (p.IpRanges ?? []).some((r) => r.CidrIp === "0.0.0.0/0"),
+    );
+    const label = sg.GroupName ?? sg.GroupId;
+    if (allowAll) {
+      fail(
+        `${STACK} — ${label} has an unrestricted 0.0.0.0/0 egress rule (closed-egress default violated)`,
+      );
+    } else {
+      pass(`${STACK} — ${label} egress closed by default`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Extends `ComposureCDK-Ec2Stack` with bastion + database security groups and threads the bastion SG into the existing EC2 instance via the new `createSecurityGroupBuilder` (#164). **No new stack** — folded into the existing example so the deploy-test CI job doesn't double up on VPCs, EC2 instances, and flow log groups.

Stacked on **#164** — depends on the SG builder being merged first.

## Why fold rather than add a new stack

The earlier version of this PR added a `ComposureCDK-SecurityGroupTiersStack`. That created the same surface (VPC + EC2 + flow logs) as `ComposureCDK-Ec2Stack` just to demonstrate the SG API. Per `@laazyj`: fold the SG demo into Ec2Stack so the SG builder is exercised end-to-end without paying for a duplicate VPC + EC2 + log group on every CI deploy-test run.

## What the merged stack demonstrates

- **Peer-SG ingress via `Ref`**: `database.addIngressRule(ref<SecurityGroupBuilderResult>("bastion").get("securityGroup"), Port.tcp(5432), …)` — the canonical "DB accepts Postgres from bastion only" pattern resolves at build time.
- **Cross-builder `Ref`**: the `InstanceBuilder` consumes the bastion SG's output as `Resolvable<ISecurityGroup>`, so the same Ref machinery threads SG → instance as it does VPC → instance.
- **Closed-egress default**: surfaces as the `255.255.255.255/32` ICMP placeholder on both SGs in synth output; smoke test verifies the absence of any `0.0.0.0/0` ALL-traffic egress on the deployed SGs.
- **`addSelfIngress`**: emits the database's intra-tier replication rule as a standalone `SecurityGroupIngress` against the SG's own GroupId.
- **Recommended alarms + SNS routing** (already present, kept): the existing alarm-actions-policy wiring continues to route every instance alarm to the alert topic.

## Synth-time verification

`npx nx synth examples -- ComposureCDK-Ec2Stack` produces exactly:

- 2 `AWS::EC2::SecurityGroup` resources (bastion + database) — both with the closed-egress placeholder
- 2 standalone `AWS::EC2::SecurityGroupIngress` resources (bastion→DB peer + DB self-ingress)
- 1 `AWS::EC2::Instance` with `SecurityGroupIds: [{ Fn::GetAtt: [<bastion>, "GroupId"] }]` — confirming `.securityGroup(ref)` fully suppresses CDK's auto-instance-SG and the cross-builder Ref resolves the correct SG
- 8 alarms (4 EC2 + 4 SNS topic) wired to the alert topic via `alarmActionsPolicy`

## Code review findings caught + fixed

Medium-effort `code-review` skill caught:

1. **OIDC role comment referenced the now-deleted SG-tiers stack** — updated to attribute `ec2:DescribeSecurityGroups` to `ComposureCDK-Ec2Stack`.
2. **Test loose-matched any `Fn::GetAtt`-by-`GroupId`** rather than pinning the bastion SG specifically — could pass even if Ref resolved to the database SG. Replaced with an assertion that captures the bastion's logical id from the standalone ingress rule and pins the instance's `SecurityGroupIds` to that exact id.
3. **Smoke test never verified the live instance is in the bastion SG** — only checked that SG rules existed. Added a `describe-instances` call that confirms `Reservations[].Instances[].SecurityGroups` includes the bastion's `GroupId`. Dry-run with a regression scenario (instance wired to database SG) fires the correct failure.
4. **JSDoc was misleading** about flipping `natGateways` — the closed-egress default means just enabling NAT doesn't restore outbound. Rewrote the operational note.
5. **README "Costs" section** still claimed indefinite free-tier coverage; now mentions EC2 + flow-log charges and the 12-month free-tier window.

## Test plan

- [x] `npx nx test examples` — 93/93 tests pass (12 ec2-app tests, snapshot regenerated)
- [x] `npx nx synth examples -- ComposureCDK-Ec2Stack` — clean synth, exact resource counts verified
- [x] Smoke-module dry-run against mock AWS data (happy path: 6 pass signals) and regression scenario (instance wired to wrong SG: correct fail emitted)
- [x] `npm run lint` + `npm run format:check` — clean
- [x] `npm run verify` chain via pre-push hook — green
- [ ] Live deploy + smoke against a sandbox account (requires the OIDC-role IAM-policy redeploy in this PR to land first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
