### PR TITLE
feat(dynamodb): add @composurecdk/dynamodb package with TableBuilder (first draft)

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -51,6 +51,10 @@
       "gatedBy": "aws-certificatemanager.KeyAlgorithm (introduced 2.119.0)"
     },
     "lambda": { "floor": "2.168.0", "gatedBy": "aws-lambda.MetricType (introduced 2.168.0)" },
-    "route53": { "floor": "2.216.0", "gatedBy": "aws-route53.HttpsRecord (introduced 2.216.0)" }
+    "route53": { "floor": "2.216.0", "gatedBy": "aws-route53.HttpsRecord (introduced 2.216.0)" },
+    "dynamodb": {
+      "floor": "2.170.0",
+      "gatedBy": "aws-dynamodb.TableProps.pointInTimeRecoverySpecification builder default (the recovery-period-capable PITR spec, ~2.169.0). DRAFT ESTIMATE — validate with `node scripts/cdk-floors.mjs establish` before release. Also deletionProtection (~2.97.0)."
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1918,6 +1918,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@composurecdk/dynamodb": {
+      "resolved": "packages/dynamodb",
+      "link": true
+    },
     "node_modules/@composurecdk/ec2": {
       "resolved": "packages/ec2",
       "link": true
@@ -8872,6 +8876,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
+        "@composurecdk/cloudformation": "^0.8.0",
         "aws-cdk-lib": "^2.1.0",
         "constructs": "^10.0.0"
       }
