### PR TITLE
feat(lambda): remind when SQS event source lacks a 6x visibility-timeout target

### DIFF
--- a/packages/lambda/src/event-sources/event-source-warnings.ts
+++ b/packages/lambda/src/event-sources/event-source-warnings.ts
@@ -1,0 +1,87 @@
+import { Annotations, Token } from "aws-cdk-lib";
+import type { FunctionProps } from "aws-cdk-lib/aws-lambda";
+import type { IConstruct } from "constructs";
+import type { EventSourceKind } from "./composure-event-source.js";
+
+/**
+ * AWS guidance: an SQS source queue's `visibilityTimeout` should be at least
+ * this multiple of the consumer function's `timeout`, so Lambda has room to
+ * retry a throttled batch before a message becomes visible again.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+ */
+const SQS_VISIBILITY_TIMEOUT_MULTIPLIER = 6;
+
+/**
+ * Suppression id for the SQS visibility-timeout reminder. Stable and part of
+ * the public surface — callers silence the warning with
+ * `Annotations.of(scope).acknowledgeWarning(SQS_VISIBILITY_TIMEOUT_ANNOTATION)`,
+ * so it must not be renamed casually.
+ */
+const SQS_VISIBILITY_TIMEOUT_ANNOTATION = "@composurecdk/lambda:sqs-visibility-timeout";
+
+/**
+ * Emits the cross-component invariant reminders for a single attached event
+ * source. `FunctionBuilder` dispatches on {@link EventSourceKind} so it never
+ * has to `instanceof` CDK internals — mirroring the kind-keyed contextual
+ * alarm specs in `function-alarms.ts`.
+ *
+ * @internal
+ */
+export type EventSourceInvariantWarner = (
+  scope: IConstruct,
+  id: string,
+  key: string,
+  props: Pick<FunctionProps, "timeout">,
+) => void;
+
+/**
+ * Per-kind invariant reminders, keyed by {@link EventSourceKind}. `undefined`
+ * for a kind with no cross-component invariant to surface (e.g. a bare
+ * escape-hatch source attached as `"unknown"`).
+ *
+ * @internal
+ */
+export const EVENT_SOURCE_INVARIANT_WARNERS: Record<
+  EventSourceKind,
+  EventSourceInvariantWarner | undefined
+> = {
+  sqs: warnSqsVisibilityTimeout,
+  unknown: undefined,
+};
+
+/**
+ * Reminds that the source queue's `visibilityTimeout` should be ≥ 6× the
+ * consumer function's `timeout`.
+ *
+ * This is a **contextual reminder**, not a true comparison: the concrete
+ * `Queue` construct does not expose `visibilityTimeout` (only `QueueProps`
+ * carries it), so a consuming builder that receives the queue via `ref()`
+ * cannot read the value to compare it (tracked in laazyj/composureCDK#122).
+ * We therefore state the function's own timeout and the computed 6× target
+ * and leave the operator to confirm the queue side.
+ */
+function warnSqsVisibilityTimeout(
+  scope: IConstruct,
+  id: string,
+  key: string,
+  props: Pick<FunctionProps, "timeout">,
+): void {
+  const { timeout } = props;
+  // No timeout means no 6× target to state — stay quiet rather than guess.
+  if (timeout === undefined) return;
+
+  const timeoutSeconds = timeout.toSeconds();
+  // A timeout threaded through a CFN parameter is unknown at synth time;
+  // a target derived from a token would be noise, not guidance.
+  if (Token.isUnresolved(timeoutSeconds)) return;
+
+  const target = timeoutSeconds * SQS_VISIBILITY_TIMEOUT_MULTIPLIER;
+  Annotations.of(scope).addWarningV2(
+    SQS_VISIBILITY_TIMEOUT_ANNOTATION,
+    `FunctionBuilder "${id}": SQS event source "${key}" — consumer function timeout is ` +
+      `${String(timeoutSeconds)}s; ensure the source queue's visibilityTimeout is >= ` +
+      `${String(target)}s (${String(SQS_VISIBILITY_TIMEOUT_MULTIPLIER)}x) so Lambda can retry ` +
+      `a throttled batch. See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html`,
+  );
+}

--- a/packages/lambda/src/event-sources/sqs-event-source.ts
+++ b/packages/lambda/src/event-sources/sqs-event-source.ts
@@ -44,16 +44,20 @@ export const DEFAULT_SQS_EVENT_SOURCE_PROPS: Pick<
  *
  * Applies {@link DEFAULT_SQS_EVENT_SOURCE_PROPS}; pass `props` to override.
  *
- * ## Cross-component invariants (not enforced)
+ * ## Cross-component invariants
  *
  * AWS Well-Architected guidance spans the queue and the function:
  * - the source queue's visibility timeout should be ≥ 6× the function
  *   timeout, leaving room for Lambda to retry a throttled batch;
  * - the source queue's redrive `maxReceiveCount` should be ≥ 5 before the DLQ.
  *
