### PR TITLE
feat(ci): per-package floor enforcement via the unit suites (ADR-0008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,66 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  # Derive the distinct floors from cdk-floors.json so the enforce matrix
+  # stays in sync without duplicating values in YAML.
+  cdk-floors-list:
+    name: List CDK floors
+    runs-on: ubuntu-latest
+    outputs:
+      floors: ${{ steps.read.outputs.floors }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Read distinct floors from manifest
+        id: read
+        run: |
+          node -e '
+            const m = JSON.parse(require("node:fs").readFileSync("cdk-floors.json", "utf8")).floors;
+            const rows = Object.entries(m)
+              .sort((a, b) => a[0].localeCompare(b[0]))
+              .map(([pkg, e]) => `  ${pkg.padEnd(16)} ${e.floor}  (${e.gatedBy})`)
+              .join("\n");
+            const floors = [...new Set(Object.values(m).map((e) => e.floor))];
+            console.log("Per-package aws-cdk-lib floors (cdk-floors.json):\n" + rows);
+            console.log("\nDistinct floors -> enforce matrix shards: " + JSON.stringify(floors));
+            require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, "floors=" + JSON.stringify(floors) + "\n");
+          '
+
+  # For each declared floor, pin aws-cdk-lib to it (npm overrides, clean install)
+  # and run that floor's package group's unit suite against it. The suites
+  # synthesise builders + policies via partial-matcher assertions, so this
+  # catches both import-time (missing named export) and runtime (calling a
+  # too-new method, e.g. the #146 Aspect call) version-gated APIs. One floor per
+  # shard; the shard's fresh checkout is the clean tree the override needs.
+  cdk-floors-enforce:
+    name: Enforce aws-cdk-lib@${{ matrix.floor }}
+    needs: cdk-floors-list
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NX_DAEMON: false
+      CDK_FLOORS_FLOOR: ${{ matrix.floor }}
+    strategy:
+      fail-fast: false
+      matrix:
+        floor: ${{ fromJSON(needs.cdk-floors-list.outputs.floors) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      # No `npm ci` — enforce does the floor-pinned install itself, and the
+      # fresh checkout is the clean tree the npm override requires.
+      - name: Enforce
+        run: npm run cdk-floors:enforce

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -69,31 +69,32 @@ installed CDK tags the resource and assert tags-present-or-gracefully-absent
 accordingly, so `enforce` stays green at the floor without weakening the assertion
 at the latest CDK.
 
-`scripts/cdk-floors.mjs` provides four modes (npm scripts `cdk-floors:*`),
-landing across a small sequence of PRs:
+`scripts/cdk-floors.mjs` provides the modes (npm scripts `cdk-floors:*`):
 
 - **`apply`** — writes each package's `peerDependencies.aws-cdk-lib` from the
-  manifest. _(This PR.)_
+  manifest.
 - **`check`** — asserts package.json ranges match the manifest. Cheap; runs in
-  the main CI job and `verify`. _(This PR.)_
-- **`enforce`** — loads each package against a real install of its own declared
-  floor and fails if any doesn't. The "don't breach the floor" PR gate.
-  _(Follow-up PR.)_
-- **`establish`** — packs the graph and loads every package against a
-  descending ladder of real aws-cdk-lib releases, recording the lowest each
-  loads on and the gating export. Writes a ladder-granular draft
-  (`cdk-floors.discovered.json`) to be refined into `cdk-floors.json`. Re-run
-  it to **prove a new, lower floor** when deliberately grandfathering older
-  support. _(Follow-up PR — discovery / floor-research tool.)_
+  the main CI job and `verify`.
+- **`enforce`** — for each declared floor, forces aws-cdk-lib to it (a temporary
+  npm `overrides` on a from-scratch install, which binds every copy in the tree
+  rather than just the hoisted one), asserts the floor actually bound, then runs
+  that floor's package group's unit suite against it. The "don't breach the
+  floor" PR gate, sharded one floor per CI job. The suites synthesise builders
+  and policies via partial-matcher assertions, so this catches both import-time
+  (missing named export) and runtime (a too-new method call, e.g. the #146
+  `CfnAlarm.isCfnAlarm` inside an Aspect) version-gated APIs.
+- **`establish`** _(planned)_ — discovery tool: probes every package against a
+  descending ladder of real aws-cdk-lib releases to record the lowest each
+  loads on and the gating export, as a draft to refine into `cdk-floors.json`.
+  Used when establishing or **deliberately lowering** a floor.
 
-Floor values are measured at the **import-time** boundary (named exports a
-package pulls from aws-cdk-lib), where every constraint observed so far lives.
-The per-package unit suites — run on every commit against the latest CDK —
-catch runtime regressions in the supported range. A separate on-demand
-diagnostic synth tool exists for ad-hoc validation at any chosen aws-cdk-lib
-version (bug repro, candidate-floor validation, release prep); it is not a PR
-gate, because no single fixed CDK version is the right one to test against
-continuously.
+Why `overrides` + a from-scratch install: every package also carries
+`aws-cdk-lib` as a `devDependency` at the latest version, so simply downgrading
+the hoisted root copy leaves a nested latest copy that the package's suite would
+resolve instead — `enforce` would then silently pass against the wrong version.
+An `overrides` entry forces the floor across the whole tree, but npm only honours
+it on a clean install; hence the from-scratch reinstall and the post-install
+resolution assertion that fails loudly if the floor did not actually bind.
 
 This complements the static guard already in place: the
 `composurecdk/no-cdk-api-above-floor` ESLint rule (`@composurecdk/eslint-plugin`)
@@ -104,16 +105,16 @@ blocks known version-gated APIs at lint time, so they can't be written into
 
 - Consumers get honest, per-package ranges; low-floor packages stay broadly
   installable.
-- The ranges become regression-proof in two layers: `check` (this PR) stops
-  package.json drifting from the manifest, and `enforce` (follow-up PR) stops
-  a package quietly requiring a newer CDK than its declared floor.
+- The ranges become regression-proof in two layers: `check` stops package.json
+  drifting from the manifest, and `enforce` stops a package quietly requiring a
+  newer CDK than its declared floor — at both the import-time and runtime
+  boundaries, since it runs the real unit suites at the floor.
 - Lowering a floor is a deliberate, evidenced act: remove the requiring API,
-  re-run `establish` against the candidate floor, validate the composed synth
-  against it, refine the manifest, `apply`.
-- The import probe is a lower bound; a runtime-only requirement could push a
-  floor above the measured value. The per-package unit suites at latest CDK
-  catch new regressions; the diagnostic synth tool validates candidate floors
-  before they're applied.
+  use `establish` to prove the lower floor, refine the manifest, `apply`.
+- `enforce` mutates the tree (override + reinstall per floor). In CI each shard
+  is a throwaway checkout; locally it requires `--force` and restores
+  package.json / package-lock.json / node_modules afterwards (and on Ctrl-C),
+  so it never leaves a stray override or a floor-pinned install behind.
 - Floors are pinned to the exact introducing release. They will rise over time
   as packages adopt newer CDK features — that is expected and intentional, and
   the tooling makes each change measured rather than assumed.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "npx nx run-many -t test",
     "cdk-floors:apply": "node scripts/cdk-floors.mjs apply",
     "cdk-floors:check": "node scripts/cdk-floors.mjs check",
+    "cdk-floors:enforce": "node scripts/cdk-floors.mjs enforce",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
     "clean": "npx nx run-many -t clean && npx nx reset && rm -rf node_modules",

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -2,22 +2,36 @@
 
 /**
  * Per-package aws-cdk-lib floor tooling. `cdk-floors.json` is the curated
- * source of truth (package -> { floor, gatedBy }); this script reads it and
- * keeps each package's `peerDependencies.aws-cdk-lib` in sync.
+ * source of truth (package -> { floor, gatedBy }); this script reads it,
+ * keeps each package's `peerDependencies.aws-cdk-lib` in sync, and verifies
+ * the declared floors actually hold by running each package's existing unit
+ * suite against a real install of its own floor.
  *
  * - `apply` writes each package's `peerDependencies.aws-cdk-lib` from the
  *   manifest. Run it after editing `cdk-floors.json`.
  * - `check` asserts every package.json matches the manifest, exiting non-zero
  *   on drift. Cheap; wired into the main CI job and `npm run verify`.
+ * - `enforce` pins aws-cdk-lib to a declared floor (via a temporary npm
+ *   `overrides`, which forces every copy in the tree, not just the hoisted
+ *   one) on a from-scratch install, asserts the floor actually bound, then
+ *   runs that floor's package group's unit suite against it. Catches both
+ *   import-time (missing named export) and runtime (calling a too-new method,
+ *   e.g. the #146 `CfnAlarm.isCfnAlarm` inside an Aspect) version-gated APIs.
+ *   CI runs it as a matrix, one floor per shard. Locally it requires `--force`
+ *   and restores package.json / package-lock.json / node_modules when done
+ *   (and on Ctrl-C). See ADR-0008.
  *
- * The discovery side (how floor values are arrived at) and the enforcement
- * side (running each package against a real install of its declared floor)
- * are separate follow-up tools — see ADR-0008.
- *
- * Usage: node scripts/cdk-floors.mjs <apply|check>
+ * Usage:
+ *   node scripts/cdk-floors.mjs apply
+ *   node scripts/cdk-floors.mjs check
+ *   node scripts/cdk-floors.mjs enforce              # every floor (CI: all shards)
+ *   node scripts/cdk-floors.mjs enforce 2.118.0      # one floor (CI matrix shard)
+ *   CDK_FLOORS_FLOOR=2.118.0 node scripts/cdk-floors.mjs enforce
+ *   node scripts/cdk-floors.mjs enforce --force      # local: also restores after
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -74,11 +88,163 @@ function check() {
   );
 }
 
+function groupByFloor(floors) {
+  const byFloor = new Map();
+  for (const [pkg, { floor }] of Object.entries(floors)) {
+    if (!byFloor.has(floor)) byFloor.set(floor, []);
+    byFloor.get(floor).push(`@composurecdk/${pkg}`);
+  }
+  return byFloor;
+}
+
+/** The aws-cdk-lib version `pkgName` actually resolves, from inside its own dir. */
+function resolvedVersionFor(pkgName) {
+  const cwd = join(PACKAGES_DIR, pkgName.replace("@composurecdk/", ""));
+  return execFileSync(
+    process.execPath,
+    ["-e", "process.stdout.write(require('aws-cdk-lib/package.json').version)"],
+    { cwd, encoding: "utf8" },
+  ).trim();
+}
+
+/**
+ * For each target floor: temporarily force aws-cdk-lib to that floor via npm
+ * `overrides` on a from-scratch install (overrides only bind on a clean tree),
+ * assert a package in the group actually resolves the floor, then run that
+ * group's unit suite. With no arg, runs every floor; with a floor arg or
+ * `CDK_FLOORS_FLOOR`, just that one (a CI matrix shard).
+ *
+ * Mutates package.json / package-lock.json / node_modules. They are restored
+ * on completion and on SIGINT/SIGTERM, so a local run never leaves a stray
+ * `overrides` entry or a floor-pinned install behind.
+ */
+function enforce() {
+  const requested = process.env.CDK_FLOORS_FLOOR ?? process.argv[3];
+  const hasRequested = requested !== undefined && requested !== "" && requested !== "--force";
+  const byFloor = groupByFloor(readFloors());
+  if (hasRequested && !byFloor.has(requested)) {
+    console.error(
+      `cdk-floors enforce: no packages declare aws-cdk-lib floor ${requested}.\n` +
+        `  Known floors: ${[...byFloor.keys()].join(", ")}`,
+    );
+    process.exit(1);
+  }
+  const targets = hasRequested ? [[requested, byFloor.get(requested)]] : [...byFloor];
+
+  const local = process.env.CI === undefined;
+  if (local && !process.argv.includes("--force")) {
+    console.error(
+      "cdk-floors enforce rewrites package.json and reinstalls node_modules per floor.\n" +
+        "Re-run with --force to confirm; the workspace is restored automatically afterwards.",
+    );
+    process.exit(1);
+  }
+
+  const PKG = join(REPO_ROOT, "package.json");
+  const LOCK = join(REPO_ROOT, "package-lock.json");
+  const NODE_MODULES = join(REPO_ROOT, "node_modules");
+  const pkgBackup = readFileSync(PKG, "utf8");
+  const lockBackup = existsSync(LOCK) ? readFileSync(LOCK, "utf8") : undefined;
+  let mutated = false;
+
+  // Restoring package.json + lock is just file writes, so it is safe to run
+  // from a signal handler; the heavier `npm ci` only runs on the normal path.
+  const restoreManifest = () => {
+    writeFileSync(PKG, pkgBackup);
+    if (lockBackup !== undefined) writeFileSync(LOCK, lockBackup);
+  };
+  const onSignal = () => {
+    restoreManifest();
+    if (mutated && local) {
+      console.error(
+        "\nInterrupted — restored package.json/package-lock.json. node_modules may still " +
+          "be pinned to a floor; run `npm ci` to restore it.",
+      );
+    }
+    process.exit(130);
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  let exitCode = 0;
+  try {
+    for (const [floor, group] of targets) {
+      console.log(`\n=== Enforcing aws-cdk-lib@${floor} for ${group.length} package(s) ===`);
+      mutated = true;
+
+      // Derive the override from the pristine backup each time (so floors don't
+      // compound) and install from scratch — overrides only bind on a clean tree.
+      const manifest = JSON.parse(pkgBackup);
+      manifest.overrides = { ...manifest.overrides, "aws-cdk-lib": floor };
+      writeFileSync(PKG, `${JSON.stringify(manifest, null, 2)}\n`);
+      // Both must go for npm to re-resolve under the override: with node_modules
+      // present npm reports "up to date", and with the lockfile present it
+      // installs the locked (latest) version regardless of the override.
+      rmSync(NODE_MODULES, { recursive: true, force: true });
+      rmSync(LOCK, { force: true });
+      execFileSync("npm", ["install", "--no-audit", "--no-fund", "--legacy-peer-deps"], {
+        cwd: REPO_ROOT,
+        stdio: "inherit",
+      });
+
+      // Hard gate: confirm the floor bound for this group (not a nested latest
+      // copy), so the run can never silently pass against the wrong version.
+      const sample = group[0];
+      const got = resolvedVersionFor(sample);
+      if (got !== floor) {
+        throw new Error(
+          `floor pin failed: ${sample} resolves aws-cdk-lib ${got}, expected ${floor} — ` +
+            "the override did not bind (stale node_modules?).",
+        );
+      }
+      console.log(`  ${sample} resolves aws-cdk-lib ${got} ✓`);
+
+      try {
+        execFileSync(
+          "npx",
+          ["nx", "run-many", "-t", "test", "--projects", group.join(","), "--skip-nx-cache"],
+          { cwd: REPO_ROOT, stdio: "inherit", env: { ...process.env, NX_DAEMON: "false" } },
+        );
+        console.log(`✓ aws-cdk-lib@${floor} (${group.length} package(s)) ok`);
+      } catch {
+        exitCode = 1;
+        console.error(`✗ aws-cdk-lib@${floor} FAILED`);
+      }
+    }
+  } catch (error) {
+    exitCode = 1;
+    console.error(`\ncdk-floors enforce errored: ${error.message}`);
+  } finally {
+    restoreManifest();
+    if (mutated && local) {
+      console.log("\nRestoring workspace (npm ci) …");
+      execFileSync("npm", ["ci", "--no-audit", "--no-fund"], { cwd: REPO_ROOT, stdio: "inherit" });
+      // A failed floor build leaves a `.tshy-build` dir behind, which would
+      // break the next `npm run lint`; clear tshy intermediates so the
+      // restored tree is clean.
+      for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        rmSync(join(PACKAGES_DIR, entry.name, ".tshy"), { recursive: true, force: true });
+        rmSync(join(PACKAGES_DIR, entry.name, ".tshy-build"), { recursive: true, force: true });
+      }
+    }
+  }
+
+  if (exitCode === 0) {
+    console.log(
+      "\ncdk-floors enforce passed (every package's unit suite ran against its declared floor)",
+    );
+  }
+  process.exit(exitCode);
+}
+
 const mode = process.argv[2];
-const modes = { apply, check };
+const modes = { apply, check, enforce };
 if (modes[mode] !== undefined) {
   modes[mode]();
 } else {
-  console.error(`Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check>`);
+  console.error(
+    `Unknown mode "${mode ?? ""}". Usage: node scripts/cdk-floors.mjs <apply|check|enforce>`,
+  );
   process.exit(1);
 }


### PR DESCRIPTION
## What

Adds per-package aws-cdk-lib **floor enforcement**: a CI matrix that, for each declared floor in `cdk-floors.json`, pins aws-cdk-lib to that floor (npm `overrides` + clean install), asserts it bound, and runs that floor's package group's unit suite against it. Catches both import-time and runtime version-gated API use. See ADR-0008.

Also: the `List CDK floors` step now echoes the full package→floor→gatedBy map and the derived shard list to the build log.

## Status (rebased onto main, with #171/#172 merged)

The s3 (2.123.0) and cloudfront (2.124.0) corrections are merged, so those shards are green. The matrix now surfaces the **next** mis-floored packages — these are being fixed in their own follow-up PRs and must land before this merges:

- ✅ `2.119.0` acm · `2.123.0` s3 · `2.124.0` cloudfront · `2.216.0` route53
- ❌ `2.0.0` cloudformation — test harness needs `aws-cdk-lib/assertions` (~2.1.0)
- ❌ `2.1.0` group — src uses `Annotations.addWarningV2` / `QueueEncryption.SQS_MANAGED`; some tests use newer matchers
- ❌ `2.54.0` ec2 — src needs `IKeyPair` (2.116.0)
- ❌ `2.168.0` lambda — test uses `PropertyInjectors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)