### PR TITLE
fix(s3): raise aws-cdk-lib floor to 2.123.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -23,7 +23,10 @@
     },
     "apigateway": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
     "ec2": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
-    "s3": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "s3": {
+      "floor": "2.123.0",
+      "gatedBy": "aws-s3-deployment.BucketDeploymentProps.logGroup (introduced 2.123.0). Builder tags reaching alarms degrade gracefully below 2.138.0 (when AWS::CloudWatch::Alarm became taggable) and are not floor-gating."
+    },
     "cloudfront": {
       "floor": "2.118.0",
       "gatedBy": "aws-cloudfront.FunctionRuntime (introduced 2.118.0)"

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -39,6 +39,29 @@ and enforces it.** Floors are monotonic with the peer graph — a package's floo
 is the max of its own aws-cdk-lib usage and its `@composurecdk` peers' floors,
 which holds automatically because a package can only load once its peers do.
 
+### What a floor guarantees
+
+A floor guarantees the builders **do not hard-fail** (throw at synth, or fail to
+import a missing export) on that aws-cdk-lib version. It does **not** promise that
+every convenience renders identically all the way down.
+
+The distinction matters for **tag propagation**. Builder `.tag()`/`.tags()` reach
+a construct via the CDK Tags aspect, which can only write tags onto an L1 that AWS
+has made taggable. Several L1s gained tag support well after they first shipped —
+e.g. `AWS::CloudWatch::Alarm` only became taggable in aws-cdk-lib **2.138.0** and
+`AWS::CloudFront::Function` in **2.251.0**. Below those versions, builder tags on
+those resources are **silently dropped** — the template synthesises correctly,
+the tags just do not appear. This is benign graceful degradation, not a crash, so
+it does **not** gate the floor: pinning `cloudwatch`/`s3` at the alarm-tagging
+version (or `cloudfront` at 2.251.0) purely to render tags would needlessly punish
+the far more common case of a consumer who tags nothing. Consumers who need tags on
+those resources must run an aws-cdk-lib new enough to support tagging them.
+
+The unit suites encode this: tag-propagation tests probe (by synthesis) whether the
+installed CDK tags the resource and assert tags-present-or-gracefully-absent
+accordingly, so `enforce` stays green at the floor without weakening the assertion
+at the latest CDK.
+
 `scripts/cdk-floors.mjs` provides four modes (npm scripts `cdk-floors:*`),
 landing across a small sequence of PRs:
 

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.54.0",
+    "aws-cdk-lib": "^2.123.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/s3/test/bucket-builder.test.ts
+++ b/packages/s3/test/bucket-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { App, Duration, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createBucketBuilder } from "../src/bucket-builder.js";
@@ -15,6 +15,28 @@ function synthTemplate(
   configureFn(builder);
   builder.build(stack, "TestBucket");
   return Template.fromStack(stack);
+}
+
+/**
+ * Whether the installed aws-cdk-lib renders tags onto `AWS::CloudWatch::Alarm`.
+ * The resource only became taggable in aws-cdk-lib 2.138.0 — above this
+ * package's floor — so below that, builder tags are silently dropped rather
+ * than failing synth (documented graceful degradation). Probing by synthesis
+ * (rather than `TagManager.isTaggable`, which only detects the v1 taggable
+ * interface) keeps the test correct across the whole supported range.
+ */
+function alarmsAreTaggable(): boolean {
+  const probe = new Stack(new App(), "TagProbe");
+  const alarm = new Alarm(probe, "Probe", {
+    metric: new Metric({ namespace: "AWS/S3", metricName: "AllRequests" }),
+    threshold: 1,
+    evaluationPeriods: 1,
+  });
+  Tags.of(alarm).add("probe", "1");
+  const probed = Object.values(
+    Template.fromStack(probe).findResources("AWS::CloudWatch::Alarm"),
+  )[0] as { Properties?: { Tags?: unknown } } | undefined;
+  return probed?.Properties?.Tags !== undefined;
 }
 
 /** Disables access logging so tests that don't need it get a single-bucket template. */
@@ -508,12 +530,19 @@ describe("BucketBuilder", () => {
       const template = Template.fromStack(stack);
       const alarms = template.findResources("AWS::CloudWatch::Alarm");
       expect(Object.keys(alarms).length).toBeGreaterThan(0);
+      const taggable = alarmsAreTaggable();
       for (const resource of Object.values(alarms) as {
         Properties: { Tags?: { Key: string; Value: string }[] };
       }[]) {
-        expect(resource.Properties.Tags).toEqual(
-          expect.arrayContaining([{ Key: "Owner", Value: "platform" }]),
-        );
+        if (taggable) {
+          expect(resource.Properties.Tags).toEqual(
+            expect.arrayContaining([{ Key: "Owner", Value: "platform" }]),
+          );
+        } else {
+          // Below aws-cdk-lib 2.138.0 the L1 carries no Tags; the builder's
+          // tags are silently dropped rather than breaking synth.
+          expect(resource.Properties.Tags).toBeUndefined();
+        }
       }
     });
 

--- a/packages/s3/test/bucket-deployment-builder.test.ts
+++ b/packages/s3/test/bucket-deployment-builder.test.ts
@@ -3,7 +3,7 @@ import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Distribution } from "aws-cdk-lib/aws-cloudfront";
-import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Ref, ref } from "@composurecdk/core";
@@ -112,7 +112,7 @@ describe("BucketDeploymentBuilder", () => {
       const bucket = new Bucket(stack, "Bucket");
       const distribution = new Distribution(stack, "CDN", {
         defaultBehavior: {
-          origin: S3BucketOrigin.withOriginAccessControl(bucket),
+          origin: new HttpOrigin(bucket.bucketRegionalDomainName),
         },
       });
 
@@ -147,7 +147,7 @@ describe("BucketDeploymentBuilder", () => {
       const bucket = new Bucket(stack, "Bucket");
       const distribution = new Distribution(stack, "CDN", {
         defaultBehavior: {
-          origin: S3BucketOrigin.withOriginAccessControl(bucket),
+          origin: new HttpOrigin(bucket.bucketRegionalDomainName),
         },
       });
 
@@ -200,7 +200,7 @@ describe("BucketDeploymentBuilder", () => {
       const bucket = new Bucket(stack, "Bucket");
       const distribution = new Distribution(stack, "CDN", {
         defaultBehavior: {
-          origin: S3BucketOrigin.withOriginAccessControl(bucket),
+          origin: new HttpOrigin(bucket.bucketRegionalDomainName),
         },
       });
 


### PR DESCRIPTION
## What

Raises `@composurecdk/s3`'s `peerDependencies.aws-cdk-lib` floor from `^2.54.0` to `^2.123.0`.

## Why

`BucketDeploymentBuilder` passes `BucketDeploymentProps.logGroup`, which only exists from aws-cdk-lib **2.123.0** (verified absent at 2.122.0). The old `^2.54.0` floor was import-derived (measured from named exports only) and never exercised this runtime usage, so consumers on 2.54.0–2.122.x silently lost the deployment log group despite the declared support.

## Suite honesty at the floor

The unit suite is updated so it passes at the real floor without weakening assertions at the latest CDK:

- **`bucket-deployment-builder.test.ts`** — distribution fixtures use `HttpOrigin` instead of `S3BucketOrigin` (which postdates the floor and isn't S3-origin-specific to anything under test).
- **`bucket-builder.test.ts`** — the alarm tag-propagation test now probes (by synthesis) whether the installed CDK tags `AWS::CloudWatch::Alarm` and asserts tags-present **or** gracefully-absent. Alarms only became taggable in **2.138.0**; below that, builder tags are silently dropped — benign graceful degradation, not a hard failure, so it does **not** gate the floor.

## ADR

Adds a "What a floor guarantees" section to [ADR-0008](docs/adr/0008-aws-cdk-lib-version-floors.md): a floor guarantees no *hard* failure (throw / missing import), not full feature fidelity; cosmetic conveniences (tag propagation) may degrade gracefully below the version that made the L1 taggable.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; s3 suite green at latest (79 tests) **and** at the 2.123.0 floor (clean-install enforce run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)