### PR TITLE
fix(events): raise aws-cdk-lib floor to 2.85.0

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -23,8 +23,8 @@
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs)"
     },
     "events": {
-      "floor": "2.1.0",
-      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-events)"
+      "floor": "2.85.0",
+      "gatedBy": "aws-stepfunctions.DefinitionBody used by target-helpers.test (introduced 2.85.0); also Match.stringLikeRegexp used by rule-alarms.test (2.9.0)"
     },
     "budgets": {
       "floor": "2.1.0",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.85.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/events/test/fixtures/lambda/bootstrap
+++ b/packages/events/test/fixtures/lambda/bootstrap
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Placeholder bootstrap for a PROVIDED_AL2 Lambda. The events tests use this
+# only to construct a valid Function fixture as a rule target; it is never
+# invoked. PROVIDED_AL2 rejects Code.fromInline, hence the on-disk asset.
+exec true

--- a/packages/events/test/rule-alarms.test.ts
+++ b/packages/events/test/rule-alarms.test.ts
@@ -13,9 +13,9 @@ function newStack(): Stack {
 
 function makeFn(stack: Stack): LambdaFn {
   return new LambdaFn(stack, "Handler", {
-    runtime: Runtime.NODEJS_20_X,
-    handler: "index.handler",
-    code: Code.fromInline("exports.handler = async () => {};"),
+    runtime: Runtime.PROVIDED_AL2,
+    handler: "bootstrap",
+    code: Code.fromAsset("test/fixtures/lambda"),
   });
 }
 

--- a/packages/events/test/rule-builder.test.ts
+++ b/packages/events/test/rule-builder.test.ts
@@ -13,9 +13,9 @@ function newStack(): Stack {
 
 function makeFn(stack: Stack, id = "Handler"): LambdaFn {
   return new LambdaFn(stack, id, {
-    runtime: Runtime.NODEJS_20_X,
-    handler: "index.handler",
-    code: Code.fromInline("exports.handler = async () => {};"),
+    runtime: Runtime.PROVIDED_AL2,
+    handler: "bootstrap",
+    code: Code.fromAsset("test/fixtures/lambda"),
   });
 }
 

--- a/packages/events/test/targets/target-helpers.test.ts
+++ b/packages/events/test/targets/target-helpers.test.ts
@@ -22,9 +22,9 @@ function newStack(): Stack {
 
 function makeFn(stack: Stack, id = "Handler"): LambdaFn {
   return new LambdaFn(stack, id, {
-    runtime: Runtime.NODEJS_20_X,
-    handler: "index.handler",
-    code: Code.fromInline("exports.handler = async () => {};"),
+    runtime: Runtime.PROVIDED_AL2,
+    handler: "bootstrap",
+    code: Code.fromAsset("test/fixtures/lambda"),
   });
 }
 


### PR DESCRIPTION
## What

Raises `@composurecdk/events`'s `peerDependencies.aws-cdk-lib` floor from `^2.1.0` to `^2.85.0`. Surfaced by #170's enforce matrix.

## Why

The events suite uses two aws-cdk-lib APIs above the import-derived `^2.1.0` floor:

- **`aws-stepfunctions.DefinitionBody`** — used by `target-helpers.test`; introduced **2.85.0** (binding).
- **`aws-cdk-lib/assertions.Match.stringLikeRegexp`** — used by `rule-alarms.test`; introduced **2.9.0**.

The fixtures previously also used `Runtime.NODEJS_20_X` (introduced 2.107.0). That was gratuitous (a placeholder runtime for a fixture Lambda) and *any* specific Node runtime is on an EOL cycle — `NODEJS_18_X` is `@deprecated` at latest, `NODEJS_20_X` will follow eventually, forcing future floor bumps for purely-cosmetic-to-the-test reasons.

Swapped to **`Runtime.PROVIDED_AL2`** — Amazon Linux 2 custom runtime, available from early CDK, no language-version lifecycle, never `@deprecated`. Because PROVIDED_AL2 rejects `Code.fromInline`, the fixtures now use `Code.fromAsset("test/fixtures/lambda")` pointing at a tiny placeholder `bootstrap` script — never invoked, only loaded as a synth asset.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; events suite green at latest (27 tests) **and** at 2.85.0 via the enforce gate (27 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)