### PR TITLE
fix(cloudfront): bump aws-cdk-lib floor to 2.124.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -28,8 +28,8 @@
       "gatedBy": "aws-s3-deployment.BucketDeploymentProps.logGroup (introduced 2.123.0). Builder tags reaching alarms degrade gracefully below 2.138.0 (when AWS::CloudWatch::Alarm became taggable) and are not floor-gating."
     },
     "cloudfront": {
-      "floor": "2.118.0",
-      "gatedBy": "aws-cloudfront.FunctionRuntime (introduced 2.118.0)"
+      "floor": "2.124.0",
+      "gatedBy": "aws-cloudfront.FunctionProps.keyValueStore association wiring (introduced 2.124.0); also peers @composurecdk/s3 at 2.123.0. Builder tags reaching CloudFront Functions degrade gracefully below 2.251.0 and are not floor-gating."
     },
     "acm": {
       "floor": "2.119.0",

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -57,6 +57,13 @@ version (or `cloudfront` at 2.251.0) purely to render tags would needlessly puni
 the far more common case of a consumer who tags nothing. Consumers who need tags on
 those resources must run an aws-cdk-lib new enough to support tagging them.
 
+Functional gaps are treated differently from cosmetic ones. Where a too-old CDK
+would silently produce a **broken** resource rather than a merely-untagged one,
+the requiring feature _does_ raise the floor — e.g. `cloudfront` floors at 2.124.0
+because `aws-cloudfront.FunctionProps.keyValueStore` only wires the key-value-store
+association from that release, and a function silently missing its store is a
+runtime defect, not cosmetic.
+
 The unit suites encode this: tag-propagation tests probe (by synthesis) whether the
 installed CDK tags the resource and assert tags-present-or-gracefully-absent
 accordingly, so `enforce` stays green at the floor without weakening the assertion

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/s3": "^0.8.0",
-    "aws-cdk-lib": "^2.118.0",
+    "aws-cdk-lib": "^2.124.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudfront/test/behavior-function-alarms.test.ts
+++ b/packages/cloudfront/test/behavior-function-alarms.test.ts
@@ -3,7 +3,7 @@ import { App, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { S3BucketOrigin, HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { FunctionCode, FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
 import { createDistributionBuilder } from "../src/distribution-builder.js";
 
@@ -27,7 +27,7 @@ function buildResult(
 function withOrigin(builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) {
   const bucket = new Bucket(stack, "TestBucket");
   builder
-    .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+    .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
     .accessLogs(false)
     // Suppress only the distribution-level alarms so each test can focus on
     // function alarms. Note: `.recommendedAlarms(false)` would also disable
@@ -353,7 +353,7 @@ describe("region signposting", () => {
   it("emits no warning when no alarms are created, regardless of region", () => {
     const stack = buildInRegion("us-west-2", (b, stack) => {
       const bucket = new Bucket(stack, "TestBucket");
-      b.origin(S3BucketOrigin.withOriginAccessControl(bucket))
+      b.origin(new HttpOrigin(bucket.bucketRegionalDomainName))
         .accessLogs(false)
         .recommendedAlarms(false);
     });

--- a/packages/cloudfront/test/behavior-functions.test.ts
+++ b/packages/cloudfront/test/behavior-functions.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
+import { App, Stack, Tags } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { S3BucketOrigin, HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import {
   CachePolicy,
+  Function as CfFunction,
   FunctionCode,
   FunctionEventType,
   FunctionRuntime,
-  ImportSource,
   KeyValueStore,
 } from "aws-cdk-lib/aws-cloudfront";
 import { ref } from "@composurecdk/core";
@@ -23,7 +23,7 @@ const INLINE_CODE = `
 
 function withBucketOrigin(stack: Stack) {
   const bucket = new Bucket(stack, "TestBucket");
-  return S3BucketOrigin.withOriginAccessControl(bucket);
+  return new HttpOrigin(bucket.bucketRegionalDomainName);
 }
 
 function synthTemplate(
@@ -172,9 +172,9 @@ describe("default behavior inline functions", () => {
   it("associates a KeyValueStore with the Function", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
-    const kvs = new KeyValueStore(stack, "Kvs", {
-      source: ImportSource.fromInline(JSON.stringify({ data: [{ key: "a", value: "b" }] })),
-    });
+    // No seed source: the test asserts only the store/function association, and
+    // ImportSource.fromInline postdates this package's aws-cdk-lib floor.
+    const kvs = new KeyValueStore(stack, "Kvs", {});
 
     createDistributionBuilder()
       .origin(withBucketOrigin(stack))
@@ -284,9 +284,7 @@ describe("default behavior inline functions", () => {
   it("throws when keyValueStore is used with a non-JS_2_0 runtime", () => {
     expect(() =>
       synthTemplate((b, stack) => {
-        const kvs = new KeyValueStore(stack, "Kvs", {
-          source: ImportSource.fromInline(JSON.stringify({ data: [{ key: "a", value: "b" }] })),
-        });
+        const kvs = new KeyValueStore(stack, "Kvs", {});
         b.origin(withBucketOrigin(stack))
           .accessLogs(false)
           .recommendedAlarms(false)
@@ -474,8 +472,8 @@ describe("additional path-pattern behaviors", () => {
       .accessLogs(false)
       .recommendedAlarms(false)
       .behavior("/api/*", {
-        origin: ref<BucketBuilderResult>("api").map((r) =>
-          S3BucketOrigin.withOriginAccessControl(r.bucket),
+        origin: ref<BucketBuilderResult>("api").map(
+          (r) => new HttpOrigin(r.bucket.bucketRegionalDomainName),
         ),
       })
       .build(stack, "TestDistribution", {
@@ -503,6 +501,24 @@ describe("additional path-pattern behaviors", () => {
     });
   });
 });
+
+/**
+ * Whether the installed aws-cdk-lib renders tags onto `AWS::CloudFront::Function`.
+ * The resource only became taggable in aws-cdk-lib 2.251.0 — far above this
+ * package's floor — so below that, builder tags are silently dropped rather
+ * than failing synth (documented graceful degradation). Probing by synthesis
+ * (rather than `TagManager.isTaggable`, which only detects the v1 taggable
+ * interface) keeps the test correct across the whole supported range.
+ */
+function cloudFrontFunctionsAreTaggable(): boolean {
+  const probe = new Stack(new App(), "TagProbe");
+  const fn = new CfFunction(probe, "Probe", { code: FunctionCode.fromInline(INLINE_CODE) });
+  Tags.of(fn).add("probe", "1");
+  const probed = Object.values(
+    Template.fromStack(probe).findResources("AWS::CloudFront::Function"),
+  )[0] as { Properties?: { Tags?: unknown } } | undefined;
+  return probed?.Properties?.Tags !== undefined;
+}
 
 describe("builder-level tags reach inline CloudFront Functions", () => {
   it("applies .tag()/.tags() to every CloudFront Function created by the builder", () => {
@@ -540,13 +556,20 @@ describe("builder-level tags reach inline CloudFront Functions", () => {
       { Properties?: { Tags?: CfnTagEntry[] } }
     >;
     expect(Object.keys(fns)).toHaveLength(2);
+    const taggable = cloudFrontFunctionsAreTaggable();
     for (const fn of Object.values(fns)) {
-      expect(fn.Properties?.Tags).toEqual(
-        expect.arrayContaining([
-          { Key: "Project", Value: "claude-rig" },
-          { Key: "Owner", Value: "platform" },
-        ]),
-      );
+      if (taggable) {
+        expect(fn.Properties?.Tags).toEqual(
+          expect.arrayContaining([
+            { Key: "Project", Value: "claude-rig" },
+            { Key: "Owner", Value: "platform" },
+          ]),
+        );
+      } else {
+        // Below aws-cdk-lib 2.251.0 the L1 carries no Tags; the builder's tags
+        // are silently dropped rather than breaking synth.
+        expect(fn.Properties?.Tags).toBeUndefined();
+      }
     }
   });
 });

--- a/packages/cloudfront/test/cloudfront-alarm-builder.test.ts
+++ b/packages/cloudfront/test/cloudfront-alarm-builder.test.ts
@@ -3,7 +3,7 @@ import { App, Duration, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { HttpOrigin, S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { type Distribution, FunctionCode, FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
 import { compose, ref } from "@composurecdk/core";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
@@ -34,7 +34,7 @@ function buildDistribution(
   const stack = new Stack(app, "TestStack");
   const builder = createDistributionBuilder().recommendedAlarms(false);
   const bucket = new Bucket(stack, "TestBucket");
-  builder.origin(S3BucketOrigin.withOriginAccessControl(bucket)).accessLogs(false);
+  builder.origin(new HttpOrigin(bucket.bucketRegionalDomainName)).accessLogs(false);
   configureFn?.(builder);
   const result = builder.build(stack, "TestDistribution");
   return { app, stack, result };
@@ -175,7 +175,7 @@ describe("createCloudFrontAlarmBuilder", () => {
       const distStack = new Stack(app, "DistStack", distStackProps);
       const bucket = new Bucket(distStack, "TestBucket");
       const result = createDistributionBuilder()
-        .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+        .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
         .accessLogs(false)
         .recommendedAlarms(false)
         .defaultBehavior({
@@ -231,7 +231,7 @@ describe("createCloudFrontAlarmBuilder", () => {
       const system = compose(
         {
           cdn: createDistributionBuilder()
-            .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+            .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
             .accessLogs(false)
             .recommendedAlarms(false)
             .defaultBehavior({
@@ -280,7 +280,7 @@ describe("createCloudFrontAlarmBuilder", () => {
       compose(
         {
           cdn: createDistributionBuilder()
-            .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+            .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
             .accessLogs(false)
             .recommendedAlarms(false)
             .defaultBehavior({
@@ -326,7 +326,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const stack = new Stack(app, "TestStack");
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
-      .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+      .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
       .accessLogs(false)
       .defaultBehavior({
         functions: [viewerRequestFn],
@@ -344,7 +344,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const stack = new Stack(app, "TestStack");
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
-      .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+      .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
       .accessLogs(false)
       .recommendedAlarms(false)
       .defaultBehavior({
@@ -361,7 +361,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const stack = new Stack(app, "TestStack");
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
-      .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+      .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
       .accessLogs(false)
       .recommendedAlarms(false)
       .addAlarm("custom4xx", (a) =>
@@ -388,7 +388,7 @@ describe("DistributionBuilder.recommendedAlarms semantics", () => {
     const stack = new Stack(app, "TestStack");
     const bucket = new Bucket(stack, "TestBucket");
     const result = createDistributionBuilder()
-      .origin(S3BucketOrigin.withOriginAccessControl(bucket))
+      .origin(new HttpOrigin(bucket.bucketRegionalDomainName))
       .accessLogs(false)
       .recommendedAlarms(false)
       .defaultBehavior({

--- a/packages/cloudfront/test/distribution-alarms.test.ts
+++ b/packages/cloudfront/test/distribution-alarms.test.ts
@@ -4,7 +4,7 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { createDistributionBuilder } from "../src/distribution-builder.js";
 
 function buildResult(
@@ -20,7 +20,7 @@ function buildResult(
 
 function withOrigin(builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) {
   const bucket = new Bucket(stack, "TestBucket");
-  builder.origin(S3BucketOrigin.withOriginAccessControl(bucket)).accessLogs(false);
+  builder.origin(new HttpOrigin(bucket.bucketRegionalDomainName)).accessLogs(false);
 }
 
 describe("recommended alarms", () => {

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { HttpOrigin, S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import {
   CachePolicy,
   type Distribution,
@@ -29,7 +29,7 @@ function synthTemplate(
 
 function withBucketOrigin(stack: Stack) {
   const bucket = new Bucket(stack, "TestBucket");
-  return S3BucketOrigin.withOriginAccessControl(bucket);
+  return new HttpOrigin(bucket.bucketRegionalDomainName);
 }
 
 describe("DistributionBuilder", () => {
@@ -38,7 +38,7 @@ describe("DistributionBuilder", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       const builder = createDistributionBuilder().origin(origin).accessLogs(false);
       const result = builder.build(stack, "TestDistribution");
@@ -244,7 +244,7 @@ describe("DistributionBuilder", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       const result = createDistributionBuilder().origin(origin).build(stack, "TestDistribution");
 
@@ -255,7 +255,7 @@ describe("DistributionBuilder", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       const result = createDistributionBuilder()
         .origin(origin)
@@ -270,7 +270,7 @@ describe("DistributionBuilder", () => {
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
       const logBucket = new Bucket(stack, "LogBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       const result = createDistributionBuilder()
         .origin(origin)
@@ -307,7 +307,7 @@ describe("DistributionBuilder", () => {
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
       const logBucket = new Bucket(stack, "LogBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       createDistributionBuilder()
         .origin(origin)
@@ -351,7 +351,7 @@ describe("DistributionBuilder", () => {
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
       const logBucket = new Bucket(stack, "LogBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       expect(() =>
         createDistributionBuilder()
@@ -420,8 +420,8 @@ describe("DistributionBuilder", () => {
 
       const builder = createDistributionBuilder()
         .origin(
-          ref<BucketBuilderResult>("site").map((r) =>
-            S3BucketOrigin.withOriginAccessControl(r.bucket),
+          ref<BucketBuilderResult>("site").map(
+            (r) => new HttpOrigin(r.bucket.bucketRegionalDomainName),
           ),
         )
         .accessLogs(false);
@@ -436,7 +436,7 @@ describe("DistributionBuilder", () => {
         DistributionConfig: Match.objectLike({
           Origins: Match.arrayWith([
             Match.objectLike({
-              S3OriginConfig: Match.anyValue(),
+              CustomOriginConfig: Match.anyValue(),
             }),
           ]),
         }),
@@ -508,7 +508,7 @@ describe("DistributionBuilder", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       const builder = createDistributionBuilder().origin(origin);
       builder.build(stack, "TestDistribution");
@@ -541,7 +541,7 @@ describe("DistributionBuilder", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
       const bucket = new Bucket(stack, "TestBucket");
-      const origin = S3BucketOrigin.withOriginAccessControl(bucket);
+      const origin = new HttpOrigin(bucket.bucketRegionalDomainName);
 
       const builder = createDistributionBuilder().origin(origin).accessLogs(false);
       builder.build(stack, "TestDistribution");


### PR DESCRIPTION
> **Stacked on #171** (base is `fix/cdk-floors-s3`, not `main`). Merge #171 first; this PR's diff will retarget to `main` automatically once #171 lands.

## What

Raises `@composurecdk/cloudfront`'s `peerDependencies.aws-cdk-lib` floor from `^2.118.0` to `^2.124.0`.

## Why

Two reasons, both above the old import-derived `^2.118.0`:

1. **`FunctionProps.keyValueStore` wiring (2.124.0).** `DistributionBuilder` forwards `keyValueStore` to inline CloudFront Functions; the `KeyValueStoreAssociations` are only wired from aws-cdk-lib **2.124.0** (verified absent at 2.123.0). Below that the store is silently dropped, leaving a deployed function without its data store — a *functional* defect (not cosmetic), so it gates the floor.
2. **Peer monotonicity.** cloudfront peer-depends on `@composurecdk/s3`, whose floor is 2.123.0 (#171). 2.124.0 ≥ 2.123.0.

## Suite honesty at the floor

- Distribution fixtures use `HttpOrigin` instead of `S3BucketOrigin` (postdates the floor; the builder is origin-agnostic). The one S3-shaped assertion becomes `CustomOriginConfig`.
- The `KeyValueStore` fixture drops `ImportSource.fromInline` (postdates the floor); the test asserts the *association*, not seed data.
- The function tag-propagation test probes taggability and asserts tags-present **or** gracefully-absent. `AWS::CloudFront::Function` only became taggable in **2.251.0**; below that, builder tags are silently dropped (benign degradation, not floor-gating).

## ADR

Extends [ADR-0008](docs/adr/0008-aws-cdk-lib-version-floors.md) with the functional-vs-cosmetic distinction: a feature that would silently produce a *broken* resource (keyValueStore) raises the floor, whereas a merely-untagged resource does not.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; cloudfront suite green at latest (106 tests) **and** at the 2.124.0 floor (clean-install enforce run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)