@@ -8893,6 +8898,28 @@
       },
       "peerDependencies": {
         "constructs": "^10.6.0"
+      }
+    },
+    "packages/dynamodb": {
+      "name": "@composurecdk/dynamodb",
+      "version": "0.8.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.9.1",
+        "aws-cdk-lib": "^2.257.0",
+        "constructs": "^10.6.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@composurecdk/cloudformation": "^0.8.0",
+        "@composurecdk/cloudwatch": "^0.8.0",
+        "@composurecdk/core": "^0.8.0",
+        "aws-cdk-lib": "^2.170.0",
+        "constructs": "^10.0.0"
       }
     },
     "packages/ec2": {
@@ -9072,6 +9099,7 @@
         "@composurecdk/cloudfront": "^0.8.0",
         "@composurecdk/cloudwatch": "^0.8.0",
         "@composurecdk/core": "^0.8.0",
+        "@composurecdk/dynamodb": "^0.8.0",
         "@composurecdk/ec2": "^0.8.0",
         "@composurecdk/events": "^0.8.0",
         "@composurecdk/iam": "^0.8.0",

--- a/packages/dynamodb/README.md
+++ b/packages/dynamodb/README.md
@@ -1,0 +1,143 @@
+# @composurecdk/dynamodb
+
+DynamoDB table builder for [ComposureCDK](../../README.md).
+
+This package provides a fluent builder for DynamoDB tables with secure, AWS-recommended defaults and built-in CloudWatch alarms. It wraps the CDK [Table](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.Table.html) construct — refer to the CDK documentation for the full set of configurable properties.
+
+## Table Builder
+
+```ts
+import { AttributeType, StreamViewType } from "aws-cdk-lib/aws-dynamodb";
+import { createTableBuilder } from "@composurecdk/dynamodb";
+
+const orders = createTableBuilder()
+  .partitionKey({ name: "orderId", type: AttributeType.STRING })
+  .sortKey({ name: "createdAt", type: AttributeType.NUMBER })
+  .stream(StreamViewType.NEW_AND_OLD_IMAGES)
+  .build(stack, "Orders");
+```
+
+Every [TableProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.TableProps.html) property is available as a fluent setter on the builder. `partitionKey` is the one property the builder does not default — the key schema is workload-specific, so it must be set before `build()`.
+
+## Secure Defaults
+
+`createTableBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.
+
+| Property                           | Default                                | Rationale                                                                                                                                                                                                                                                                                                                           |
+| ---------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `billingMode`                      | `BillingMode.PAY_PER_REQUEST`          | On-demand capacity — no forecasting, scales with traffic, avoids throttling from under-provisioning. Switch to `PROVISIONED` (implicitly, by setting `.readCapacity()` / `.writeCapacity()`) for steady, predictable workloads.                                                                                                     |
+| `encryption`                       | `TableEncryption.AWS_MANAGED`          | Encrypts at rest with the AWS-managed `aws/dynamodb` KMS key — visible in the account and logged in CloudTrail, unlike the free AWS-owned default key. Bring-your-own KMS is opt-in via `.encryptionKey(key)`. ([Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-data-at-rest.html)) |
+| `pointInTimeRecoverySpecification` | `{ pointInTimeRecoveryEnabled: true }` | Continuous backups — restore to any second in the preceding 35 days. ([PITR](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html))                                                                                                                                                            |
+| `deletionProtection`               | `true`                                 | Blocks table deletion (API, console, or `cdk destroy`) until explicitly disabled. Override with `.deletionProtection(false)` for ephemeral tables.                                                                                                                                                                                  |
+
+The defaults are exported as `TABLE_DEFAULTS` for visibility and testing:
+
+```ts
+import { TABLE_DEFAULTS } from "@composurecdk/dynamodb";
+```
+
+### Defaults that yield to a sibling you set
+
+Two defaults are mutually exclusive with a sibling property and step aside when you set it ([ADR-0009](../../docs/adr/0009-defaults-yield-to-mutually-exclusive-siblings.md)):
+
+- Setting `.readCapacity()` / `.writeCapacity()` drops the `PAY_PER_REQUEST` default so CDK uses `PROVISIONED` billing.
+- Setting `.encryptionKey()` infers `TableEncryption.CUSTOMER_MANAGED` (CDK only accepts a key under customer-managed encryption).
+
+## DynamoDB Streams
+
+Enable a stream with `.stream(StreamViewType…)`. The build result surfaces the stream ARN so a downstream component can wire a consumer:
+
+```ts
+const result = createTableBuilder()
+  .partitionKey({ name: "pk", type: AttributeType.STRING })
+  .stream(StreamViewType.NEW_AND_OLD_IMAGES)
+  .build(stack, "Events");
+
+result.tableStreamArn; // string — feed into a Lambda DynamoEventSource, etc.
+result.table; // the Table itself, which a DynamoEventSource consumes
+```
+
+The classic `Table` construct has no distinct stream construct — the stream is an attribute of the table — so the result exposes `tableStreamArn` directly rather than a separate construct.
+
+## Recommended Alarms
+
+The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#DynamoDB) by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.
+
+| Alarm                 | Metric                                      | Default threshold | Rationale                                                        |
+| --------------------- | ------------------------------------------- | ----------------- | ---------------------------------------------------------------- |
+| `systemErrors`        | `SystemErrors` (Sum across core ops, 1 min) | > 0               | Server-side (HTTP 500) faults — a table availability signal.     |
+| `readThrottleEvents`  | `ReadThrottleEvents` (Sum, 1 min)           | > 0               | Read throttling — hot partition or insufficient read capacity.   |
+| `writeThrottleEvents` | `WriteThrottleEvents` (Sum, 1 min)          | > 0               | Write throttling — hot partition or insufficient write capacity. |
+
+The thresholds are deliberately strict — a healthy table should sit at zero. Tune them up for workloads where brief, self-correcting throttling under burst is acceptable.
+
+`SystemErrors` is emitted per-operation, and a CloudWatch alarm on a metric-math expression can reference at most 10 metrics, so the `systemErrors` alarm sums the ten core data-plane operations (`GetItem`, `BatchGetItem`, `Query`, `Scan`, `PutItem`, `UpdateItem`, `DeleteItem`, `BatchWriteItem`, `TransactGetItems`, `TransactWriteItems`). The PartiQL statement operations and the stream `GetRecords` operation are excluded; add a custom alarm if your errors live there.
+
+The defaults are exported as `TABLE_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { TABLE_ALARM_DEFAULTS } from "@composurecdk/dynamodb";
+```
+
+### What is not alarmed by default
+
+- **Account-level utilization alarms** (`AccountProvisionedReadCapacityUtilization`, `AccountProvisionedWriteCapacityUtilization`) from the AWS recommended-alarms list are account-scoped, not table-scoped, so they do not belong to a per-table builder.
+- **Provisioned-capacity utilization** (consumed vs. provisioned) only applies to `PROVISIONED` tables; the default billing mode here is on-demand. Add it via `addAlarm` on a provisioned table.
+- **`UserErrors` / `ConditionalCheckFailedRequests`** are caller- or application-level signals (HTTP 400) and too workload-dependent for a useful generic threshold.
+
+### Customizing thresholds
+
+Override individual alarm properties via `recommendedAlarms`. Unspecified fields keep their defaults.
+
+```ts
+const table = createTableBuilder()
+  .partitionKey({ name: "pk", type: AttributeType.STRING })
+  .recommendedAlarms({
+    readThrottleEvents: { threshold: 10, evaluationPeriods: 3 },
+  });
+```
+
+### Disabling alarms
+
+```ts
+builder.recommendedAlarms(false);
+// or
+builder.recommendedAlarms({ enabled: false });
+// or individually
+builder.recommendedAlarms({ writeThrottleEvents: false });
+```
+
+### Custom alarms
+
+Add custom alarms alongside the recommended ones via `addAlarm`. The callback receives an `AlarmDefinitionBuilder` typed to `ITable`, so the metric factory has access to the table's metric helpers.
+
+```ts
+import { Duration } from "aws-cdk-lib";
+
+const table = createTableBuilder()
+  .partitionKey({ name: "pk", type: AttributeType.STRING })
+  .addAlarm("userErrors", (alarm) =>
+    alarm
+      .metric((table) => table.metricUserErrors({ period: Duration.minutes(5) }))
+      .threshold(5)
+      .greaterThan()
+      .description("Table is returning client-side (HTTP 400) errors."),
+  );
+```
+
+### Applying alarm actions
+
+Alarms are returned in the build result as `Record<string, Alarm>`:
+
+```ts
+const result = createTableBuilder()
+  .partitionKey({ name: "pk", type: AttributeType.STRING })
+  .build(stack, "Orders");
+
+const alertTopic = new Topic(stack, "AlertTopic");
+for (const alarm of Object.values(result.alarms)) {
+  alarm.addAlarmAction(new SnsAction(alertTopic));
+}
+```
+
+For composing the alarm-actions wiring across multiple builders in a single `compose` system, see [`alarmActionsPolicy`](../cloudwatch/README.md) in `@composurecdk/cloudwatch`.

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@composurecdk/dynamodb",
+  "version": "0.8.3",
+  "description": "Composable DynamoDB table builder with well-architected defaults",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laazyj/composureCDK",
+    "directory": "packages/dynamodb"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist .tshy .tshy-build",
+    "build": "tshy",
+    "typecheck": "tsc --noEmit",
+    "check:exports": "attw --pack . --profile node16 && publint",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [],
+  "author": "Jason Duffett (https://github.com/laazyj)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "tshy": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    }
+  },
+  "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.8.0",
+    "@composurecdk/cloudwatch": "^0.8.0",
+    "@composurecdk/core": "^0.8.0",
+    "aws-cdk-lib": "^2.170.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "aws-cdk-lib": "^2.257.0",
+    "constructs": "^10.6.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
+}

--- a/packages/dynamodb/src/defaults.ts
+++ b/packages/dynamodb/src/defaults.ts
@@ -1,0 +1,68 @@
+import { BillingMode, TableEncryption, type TableProps } from "aws-cdk-lib/aws-dynamodb";
+
+/**
+ * Secure, AWS-recommended defaults applied to every DynamoDB table built
+ * with {@link createTableBuilder}. Each property can be individually
+ * overridden via the builder's fluent API.
+ *
+ * `partitionKey` is intentionally not defaulted — the key schema is the
+ * single most workload-specific decision for a table and there is no safe
+ * generic value. The builder requires it to be set before {@link Lifecycle.build}.
+ */
+export const TABLE_DEFAULTS: Partial<TableProps> = {
+  /**
+   * On-demand (pay-per-request) capacity. Removes the need to forecast and
+   * provision read/write capacity, scales instantly with traffic, and avoids
+   * throttling caused by under-provisioning — the safe default for variable
+   * or unknown workloads. Switch to {@link BillingMode.PROVISIONED} with
+   * `.readCapacity()` / `.writeCapacity()` for steady, predictable traffic
+   * where provisioned capacity is more cost-effective.
+   *
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/capacity.html
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html
+   */
+  billingMode: BillingMode.PAY_PER_REQUEST,
+
+  /**
+   * Encrypt at rest with an AWS-managed KMS key (`aws/dynamodb`) rather than
+   * the default AWS-owned key. The AWS-managed key is visible in the account's
+   * KMS console and its use is logged in CloudTrail, giving an auditable record
+   * of table encryption — what the Security Pillar asks for. Bring-your-own KMS
+   * is opt-in: set `.encryptionKey(key)` and the builder infers
+   * {@link TableEncryption.CUSTOMER_MANAGED}.
+   *
+   * Note: the AWS-managed key incurs KMS API request charges that the free,
+   * AWS-owned key does not. Override with `.encryption(TableEncryption.DEFAULT)`
+   * to fall back to the AWS-owned key.
+   *
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-data-at-rest.html
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html
+   */
+  encryption: TableEncryption.AWS_MANAGED,
+
+  /**
+   * Enable point-in-time recovery (continuous backups). Lets the table be
+   * restored to any second within the preceding 35 days, protecting against
+   * accidental writes, deletes, and application-level corruption. The Reliability
+   * Pillar treats automated, restorable backups as table stakes for stateful
+   * services.
+   *
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/rel_backing_up_data_identified_backups_data.html
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html
+   */
+  pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+
+  /**
+   * Enable deletion protection so the table cannot be deleted by an API call,
+   * console action, or `cdk destroy` until protection is explicitly turned off.
+   * Guards production data against accidental teardown.
+   *
+   * This is intentionally heavier than CDK's default `RemovalPolicy.RETAIN`
+   * (which only orphans the table from the stack): deletion protection blocks
+   * the delete operation itself. Override with `.deletionProtection(false)` for
+   * ephemeral or test tables you expect to tear down.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.Basics.html#WorkingWithTables.Basics.DeletionProtection
+   */
+  deletionProtection: true,
+};

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  createTableBuilder,
+  type ITableBuilder,
+  type TableBuilderProps,
+  type TableBuilderResult,
+} from "./table-builder.js";
+export { TABLE_DEFAULTS } from "./defaults.js";
+export { type TableAlarmConfig } from "./table-alarm-config.js";
+export { TABLE_ALARM_DEFAULTS } from "./table-alarm-defaults.js";

--- a/packages/dynamodb/src/table-alarm-config.ts
+++ b/packages/dynamodb/src/table-alarm-config.ts
@@ -1,0 +1,61 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for a DynamoDB table.
+ * All applicable alarms are enabled by default with AWS-recommended
+ * thresholds. Set individual alarms to `false` to disable them, or provide
+ * an {@link AlarmConfig} to tune thresholds.
+ *
+ * The defaults target a table-scoped view of availability and throttling.
+ * Account-level recommended alarms (e.g. `AccountProvisionedReadCapacityUtilization`)
+ * and provisioned-capacity utilization alarms are not created here — see the
+ * package README for the rationale.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#DynamoDB
+ */
+export interface TableAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm on server-side errors (HTTP 500) returned by the table. These are
+   * faults on the DynamoDB side rather than the caller's, so any sustained
+   * occurrence is worth surfacing. Summed across all operations.
+   *
+   * Metric: `AWS/DynamoDB SystemErrors` (summed per-operation via a math
+   * expression), statistic Sum, period 1 minute.
+   * Default threshold: > 0.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#DynamoDB
+   */
+  systemErrors?: AlarmConfig | false;
+
+  /**
+   * Alarm when read requests are throttled. On an on-demand table sustained
+   * read throttling signals traffic ramping faster than DynamoDB's adaptive
+   * scaling can follow, or a hot partition; on a provisioned table it signals
+   * under-provisioned read capacity.
+   *
+   * Metric: `AWS/DynamoDB ReadThrottleEvents`, statistic Sum, period 1 minute.
+   * Default threshold: > 0.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html
+   */
+  readThrottleEvents?: AlarmConfig | false;
+
+  /**
+   * Alarm when write requests are throttled. As with read throttling, this
+   * indicates a hot partition or capacity that cannot keep up with the write
+   * rate.
+   *
+   * Metric: `AWS/DynamoDB WriteThrottleEvents`, statistic Sum, period 1 minute.
+   * Default threshold: > 0.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html
+   */
+  writeThrottleEvents?: AlarmConfig | false;
+}

--- a/packages/dynamodb/src/table-alarm-defaults.ts
+++ b/packages/dynamodb/src/table-alarm-defaults.ts
@@ -1,0 +1,59 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+
+interface TableAlarmDefaults {
+  enabled: true;
+  systemErrors: AlarmConfigDefaults;
+  readThrottleEvents: AlarmConfigDefaults;
+  writeThrottleEvents: AlarmConfigDefaults;
+}
+
+/**
+ * AWS-recommended default alarm configuration for DynamoDB tables.
+ *
+ * Thresholds are deliberately strict (> 0) because the metrics they watch —
+ * server-side errors and throttling — should be at or near zero for a healthy
+ * table. Tune them up via `recommendedAlarms` for workloads where a low rate
+ * of throttling is expected and acceptable (e.g. cost-optimised provisioned
+ * tables that lean on burst capacity).
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#DynamoDB
+ */
+export const TABLE_ALARM_DEFAULTS: TableAlarmDefaults = {
+  enabled: true,
+
+  /**
+   * > 0 — any server-side (HTTP 500) error is an availability signal worth
+   * investigating. NOT_BREACHING for missing data: a table with no traffic
+   * emits no SystemErrors datapoints and should stay OK.
+   */
+  systemErrors: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /**
+   * > 0 — surface read throttling immediately. Conservative starting point;
+   * raise the threshold or `evaluationPeriods` for workloads where brief,
+   * self-correcting throttling under burst is tolerable.
+   */
+  readThrottleEvents: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /**
+   * > 0 — surface write throttling immediately, on the same basis as read
+   * throttling.
+   */
+  writeThrottleEvents: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};

--- a/packages/dynamodb/src/table-alarms.ts
+++ b/packages/dynamodb/src/table-alarms.ts
@@ -1,0 +1,161 @@
+import { Duration } from "aws-cdk-lib";
+import {
+  type Alarm,
+  ComparisonOperator,
+  type MathExpression,
+  Metric,
+  Stats,
+} from "aws-cdk-lib/aws-cloudwatch";
+import { type ITable, Operation } from "aws-cdk-lib/aws-dynamodb";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { TableAlarmConfig } from "./table-alarm-config.js";
+import { TABLE_ALARM_DEFAULTS } from "./table-alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.minutes(1);
+const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+
+/**
+ * Operations the default `systemErrors` alarm sums over. A CloudWatch alarm on
+ * a metric-math expression may reference at most 10 individual metrics, and
+ * DynamoDB defines 14 operations — so the full-table aggregate cannot be
+ * alarmed directly. These ten are the core SDK data-plane operations (single
+ * item, query/scan, batch, and transactions); the PartiQL statement operations
+ * and the stream `GetRecords` operation are omitted. Override via a custom
+ * `addAlarm` if your workload's error profile lives in the excluded set.
+ */
+const SYSTEM_ERROR_OPERATIONS: Operation[] = [
+  Operation.GET_ITEM,
+  Operation.BATCH_GET_ITEM,
+  Operation.QUERY,
+  Operation.SCAN,
+  Operation.PUT_ITEM,
+  Operation.UPDATE_ITEM,
+  Operation.DELETE_ITEM,
+  Operation.BATCH_WRITE_ITEM,
+  Operation.TRANSACT_GET_ITEMS,
+  Operation.TRANSACT_WRITE_ITEMS,
+];
+
+/**
+ * Builds a table-scoped `AWS/DynamoDB` metric with the `TableName` dimension.
+ */
+function tableMetric(table: ITable, metricName: string): Metric {
+  return new Metric({
+    namespace: "AWS/DynamoDB",
+    metricName,
+    dimensionsMap: { TableName: table.tableName },
+    statistic: Stats.SUM,
+    period: METRIC_PERIOD,
+  });
+}
+
+/**
+ * Resolves the recommended alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s for a DynamoDB table.
+ */
+export function resolveTableAlarmDefinitions(
+  table: ITable,
+  config: TableAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.systemErrors !== false) {
+    const cfg = resolveAlarmConfig(config?.systemErrors, TABLE_ALARM_DEFAULTS.systemErrors);
+    definitions.push({
+      key: "systemErrors",
+      alarmName: cfg.alarmName,
+      // metricSystemErrorsForOperations sums SystemErrors across the given
+      // operations into a single MathExpression — the per-operation dimension
+      // means there is no single plain Metric for "errors on this table".
+      metric: table.metricSystemErrorsForOperations({
+        period: METRIC_PERIOD,
+        operations: SYSTEM_ERROR_OPERATIONS,
+      }) as MathExpression,
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `DynamoDB table is returning server-side (HTTP 500) errors, summed across the core data-plane operations. ` +
+        `Threshold: > ${String(cfg.threshold)} in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.readThrottleEvents !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.readThrottleEvents,
+      TABLE_ALARM_DEFAULTS.readThrottleEvents,
+    );
+    definitions.push({
+      key: "readThrottleEvents",
+      alarmName: cfg.alarmName,
+      metric: tableMetric(table, "ReadThrottleEvents"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `DynamoDB table read requests are being throttled, indicating a hot partition or ` +
+        `insufficient read capacity. Threshold: > ${String(cfg.threshold)} in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  if (config?.writeThrottleEvents !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.writeThrottleEvents,
+      TABLE_ALARM_DEFAULTS.writeThrottleEvents,
+    );
+    definitions.push({
+      key: "writeThrottleEvents",
+      alarmName: cfg.alarmName,
+      metric: tableMetric(table, "WriteThrottleEvents"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `DynamoDB table write requests are being throttled, indicating a hot partition or ` +
+        `insufficient write capacity. Threshold: > ${String(cfg.threshold)} in ${METRIC_PERIOD_LABEL}.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates AWS-recommended CloudWatch alarms for a DynamoDB table, merging
+ * recommended definitions with any custom alarm builders.
+ *
+ * @param scope - CDK construct scope for creating alarm constructs.
+ * @param id - Base identifier for alarm construct ids.
+ * @param table - The DynamoDB table to create alarms for.
+ * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @returns A record mapping alarm keys to their created Alarm constructs.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#DynamoDB
+ */
+export function createTableAlarms(
+  scope: IConstruct,
+  id: string,
+  table: ITable,
+  config: TableAlarmConfig | false | undefined,
+  customAlarms: AlarmDefinitionBuilder<ITable>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? TABLE_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveTableAlarmDefinitions(table, config);
+  const custom = customAlarms.map((b) => b.resolve(table));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/dynamodb/src/table-builder.ts
+++ b/packages/dynamodb/src/table-builder.ts
@@ -1,0 +1,192 @@
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { type ITable, Table, TableEncryption, type TableProps } from "aws-cdk-lib/aws-dynamodb";
+import { type IConstruct } from "constructs";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { TableAlarmConfig } from "./table-alarm-config.js";
+import { createTableAlarms } from "./table-alarms.js";
+import { TABLE_DEFAULTS } from "./defaults.js";
+
+/**
+ * Configuration properties for the DynamoDB table builder.
+ *
+ * Extends the CDK {@link TableProps} with additional builder-specific options.
+ */
+export interface TableBuilderProps extends TableProps {
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates recommended alarms with sensible
+   * thresholds for server-side errors and read/write throttling. Individual
+   * alarms can be customized or disabled. Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification methods are
+   * user-specific. Access alarms from the build result or use an `afterBuild`
+   * hook to apply actions.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#DynamoDB
+   */
+  recommendedAlarms?: TableAlarmConfig | false;
+}
+
+/**
+ * The build output of an {@link ITableBuilder}. Contains the CDK constructs
+ * created during {@link Lifecycle.build}, keyed by role.
+ */
+export interface TableBuilderResult {
+  /** The DynamoDB table construct created by the builder. */
+  table: Table;
+
+  /**
+   * The table's DynamoDB Streams ARN, or `undefined` when no stream is
+   * configured (the default).
+   *
+   * The classic {@link Table} construct does not expose a distinct stream
+   * construct — the stream is an attribute of the table. This field surfaces
+   * it directly so downstream components can wire a stream consumer (e.g. a
+   * Lambda `DynamoEventSource`) via `ref()` without reaching into the table.
+   * The table itself (`result.table`) is what a `DynamoEventSource` consumes.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
+   */
+  tableStreamArn?: string;
+
+  /**
+   * CloudWatch alarms created for the table, keyed by alarm name.
+   *
+   * Includes both AWS-recommended alarms and any custom alarms added via
+   * {@link ITableBuilder.addAlarm}. Access individual alarms by key (e.g.
+   * `result.alarms.systemErrors`).
+   *
+   * No alarm actions are configured — apply them via the result or an
+   * `afterBuild` hook.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#DynamoDB
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS DynamoDB table.
+ *
+ * Each configuration property from the CDK {@link TableProps} is exposed as an
+ * overloaded method: call with a value to set it (returns the builder for
+ * chaining), or call with no arguments to read the current value.
+ *
+ * The builder implements {@link Lifecycle}, so it can be used directly as a
+ * component in a {@link compose | composed system}. When built, it creates a
+ * DynamoDB table with the configured properties — merged with secure,
+ * AWS-recommended {@link TABLE_DEFAULTS} — and returns a {@link TableBuilderResult}.
+ *
+ * The builder also creates AWS-recommended CloudWatch alarms by default. Alarms
+ * can be customized or disabled via the `recommendedAlarms` property. Custom
+ * alarms can be added via the {@link addAlarm} method.
+ *
+ * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.Table.html
+ *
+ * @example
+ * ```ts
+ * import { AttributeType, StreamViewType } from "aws-cdk-lib/aws-dynamodb";
+ *
+ * const orders = createTableBuilder()
+ *   .partitionKey({ name: "pk", type: AttributeType.STRING })
+ *   .sortKey({ name: "sk", type: AttributeType.STRING })
+ *   .stream(StreamViewType.NEW_AND_OLD_IMAGES);
+ * ```
+ */
+export type ITableBuilder = ITaggedBuilder<TableBuilderProps, TableBuilder>;
+
+class TableBuilder implements Lifecycle<TableBuilderResult> {
+  props: Partial<TableBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<ITable>[] = [];
+
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<ITable>) => AlarmDefinitionBuilder<ITable>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<ITable>(key)));
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: TableBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
+  }
+
+  build(scope: IConstruct, id: string): TableBuilderResult {
+    const { recommendedAlarms: alarmConfig, ...tableProps } = this.props;
+
+    const mergedProps = mergeTableDefaults(tableProps);
+
+    const table = new Table(scope, id, mergedProps);
+
+    const alarms = createTableAlarms(scope, id, table, alarmConfig, this.#customAlarms);
+
+    return { table, tableStreamArn: table.tableStreamArn, alarms };
+  }
+}
+
+/**
+ * Merges {@link TABLE_DEFAULTS} under the user's props, then resolves the two
+ * cases where a default is mutually exclusive with a sibling the user set
+ * (ADR-0009): the `billingMode` default yields to provisioned capacity, and
+ * the `encryption` default yields to a customer-managed key.
+ */
+function mergeTableDefaults(props: Partial<TableProps>): TableProps {
+  const merged = { ...TABLE_DEFAULTS, ...props } as TableProps & {
+    billingMode?: TableProps["billingMode"];
+    encryption?: TableEncryption;
+  };
+
+  // billingMode (default PAY_PER_REQUEST) is mutually exclusive with
+  // readCapacity / writeCapacity. If the user set capacity but not the mode,
+  // drop the on-demand default so CDK falls back to PROVISIONED. Setting both
+  // explicitly is left for CDK to reject.
+  const userSetCapacity = props.readCapacity !== undefined || props.writeCapacity !== undefined;
+  if (userSetCapacity && props.billingMode === undefined) {
+    delete merged.billingMode;
+  }
+
+  // encryption (default AWS_MANAGED) is mutually exclusive with a user-supplied
+  // encryptionKey, which CDK only accepts under CUSTOMER_MANAGED. Providing a
+  // key is an unambiguous request for customer-managed encryption, so infer the
+  // mode rather than forcing the user to set both.
+  if (props.encryptionKey !== undefined && props.encryption === undefined) {
+    merged.encryption = TableEncryption.CUSTOMER_MANAGED;
+  }
+
+  return merged;
+}
+
+/**
+ * Creates a new {@link ITableBuilder} for configuring an AWS DynamoDB table.
+ *
+ * This is the entry point for defining a DynamoDB table component. The returned
+ * builder exposes every {@link TableBuilderProps} property as a fluent
+ * setter/getter and implements {@link Lifecycle} for use with {@link compose}.
+ *
+ * @returns A fluent builder for an AWS DynamoDB table.
+ *
+ * @example
+ * ```ts
+ * import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
+ *
+ * const orders = createTableBuilder().partitionKey({
+ *   name: "orderId",
+ *   type: AttributeType.STRING,
+ * });
+ *
+ * // Use standalone:
+ * const result = orders.build(stack, "Orders");
+ *
+ * // Or compose into a system, wiring the stream into a Lambda:
+ * const system = compose(
+ *   { orders, processor: createFunctionBuilder() },
+ *   { orders: [], processor: ["orders"] },
+ * );
+ * ```
+ */
+export function createTableBuilder(): ITableBuilder {
+  return taggedBuilder<TableBuilderProps, TableBuilder>(TableBuilder);
+}

--- a/packages/dynamodb/test/table-alarms.test.ts
+++ b/packages/dynamodb/test/table-alarms.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
+import { createTableBuilder } from "../src/table-builder.js";
+
+const PK = { name: "pk", type: AttributeType.STRING };
+
+function build(configureFn?: (builder: ReturnType<typeof createTableBuilder>) => void): {
+  result: ReturnType<ReturnType<typeof createTableBuilder>["build"]>;
+  template: Template;
+} {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createTableBuilder().partitionKey(PK);
+  configureFn?.(builder);
+  const result = builder.build(stack, "TestTable");
+  return { result, template: Template.fromStack(stack) };
+}
+
+describe("table alarms", () => {
+  describe("recommended alarms", () => {
+    it("creates the three recommended alarms by default", () => {
+      const { result, template } = build();
+
+      expect(Object.keys(result.alarms).sort()).toEqual([
+        "readThrottleEvents",
+        "systemErrors",
+        "writeThrottleEvents",
+      ]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 3);
+    });
+
+    it("alarms on read throttle events with a > 0 threshold", () => {
+      const { template } = build();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ReadThrottleEvents",
+        Namespace: "AWS/DynamoDB",
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+      });
+    });
+
+    it("alarms on write throttle events with a > 0 threshold", () => {
+      const { template } = build();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "WriteThrottleEvents",
+        Namespace: "AWS/DynamoDB",
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+      });
+    });
+
+    it("alarms on system errors via a math expression across operations", () => {
+      const { template } = build();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Metrics: Match.arrayWith([Match.objectLike({ Expression: Match.anyValue() })]),
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+      });
+    });
+  });
+
+  describe("customizing and disabling", () => {
+    it("disables all recommended alarms when recommendedAlarms is false", () => {
+      const { result, template } = build((b) => b.recommendedAlarms(false));
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("disables all recommended alarms when enabled is false", () => {
+      const { result } = build((b) => b.recommendedAlarms({ enabled: false }));
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+    });
+
+    it("disables an individual alarm", () => {
+      const { result } = build((b) => b.recommendedAlarms({ writeThrottleEvents: false }));
+
+      expect(Object.keys(result.alarms).sort()).toEqual(["readThrottleEvents", "systemErrors"]);
+    });
+
+    it("overrides an individual alarm threshold", () => {
+      const { template } = build((b) =>
+        b.recommendedAlarms({ readThrottleEvents: { threshold: 10, evaluationPeriods: 3 } }),
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ReadThrottleEvents",
+        Threshold: 10,
+        EvaluationPeriods: 3,
+      });
+    });
+  });
+
+  describe("custom alarms", () => {
+    it("creates a custom alarm alongside the recommended ones", () => {
+      const { result, template } = build((b) =>
+        b.addAlarm("userErrors", (a) =>
+          a
+            .metric((table) => table.metricUserErrors({ period: Duration.minutes(5) }))
+            .threshold(5)
+            .greaterThan()
+            .description("Table is returning client-side (HTTP 400) errors."),
+        ),
+      );
+
+      expect(result.alarms.userErrors).toBeDefined();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "UserErrors",
+        Namespace: "AWS/DynamoDB",
+        Threshold: 5,
+        ComparisonOperator: "GreaterThanThreshold",
+      });
+    });
+  });
+});

