### PR TITLE
fix(sns): raise aws-cdk-lib floor to 2.178.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -9,7 +9,10 @@
       "floor": "2.1.0",
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch)"
     },
-    "sns": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sns)" },
+    "sns": {
+      "floor": "2.178.0",
+      "gatedBy": "aws-sns.TopicProps.enforceSSL builder default — the prop typechecks from 2.129.0 but the L2 only wires the SSL-enforcing TopicPolicy from 2.178.0, below which the security default silently no-ops. Also Annotations.addWarningV2 (2.93.0)"
+    },
     "sqs": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sqs)" },
     "iam": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-iam)" },
     "logs": {

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.178.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Raises `@composurecdk/sns`'s `peerDependencies.aws-cdk-lib` floor from `^2.1.0` to `^2.178.0`. Surfaced by #170's enforce matrix.

## Why

TopicBuilder sets builder defaults that need newer aws-cdk-lib than the import-derived floor:

- **`TopicProps.enforceSSL`** — typechecks from **2.129.0**, but the L2 only **wires** the SSL-enforcing `AWS::SNS::TopicPolicy` from **2.178.0**. Below that, setting `enforceSSL: true` silently drops the policy that denies non-TLS publishes — a *security* default silently degraded, not a cosmetic gap, so it gates the floor (parallels the `keyValueStore` decision for cloudfront).
- **`Annotations.addWarningV2`** — used by `subscription-defaults.ts`, introduced in **2.93.0**. Subsumed by 2.178.0.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; sns suite green at latest **and** at 2.178.0 via the enforce gate (66 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)