### PR TITLE
fix(ec2): raise aws-cdk-lib floor to 2.140.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -22,7 +22,10 @@
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-budgets)"
     },
     "apigateway": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
-    "ec2": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "ec2": {
+      "floor": "2.140.0",
+      "gatedBy": "aws-ec2.InstanceProps.ebsOptimized (introduced 2.140.0); also IKeyPair / InstanceProps.keyPair (2.116.0)"
+    },
     "s3": {
       "floor": "2.123.0",
       "gatedBy": "aws-s3-deployment.BucketDeploymentProps.logGroup (introduced 2.123.0). Builder tags reaching alarms degrade gracefully below 2.138.0 (when AWS::CloudWatch::Alarm became taggable) and are not floor-gating."

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.54.0",
+    "aws-cdk-lib": "^2.140.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Raises `@composurecdk/ec2`'s `peerDependencies.aws-cdk-lib` floor from `^2.54.0` to `^2.140.0`. Surfaced by the floor-enforcement matrix in #170 (the `2.54.0` shard was red).

## Why

`InstanceBuilder` uses two aws-cdk-lib features above the old import-derived floor:

- **`InstanceProps.ebsOptimized`** — a builder default set in `instance-defaults.ts`; introduced in **2.140.0** (verified absent at 2.139.0). As an object-literal default it's a hard typecheck error below that, not a graceful no-op.
- **`IKeyPair` / `InstanceProps.keyPair`** — the EC2 KeyPair L2; introduced in **2.116.0** (verified absent at 2.115.0).

The old `^2.54.0` was measured from a named export (`aws-cloudwatch.Stats`) and never exercised these, so consumers on 2.54.0–2.139.x would hit a synth-time failure.

`apigateway` shared the 2.54.0 floor but is unaffected — its suite passes at 2.54.0, so it stays there.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; enforce suite green for **ec2 at 2.140.0** (108 tests) and **apigateway at 2.54.0** (76 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)