--- a/packages/dynamodb/test/table-builder.test.ts
+++ b/packages/dynamodb/test/table-builder.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  AttributeType,
+  BillingMode,
+  type ITable,
+  StreamViewType,
+  TableEncryption,
+} from "aws-cdk-lib/aws-dynamodb";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import { createTableBuilder } from "../src/table-builder.js";
+
+const PK = { name: "pk", type: AttributeType.STRING };
+
+function synthTemplate(
+  configureFn?: (builder: ReturnType<typeof createTableBuilder>) => void,
+): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createTableBuilder().partitionKey(PK);
+  configureFn?.(builder);
+  builder.build(stack, "TestTable");
+  return Template.fromStack(stack);
+}
+
+describe("TableBuilder", () => {
+  describe("build", () => {
+    it("returns a TableBuilderResult with a table property", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createTableBuilder().partitionKey(PK).build(stack, "TestTable");
+
+      expect(result).toBeDefined();
+      expect(result.table).toBeDefined();
+    });
+
+    it("creates exactly one DynamoDB table", () => {
+      const template = synthTemplate();
+
+      template.resourceCountIs("AWS::DynamoDB::Table", 1);
+    });
+
+    it("exposes the alarms record in the result", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createTableBuilder().partitionKey(PK).build(stack, "TestTable");
+
+      expect(result.alarms).toBeDefined();
+      expect(typeof result.alarms).toBe("object");
+    });
+
+    it("leaves tableStreamArn undefined when no stream is configured", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createTableBuilder().partitionKey(PK).build(stack, "TestTable");
+
+      expect(result.tableStreamArn).toBeUndefined();
+    });
+
+    it("exposes tableStreamArn when a stream is configured", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createTableBuilder()
+        .partitionKey(PK)
+        .stream(StreamViewType.NEW_AND_OLD_IMAGES)
+        .build(stack, "TestTable");
+
+      expect(result.tableStreamArn).toBeDefined();
+    });
+  });
+
+  describe("secure defaults", () => {
+    it("uses on-demand (PAY_PER_REQUEST) billing by default", () => {
+      const template = synthTemplate();
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        BillingMode: "PAY_PER_REQUEST",
+      });
+    });
+
+    it("encrypts at rest with an AWS-managed KMS key by default", () => {
+      const template = synthTemplate();
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        SSESpecification: { SSEEnabled: true },
+      });
+    });
+
+    it("enables point-in-time recovery by default", () => {
+      const template = synthTemplate();
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+      });
+    });
+
+    it("enables deletion protection by default", () => {
+      const template = synthTemplate();
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        DeletionProtectionEnabled: true,
+      });
+    });
+
+    it("allows deletion protection to be disabled via the fluent API", () => {
+      const template = synthTemplate((b) => b.deletionProtection(false));
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        DeletionProtectionEnabled: false,
+      });
+    });
+  });
+
+  describe("billingMode yields to provisioned capacity (ADR-0009)", () => {
+    it("switches to provisioned billing when read/write capacity is set", () => {
+      const template = synthTemplate((b) => b.readCapacity(5).writeCapacity(5));
+
+      // The on-demand default is dropped, so CDK falls back to PROVISIONED.
+      // PROVISIONED is the CFN default for BillingMode, so CDK omits the
+      // property — the presence of ProvisionedThroughput is the signal.
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        BillingMode: Match.absent(),
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+      });
+    });
+
+    it("honours an explicit PAY_PER_REQUEST override", () => {
+      const template = synthTemplate((b) => b.billingMode(BillingMode.PAY_PER_REQUEST));
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        BillingMode: "PAY_PER_REQUEST",
+      });
+    });
+  });
+
+  describe("encryption yields to a customer-managed key (ADR-0009)", () => {
+    it("infers CUSTOMER_MANAGED encryption when an encryptionKey is supplied", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const key = new Key(stack, "Key");
+
+      createTableBuilder().partitionKey(PK).encryptionKey(key).build(stack, "TestTable");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        SSESpecification: { SSEEnabled: true, SSEType: "KMS", KMSMasterKeyId: Match.anyValue() },
+      });
+    });
+
+    it("allows falling back to the free AWS-owned key", () => {
+      const template = synthTemplate((b) => b.encryption(TableEncryption.DEFAULT));
+
+      // The AWS-owned key (CDK's TableEncryption.DEFAULT) synthesises as
+      // SSEEnabled: false — DynamoDB still encrypts, just with the free key.
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        SSESpecification: { SSEEnabled: false },
+      });
+    });
+  });
+
+  describe("synthesised output", () => {
+    it("creates a table with the specified name and key schema", () => {
+      const template = synthTemplate((b) =>
+        b.tableName("orders").sortKey({ name: "sk", type: AttributeType.NUMBER }),
+      );
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        TableName: "orders",
+        KeySchema: [
+          { AttributeName: "pk", KeyType: "HASH" },
+          { AttributeName: "sk", KeyType: "RANGE" },
+        ],
+      });
+    });
+
+    it("forwards the stream view type to the underlying CDK construct", () => {
+      const template = synthTemplate((b) => b.stream(StreamViewType.NEW_IMAGE));
+
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        StreamSpecification: { StreamViewType: "NEW_IMAGE" },
+      });
+    });
+  });
+
+  describe("copy", () => {
+    it("preserves custom alarms across .copy()", () => {
+      const userErrors = (table: ITable): Metric =>
+        new Metric({
+          namespace: "AWS/DynamoDB",
+          metricName: "UserErrors",
+          dimensionsMap: { TableName: table.tableName },
+          statistic: "Sum",
+        });
+
+      assertCopyPreservesState({
+        factory: () => createTableBuilder().partitionKey(PK),
+        configure: (b) => {
+          b.addAlarm("firstCustom", (a) => a.metric(userErrors).threshold(1).greaterThan());
+        },
+        mutate: (b) => {
+          b.addAlarm("secondCustom", (a) => a.metric(userErrors).threshold(5).greaterThan());
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Table"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
+    });
+  });
+});

--- a/packages/dynamodb/tsconfig.json
+++ b/packages/dynamodb/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -29,6 +29,7 @@
     "@composurecdk/cloudfront": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
+    "@composurecdk/dynamodb": "^0.8.0",
     "@composurecdk/ec2": "^0.8.0",
     "@composurecdk/events": "^0.8.0",
     "@composurecdk/iam": "^0.8.0",

--- a/packages/module-compat/test/dual-packages.ts
+++ b/packages/module-compat/test/dual-packages.ts
@@ -13,6 +13,7 @@ export const DUAL_PACKAGES = [
   { name: "@composurecdk/cloudformation", probe: "createStackBuilder" },
   { name: "@composurecdk/cloudfront", probe: "createDistributionBuilder" },
   { name: "@composurecdk/cloudwatch", probe: "createAlarms" },
+  { name: "@composurecdk/dynamodb", probe: "createTableBuilder" },
   { name: "@composurecdk/ec2", probe: "createInstanceBuilder" },
   { name: "@composurecdk/events", probe: "createRuleBuilder" },
   { name: "@composurecdk/iam", probe: "createRoleBuilder" },


### PR DESCRIPTION
**Closed in favour of the revised approach captured in https://github.com/laazyj/composureCDK/issues/121#issuecomment-4757053415.**

The investigation under design-question #1 (`Table` vs `TableV2`) changed the design: instead of a single classic-`Table` builder, the package will ship **two thin builders sharing internals** — `createTableBuilder()` (→ `TableV2`, the recommended default) and `createClassicTableBuilder()` (→ classic `Table`, for the V1-only `importSource` and tooling parity). A single unified builder was ruled out by the `encryption` prop key-collision (incompatible types under the same key) against the library's Proxy-over-CDK-props model.

This draft is not abandoned wholesale — the **alarms module, alarm config/defaults, and the classic builder + tests** are reusable and called out in the issue plan. A fresh PR will be raised against the new design.

Branch `claude/dynamodb-package-draft-5vntjs` is retained for reference.