### PR TITLE
fix(budgets): raise aws-cdk-lib floor to 2.93.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -24,8 +24,8 @@
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-events)"
     },
     "budgets": {
-      "floor": "2.1.0",
-      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-budgets)"
+      "floor": "2.93.0",
+      "gatedBy": "Annotations.addWarningV2 used by budget-alarm-builder.ts and currency.ts (introduced 2.93.0)"
     },
     "apigateway": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
     "ec2": {

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -40,7 +40,7 @@
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.93.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Raises `@composurecdk/budgets`'s `peerDependencies.aws-cdk-lib` floor from `^2.1.0` to `^2.93.0`. Surfaced by #170's enforce matrix.

## Why

`BudgetAlarmBuilder` and the currency validator both call `Annotations.addWarningV2`, introduced in aws-cdk-lib **2.93.0**. The previous `^2.1.0` was measured from the `aws-budgets` subpath only and never exercised the warning path, so consumers on 2.1.0–2.92.x would hit a `TypeError` at synth as soon as the builder emitted any warning.

`BUDGET_DEFAULTS` itself contains only plain strings (no version-gated CDK props), so there's no enforceSSL-style cascade above 2.93.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; budgets suite green at latest **and** at 2.93.0 via the enforce gate (70 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)