### PR TITLE
chore(release): v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 0.8.3 (2026-06-01)
+
+### 🚀 Features
+
+- aws-cdk-lib floor diagnostics (ADR-0008) ([#161](https://github.com/laazyj/composureCDK/pull/161))
+- **ci:** per-package floor enforcement via the unit suites (ADR-0008) ([#170](https://github.com/laazyj/composureCDK/pull/170), [#146](https://github.com/laazyj/composureCDK/issues/146))
+- **cloudwatch:** per-alarm constructId override ([#185](https://github.com/laazyj/composureCDK/pull/185), [#149](https://github.com/laazyj/composureCDK/issues/149))
+- **examples:** exercise SG builder in Ec2Stack (avoid duplicate deploy) ([#164](https://github.com/laazyj/composureCDK/issues/164))
+
+### 🩹 Fixes
+
+- **budgets:** raise aws-cdk-lib floor to 2.93.0 ([#179](https://github.com/laazyj/composureCDK/pull/179))
+- **cloudformation:** raise aws-cdk-lib floor to 2.1.0 ([4a5290c](https://github.com/laazyj/composureCDK/commit/4a5290c))
+- **cloudfront:** bump aws-cdk-lib floor to 2.124.0 ([5d0fe84](https://github.com/laazyj/composureCDK/commit/5d0fe84))
+- **ec2:** raise aws-cdk-lib floor to 2.140.0 ([13e2f95](https://github.com/laazyj/composureCDK/commit/13e2f95))
+- **events:** raise aws-cdk-lib floor to 2.85.0 ([#181](https://github.com/laazyj/composureCDK/pull/181))
+- **iam:** raise aws-cdk-lib floor to 2.26.0 ([#180](https://github.com/laazyj/composureCDK/pull/180))
+- **s3:** raise aws-cdk-lib floor to 2.123.0 ([4620ec3](https://github.com/laazyj/composureCDK/commit/4620ec3))
+- **sns:** raise aws-cdk-lib floor to 2.178.0 ([541dc10](https://github.com/laazyj/composureCDK/commit/541dc10))
+- **sqs:** raise aws-cdk-lib floor to 2.93.0 ([#178](https://github.com/laazyj/composureCDK/pull/178))
+
+### ❤️ Thank You
+
+- Jason Duffett
+
 ## 0.8.2 (2026-05-28)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -8749,7 +8749,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8771,7 +8771,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8794,7 +8794,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8810,13 +8810,13 @@
         "@composurecdk/cloudformation": "^0.8.0",
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
-        "aws-cdk-lib": "^2.1.0",
+        "aws-cdk-lib": "^2.93.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8830,13 +8830,13 @@
       },
       "peerDependencies": {
         "@composurecdk/core": "^0.8.0",
-        "aws-cdk-lib": "^2.0.0",
+        "aws-cdk-lib": "^2.1.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8853,13 +8853,13 @@
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
         "@composurecdk/s3": "^0.8.0",
-        "aws-cdk-lib": "^2.118.0",
+        "aws-cdk-lib": "^2.124.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8878,7 +8878,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -8897,7 +8897,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8914,13 +8914,13 @@
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
         "@composurecdk/logs": "^0.8.0",
-        "aws-cdk-lib": "^2.54.0",
+        "aws-cdk-lib": "^2.140.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8935,7 +8935,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8950,13 +8950,13 @@
       "peerDependencies": {
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
-        "aws-cdk-lib": "^2.1.0",
+        "aws-cdk-lib": "^2.85.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.257.0",
@@ -8985,7 +8985,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9000,13 +9000,13 @@
       "peerDependencies": {
         "@composurecdk/cloudformation": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
-        "aws-cdk-lib": "^2.1.0",
+        "aws-cdk-lib": "^2.26.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@composurecdk/iam": "^0.8.0",
@@ -9031,7 +9031,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9052,7 +9052,7 @@
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9085,7 +9085,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9108,7 +9108,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9125,13 +9125,13 @@
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
         "@composurecdk/logs": "^0.8.0",
-        "aws-cdk-lib": "^2.54.0",
+        "aws-cdk-lib": "^2.123.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9147,13 +9147,13 @@
         "@composurecdk/cloudformation": "^0.8.0",
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
-        "aws-cdk-lib": "^2.1.0",
+        "aws-cdk-lib": "^2.178.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9169,7 +9169,7 @@
         "@composurecdk/cloudformation": "^0.8.0",
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
-        "aws-cdk-lib": "^2.1.0",
+        "aws-cdk-lib": "^2.93.0",
         "constructs": "^10.0.0"
       }
     }

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.8.3**.

Generated by `release-prepare` workflow run [#26738961866](https://github.com/laazyj/composureCDK/actions/runs/26738961866).

## Merge checklist

- [x] CI is green
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.8.3`, which triggers `release.yml` (deploy-test → npm publish).