### PR TITLE
feat(core): expose resolved builder configuration on results (resolvedProps)

### DIFF
--- a/docs/adr/0011-resolved-props-on-results.md
+++ b/docs/adr/0011-resolved-props-on-results.md
@@ -1,0 +1,128 @@
+# ADR 0011: Expose a builder's resolved configuration on its result
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+
+## Context
+
+Builders frequently need to inspect a property that configured a _sibling_
+component, but the CDK L2 construct does not expose it as a public readonly
+member. The value lives only on the `*Props` interface, which CDK treats as a
+write-only struct ([CDK design guidelines][cdk-guidelines]) — once the
+construct is built, the value is unrecoverable from the construct alone.
+
+The case that surfaced this (laazyj/composureCDK#122, blocking #118): the
+SQS↔Lambda visibility-timeout invariant — a source queue's `visibilityTimeout`
+should be ≥ 6× the consumer function's `timeout`. The `Queue` construct does
+not expose `visibilityTimeout`; only `QueueProps` carries it. A consumer that
+receives the queue via `ref()` therefore cannot perform a real comparison — it
+can only emit a contextual reminder (see the "not enforced" note on
+`sqsEventSource`). This is a general gap: _any_ cross-component invariant that
+depends on a write-only prop of a dependency is un-checkable today.
+
+Three facts about the codebase frame the decision:
+
+1. **The merged configuration already exists.** Every builder's `build()`
+   computes `mergedProps = { ...DEFAULTS, ...userProps }` (with any
+   `Resolvable` resolved against `context`) and hands it to the construct. It
+   is then discarded.
+2. **Results already carry more than the primary construct** — `FunctionBuilderResult.eventSources`,
+   `RuleBuilderResult.targets`, `RoleBuilderResult.inlinePolicies`,
+   `TopicBuilderResult.subscriptions`. But every "extra" today is a construct
+   or a resolved CDK object; **no result exposes the merged scalar config**
+   (a `Duration`, a number, an enum) that the construct withholds.
+3. **The builder getter is not a substitute.** `queue.visibilityTimeout()`
+   reads `props` _before_ defaults are merged and lives on the builder, which
+   a sibling never receives — siblings receive the result via `context`.
+
+[architecture.md](../architecture.md) already states the tenet "**if a builder
+creates it, the result should expose it**." Resolved configuration is part of
+that completeness, not just constructs.
+
+## Decision
+
+**A builder result exposes the resolved configuration it handed to its CDK
+construct under a uniform `resolvedProps` field.**
+
+1. **Field name and shape.** Every `*BuilderResult` that wraps a CDK construct
+   gains `resolvedProps: ResolvedProps<TConstructProps>`. `ResolvedProps<P>`
+   (new, in `@composurecdk/core`) is `Readonly<{ [K in keyof P]?: Resolved<P[K]> }>`:
+   every key optional (a prop may be unset, and not every prop has a default),
+   read-only (a record of what was built, not a mutable handle), and any
+   `Resolvable<T>` collapsed to its resolved `T`.
+
+2. **Semantics: post-default, post-resolve, pre-token-resolution.** The value
+   is exactly the object passed to the construct — defaults applied,
+   `ref()`s resolved against `context`. It is _not_ deep-resolved: a value may
+   still be an unresolved CDK `Token` (e.g. threaded from a `CfnParameter`).
+   Consumers comparing values must guard with `Token.isUnresolved`, exactly as
+   `QueueBuilder`'s in-builder `warnIfLowMaxReceiveCount` already does.
+
+3. **Typed off the CDK props, not the builder props.** The merged object is
+   CDK-props-shaped — builder-specific keys (`recommendedAlarms`) are
+   destructured out before the merge, and widened keys (`role: Resolvable<IRole>`)
+   are collapsed back to the construct's type (`IRole`). So `QueueBuilderResult`
+   uses `ResolvedProps<QueueProps>`, not `ResolvedProps<QueueBuilderProps>`.
+
+4. **Scope is the full merged prop set, not a curated subset.** A curated
+   subset reintroduces the "which props will a consumer need?" guessing this
+   ADR exists to remove, and the full bag is already in hand at zero cost.
+   Where a _specific_ value warrants sharper ergonomics or a narrower type, a
+   builder may _additionally_ promote it to a named top-level result field —
+   `resolvedProps` is the floor, not a ceiling.
+
+5. **Originates in `build()`, returned as a shallow copy.** Each `build()`
+   returns `resolvedProps: { ...mergedProps }`. The copy avoids handing out a
+   reference to the literal object the construct retains. This is deliberately
+   _not_ a decorator (ADR-0006): a decorator can only wrap the returned result,
+   and `mergedProps` is internal to `build()` — the value must originate there.
+   `ResolvedProps<P>` keeps the _type_ uniform across packages without
+   per-builder machinery.
+
+This PR lands the mechanism (`ResolvedProps` in core) plus the contract on the
+two motivating builders — `QueueBuilder` (the #118 unblocker) and
+`FunctionBuilder` (which exercises the `Resolvable` collapse via its
+`role` prop). Rolling the field out to the remaining `*BuilderResult` types is
+a mechanical follow-up, mirroring how ADR-0010 landed a central mechanism plus
+first adopters.
+
+## Consequences
+
+- **Cross-component invariants become real checks.** A consumer holding a
+  `ref()` to a `QueueBuilderResult` reads `result.resolvedProps.visibilityTimeout`
+  and compares it (token-guarded) against its own `timeout`. This unblocks
+  #118/#123/#124 and any future invariant of the same shape.
+- **The result contract widens.** `resolvedProps` exposes the entire prop bag,
+  including values with no cross-component use and potentially sensitive ones
+  (e.g. a Lambda's `environment`). This is in-process only and never
+  serialised, but it is a public contract — adding it is a minor/feature
+  change, never a patch.
+- **`.copy()` is unaffected.** `resolvedProps` is build-time output, not
+  builder state; it does not interact with `props` cloning or `[COPY_STATE]`.
+- **Adopting a new builder is one line plus a type.** Return
+  `resolvedProps: { ...mergedProps }` and type the field
+  `ResolvedProps<TConstructProps>`. A lint rule could later require the field
+  on library results; out of scope here.
+
+## Alternatives considered
+
+- **Curated, named result fields per builder** (`QueueBuilderResult.visibilityTimeout`).
+  Rejected as the _primary_ mechanism: precise and low-surface, but reactive —
+  every new invariant is a result-type edit, and there is no single predictable
+  place for a consumer to look, which #122 explicitly asks for. Retained as an
+  opt-in refinement _on top of_ `resolvedProps` (decision point 4).
+- **A typed capability/provider channel** (Bazel/Gradle-style providers keyed
+  by a `Symbol.for(...)` brand). Rejected for now: it decouples consumer needs
+  from prop shape and advertises only what is meant to be consumed, but it is
+  disproportionate machinery for the single invariant on the table. Revisit if
+  a richer producer→consumer contract emerges.
+- **A decorator applying `resolvedProps`** (ADR-0006 family). Rejected: a
+  decorator cannot see `mergedProps`, which is internal to `build()`; it could
+  only re-expose what `build()` already returns. The value must originate in
+  `build()` regardless, so a decorator adds the stacking type-cost ADR-0006
+  flags for no benefit here.
+- **Status quo — contextual reminders only.** Rejected: it leaves the entire
+  class of write-only-prop invariants permanently un-checkable, which is the
+  case this ADR exists to close.
+
+[cdk-guidelines]: https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0008: Per-package aws-cdk-lib version floors](0008-aws-cdk-lib-version-floors.md)
 - [ADR-0009: Defaults yield to a mutually-exclusive user-set sibling prop](0009-defaults-yield-to-mutually-exclusive-siblings.md)
 - [ADR-0010: AWS-property constraints — a catalogue with central mechanism and local data](0010-aws-property-constraints.md)
+- [ADR-0011: Expose a builder's resolved configuration on its result](0011-resolved-props-on-results.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,8 @@ Resources that are created but not returned are invisible to the rest of the sys
 
 The rule: **if a builder creates it, the result should expose it.**
 
+This extends to resolved _configuration_, not just constructs. A CDK L2 construct often does not re-expose the props that configured it (CDK treats props as a write-only struct), so a value like an SQS queue's `visibilityTimeout` is unrecoverable from the `Queue` alone. To keep cross-component invariants checkable, a builder result exposes the defaulted, resolved configuration it handed to its construct under a uniform `resolvedProps: ResolvedProps<TConstructProps>` field. A consumer that receives the result via `ref()` can then read a write-only prop and perform a real comparison (token-guarded) instead of emitting a contextual reminder. See [ADR-0011](adr/0011-resolved-props-on-results.md).
+
 ### Why an interface, not a base class
 
 Components are composed, not inherited. A component is any object with a `build` method that matches the signature. This keeps the coupling to ComposureCDK minimal — a component does not need to extend a framework class, call `super()`, or conform to a class hierarchy. It just implements a single method.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,15 @@ export {
 } from "./compose.js";
 export { CyclicDependencyError } from "./cyclic-dependency-error.js";
 export { type Lifecycle } from "./lifecycle.js";
-export { Ref, ref, resolve, isRef, type Resolvable } from "./ref.js";
+export {
+  Ref,
+  ref,
+  resolve,
+  isRef,
+  type Resolvable,
+  type Resolved,
+  type ResolvedProps,
+} from "./ref.js";
 export {
   type StackStrategy,
   type ScopeFactory,

--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -146,6 +146,37 @@ export function ref<T extends object, U>(
 export type Resolvable<T> = T | Ref<T>;
 
 /**
+ * Collapses a property type to its resolved form: a {@link Ref}`<U>` (or a
+ * {@link Resolvable}`<U>`) becomes `U`; a concrete `T` is unchanged.
+ *
+ * Used by {@link ResolvedProps} so a configuration snapshot reflects the value
+ * that was passed to the construct, not the pre-resolution `T | Ref<T>` union.
+ */
+export type Resolved<T> = T extends Ref<infer U> ? U : T;
+
+/**
+ * The post-default, post-resolve configuration a builder hands to its CDK
+ * construct, exposed on the builder's result so a consuming component can read
+ * a value the L2 construct does not re-surface as a public readonly member
+ * (for example an SQS queue's `visibilityTimeout`).
+ *
+ * Derived from a props interface `P`:
+ * - **every key is optional** — a builder may leave a prop unset, and not
+ *   every prop carries a default;
+ * - **every key is read-only** — the snapshot is a record of what was built,
+ *   not a mutable handle;
+ * - **`Resolvable` values are collapsed** ({@link Resolved}) — the snapshot
+ *   holds the resolved value handed to the construct.
+ *
+ * Values may still be unresolved CDK `Token`s (e.g. threaded from a
+ * CloudFormation parameter); a consumer comparing them must guard with
+ * `Token.isUnresolved`. See ADR-0011 for the result-type contract.
+ */
+export type ResolvedProps<P extends object> = Readonly<{
+  [K in keyof P]?: Resolved<P[K]>;
+}>;
+
+/**
  * Type guard that checks whether a value is a {@link Ref}.
  *
  * Recognises a `Ref` by its {@link REF_BRAND} symbol rather than `instanceof`,

--- a/packages/core/test/ref.test.ts
+++ b/packages/core/test/ref.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ref, resolve, isRef, REF_BRAND, type Resolvable } from "../src/ref.js";
+import { ref, resolve, isRef, REF_BRAND, type Resolvable, type ResolvedProps } from "../src/ref.js";
 
 interface FakeResult {
   value: string;
@@ -137,6 +137,36 @@ describe("Resolvable utilities", () => {
       const value: Resolvable<FakeResult> = { value: "concrete", nested: { id: 0 } };
 
       expect(resolve(value, fakeContext)).toEqual({ value: "concrete", nested: { id: 0 } });
+    });
+  });
+
+  describe("ResolvedProps", () => {
+    interface Props {
+      timeout: number;
+      role: Resolvable<{ arn: string }>;
+    }
+
+    it("makes every key optional", () => {
+      const snapshot: ResolvedProps<Props> = {};
+
+      expect(snapshot).toEqual({});
+    });
+
+    it("collapses a Resolvable prop to its resolved type", () => {
+      // The snapshot holds the resolved value, not the `T | Ref<T>` union —
+      // a concrete `{ arn }` is accepted; a `Ref` would not type-check here.
+      const snapshot: ResolvedProps<Props> = { timeout: 10, role: { arn: "x" } };
+
+      expect(snapshot.role?.arn).toBe("x");
+    });
+
+    it("is read-only", () => {
+      const snapshot: ResolvedProps<Props> = { timeout: 10 };
+
+      // @ts-expect-error resolvedProps is a read-only snapshot, not a handle
+      snapshot.timeout = 20;
+
+      expect(snapshot.timeout).toBe(20);
     });
   });
 });

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -7,7 +7,13 @@ import {
 } from "aws-cdk-lib/aws-lambda";
 import type { ILogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import {
+  COPY_STATE,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+  type ResolvedProps,
+} from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import {
@@ -133,6 +139,23 @@ export interface FunctionBuilderResult {
    * Always present — `{}` when no event sources were added.
    */
   eventSources: Record<string, IEventSource>;
+
+  /**
+   * The defaulted, resolved configuration handed to the {@link LambdaFunction}
+   * construct — `{ ...FUNCTION_DEFAULTS, ...userProps }` with the auto-created
+   * log group and the resolved execution role merged in, and any `ref()`
+   * (e.g. {@link FunctionBuilderProps.role}) collapsed to its resolved value.
+   *
+   * Exposes values the CDK {@link LambdaFunction} does not re-surface as
+   * public readonly members (e.g. {@link FunctionProps.timeout}), so a
+   * consuming component that receives this result via `ref()` can perform a
+   * real cross-component invariant check — for instance comparing a source
+   * queue's `visibilityTimeout` against this function's `timeout`.
+   *
+   * Values may be unresolved CDK tokens when threaded from a CloudFormation
+   * parameter; guard with `Token.isUnresolved` before comparing. See ADR-0011.
+   */
+  resolvedProps: ResolvedProps<FunctionProps>;
 }
 
 /**
@@ -374,7 +397,14 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
       throw new Error(`FunctionBuilder "${id}": Lambda function has no execution role.`);
     }
 
-    return { function: fn, role: resolvedRole, logGroup, alarms, eventSources };
+    return {
+      function: fn,
+      role: resolvedRole,
+      logGroup,
+      alarms,
+      eventSources,
+      resolvedProps: { ...mergedProps },
+    };
   }
 
   #buildDefaultRole(

--- a/packages/lambda/test/function-builder.test.ts
+++ b/packages/lambda/test/function-builder.test.ts
@@ -53,6 +53,44 @@ describe("FunctionBuilder", () => {
     });
   });
 
+  describe("resolvedProps", () => {
+    it("exposes merged defaults and the timeout the Function does not re-surface", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createFunctionBuilder()
+        .runtime(Runtime.NODEJS_22_X)
+        .handler("index.handler")
+        .code(Code.fromInline("exports.handler = async () => {}"))
+        .timeout(Duration.seconds(30))
+        .build(stack, "TestFunction");
+
+      expect(result.resolvedProps.tracing).toBe(Tracing.ACTIVE);
+      expect(result.resolvedProps.loggingFormat).toBe(LoggingFormat.JSON);
+      expect(result.resolvedProps.timeout?.toSeconds()).toBe(30);
+    });
+
+    it("collapses a ref()'d role to the resolved IRole in the snapshot", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+
+      const system = compose(
+        {
+          sharedRole: createServiceRoleBuilder("lambda.amazonaws.com"),
+          handler: createFunctionBuilder()
+            .runtime(Runtime.NODEJS_22_X)
+            .handler("index.handler")
+            .code(Code.fromInline("exports.handler = async () => {}"))
+            .role(ref<RoleBuilderResult>("sharedRole").get("role")),
+        },
+        { sharedRole: [], handler: ["sharedRole"] },
+      );
+
+      const result = system.build(stack, "Sys");
+
+      expect(result.handler.resolvedProps.role).toBe(result.sharedRole.role);
+    });
+  });
+
   describe("synthesised output", () => {
     it("creates a Lambda function with the specified runtime", () => {
       const template = synthTemplate((b) =>

--- a/packages/sqs/src/queue-builder.ts
+++ b/packages/sqs/src/queue-builder.ts
@@ -2,7 +2,7 @@ import { Annotations, Token } from "aws-cdk-lib";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type IQueue, Queue, type QueueProps } from "aws-cdk-lib/aws-sqs";
 import { type IConstruct } from "constructs";
-import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, type ResolvedProps } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { QueueAlarmConfig } from "./queue-alarm-config.js";
@@ -63,6 +63,23 @@ export interface QueueBuilderResult {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
    */
   alarms: Record<string, Alarm>;
+
+  /**
+   * The defaulted, resolved configuration handed to the {@link Queue}
+   * construct — `{ ...QUEUE_DEFAULTS, ...userProps }`.
+   *
+   * Exposes values the CDK {@link Queue} does not re-surface as public
+   * readonly members (e.g. {@link QueueProps.visibilityTimeout}), so a
+   * consuming component that receives this result via `ref()` can perform a
+   * real cross-component invariant check rather than emitting a contextual
+   * reminder — for instance comparing this queue's `visibilityTimeout`
+   * against a consumer function's `timeout`.
+   *
+   * Values may be unresolved CDK {@link Token}s when threaded from a
+   * CloudFormation parameter; guard with `Token.isUnresolved` before
+   * comparing. See ADR-0011.
+   */
+  resolvedProps: ResolvedProps<QueueProps>;
 }
 
 /**
@@ -112,10 +129,10 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
   build(scope: IConstruct, id: string): QueueBuilderResult {
     const { recommendedAlarms: alarmConfig, ...queueProps } = this.props;
 
-    const mergedProps = {
+    const mergedProps: Partial<QueueProps> = {
       ...QUEUE_DEFAULTS,
       ...queueProps,
-    } as QueueBuilderProps;
+    };
 
     warnIfLowMaxReceiveCount(scope, id, mergedProps);
 
@@ -123,7 +140,7 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
 
     const alarms = createQueueAlarms(scope, id, queue, alarmConfig, this.#customAlarms);
 
-    return { queue, alarms };
+    return { queue, alarms, resolvedProps: { ...mergedProps } };
   }
 }
 

--- a/packages/sqs/test/queue-builder.test.ts
+++ b/packages/sqs/test/queue-builder.test.ts
@@ -45,6 +45,49 @@ describe("QueueBuilder", () => {
     });
   });
 
+  describe("resolvedProps", () => {
+    it("exposes the merged defaults handed to the queue construct", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createQueueBuilder().build(stack, "TestQueue");
+
+      expect(result.resolvedProps.enforceSSL).toBe(true);
+      expect(result.resolvedProps.encryption).toBe(QueueEncryption.SQS_MANAGED);
+      expect(result.resolvedProps.receiveMessageWaitTime?.toSeconds()).toBe(20);
+    });
+
+    it("exposes a write-only prop the Queue construct does not re-surface", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createQueueBuilder()
+        .visibilityTimeout(Duration.seconds(90))
+        .build(stack, "TestQueue");
+
+      expect(result.resolvedProps.visibilityTimeout?.toSeconds()).toBe(90);
+    });
+
+    it("lets a user value override a default in the snapshot", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createQueueBuilder()
+        .receiveMessageWaitTime(Duration.seconds(5))
+        .build(stack, "TestQueue");
+
+      expect(result.resolvedProps.receiveMessageWaitTime?.toSeconds()).toBe(5);
+    });
+
+    it("preserves nested values by reference so unresolved tokens pass through", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const visibilityTimeout = Duration.seconds(45);
+      const result = createQueueBuilder()
+        .visibilityTimeout(visibilityTimeout)
+        .build(stack, "TestQueue");
+
+      expect(result.resolvedProps.visibilityTimeout).toBe(visibilityTimeout);
+    });
+  });
+
   describe("secure defaults", () => {
     it("enables enforceSSL by default — deny on aws:SecureTransport=false", () => {
       const template = synthTemplate();


### PR DESCRIPTION
Closes the mechanism portion of #122 (and unblocks #118/#123/#124).

## Problem

Builders need to inspect a property that configured a **sibling** component, but the CDK L2 construct doesn't re-expose it as a public readonly member — CDK treats props as a write-only struct. The motivating case: the SQS↔Lambda visibility-timeout invariant (a queue's `visibilityTimeout` should be ≥ 6× the consumer's `timeout`). `Queue` doesn't expose `visibilityTimeout`; only `QueueProps` carries it, so a consumer receiving the queue via `ref()` can only emit a contextual reminder, never a real comparison (see the "not enforced" note on `sqsEventSource`).

Three facts make the value unreachable today: the construct doesn't re-expose it; the builder getter reads `props` *before* defaults are merged and lives on the builder (which siblings never receive); and the invariant spans two components, so only the consumer — which already knows its own side — can check it.

## Approach (per the [analysis on #122](https://github.com/laazyj/composureCDK/issues/122#issuecomment-4663832379), recommended Option A)

A builder result exposes the resolved configuration it handed to its CDK construct under a uniform `resolvedProps` field. The merged object already exists inside every `build()` (`{ ...DEFAULTS, ...userProps }`, refs resolved) — it was simply being discarded. This extends the existing "build results must be complete" tenet from constructs to resolved configuration.

```ts
const orders = createQueueBuilder().visibilityTimeout(Duration.seconds(30));
const result = orders.build(stack, "Orders");
result.resolvedProps.visibilityTimeout; // Duration | undefined — the Queue construct never exposes this
```

A consumer holding a `ref()` to the result can now run a real, token-guarded check instead of a reminder.

## Changes

- **core** — `ResolvedProps<P>` (and `Resolved<T>`): `Readonly<{ [K in keyof P]?: Resolved<P[K]> }>` — every key optional and read-only, with any `Resolvable<T>` collapsed to its resolved `T`. Exported from the package root.
- **sqs** — `QueueBuilderResult.resolvedProps: ResolvedProps<QueueProps>` (the #118 unblocker).
- **lambda** — `FunctionBuilderResult.resolvedProps: ResolvedProps<FunctionProps>`, which exercises the `Resolvable` collapse via the widened `role` prop.
- **docs** — [ADR-0011](docs/adr/0011-resolved-props-on-results.md) records the result-type contract and the alternatives weighed (curated named fields, capability channel, decorator, status quo); `architecture.md` and the ADR index updated.

## Design notes

- **Semantics: post-default, post-resolve, *not* token-resolved.** A value may still be an unresolved CDK `Token`; consumers guard with `Token.isUnresolved`, exactly as `QueueBuilder`'s existing `warnIfLowMaxReceiveCount` does.
- **Typed off the CDK props, not the builder props** — builder-specific keys (`recommendedAlarms`) are destructured out before the merge, and widened keys collapse back to the construct's type.
- **Originates in `build()`** (returned as a shallow copy), deliberately not a decorator: a decorator can't see `mergedProps`, which is internal to `build()`. ADR-0011 §Alternatives covers this.
- **Scope:** full merged prop set, not a curated subset — `resolvedProps` is the floor; a builder may *additionally* promote a specific value to a named field.

## Scope / follow-up

This lands the mechanism plus the two motivating builders. Rolling `resolvedProps` out to the remaining ~33 `*BuilderResult` types is a mechanical follow-up (mirrors how ADR-0010 shipped a central mechanism plus first adopters). The actual `sqsEventSource` invariant check that consumes this is #123/#124.

## Verification

`npm run verify` green (build, `check:exports`, lint, test across all 19 projects). New tests: `resolvedProps` defaults/override/write-only-prop/by-reference on `QueueBuilder`; defaults + `ref()`-role collapse on `FunctionBuilder`; type-level optional/collapse/readonly assertions on `ResolvedProps` in core.

> [!NOTE]
> One maintainer call flagged in the #122 analysis: `resolvedProps` exposes the *full* prop bag, including values with no cross-component use and potentially sensitive ones (e.g. a Lambda's `environment`). It's in-process only and never serialised, but it is a public contract widening. If that's unwelcome, the fallback is curated named fields under a single namespace — happy to adjust.

https://claude.ai/code/session_013qoPQbmyWj5sGHpNWTT3jQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013qoPQbmyWj5sGHpNWTT3jQ)_