### PR TITLE
chore: make `clean` actually clean (nx cache + node_modules)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cdk-floors:check": "node scripts/cdk-floors.mjs check",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
-    "clean": "npx nx run-many -t clean",
+    "clean": "npx nx run-many -t clean && npx nx reset && rm -rf node_modules",
     "verify": "npm run format:check && npm run build && npm run check:exports && npm run lint && npm run cdk-floors:check && npm run test",
     "release:dryrun": "node scripts/release-dryrun.mjs",
     "prepare": "husky"


### PR DESCRIPTION
`npm run clean` only ran each package's `clean` target (removing `dist` / `.tshy` build artifacts) — it left the **nx cache** (`.nx/`) and **node_modules** in place. So "clean" didn't actually produce a clean tree, and a stale nx cache can serve task results that no longer reflect source.

## Change

```diff
- "clean": "npx nx run-many -t clean",
+ "clean": "npx nx run-many -t clean && npx nx reset && rm -rf node_modules",
```

- `nx reset` clears the nx cache + workspace-data and stops the daemon (verified: `.nx/` 93M → 0B).
- `rm -rf node_modules` runs **last** — nx lives in node_modules, so the nx steps must complete first. Matches the repo's existing `rm -rf` convention (the per-package `clean` targets already do `rm -rf dist .tshy .tshy-build`).

## Heads-up

`npm run clean` now requires a follow-up `npm install` (node_modules is gone). That's the honest meaning of a clean tree. **No CI impact** — CI uses `npm ci`, and `verify` doesn't call `clean`. If you'd prefer plain `clean` to stay artifacts-only, say so and I'll split a `clean:deep` instead.

(Groundwork for the upcoming per-package floor enforcement, whose pinned-version install is only honoured on a from-scratch install — a real clean is the precondition.)