### PR TITLE
chore(release): v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.8.2 (2026-05-28)
+
+### 🚀 Features
+
+- per-package aws-cdk-lib peer floors (ADR-0008) ([#146](https://github.com/laazyj/composureCDK/issues/146))
+- **ec2:** SecurityGroup builder with closed-egress default ([#152](https://github.com/laazyj/composureCDK/issues/152))
+
+### ❤️ Thank You
+
+- Jason Duffett
+
 ## 0.8.1 (2026-05-26)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -8749,7 +8749,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8771,7 +8771,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8794,7 +8794,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8816,7 +8816,7 @@
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8836,7 +8836,7 @@
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8859,7 +8859,7 @@
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8878,7 +8878,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -8897,7 +8897,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8920,7 +8920,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8935,7 +8935,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8956,7 +8956,7 @@
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.257.0",
@@ -8985,7 +8985,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9006,7 +9006,7 @@
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@composurecdk/iam": "^0.8.0",
@@ -9031,7 +9031,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9052,7 +9052,7 @@
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9085,7 +9085,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9108,7 +9108,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9131,7 +9131,7 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9153,7 +9153,7 @@
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.8.2**.

Generated by `release-prepare` workflow run [#26556027225](https://github.com/laazyj/composureCDK/actions/runs/26556027225).

## Merge checklist

- [x] CI is green
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.8.2`, which triggers `release.yml` (deploy-test → npm publish).