### PR TITLE
test(cloudwatch): supply alarmName to CfnCompositeAlarm fixtures

### DIFF
--- a/packages/cloudwatch/test/policy-matcher.test.ts
+++ b/packages/cloudwatch/test/policy-matcher.test.ts
@@ -28,7 +28,10 @@ describe("isCfnAlarm / isCfnCompositeAlarm", () => {
   it("identifies each L1 alarm kind and rejects the other", () => {
     const stack = new Stack(new App(), "TestStack");
     const alarm = makeCfnAlarm(stack, "Alarm");
-    const composite = new CfnCompositeAlarm(stack, "Composite", { alarmRule: "ALARM(x)" });
+    const composite = new CfnCompositeAlarm(stack, "Composite", {
+      alarmName: "TestComposite",
+      alarmRule: "ALARM(x)",
+    });
 
     expect(isCfnAlarm(alarm)).toBe(true);
     expect(isCfnCompositeAlarm(alarm)).toBe(false);
@@ -47,7 +50,10 @@ describe("isCfnAlarm / isCfnCompositeAlarm", () => {
   it("works on aws-cdk-lib < 2.231.0 (no isCfn* statics)", () => {
     const stack = new Stack(new App(), "TestStack");
     const alarm = makeCfnAlarm(stack, "Alarm");
-    const composite = new CfnCompositeAlarm(stack, "Composite", { alarmRule: "ALARM(x)" });
+    const composite = new CfnCompositeAlarm(stack, "Composite", {
+      alarmName: "TestComposite",
+      alarmRule: "ALARM(x)",
+    });
 
     withoutIsCfnStatics(() => {
       expect(isCfnAlarm(alarm)).toBe(true);


### PR DESCRIPTION
## What

Adds `alarmName: "TestComposite"` to the two `new CfnCompositeAlarm(...)` fixtures in `policy-matcher.test.ts`. Resolves the cloudwatch part of the `2.1.0` shard in #170 with **no floor change** (cloudwatch stays at 2.1.0).

## Why

`CfnCompositeAlarmProps.alarmName` was **required** at aws-cdk-lib 2.1.0 (its CFN spec at that release marked it required); it later became optional. The fixtures had omitted it, so the suite failed typecheck on the 2.1.0 shard even though the CDK code being tested works fine at 2.1.0.

Supplying `alarmName` is a zero-impact fixture change — still accepted at the latest CDK — and avoids raising the cloudwatch floor for a test-only ergonomic improvement.

## Validation

`format:check`, `lint`, `cdk-floors:check` pass; cloudwatch suite green at latest (87 tests) **and** at 2.1.0 via a targeted override pin (87 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)