### PR TITLE
fix(ec2): let user-pinned availabilityZones override default maxAzs

### DIFF
--- a/docs/adr/0009-defaults-yield-to-mutually-exclusive-siblings.md
+++ b/docs/adr/0009-defaults-yield-to-mutually-exclusive-siblings.md
@@ -1,0 +1,56 @@
+# ADR 0009: Defaults yield to a mutually-exclusive user-set sibling prop
+
+- **Status:** Accepted
+- **Date:** 2026-06-06
+
+## Context
+
+Builders apply defaults with a single spread in `build()`:
+`{ ...DEFAULTS, ...this.props }`. The defaults doctrine
+([architecture.md](../architecture.md#defaults)) promises that every default
+is "individually overridable through the existing fluent API." Because user
+values are spread last, a user value overrides a default **on the same key**.
+
+Some CDK props are mutually exclusive with a sibling: setting one forbids the
+other. `VpcProps` is the first case in the library — CDK rejects a `Vpc`
+configured with both `availabilityZones` and `maxAzs`. `VPC_DEFAULTS` ships
+`maxAzs: 2` (a deliberate cost/HA balance). A user who sets
+`availabilityZones` — the supported way to pin AZs for a deterministic,
+credential-free `cdk synth` — finds the default `maxAzs` still present in the
+merged props, because it lives on a _different_ key. Synth then fails with
+`Vpc supports 'availabilityZones' or 'maxAzs', but not both`
+(issue [#153](https://github.com/laazyj/composureCDK/issues/153)).
+
+The default was effectively un-overridable through its legitimate sibling API,
+contradicting the doctrine. The existing build-time mutual-exclusivity pattern
+in `function-builder.ts` and `certificate-builder.ts` covers _user-vs-user_
+conflicts (throw when two user choices collide); this is the new
+_default-vs-user_ dimension.
+
+## Decision
+
+When a default-supplied prop is mutually exclusive with a sibling prop, the
+builder resolves the conflict in `build()`:
+
+1. **If the user sets the sibling and not the default's key**, omit the
+   conflicting default from the merge. User intent wins silently — this is the
+   same "user value takes precedence over a default" guarantee, extended to a
+   sibling key.
+2. **If the user sets both keys explicitly**, throw a descriptive error. This
+   is a genuine user conflict, indistinguishable in a flat `props` record from
+   either order of assignment, so it fails fast rather than guessing.
+
+The default value itself is left in `defaults.ts` unchanged — the resolution
+is purely a `build()`-time merge concern.
+
+## Consequences
+
+- Pinned-AZ VPCs synth offline without dropping the cost-conscious 2-AZ
+  default for everyone, and the default stays auditable in `VPC_DEFAULTS`.
+- A small amount of conflict-aware logic lives in `build()`, mirroring the
+  existing mutual-exclusivity throws. Builder authors adding a default that is
+  mutually exclusive with a sibling must apply this rule.
+- The fix is per-instance. If default-vs-sibling collisions recur, that is the
+  signal to weigh a generic, typed primitive in `@composurecdk/core` rather
+  than repeating the pattern; an untyped `.unset()` escape hatch was rejected
+  for pushing the burden onto users and leaking which props are defaults.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0006: Decorator pattern for cross-cutting builder features](0006-decorator-builder-pattern.md)
 - [ADR-0007: Dual ESM/CJS publishing as an enforced standard](0007-dual-esm-cjs-publishing.md)
 - [ADR-0008: Per-package aws-cdk-lib version floors](0008-aws-cdk-lib-version-floors.md)
+- [ADR-0009: Defaults yield to a mutually-exclusive user-set sibling prop](0009-defaults-yield-to-mutually-exclusive-siblings.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,7 @@ For nested properties like `deployOptions`, the builder performs a targeted deep
 - **Every default property has a JSDoc annotation** linking to the specific AWS recommendation it implements, preferring the [AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html) and its lenses (e.g. Serverless Applications Lens, Security Pillar) as the primary source. This keeps each default traceable and auditable.
 - **Defaults are exported** so consumers can inspect them, reference them in documentation, or use them in tests.
 - **Build-time resources** (such as the `LogGroup` auto-created for API Gateway access logging) are only created when the user has not provided their own. This avoids creating unused resources when the user has a custom setup.
+- **A default yields to a mutually-exclusive sibling.** Same-key override falls out of the spread, but when a default is mutually exclusive with a _different_ prop the user sets (e.g. a VPC's `maxAzs` default vs. user-set `availabilityZones`), `build()` drops the conflicting default so user intent still wins; setting both keys explicitly throws. See [ADR-0009](adr/0009-defaults-yield-to-mutually-exclusive-siblings.md).
 
 ## Ref
 

--- a/packages/ec2/src/vpc-builder.ts
+++ b/packages/ec2/src/vpc-builder.ts
@@ -97,11 +97,25 @@ class VpcBuilder implements Lifecycle<VpcBuilderResult> {
 
     const { flowLogsLogGroup, flowLogProps } = resolveFlowLogs(scope, id, flowLogsConfig);
 
+    // CDK accepts `availabilityZones` or `maxAzs`, but not both. When the user
+    // pins AZs explicitly, the default `maxAzs` must yield to their intent;
+    // setting both is a genuine conflict and fails fast.
+    const userPinnedAzs = vpcProps.availabilityZones !== undefined;
+    if (userPinnedAzs && vpcProps.maxAzs !== undefined) {
+      throw new Error(
+        `VpcBuilder "${id}": .availabilityZones() and .maxAzs() are mutually exclusive — ` +
+          `CDK accepts one or the other, not both.`,
+      );
+    }
+
     const mergedProps = {
       ...VPC_DEFAULTS,
       ...flowLogProps,
       ...vpcProps,
     };
+    if (userPinnedAzs) {
+      delete mergedProps.maxAzs;
+    }
 
     return {
       vpc: new Vpc(scope, id, mergedProps),

--- a/packages/ec2/test/vpc-builder.test.ts
+++ b/packages/ec2/test/vpc-builder.test.ts
@@ -151,4 +151,34 @@ describe("VpcBuilder", () => {
       ).toThrow(/configure.*cannot be combined with.*destination/);
     });
   });
+
+  describe("availabilityZones", () => {
+    it("synthesizes with pinned AZs without a context lookup", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", {
+        env: { account: "111111111111", region: "us-east-1" },
+      });
+
+      createVpcBuilder().availabilityZones(["us-east-1a", "us-east-1b"]).build(stack, "Network");
+      const template = Template.fromStack(stack);
+
+      // The default maxAzs yields to the pinned AZs: 2 AZs x (public + private)
+      // = 4 subnets, and synth succeeds without the maxAzs/availabilityZones clash.
+      template.resourceCountIs("AWS::EC2::Subnet", 4);
+    });
+
+    it("throws when both availabilityZones and maxAzs are set", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack", {
+        env: { account: "111111111111", region: "us-east-1" },
+      });
+
+      expect(() =>
+        createVpcBuilder()
+          .availabilityZones(["us-east-1a", "us-east-1b"])
+          .maxAzs(2)
+          .build(stack, "Network"),
+      ).toThrow(/availabilityZones\(\) and \.maxAzs\(\) are mutually exclusive/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`VPC_DEFAULTS` ships `maxAzs: 2`, which `VpcBuilder.build()` spread into the `Vpc` props regardless of whether the user set the mutually-exclusive `availabilityZones`. CDK rejects a `Vpc` configured with both (`Vpc supports 'availabilityZones' or 'maxAzs', but not both`), so pinning AZs for a deterministic, credential-free `cdk synth` failed at synth time. The default was effectively un-overridable through its legitimate sibling API, contradicting the project's defaults doctrine.

Fixes #153.

## What changed

- **`packages/ec2/src/vpc-builder.ts`** — `build()` now drops the default `maxAzs` when the user pins `availabilityZones`, so user intent wins. Setting **both** explicitly throws a descriptive error, mirroring the build-time mutual-exclusivity handling already in `function-builder.ts` and `certificate-builder.ts`.
- **`packages/ec2/test/vpc-builder.test.ts`** — adds two cases: pinned-AZ synth succeeds offline (4 subnets, no clash) and the both-set case throws.
- **Docs** — new `ADR-0009` capturing the *default-yields-to-mutually-exclusive-sibling* rule (and explicitly deferring a generic `@composurecdk/core` primitive until the pattern recurs), an index entry in `docs/adr/README.md`, and an amendment to the Defaults section of `docs/architecture.md`.

## Design notes

Chose the localised builder-layer fix (Option 1 from the issue) over dropping the default (Option 3 reverses the deliberate cost-conscious 2-AZ stance and silently re-shapes every existing VPC) and over a generic `.unset()` core primitive (Option 2 is invasive and pushes the burden onto users). The novel dimension here is *default-vs-user* rather than the existing *user-vs-user* mutual exclusivity — documented in ADR-0009.

## Verification

`npm run verify` (build + `check:exports` + lint + test) passes across all projects; the ec2 suite is 110/110.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZH34ZsVTJUMDMyWySyjz7)_