### PR TITLE
fix(sqs): raise aws-cdk-lib floor to 2.93.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -10,7 +10,10 @@
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch)"
     },
     "sns": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sns)" },
-    "sqs": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sqs)" },
+    "sqs": {
+      "floor": "2.93.0",
+      "gatedBy": "Annotations.addWarningV2 used by queue-builder.ts (introduced 2.93.0); also QueueEncryption.SQS_MANAGED (~2.45) and QueueProps.enforceSSL (~2.50) builder defaults"
+    },
     "iam": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-iam)" },
     "logs": {
       "floor": "2.1.0",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.93.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Raises `@composurecdk/sqs`'s `peerDependencies.aws-cdk-lib` floor from `^2.1.0` to `^2.93.0`. Surfaced by #170's enforce matrix.

## Why

QueueBuilder uses three aws-cdk-lib APIs above the import-derived `^2.1.0` floor:

- **`Annotations.addWarningV2`** (queue-builder.ts) — introduced **2.93.0**. The binding constraint.
- **`QueueProps.enforceSSL`** (defaults.ts) — typechecks and wires the SSL-deny `QueuePolicy` from ~2.50.0. (Probed: type + wire land together for sqs, unlike sns which had a gap.)
- **`QueueEncryption.SQS_MANAGED`** (defaults.ts) — introduced ~2.45.0.

All subsumed by 2.93.0; no need to climb higher.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; sqs suite green at latest **and** at 2.93.0 via the enforce gate (33 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)