### PR TITLE
fix(cloudformation): raise aws-cdk-lib floor to 2.1.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -1,7 +1,10 @@
 {
   "$comment": "Per-package aws-cdk-lib floors — the source of truth for each package's peerDependencies.aws-cdk-lib range. `node scripts/cdk-floors.mjs establish` discovers these (ladder-granular); the values here are refined to the exact introducing release and validated by loading each package against real installs. `apply` writes them to package.json; `check` asserts package.json matches. To grandfather older support, drop the requiring API, re-run establish to prove the lower floor, then apply.",
   "floors": {
-    "cloudformation": { "floor": "2.0.0", "gatedBy": "imports only the aws-cdk-lib root entry" },
+    "cloudformation": {
+      "floor": "2.1.0",
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/assertions, aws-cdk-lib/aws-*) used by the suite. Src itself only needs the root entry (2.0.0), but the enforce model requires the suite to run, and `aws-cdk-lib/assertions` is table stakes for builder tests."
+    },
     "cloudwatch": {
       "floor": "2.1.0",
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch)"

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Raises `@composurecdk/cloudformation`'s `peerDependencies.aws-cdk-lib` floor from `^2.0.0` to `^2.1.0`. Resolves the `2.0.0` shard in #170's enforce matrix.

## Why

Src only imports the aws-cdk-lib root entry, so 2.0.0 was technically fine for it. But the unit suite imports `aws-cdk-lib/assertions` (table stakes for builder tests) and `aws-cdk-lib/aws-s3` / `aws-cdk-lib/aws-sns` / `aws-cdk-lib/aws-iam` to construct tag targets — and those subpath exports only resolve from aws-cdk-lib **2.1.0**.

A floor we cannot suite-validate is a claim we cannot defend, so cloudformation moves to the lowest CDK version where the harness works.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass. Validated with a targeted manual pin (npm `overrides` aws-cdk-lib=2.1.0 + clean install + cloudformation suite alone): **76 tests pass**.

The full `2.1.0` shard in #170 will go green once the other packages currently in that group (sns/sqs/budgets/iam/events) are also fixed in their own follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)