### PR TITLE
fix(iam): raise aws-cdk-lib floor to 2.26.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -14,7 +14,10 @@
       "gatedBy": "aws-sns.TopicProps.enforceSSL builder default — the prop typechecks from 2.129.0 but the L2 only wires the SSL-enforcing TopicPolicy from 2.178.0, below which the security default silently no-ops. Also Annotations.addWarningV2 (2.93.0)"
     },
     "sqs": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-sqs)" },
-    "iam": { "floor": "2.1.0", "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-iam)" },
+    "iam": {
+      "floor": "2.26.0",
+      "gatedBy": "aws-iam.PolicyStatement.resources getter used by statement-builder.test.ts (introduced 2.26.0); also Match.stringLikeRegexp used by role-builder.test.ts (2.9.0)"
+    },
     "logs": {
       "floor": "2.1.0",
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs)"

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.26.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Raises `@composurecdk/iam`'s `peerDependencies.aws-cdk-lib` floor from `^2.1.0` to `^2.26.0`. Surfaced by #170's enforce matrix.

## Why

The src itself only uses long-stable `aws-iam` APIs, but per ADR-0008 we measure the floor at suite granularity — a floor that fails the unit suite is a claim we cannot defend. Two test-only APIs gate above 2.1.0:

- **`aws-iam.PolicyStatement.resources` getter** — used by `statement-builder.test.ts` to assert the built statement's resources; introduced **2.26.0**. The binding constraint.
- **`aws-cdk-lib/assertions.Match.stringLikeRegexp`** — used by `role-builder.test.ts` to assert a managed-policy ARN contains the policy name; introduced **2.9.0**.

Both APIs are early/mid-2022 CDK, so the bump from 2.1.0 → 2.26.0 is small. Kept the assertions precise (didn't refactor to coarser `JSON.stringify(...).toContain(...)`).

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; iam suite green at latest **and** at 2.26.0 via the enforce gate (22 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)