### PR TITLE
refactor(cloudwatch): migrate alarmName validator to the constraint catalogue

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -17,7 +17,8 @@ character set and links the relevant AWS doc.
 Cross-cutting tag key/value validation is not listed here; it is applied automatically by
 `taggedBuilder` and reachable directly via `validateTag` in `@composurecdk/cloudformation`.
 
-| Package             | Constraint                 | Validate                                        | Sanitize |
-| ------------------- | -------------------------- | ----------------------------------------------- | -------- |
-| `@composurecdk/ec2` | `securityGroupDescription` | `constraints.validate.securityGroupDescription` | —        |
-| `@composurecdk/ec2` | `securityGroupName`        | `constraints.validate.securityGroupName`        | —        |
+| Package                    | Constraint                 | Validate                                        | Sanitize |
+| -------------------------- | -------------------------- | ----------------------------------------------- | -------- |
+| `@composurecdk/cloudwatch` | `alarmName`                | `constraints.validate.alarmName`                | —        |
+| `@composurecdk/ec2`        | `securityGroupDescription` | `constraints.validate.securityGroupDescription` | —        |
+| `@composurecdk/ec2`        | `securityGroupName`        | `constraints.validate.securityGroupName`        | —        |

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -37,6 +37,7 @@
     }
   },
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.8.0",
     "aws-cdk-lib": "^2.1.0",
     "constructs": "^10.0.0"
   },

--- a/packages/cloudwatch/src/alarm-name.ts
+++ b/packages/cloudwatch/src/alarm-name.ts
@@ -1,3 +1,5 @@
+import { charSets, stringConstraint, validateString } from "@composurecdk/cloudformation";
+
 declare const alarmNameBrand: unique symbol;
 
 /**
@@ -7,30 +9,37 @@ declare const alarmNameBrand: unique symbol;
  */
 export type AlarmName = string & { readonly [alarmNameBrand]: true };
 
-const VALID_CHARS = /^[A-Za-z0-9\-_./#:()+ =@]+$/;
-const MAX_LEN = 255;
+/**
+ * The CloudWatch AlarmName constraint. Its character set is exactly the shared
+ * `charSets.ALNUM` + `charSets.AWS_NAME_PUNCT` spine with no property-specific
+ * tail — a clean reuse of the catalogue fragments. See ADR-0010.
+ */
+const ALARM_NAME = stringConstraint({
+  name: "CloudWatch AlarmName",
+  charClass: `${charSets.ALNUM}${charSets.AWS_NAME_PUNCT}`,
+  minLength: 1,
+  maxLength: 255,
+  allowed: "A-Z a-z 0-9 space and - _ . / # : ( ) + = @",
+  source:
+    "https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html",
+});
+
+/** Validates a CloudWatch alarm name against {@link ALARM_NAME}. @throws on invalid input. */
+export function validateAlarmName(value: string): void {
+  validateString(value, ALARM_NAME);
+}
 
 /**
- * Validates and brands a string as an {@link AlarmName}. The string is used
- * verbatim — no sanitisation — so what the caller writes is exactly what
- * appears in CloudWatch.
+ * Validates and brands a string as an {@link AlarmName}. Surrounding whitespace
+ * is trimmed, then the value is used verbatim — so what the caller writes is
+ * exactly what appears in CloudWatch.
  *
  * @throws If the input is empty, exceeds 255 chars, or contains characters
- * outside CloudWatch's allowed set: `[A-Za-z0-9-_./#:()+ =@]`.
+ * outside CloudWatch's allowed set.
  */
 export function alarmName(input: string): AlarmName {
   const trimmed = input.trim();
-  if (trimmed.length === 0) {
-    throw new Error("alarm name cannot be empty");
-  }
-  if (trimmed.length > MAX_LEN) {
-    throw new Error(`alarm name exceeds ${String(MAX_LEN)} chars: "${trimmed}"`);
-  }
-  if (!VALID_CHARS.test(trimmed)) {
-    throw new Error(
-      `alarm name contains invalid characters (allowed: A-Z a-z 0-9 - _ . / # : ( ) + = @ space): "${trimmed}"`,
-    );
-  }
+  validateAlarmName(trimmed);
   return trimmed as AlarmName;
 }
 

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -1,3 +1,6 @@
+import type { ConstraintNamespace } from "@composurecdk/cloudformation";
+import { validateAlarmName } from "./alarm-name.js";
+
 export type { AlarmConfig, AlarmConfigDefaults } from "./alarm-config.js";
 export type { AlarmDefinition, AlarmMetric } from "./alarm-definition.js";
 export { AlarmDefinitionBuilder } from "./alarm-definition-builder.js";
@@ -17,3 +20,15 @@ export {
   type AlarmNameRule,
   type AlarmNameTransformContext,
 } from "./policies/alarm-name-policy.js";
+
+/**
+ * This package's AWS-property constraints, grouped by application strategy.
+ * The `constraints.validate.*` / `constraints.sanitize.*` shape is identical in
+ * every builder package; the underlying constraint definition stays
+ * module-private. The branded {@link alarmName} constructor layers on top of the
+ * same validation. See ADR-0010.
+ */
+export const constraints = {
+  validate: { alarmName: validateAlarmName },
+  sanitize: {},
+} satisfies ConstraintNamespace;

--- a/packages/cloudwatch/test/alarm-name-policy.test.ts
+++ b/packages/cloudwatch/test/alarm-name-policy.test.ts
@@ -181,6 +181,6 @@ describe("alarmNamePolicy", () => {
 
     alarmNamePolicy(app, { defaults: { suffix: "bad!suffix" } });
 
-    expect(() => Template.fromStack(stack)).toThrow(/invalid characters/);
+    expect(() => Template.fromStack(stack)).toThrow(/is invalid/);
   });
 });

