### PR TITLE
chore(release): v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.8.4 (2026-06-10)
+
+### 🚀 Features
+
+- **constraints:** AWS-property constraint catalogue ([#188](https://github.com/laazyj/composureCDK/pull/188), [#166](https://github.com/laazyj/composureCDK/issues/166))
+- **neptune:** add Amazon Neptune cluster builder ([#189](https://github.com/laazyj/composureCDK/pull/189), [#141](https://github.com/laazyj/composureCDK/issues/141))
+
+### 🩹 Fixes
+
+- **ec2:** let user-pinned availabilityZones override default maxAzs ([#187](https://github.com/laazyj/composureCDK/pull/187), [#153](https://github.com/laazyj/composureCDK/issues/153))
+
+### ❤️ Thank You
+
+- Jason Duffett
+
 ## 0.8.3 (2026-06-01)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -8766,7 +8766,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8788,7 +8788,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8811,7 +8811,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8833,7 +8833,7 @@
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8853,7 +8853,7 @@
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8876,7 +8876,7 @@
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8889,13 +8889,14 @@
         "node": ">=20"
       },
       "peerDependencies": {
+        "@composurecdk/cloudformation": "^0.8.0",
         "aws-cdk-lib": "^2.1.0",
         "constructs": "^10.0.0"
       }
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -8914,7 +8915,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8937,7 +8938,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8952,7 +8953,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -8973,7 +8974,7 @@
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9004,7 +9005,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9025,7 +9026,7 @@
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@composurecdk/iam": "^0.8.0",
@@ -9050,7 +9051,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9071,7 +9072,7 @@
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9106,7 +9107,7 @@
     },
     "packages/neptune": {
       "name": "@composurecdk/neptune",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9130,7 +9131,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9153,7 +9154,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9176,7 +9177,7 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -9198,7 +9199,7 @@
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.1",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/neptune",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable Amazon Neptune cluster builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.8.4**.

Generated by `release-prepare` workflow run [#27260652017](https://github.com/laazyj/composureCDK/actions/runs/27260652017).

## Merge checklist

- [x] CI is green
- [x] Changelog reads correctly
- [x] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.8.4`, which triggers `release.yml` (deploy-test → npm publish).