### PR TITLE
feat(cloudwatch): per-alarm constructId override

### DIFF
--- a/packages/cloudwatch/README.md
+++ b/packages/cloudwatch/README.md
@@ -93,6 +93,18 @@ const alarms = createAlarms(scope, "MyFunction", definitions);
 
 Construct IDs follow the pattern `${id}${Capitalize(key)}Alarm` (e.g., `MyFunctionErrorsAlarm`).
 
+### Construct IDs
+
+Set `constructId` on a definition to override that pattern — the value is used verbatim:
+
+```ts
+const alarms = createAlarms(scope, "MyFunction", [
+  { key: "errors", constructId: "LegacyErrorsAlarm" /* …rest of the definition */ },
+]);
+```
+
+This exists for grandfathering: a CloudFormation logical ID is derived from the construct ID, and changing it replaces (drops + recreates) the alarm on deploy. Pinning `constructId` to the existing ID lets you adopt `createAlarms` for alarms already in a deployed stack without churn. Unlike the alarm _name_ — which can be rewritten at synth time by [alarmNamePolicy](#alarmnamepolicy) — the construct ID is fixed at construction, so it can only be set here, per definition. `AlarmDefinitionBuilder` exposes the same control via `.constructId(id)`.
+
 ### Alarm names
 
 Each alarm receives an explicit, hierarchical name of the form `${stackName}/${kebab(id)}/${kebab(key)}` (e.g. `payments-prod/checkout-fn/errors`) instead of CloudFormation's hash-suffixed default. Slashes render hierarchy in the console; segments are kebab-cased so names scan cleanly in dashboards, oncall pages, and email subjects, where word separation matters more than in code.

--- a/packages/cloudwatch/src/alarm-definition-builder.ts
+++ b/packages/cloudwatch/src/alarm-definition-builder.ts
@@ -14,6 +14,7 @@ import type { AlarmName } from "./alarm-name.js";
 export class AlarmDefinitionBuilder<TConstruct> {
   readonly #key: string;
   #alarmName?: AlarmName;
+  #constructId?: string;
   #metricFactory?: (construct: TConstruct) => AlarmMetric;
   #threshold = 0;
   #comparisonOperator = ComparisonOperator.GREATER_THAN_THRESHOLD;
@@ -38,6 +39,18 @@ export class AlarmDefinitionBuilder<TConstruct> {
    */
   alarmName(name: AlarmName): this {
     this.#alarmName = name;
+    return this;
+  }
+
+  /**
+   * Sets an explicit construct id for the created alarm, used verbatim. When
+   * unset, {@link createAlarms} derives `` `${id}${Capitalize(key)}Alarm` ``.
+   *
+   * Set this to preserve an existing CloudFormation logical ID when
+   * grandfathering alarms into a stack.
+   */
+  constructId(id: string): this {
+    this.#constructId = id;
     return this;
   }
 
@@ -102,6 +115,7 @@ export class AlarmDefinitionBuilder<TConstruct> {
     const definition: AlarmDefinition = {
       key: this.#key,
       alarmName: this.#alarmName,
+      constructId: this.#constructId,
       metric: this.#metricFactory(construct),
       threshold: this.#threshold,
       comparisonOperator: this.#comparisonOperator,

--- a/packages/cloudwatch/src/alarm-definition.ts
+++ b/packages/cloudwatch/src/alarm-definition.ts
@@ -21,12 +21,16 @@ export type AlarmMetric = Metric | MathExpression;
  * A fully-resolved alarm descriptor. All fields are required —
  * this is the canonical form consumed by {@link createAlarms}.
  *
- * `alarmName` is the only optional field: when omitted, {@link createAlarms}
- * derives a default via `defaultAlarmName(scope, id, key)`.
+ * `alarmName` and `constructId` are the optional fields:
+ * - `alarmName`: when omitted, {@link createAlarms} derives a default via
+ *   `defaultAlarmName(scope, id, key)`.
+ * - `constructId`: when omitted, {@link createAlarms} derives the construct id
+ *   as `` `${id}${Capitalize(key)}Alarm` ``.
  */
 export interface AlarmDefinition {
   key: string;
   alarmName?: AlarmName;
+  constructId?: string;
   metric: AlarmMetric;
   threshold: number;
   comparisonOperator: ComparisonOperator;

--- a/packages/cloudwatch/src/create-alarms.ts
+++ b/packages/cloudwatch/src/create-alarms.ts
@@ -15,11 +15,15 @@ function capitalize(s: string): string {
  * otherwise it is derived from the scope, `id`, and `def.key` via
  * {@link defaultAlarmName}.
  *
+ * Each alarm's construct id is `${id}${Capitalize(key)}Alarm`, unless the
+ * definition supplies an explicit `constructId`, which is used verbatim (e.g.
+ * to preserve an existing logical ID when grandfathering).
+ *
  * @param scope - CDK construct scope.
  * @param id - Base identifier; each alarm's construct id is `${id}${Capitalize(key)}Alarm`.
  * @param definitions - Fully-resolved alarm definitions.
  * @returns A record mapping each definition's key to its created Alarm.
- * @throws If duplicate keys are found in the definitions.
+ * @throws If duplicate keys are found, or a supplied `constructId` is empty.
  */
 export function createAlarms(
   scope: IConstruct,
@@ -35,7 +39,11 @@ export function createAlarms(
           `Disable the recommended alarm first, or use a different key.`,
       );
     }
-    alarms[def.key] = def.metric.createAlarm(scope, `${id}${capitalize(def.key)}Alarm`, {
+    if (def.constructId === "") {
+      throw new Error(`Alarm "${def.key}": constructId, when set, must be non-empty.`);
+    }
+    const constructId = def.constructId ?? `${id}${capitalize(def.key)}Alarm`;
+    alarms[def.key] = def.metric.createAlarm(scope, constructId, {
       alarmName: def.alarmName ?? defaultAlarmName(scope, id, def.key),
       threshold: def.threshold,
       evaluationPeriods: def.evaluationPeriods,

--- a/packages/cloudwatch/test/alarm-definition-builder.test.ts
+++ b/packages/cloudwatch/test/alarm-definition-builder.test.ts
@@ -147,6 +147,25 @@ describe("AlarmDefinitionBuilder", () => {
     expect(definition.alarmName).toBeUndefined();
   });
 
+  it("propagates constructId when set", () => {
+    const metric = new Metric({ namespace: "Test", metricName: "Count" });
+    const definition = new AlarmDefinitionBuilder<string>("custom")
+      .metric(() => metric)
+      .constructId("LegacyErrorsAlarm")
+      .resolve("unused");
+
+    expect(definition.constructId).toBe("LegacyErrorsAlarm");
+  });
+
+  it("leaves constructId undefined by default", () => {
+    const metric = new Metric({ namespace: "Test", metricName: "Count" });
+    const definition = new AlarmDefinitionBuilder<string>("noId")
+      .metric(() => metric)
+      .resolve("unused");
+
+    expect(definition.constructId).toBeUndefined();
+  });
+
   it("supports all comparison operators", () => {
     const metric = new Metric({ namespace: "Test", metricName: "Count" });
     const builder = () => new AlarmDefinitionBuilder<string>("op").metric(() => metric);

--- a/packages/cloudwatch/test/create-alarms.test.ts
+++ b/packages/cloudwatch/test/create-alarms.test.ts
@@ -72,6 +72,32 @@ describe("createAlarms", () => {
     expect(logicalIds.some((id) => id.startsWith("MyFuncErrorsAlarm"))).toBe(true);
   });
 
+  it("uses an explicit constructId verbatim, leaving alarmName to derive its default", () => {
+    const stack = new Stack(new App(), "MyServiceStack");
+    const definitions = [makeDefinition({ key: "errors", constructId: "LegacyErrorsAlarm" })];
+
+    createAlarms(stack, "siteAlerts", definitions);
+    const template = Template.fromStack(stack);
+
+    const logicalIds = Object.keys(template.findResources("AWS::CloudWatch::Alarm"));
+    expect(logicalIds.some((id) => id.startsWith("LegacyErrorsAlarm"))).toBe(true);
+    // The default formula must NOT be used when constructId is supplied...
+    expect(logicalIds.some((id) => id.startsWith("siteAlertsErrorsAlarm"))).toBe(false);
+    // ...and the override is independent of alarmName, which still derives its default.
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "my-service-stack/site-alerts/errors",
+    });
+  });
+
+  it("throws when a supplied constructId is empty", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const definitions = [makeDefinition({ key: "errors", constructId: "" })];
+
+    expect(() => createAlarms(stack, "MyFunc", definitions)).toThrow(
+      'Alarm "errors": constructId, when set, must be non-empty.',
+    );
+  });
+
   it("derives a default AlarmName from stack/id/key when none is supplied", () => {
     const stack = new Stack(new App(), "MyServiceStack");
     createAlarms(stack, "siteAlerts", [makeDefinition({ key: "errors" })]);


### PR DESCRIPTION
## Summary

Adds an optional, per-definition `constructId` override to alarm creation, so consumers can control the CDK construct id (and therefore the CloudFormation logical ID) of each alarm `createAlarms` produces.

- New optional `constructId?: string` on `AlarmDefinition`.
- New `.constructId(id)` fluent setter on `AlarmDefinitionBuilder`, mirroring the existing `.alarmName(...)`.
- `createAlarms` uses a supplied `constructId` **verbatim** instead of the derived `${id}${Capitalize(key)}Alarm`; an empty string throws a clear error.

When omitted, behaviour is unchanged.

## Why

Resolves the construct-id half of #149. Consumers grandfathering existing stacks (or migrating from another framework) need to preserve their existing CloudFormation logical IDs — a changed construct id changes the logical ID, which **replaces** (drops + recreates) the alarm on first deploy. Construct ids are fixed at construction time, so unlike alarm *names* (already covered by the per-definition `alarmName` field and the scope-wide `alarmNamePolicy`) they cannot be rewritten by a synth-time policy and must be set here.

This deliberately mirrors the existing `alarmName` override rather than introducing a new abstraction. A broader, library-wide construct-id strategy across all builders was considered and **deferred** — there isn't enough signal yet to justify a contract-freezing change, and `CfnResource.overrideLogicalId()` remains the preferred escape hatch in the meantime. See the decision write-up on #149.

### Scope / non-goals

- Direct `createAlarms` path only. Threading overrides through the ~14 service builders is **not** included (deferred).
- No change to `defaultAlarmName` (alarm *names* are already solved two ways).
- No ADR — reuses the existing `alarmName` field pattern.

## Design choices

- **Verbatim** — the supplied id is used exactly as given (no sanitisation), so it can match a legacy logical ID 1:1.
- **Throw on empty** — a present-but-empty `constructId` throws rather than silently falling back.

## Tests

- `constructId` used verbatim; the default formula is not applied; `alarmName` still derives its default independently.
- Empty `constructId` throws.
- Builder propagates `.constructId(...)` into the resolved definition (and leaves it undefined by default).

`npx nx test cloudwatch` (build + typecheck + 91 tests), `npm run lint`, and `npm run format:check` all pass.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)