- * These are not validated here — the queue often arrives as a `ref()` that is
- * not resolvable at configuration time. Tracked in laazyj/composureCDK#123
- * and #124.
+ * The visibility-timeout rule surfaces as a synth-time **reminder** when this
+ * source is attached to a {@link IFunctionBuilder} that has a `timeout` set.
+ * The concrete `Queue` construct does not expose `visibilityTimeout` (only
+ * `QueueProps` carries it), so the consumer cannot read the queue value for a
+ * true comparison — it states the function timeout and the computed 6× target
+ * instead. Upgrading this to a real comparison is tracked in
+ * laazyj/composureCDK#122; the `maxReceiveCount` floor is tracked in #124.
  *
  * @param queue - The source queue, concrete or a `ref()` to a sibling.
  * @param props - Overrides for {@link DEFAULT_SQS_EVENT_SOURCE_PROPS} and any

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -25,6 +25,7 @@ import {
   EVENT_SOURCE_MAPPING_ID_READERS,
   isComposureEventSource,
 } from "./event-sources/composure-event-source.js";
+import { EVENT_SOURCE_INVARIANT_WARNERS } from "./event-sources/event-source-warnings.js";
 
 const LOGS_WRITER_POLICY_NAME = "LogsWriter";
 
@@ -357,6 +358,12 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
         kind,
         eventSourceMappingId: EVENT_SOURCE_MAPPING_ID_READERS[kind]?.(eventSource),
       });