--- a/packages/cloudwatch/test/alarm-name.test.ts
+++ b/packages/cloudwatch/test/alarm-name.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { alarmName, joinAlarmName, kebab } from "../src/alarm-name.js";
+import { constraints } from "../src/index.js";
 
 describe("alarmName", () => {
   it("returns the input verbatim when valid", () => {
@@ -11,12 +12,12 @@ describe("alarmName", () => {
   });
 
   it("rejects empty input", () => {
-    expect(() => alarmName("")).toThrow(/empty/);
-    expect(() => alarmName("   ")).toThrow(/empty/);
+    expect(() => alarmName("")).toThrow(/minimum/);
+    expect(() => alarmName("   ")).toThrow(/minimum/);
   });
 
   it("rejects names longer than 255 chars", () => {
-    expect(() => alarmName("x".repeat(256))).toThrow(/255/);
+    expect(() => alarmName("x".repeat(256))).toThrow(/255-character limit/);
   });
 
   it("accepts the full CloudWatch character set", () => {
@@ -24,9 +25,9 @@ describe("alarmName", () => {
   });
 
   it("rejects characters outside CloudWatch's allowed set", () => {
-    expect(() => alarmName("oops!")).toThrow(/invalid characters/);
-    expect(() => alarmName("a&b")).toThrow(/invalid characters/);
-    expect(() => alarmName("a\nb")).toThrow(/invalid characters/);
+    expect(() => alarmName("oops!")).toThrow(/is invalid/);
+    expect(() => alarmName("a&b")).toThrow(/is invalid/);
+    expect(() => alarmName("a\nb")).toThrow(/is invalid/);
   });
 });
 
@@ -68,6 +69,17 @@ describe("joinAlarmName", () => {
   });
 
   it("validates the result", () => {
-    expect(() => joinAlarmName([])).toThrow(/empty/);
+    expect(() => joinAlarmName([])).toThrow(/minimum/);
+  });
+});
+
+describe("constraints.validate.alarmName", () => {
+  it("is exposed through the package constraints namespace", () => {
+    expect(() => {
+      constraints.validate.alarmName("payments-prod/lambda/errors");
+    }).not.toThrow();
+    expect(() => {
+      constraints.validate.alarmName("oops!");
+    }).toThrow(/CloudWatch AlarmName/);
   });
 });


### PR DESCRIPTION
Migrates `@composurecdk/cloudwatch`'s branded `alarmName` validator onto the AWS-property constraint catalogue ([ADR-0010](https://github.com/laazyj/composureCDK/blob/main/docs/adr/0010-aws-property-constraints.md)), following the pattern established in #188 (ec2).

## What changed
- The hand-rolled `VALID_CHARS` / `MAX_LEN` checks in `alarm-name.ts` are replaced by a module-private `ALARM_NAME` `StringConstraint` consumed by `validateString`. Its character set is **exactly** the shared `charSets.ALNUM + charSets.AWS_NAME_PUNCT` spine with no property-specific tail — a clean reuse of the catalogue fragments (verified to reproduce the old `/^[A-Za-z0-9\-_./#:()+ =@]+$/` over all printable ASCII).
- The branded `AlarmName` type, `alarmName()`, `joinAlarmName()`, and the stylistic `kebab()` keep their behaviour. `alarmName()` trims then delegates to the shared `validateString`, so its error messages now match the rest of the catalogue.
- Added the package `constraints` namespace (`constraints.validate.alarmName`); the `ALARM_NAME` definition stays module-private. The branded constructor layers over the same validation, per ADR-0010.
- `alarmName` now appears in the generated `docs/constraints.md`.

## Dependency note
- Adds `@composurecdk/cloudformation` (`^0.8.0`) as a **peer dependency** of cloudwatch — required to consume the mechanism. No cycle: cloudformation's only composurecdk dependency is `core` (it does not depend on cloudwatch), and the arrow points the same direction (`service → cloudformation`) that ec2/budgets/s3 already follow.

## Notes
- No `Token.isUnresolved` guard was added: the previous `alarmName` didn't skip tokens either, so this migration preserves existing behaviour (validate verbatim) rather than introducing a new behavioural change.
- `kebab` / `joinAlarmName` are stylistic/composition helpers and stay as-is, per ADR-0010's "constraint, not style" scoping.

Ran `simplify` over the diff (clean on all axes) and full `npm run verify` (19 projects) — all green.

Part of the #166 / #188 follow-up (one PR per package). With this, the two outstanding branded validators (budgets `email` in #192, cloudwatch `alarmName` here) are migrated; `construct-id` (core) and the stylistic helpers remain deliberately out of scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_011jeZwfggSHFK4eNWWLUEqW)_