+
+      // Surface any cross-component invariant that spans this source and the
+      // function (e.g. the SQS visibility-timeout ≥ 6× function-timeout rule)
+      // as a synth-time reminder, dispatched on kind so no CDK internals are
+      // inspected.
+      EVENT_SOURCE_INVARIANT_WARNERS[kind]?.(scope, id, entry.key, mergedProps);
     }
 
     const alarms = createFunctionAlarms(

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { App, Duration, Stack } from "aws-cdk-lib";
+import { App, CfnParameter, Duration, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Code, type IEventSource, Runtime } from "aws-cdk-lib/aws-lambda";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
@@ -324,5 +324,27 @@ describe("SQS visibility-timeout reminder", () => {
     baseBuilder().timeout(Duration.seconds(30)).build(stack, "Fn");
 
     expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+  });
+
+  // A token-valued timeout has no concrete 6× target at synth time, so the
+  // reminder stays silent. Only a *seconds* token reaches here: CDK converts a
+  // Lambda timeout to seconds eagerly, so a Duration.minutes(token) throws at
+  // Function construction. The token also drives the duration alarm to warn
+  // under its own ack id, so this asserts the reminder's silence specifically
+  // rather than a global absence of warnings.
+  it("does not emit the reminder for a token-valued seconds timeout", () => {
+    const stack = new Stack(new App(), "S");
+    const param = new CfnParameter(stack, "TimeoutSeconds", { type: "Number", default: 30 });
+    baseBuilder()
+      .timeout(Duration.seconds(param.valueAsNumber))
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    expect(
+      Annotations.fromStack(stack).findWarning(
+        "*",
+        Match.stringLikeRegexp("sqs-visibility-timeout"),
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { Code, type IEventSource, Runtime } from "aws-cdk-lib/aws-lambda";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { Queue } from "aws-cdk-lib/aws-sqs";
@@ -246,5 +246,83 @@ describe("event-source contextual alarms", () => {
 
     expect(result.alarms).not.toHaveProperty("ordersFailedInvocations");
     expect(result.alarms).toHaveProperty("ordersDroppedEvents");
+  });
+});
+
+describe("SQS visibility-timeout reminder", () => {
+  it("warns with the 6x target when an SQS source is attached and timeout is set", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    // The ack tag is the public suppression key, so it's asserted alongside
+    // the message — guard against an accidental rename.
+    Annotations.fromStack(stack).hasWarning(
+      "/S",
+      Match.stringLikeRegexp(
+        `SQS event source "orders" — consumer function timeout is 30s.*` +
+          "visibilityTimeout is >= 180s \\(6x\\).*" +
+          "\\[ack: @composurecdk/lambda:sqs-visibility-timeout\\]",
+      ),
+    );
+  });
+
+  it("computes the target from a minutes-based timeout", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.minutes(1))
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    Annotations.fromStack(stack).hasWarning(
+      "/S",
+      Match.stringLikeRegexp(`timeout is 60s.*visibilityTimeout is >= 360s`),
+    );
+  });
+
+  it("warns once per attached SQS source, naming each by key", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Orders")))
+      .addEventSource("refunds", sqsEventSource(new Queue(stack, "Refunds")))
+      .build(stack, "Fn");
+
+    Annotations.fromStack(stack).hasWarning(
+      "/S",
+      Match.stringLikeRegexp(`SQS event source "orders"`),
+    );
+    Annotations.fromStack(stack).hasWarning(
+      "/S",
+      Match.stringLikeRegexp(`SQS event source "refunds"`),
+    );
+  });
+
+  it("does not warn when no timeout is set", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+  });
+
+  it("does not warn for a bare escape-hatch source even when timeout is set", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource("orders", new SqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+  });
+
+  it("does not warn when no event source is attached", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder().timeout(Duration.seconds(30)).build(stack, "Fn");
+
+    expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #123.

## What

When an **SQS-kind** event source is attached to a `FunctionBuilder` *and* the function has a `timeout` set, the builder now emits a CDK `Annotations.of(scope).addWarningV2(...)` at synth time:

> FunctionBuilder "Fn": SQS event source "orders" — consumer function timeout is 30s; ensure the source queue's visibilityTimeout is >= 180s (6x) so Lambda can retry a throttled batch. See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

This surfaces the AWS Well-Architected SQS↔Lambda invariant — a consumer's source queue should set `visibilityTimeout` to **at least 6× the function `timeout`** — that nothing in the library flagged before. It shows up in `cdk synth`/`deploy` output and is suppressible by its stable id (`@composurecdk/lambda:sqs-visibility-timeout`).

## Why this approach

- **It's the established "louder than docs, softer than a synth error" mechanism.** `Annotations.addWarningV2` is already the repo's chosen tool for advisory, suppressible-by-id guidance (`budgets`, `cloudfront`, `route53`, `sqs`, `sns`). Issue #123 calls for exactly this, so no new pattern and no ADR.
- **Contextual reminder, not a hard check — by necessity.** The concrete `Queue` construct does not expose `visibilityTimeout` (only `QueueProps` carries it), and the queue typically arrives as a `ref()`. So the builder can state the function's own `timeout` and the computed 6× target, but cannot yet *compare* against the queue's actual value. Turning this into a real comparison depends on builders exposing resolved props on their result types — tracked in #122. The known limitation and upgrade path in the issue are reflected here.
- **Dispatch keyed on `EventSourceKind`, never `instanceof`.** The new `EVENT_SOURCE_INVARIANT_WARNERS` record is keyed by the same `EventSourceKind` discriminator (from #118) that the contextual *alarm* specs use, so `FunctionBuilder` reasons about a source without touching CDK internals. A bare escape-hatch `IEventSource` is kind `"unknown"` → no warner → no reminder, mirroring how contextual alarms behave.
- **Only fires when `timeout` is set.** Without a timeout there is no 6× target to state, so it stays quiet rather than guess (matching the issue's condition). Token-valued timeouts are guarded with `Token.isUnresolved` so a CFN-parameter timeout doesn't produce garbage output.

## Where it lives

- `packages/lambda/src/event-sources/event-source-warnings.ts` (new) — the `SQS_VISIBILITY_TIMEOUT_MULTIPLIER`, the stable annotation id, and the kind-keyed `EVENT_SOURCE_INVARIANT_WARNERS` dispatch. Co-located with the other event-source machinery and SQS knowledge.
- `function-builder.ts` — one call inside the existing event-source attach loop, after the source is bound, passing the already-merged props.
- `sqs-event-source.ts` — JSDoc updated: the visibility-timeout rule is now an emitted reminder (#122 upgrades it to a real check; the `maxReceiveCount` floor remains #124).

## Alternatives considered

1. **Put the rule in `function-alarms.ts` alongside the contextual alarm specs.** Rejected: an alarm is a deployed CloudWatch resource; this is synth-time advisory output. Keeping the warner in its own module under `event-sources/` keeps the two concerns separate while sharing the same kind-keyed dispatch shape.
2. **Warn even when `timeout` is unset, using the Lambda default (3s) for the target.** Rejected: the 6× target would then be 18s, which is rarely what the user intends and would fire on the `order-processor` example (which deliberately leaves `timeout` at the CDK default). The issue scopes the reminder to "function has a `timeout` set"; honoring that avoids noise.
3. **Wait for #122 and ship the real comparison directly.** Rejected: #122 is a larger result-type contract change (likely its own ADR). The reminder delivers value now and the upgrade path is non-breaking — the message becomes an accurate comparison once the queue's resolved `visibilityTimeout` is reachable via `ref()`.
4. **Emit the warning from `sqsEventSource()` at construction time.** Rejected: the factory doesn't know the consuming function's `timeout`, and the source can be a deferred `ref()`. The invariant spans both components, so the natural emit point is `FunctionBuilder.build()` where both the source kind and the merged function props are known.

## Testing

`packages/lambda/test/event-sources.test.ts` adds a `SQS visibility-timeout reminder` block covering: the 6× message + ack-id assertion, minutes-based timeout math, one reminder per attached source (named by key), and the three quiet cases (no timeout, bare escape-hatch source, no source attached).

- `nx test lambda` — 93 passed
- `nx test examples` — 91 passed (order-processor unaffected: no `timeout` set)
- `npm run lint` / `npm run format:check` — clean

https://claude.ai/code/session_018T4yXLRT4v9uySUKRadnLD

---
_Generated by [Claude Code](https://claude.ai/code/session_018T4yXLRT4v9uySUKRadnLD)_