### PR TITLE
feat(ec2): VPC interface-endpoint builder (#194)

### DIFF
--- a/packages/ec2/README.md
+++ b/packages/ec2/README.md
@@ -288,6 +288,203 @@ compose(
 
 The Security Group builder does **not** create CloudWatch alarms. Security groups do not emit CloudWatch metrics — the [AWS recommended-alarms reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html) has no SG entry. Operational visibility for SGs comes from adjacent signals (VPC Flow Logs, GuardDuty findings, CloudTrail `AuthorizeSecurityGroupIngress`/`Egress` events), none of which belong on the builder result.
 
+## Interface Endpoint Builder
+
+VPC interface endpoints (AWS PrivateLink) have no props-time surface in CDK —
+the only way to add one is the post-build `vpc.addInterfaceEndpoint(...)` call,
+whose security group is never exposed. `createInterfaceEndpointBuilder` makes an
+endpoint a first-class `compose()` component. It maps **1:1 to a CDK
+`InterfaceVpcEndpoint`** (one `service` per endpoint) and supports two security
+group modes:
+
+- **BYO** — `.securityGroups([...])` with SGs you fully manage (typically
+  sibling `SecurityGroupBuilder`s): full ingress/egress/port control.
+- **Managed shortcut** — omit `.securityGroups()` and the builder auto-creates a
+  closed SG, exposes it on the result, and `.allowDefaultPortFrom(peer)` opens
+  ingress on the service's default port.
+
+The two are mutually exclusive (combining them throws). To group several
+endpoints under one access policy, point them at the same security group.
+
+### Minimalist single service (managed shortcut)
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import {
+  createInterfaceEndpointBuilder,
+  createSecurityGroupBuilder,
+  createVpcBuilder,
+  type SecurityGroupBuilderResult,
+  type VpcBuilderResult,
+} from "@composurecdk/ec2";
+import { InterfaceVpcEndpointAwsService, SubnetType } from "aws-cdk-lib/aws-ec2";
+
+compose(
+  {
+    network: createVpcBuilder().natGateways(0),
+    bastionSg: createSecurityGroupBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .description("Bastion"),
+    ssm: createInterfaceEndpointBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .service(InterfaceVpcEndpointAwsService.SSM)
+      .subnets({ subnetType: SubnetType.PRIVATE_ISOLATED })
+      .allowDefaultPortFrom(ref<SecurityGroupBuilderResult>("bastionSg").get("securityGroup")),
+  },
+  { network: [], bastionSg: ["network"], ssm: ["network", "bastionSg"] },
+).build(stack, "App");
+// result.ssm = { endpoint: InterfaceVpcEndpoint, securityGroup: SecurityGroup }
+```
+
+The managed `securityGroup` is on the result so the **peer's egress side** can
+reference it (`bastionSg.addEgressRule(ref("ssm").get("securityGroup"), Port.tcp(443))`).
+
+### SSM access (multiple endpoints, one shared SG)
+
+SSM/Session Manager in a NAT-free VPC needs three endpoints with identical
+ingress. One endpoint per builder — share a single BYO `SecurityGroupBuilder`
+across all three. The access policy lives on the shared SG, not on individual
+endpoints:
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import {
+  createInterfaceEndpointBuilder,
+  createSecurityGroupBuilder,
+  createVpcBuilder,
+  type SecurityGroupBuilderResult,
+  type VpcBuilderResult,
+} from "@composurecdk/ec2";
+import { InterfaceVpcEndpointAwsService, Port, SubnetType } from "aws-cdk-lib/aws-ec2";
+
+compose(
+  {
+    network: createVpcBuilder().natGateways(0),
+    bastionSg: createSecurityGroupBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .description("Bastion"),
+    // One SG shared by all three endpoints — the access policy lives here.
+    endpointSg: createSecurityGroupBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .description("SSM endpoints")
+      .addIngressRule(
+        ref<SecurityGroupBuilderResult>("bastionSg").get("securityGroup"),
+        Port.tcp(443),
+      ),
+    ssm: createInterfaceEndpointBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .service(InterfaceVpcEndpointAwsService.SSM)
+      .subnets({ subnetType: SubnetType.PRIVATE_ISOLATED })
+      .securityGroups([ref<SecurityGroupBuilderResult>("endpointSg").get("securityGroup")]),
+    ssmmessages: createInterfaceEndpointBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .service(InterfaceVpcEndpointAwsService.SSM_MESSAGES)
+      .subnets({ subnetType: SubnetType.PRIVATE_ISOLATED })
+      .securityGroups([ref<SecurityGroupBuilderResult>("endpointSg").get("securityGroup")]),
+    ec2messages: createInterfaceEndpointBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .service(InterfaceVpcEndpointAwsService.EC2_MESSAGES)
+      .subnets({ subnetType: SubnetType.PRIVATE_ISOLATED })
+      .securityGroups([ref<SecurityGroupBuilderResult>("endpointSg").get("securityGroup")]),
+  },
+  {
+    network: [],
+    bastionSg: ["network"],
+    endpointSg: ["network", "bastionSg"],
+    ssm: ["network", "endpointSg"],
+    ssmmessages: ["network", "endpointSg"],
+    ec2messages: ["network", "endpointSg"],
+  },
+).build(stack, "App");
+```
+
+### Complex / custom service (BYO security group)
+
+A custom PrivateLink service on a non-443 port, with precise ingress _and_
+egress controlled by the `SecurityGroupBuilder` you already have:
+
+```ts
+import { InterfaceVpcEndpointService, Port } from "aws-cdk-lib/aws-ec2";
+
+compose(
+  {
+    network: createVpcBuilder(),
+    appSg: createSecurityGroupBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .description("App tier"),
+    endpointSg: createSecurityGroupBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .description("Partner PrivateLink endpoint")
+      .addIngressRule(ref<SecurityGroupBuilderResult>("appSg").get("securityGroup"), Port.tcp(8443))
+      .addEgressRule(ref<SecurityGroupBuilderResult>("appSg").get("securityGroup"), Port.tcp(8443)),
+    partner: createInterfaceEndpointBuilder()
+      .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+      .service(
+        new InterfaceVpcEndpointService("com.amazonaws.vpce.eu-west-1.vpce-svc-0abc123", 8443),
+      )
+      .securityGroups([ref<SecurityGroupBuilderResult>("endpointSg").get("securityGroup")]),
+  },
+  {
+    network: [],
+    appSg: ["network"],
+    endpointSg: ["network", "appSg"],
+    partner: ["network", "endpointSg"],
+  },
+).build(stack, "App");
+// result.partner = { endpoint: InterfaceVpcEndpoint }  (no managed securityGroup in BYO mode)
+```
+
+### Interface Endpoint Defaults
+
+`createInterfaceEndpointBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.
+
+| Property            | Default | Rationale                                                                                                                                                                                                       |
+| ------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `privateDnsEnabled` | `true`  | Enables `<service>.<region>.amazonaws.com` to resolve to the endpoint ENIs, keeping traffic on the AWS network without requiring application-level changes. Disabled by default in raw CDK for custom services. |
+
+The defaults are exported as `INTERFACE_ENDPOINT_DEFAULTS` for visibility and testing:
+
+```ts
+import { INTERFACE_ENDPOINT_DEFAULTS } from "@composurecdk/ec2";
+```
+
+### Recommended Alarms
+
+The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints) by default. No alarm actions are configured — wire actions via `alarmActionsPolicy` from `@composurecdk/cloudwatch`, or by accessing alarms from the build result.
+
+| Alarm            | Metric                      | Default threshold            | Created when |
+| ---------------- | --------------------------- | ---------------------------- | ------------ |
+| `packetsDropped` | PacketsDropped (Sum, 1 min) | > 0 over 5 consecutive 1-min | Always       |
+
+If your workload intentionally sends packets larger than 8,500 bytes (the PrivateLink MTU limit), raise the threshold to reduce noise from expected MTU drops:
+
+```ts
+createInterfaceEndpointBuilder()
+  .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+  .service(InterfaceVpcEndpointAwsService.SSM)
+  .recommendedAlarms({ packetsDropped: { threshold: 100 } });
+```
+
+Disable all recommended alarms:
+
+```ts
+builder.recommendedAlarms(false);
+// or
+builder.recommendedAlarms({ enabled: false });
+```
+
+Disable individual alarms:
+
+```ts
+builder.recommendedAlarms({ packetsDropped: false });
+```
+
+The defaults are exported as `INTERFACE_ENDPOINT_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { INTERFACE_ENDPOINT_ALARM_DEFAULTS } from "@composurecdk/ec2";
+```
+
 ## Volume Builder
 
 ```ts

--- a/packages/ec2/src/index.ts
+++ b/packages/ec2/src/index.ts
@@ -44,6 +44,16 @@ export {
 } from "./security-group-builder.js";
 export { SECURITY_GROUP_DEFAULTS } from "./security-group-defaults.js";
 
+export {
+  createInterfaceEndpointBuilder,
+  type IInterfaceEndpointBuilder,
+  type InterfaceEndpointBuilderProps,
+  type InterfaceEndpointBuilderResult,
+} from "./interface-endpoint-builder.js";
+export { INTERFACE_ENDPOINT_DEFAULTS } from "./interface-endpoint-defaults.js";
+export { type InterfaceEndpointAlarmConfig } from "./interface-endpoint-alarm-config.js";
+export { INTERFACE_ENDPOINT_ALARM_DEFAULTS } from "./interface-endpoint-alarm-defaults.js";
+
 /**
  * This package's AWS-property constraints, grouped by application strategy.
  * The `constraints.validate.*` / `constraints.sanitize.*` shape is identical

--- a/packages/ec2/src/interface-endpoint-alarm-config.ts
+++ b/packages/ec2/src/interface-endpoint-alarm-config.ts
@@ -1,0 +1,35 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended alarms are created for a VPC interface endpoint.
+ * All alarms are enabled by default with AWS-recommended thresholds.
+ * Set individual alarms to `false` to disable them, or provide an
+ * {@link AlarmConfig} to tune thresholds.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints
+ */
+export interface InterfaceEndpointAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable all recommended alarms.
+   * Individual alarms can also be disabled via their own entry.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the endpoint drops packets, indicating the endpoint or
+   * endpoint service is unhealthy, a security group is blocking traffic,
+   * or packets are hitting the 8,500-byte PrivateLink MTU limit.
+   *
+   * Metric: `AWS/PrivateLinkEndpoints PacketsDropped`, statistic Sum,
+   * period 1 minute. Default threshold: > 0 over 5 consecutive 1-minute
+   * windows.
+   *
+   * If your workload intentionally sends packets larger than 8,500 bytes
+   * you may want to raise the threshold to reduce noise from expected MTU
+   * drops.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints
+   */
+  packetsDropped?: AlarmConfig | false;
+}

--- a/packages/ec2/src/interface-endpoint-alarm-defaults.ts
+++ b/packages/ec2/src/interface-endpoint-alarm-defaults.ts
@@ -1,0 +1,32 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+
+interface InterfaceEndpointAlarmDefaults {
+  enabled: true;
+  packetsDropped: AlarmConfigDefaults;
+}
+
+/**
+ * AWS-recommended default alarm configuration for VPC interface endpoints.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints
+ */
+export const INTERFACE_ENDPOINT_ALARM_DEFAULTS: InterfaceEndpointAlarmDefaults = {
+  enabled: true,
+
+  /**
+   * Any sustained packet drop at the endpoint signals a connectivity or
+   * configuration problem — an unhealthy endpoint service, a security group
+   * blocking traffic, or jumbo frames exceeding the 8,500-byte PrivateLink
+   * MTU. Five consecutive 1-minute periods avoids false alarms from isolated
+   * oversized packets while still catching persistent issues quickly.
+   *
+   * @see https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-troubleshoot.html
+   */
+  packetsDropped: {
+    threshold: 0,
+    evaluationPeriods: 5,
+    datapointsToAlarm: 5,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+};

--- a/packages/ec2/src/interface-endpoint-alarms.ts
+++ b/packages/ec2/src/interface-endpoint-alarms.ts
@@ -1,0 +1,83 @@
+import { Duration } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator, Metric, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import { type InterfaceVpcEndpoint } from "aws-cdk-lib/aws-ec2";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { InterfaceEndpointAlarmConfig } from "./interface-endpoint-alarm-config.js";
+import { INTERFACE_ENDPOINT_ALARM_DEFAULTS } from "./interface-endpoint-alarm-defaults.js";
+
+const PACKETS_DROPPED_PERIOD = Duration.minutes(1);
+const PACKETS_DROPPED_PERIOD_LABEL = `${String(PACKETS_DROPPED_PERIOD.toMinutes())} minute`;
+
+function endpointMetric(
+  endpoint: InterfaceVpcEndpoint,
+  metricName: string,
+  statistic: string,
+  period: Duration,
+): Metric {
+  return new Metric({
+    namespace: "AWS/PrivateLinkEndpoints",
+    metricName,
+    dimensionsMap: { "VPC Endpoint Id": endpoint.vpcEndpointId },
+    statistic,
+    period,
+  });
+}
+
+export function resolveEndpointAlarmDefinitions(
+  endpoint: InterfaceVpcEndpoint,
+  config: InterfaceEndpointAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.packetsDropped !== false) {
+    const cfg = resolveAlarmConfig(
+      config?.packetsDropped,
+      INTERFACE_ENDPOINT_ALARM_DEFAULTS.packetsDropped,
+    );
+    definitions.push({
+      key: "packetsDropped",
+      alarmName: cfg.alarmName,
+      metric: endpointMetric(endpoint, "PacketsDropped", Stats.SUM, PACKETS_DROPPED_PERIOD),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `VPC interface endpoint is dropping packets — possible endpoint service unhealthy, ` +
+        `security group blocking traffic, or packets exceeding the 8,500-byte PrivateLink MTU. ` +
+        `Threshold: > ${String(cfg.threshold)} (sum) over ` +
+        `${String(cfg.evaluationPeriods)} x ${PACKETS_DROPPED_PERIOD_LABEL}.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates AWS-recommended CloudWatch alarms for a VPC interface endpoint,
+ * merging recommended definitions with any custom alarm builders.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints
+ */
+export function createInterfaceEndpointAlarms(
+  scope: IConstruct,
+  id: string,
+  endpoint: InterfaceVpcEndpoint,
+  config: InterfaceEndpointAlarmConfig | false | undefined,
+  customAlarms: AlarmDefinitionBuilder<InterfaceVpcEndpoint>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? INTERFACE_ENDPOINT_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveEndpointAlarmDefinitions(endpoint, config);
+  const custom = customAlarms.map((b) => b.resolve(endpoint));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/ec2/src/interface-endpoint-alarms.ts
+++ b/packages/ec2/src/interface-endpoint-alarms.ts
@@ -25,7 +25,7 @@ function endpointMetric(
   });
 }
 
-export function resolveEndpointAlarmDefinitions(
+function resolveEndpointAlarmDefinitions(
   endpoint: InterfaceVpcEndpoint,
   config: InterfaceEndpointAlarmConfig | undefined,
 ): AlarmDefinition[] {

--- a/packages/ec2/src/interface-endpoint-builder.ts
+++ b/packages/ec2/src/interface-endpoint-builder.ts
@@ -1,0 +1,259 @@
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  InterfaceVpcEndpoint,
+  type InterfaceVpcEndpointProps,
+  type IPeer,
+  type ISecurityGroup,
+  type IVpc,
+  Port,
+  type SecurityGroup,
+} from "aws-cdk-lib/aws-ec2";
+import { type IConstruct } from "constructs";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import { createSecurityGroupBuilder } from "./security-group-builder.js";
+import { INTERFACE_ENDPOINT_DEFAULTS } from "./interface-endpoint-defaults.js";
+import type { InterfaceEndpointAlarmConfig } from "./interface-endpoint-alarm-config.js";
+import { createInterfaceEndpointAlarms } from "./interface-endpoint-alarms.js";
+
+/**
+ * Configuration properties for the interface-endpoint builder.
+ *
+ * Lifts three CDK props off the props object:
+ * - `vpc` — supplied via {@link IInterfaceEndpointBuilder.vpc | .vpc()} so it
+ *   can accept a {@link Resolvable} for cross-component wiring.
+ * - `securityGroups` — supplied via
+ *   {@link IInterfaceEndpointBuilder.securityGroups | .securityGroups()} so
+ *   each can be a {@link Resolvable} (typically a sibling
+ *   `SecurityGroupBuilder`).
+ * - `open` — always `false`; ingress is explicit (see the builder docs).
+ */
+export interface InterfaceEndpointBuilderProps extends Omit<
+  InterfaceVpcEndpointProps,
+  "vpc" | "securityGroups" | "open"
+> {
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates recommended alarms with sensible
+   * thresholds. Individual alarms can be customized or disabled. Set to
+   * `false` to disable all alarms.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints
+   */
+  recommendedAlarms?: InterfaceEndpointAlarmConfig | false;
+}
+
+/**
+ * The build output of an {@link IInterfaceEndpointBuilder}.
+ *
+ * `securityGroup` is present only in **managed mode** — i.e. when the caller
+ * did *not* supply `.securityGroups(...)`, so the builder auto-created one. It
+ * is exposed so a peer's *egress* rule can `ref` it. In **BYO mode** it is
+ * `undefined`: the caller already holds refs to the security groups they
+ * passed in.
+ */
+export interface InterfaceEndpointBuilderResult {
+  endpoint: InterfaceVpcEndpoint;
+  securityGroup?: SecurityGroup;
+  alarms: Record<string, Alarm>;
+}
+
+interface AccessSpec {
+  readonly peer: Resolvable<IPeer>;
+  readonly description?: string;
+}
+
+/**
+ * A fluent builder for a single VPC interface endpoint (AWS PrivateLink).
+ *
+ * Unlike raw CDK — where interface endpoints exist only as a post-build
+ * `vpc.addInterfaceEndpoint(...)` call whose security group is never exposed —
+ * this builder is a first-class {@link compose} component. It maps 1:1 to a
+ * CDK `InterfaceVpcEndpoint` (one `service` per endpoint); group several into
+ * one access policy by pointing them at the same security group.
+ *
+ * **Security group, two modes:**
+ * - *BYO* — call {@link IInterfaceEndpointBuilder.securityGroups | .securityGroups([...])}
+ *   with security groups you fully manage (typically sibling
+ *   `SecurityGroupBuilder`s). Full ingress/egress/port control; the builder
+ *   creates no SG and `securityGroup` is absent from the result.
+ * - *Managed shortcut* — omit `.securityGroups()` and the builder auto-creates
+ *   a closed SG, exposes it on the result, and opens ingress for the peers you
+ *   pass to {@link IInterfaceEndpointBuilder.allowDefaultPortFrom} on the
+ *   service's default port.
+ *
+ * The two are mutually exclusive — combining BYO `.securityGroups()` with
+ * `.allowDefaultPortFrom()` throws, since the rule would have nowhere it
+ * could be applied that the caller isn't already managing.
+ *
+ * @see https://docs.aws.amazon.com/vpc/latest/privatelink/
+ *
+ * @example Managed shortcut (the SSM-from-bastion common case)
+ * ```ts
+ * createInterfaceEndpointBuilder()
+ *   .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+ *   .service(InterfaceVpcEndpointAwsService.SSM)
+ *   .subnets({ subnetType: SubnetType.PRIVATE_ISOLATED })
+ *   .allowDefaultPortFrom(ref<SecurityGroupBuilderResult>("bastionSg").get("securityGroup"));
+ * // result = { endpoint, securityGroup }
+ * ```
+ */
+export type IInterfaceEndpointBuilder = ITaggedBuilder<
+  InterfaceEndpointBuilderProps,
+  InterfaceEndpointBuilder
+>;
+
+class InterfaceEndpointBuilder implements Lifecycle<InterfaceEndpointBuilderResult> {
+  props: Partial<InterfaceEndpointBuilderProps> = {};
+  readonly #access: AccessSpec[] = [];
+  readonly #customAlarms: AlarmDefinitionBuilder<InterfaceVpcEndpoint>[] = [];
+  #vpc?: Resolvable<IVpc>;
+  #securityGroups?: Resolvable<ISecurityGroup>[];
+
+  /**
+   * Sets the VPC the endpoint is created in. Accepts a concrete {@link IVpc}
+   * or a {@link Ref} to a sibling {@link IVpcBuilder}.
+   */
+  vpc(vpc: Resolvable<IVpc>): this {
+    this.#vpc = vpc;
+    return this;
+  }
+
+  /**
+   * Bring-your-own security groups. Each entry is a {@link Resolvable}, so it
+   * can be a concrete {@link ISecurityGroup} or a {@link Ref} to a sibling
+   * `SecurityGroupBuilder` — giving you full ingress/egress/port control. When
+   * set, the builder creates no security group of its own and
+   * {@link InterfaceEndpointBuilderResult.securityGroup} is `undefined`.
+   *
+   * Mutually exclusive with {@link allowDefaultPortFrom}.
+   */
+  securityGroups(securityGroups: Resolvable<ISecurityGroup>[]): this {
+    this.#securityGroups = securityGroups;
+    return this;
+  }
+
+  /**
+   * Managed-SG shortcut: opens ingress on the auto-created security group from
+   * `peer`, on the endpoint service's default port (443 for AWS services, or
+   * the port the custom service was declared with). Mirrors CDK's
+   * `endpoint.connections.allowDefaultPortFrom(...)`.
+   *
+   * For an `open: true` equivalent, pass a VPC-CIDR peer
+   * (`Peer.ipv4(vpc.vpcCidrBlock)`). Mutually exclusive with
+   * {@link securityGroups}.
+   */
+  allowDefaultPortFrom(peer: Resolvable<IPeer>, description?: string): this {
+    this.#access.push({ peer, ...(description !== undefined ? { description } : {}) });
+    return this;
+  }
+
+  /**
+   * Adds a custom CloudWatch alarm alongside the recommended ones. The
+   * callback receives an {@link AlarmDefinitionBuilder} typed to the
+   * `InterfaceVpcEndpoint` construct, giving access to the endpoint at
+   * build time for metric dimension wiring.
+   */
+  addAlarm(
+    key: string,
+    configure: (
+      alarm: AlarmDefinitionBuilder<InterfaceVpcEndpoint>,
+    ) => AlarmDefinitionBuilder<InterfaceVpcEndpoint>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<InterfaceVpcEndpoint>(key)));
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: InterfaceEndpointBuilder): void {
+    target.#vpc = this.#vpc;
+    target.#securityGroups = this.#securityGroups ? [...this.#securityGroups] : undefined;
+    target.#access.push(...this.#access);
+    target.#customAlarms.push(...this.#customAlarms);
+  }
+
+  build(
+    scope: IConstruct,
+    id: string,
+    context?: Record<string, object>,
+  ): InterfaceEndpointBuilderResult {
+    const resolvedVpc = this.#vpc ? resolve(this.#vpc, context) : undefined;
+    if (!resolvedVpc) {
+      throw new Error(
+        `InterfaceEndpointBuilder "${id}" requires a VPC. Call .vpc() with an IVpc or a Ref to one.`,
+      );
+    }
+
+    const { recommendedAlarms: alarmConfig, service, ...endpointProps } = this.props;
+    if (service === undefined) {
+      throw new Error(
+        `InterfaceEndpointBuilder "${id}" requires a service. ` +
+          "Call .service() with an InterfaceVpcEndpointAwsService or a custom IInterfaceVpcEndpointService.",
+      );
+    }
+
+    const byo = this.#securityGroups;
+    if (byo !== undefined && this.#access.length > 0) {
+      throw new Error(
+        `InterfaceEndpointBuilder "${id}": .allowDefaultPortFrom() applies only to the ` +
+          "auto-created security group and cannot be combined with .securityGroups() — " +
+          "add the ingress rule to your own SecurityGroupBuilder instead.",
+      );
+    }
+
+    let managedSecurityGroup: SecurityGroup | undefined;
+    let securityGroups: ISecurityGroup[];
+    if (byo !== undefined) {
+      securityGroups = byo.map((sg) => resolve(sg, context));
+    } else {
+      managedSecurityGroup = createSecurityGroupBuilder()
+        .vpc(resolvedVpc)
+        .description(`Interface endpoint ${id}`)
+        .build(scope, `${id}Sg`).securityGroup;
+      const defaultPort = Port.tcp(service.port);
+      for (const rule of this.#access) {
+        managedSecurityGroup.addIngressRule(
+          resolve(rule.peer, context),
+          defaultPort,
+          rule.description,
+        );
+      }
+      securityGroups = [managedSecurityGroup];
+    }
+
+    const endpoint = new InterfaceVpcEndpoint(scope, id, {
+      ...INTERFACE_ENDPOINT_DEFAULTS,
+      ...endpointProps,
+      service,
+      vpc: resolvedVpc,
+      securityGroups,
+      // Always explicit: `open: true` would silently add a VPC-wide :443 rule.
+      open: false,
+    });
+
+    const alarms = createInterfaceEndpointAlarms(
+      scope,
+      id,
+      endpoint,
+      alarmConfig,
+      this.#customAlarms,
+    );
+
+    return { endpoint, securityGroup: managedSecurityGroup, alarms };
+  }
+}
+
+/**
+ * Creates a new {@link IInterfaceEndpointBuilder} for a single VPC interface
+ * endpoint. The returned builder exposes every
+ * {@link InterfaceEndpointBuilderProps} property as a fluent setter/getter,
+ * plus `.vpc()`, `.securityGroups()` (BYO), and `.allowDefaultPortFrom()`
+ * (managed-SG shortcut).
+ */
+export function createInterfaceEndpointBuilder(): IInterfaceEndpointBuilder {
+  return taggedBuilder<InterfaceEndpointBuilderProps, InterfaceEndpointBuilder>(
+    InterfaceEndpointBuilder,
+  );
+}

--- a/packages/ec2/src/interface-endpoint-defaults.ts
+++ b/packages/ec2/src/interface-endpoint-defaults.ts
@@ -1,0 +1,25 @@
+import type { InterfaceVpcEndpointProps } from "aws-cdk-lib/aws-ec2";
+
+/**
+ * Secure, AWS-recommended defaults applied to every interface endpoint built
+ * with {@link createInterfaceEndpointBuilder}. Each property can be
+ * individually overridden via the builder's fluent API.
+ *
+ * Note `open` is intentionally *not* here: the builder always sets it to
+ * `false` (see the builder's `build()`). Allowing it through would silently
+ * add a VPC-wide rule to the managed security group behind the caller's back;
+ * ingress is always explicit — via `.allowDefaultPortFrom()` (managed SG) or
+ * the BYO `SecurityGroupBuilder`.
+ */
+export const INTERFACE_ENDPOINT_DEFAULTS: Partial<InterfaceVpcEndpointProps> = {
+  /**
+   * Private DNS enables `<service>.<region>.amazonaws.com` to resolve to the
+   * endpoint ENIs instead of the public service IP addresses, keeping traffic
+   * on the AWS network without requiring application-level changes. Disabled
+   * by default in raw CDK; always on here because every AWS-service use case
+   * requires it for transparent private access.
+   *
+   * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_network_protection_private_connectivity.html
+   */
+  privateDnsEnabled: true,
+};


### PR DESCRIPTION
## What this is

Implements \`createInterfaceEndpointBuilder\` — a first-class \`compose()\` component for VPC interface endpoints (AWS PrivateLink). Closes the API surface proposed in [#194](https://github.com/laazyj/composureCDK/issues/194).

## Design

One builder maps **1:1 to a CDK \`InterfaceVpcEndpoint\`** (one \`service\` per endpoint). Security group has two mutually-exclusive modes:

- **BYO** — \`.securityGroups([...])\` with SGs you fully manage (sibling \`SecurityGroupBuilder\`s): full ingress/egress/port control. No SG created; \`securityGroup\` absent from the result.
- **Managed shortcut** — omit \`.securityGroups()\`; the builder auto-creates a closed SG, exposes it on the result, and \`.allowDefaultPortFrom(peer)\` opens ingress on the service's default port (\`service.port\`, 443 for AWS services).

Combining BYO \`.securityGroups()\` with \`.allowDefaultPortFrom()\` throws. \`open\` is always \`false\` — explicit ingress only. Group several endpoints under one access policy by pointing them at the same SG.

```
createInterfaceEndpointBuilder()
  .vpc(Resolvable<IVpc>)                              // required
  .service(InterfaceVpcEndpointAwsService | custom)   // required (fluent prop)
  .subnets(...) / .privateDnsEnabled(...)             // fluent props off InterfaceVpcEndpointProps
  .securityGroups(Resolvable<ISecurityGroup>[])        // BYO  ─┐ mutually
  .allowDefaultPortFrom(Resolvable<IPeer>, desc?)      // managed ┘ exclusive
  .recommendedAlarms({...} | false)                   // alarm config
  .addAlarm("key", alarm => ...)                      // custom alarms
// result: { endpoint, securityGroup?, alarms }
```

## Defaults

| Property | Default | Rationale |
| --- | --- | --- |
| `privateDnsEnabled` | `true` | Resolves service hostnames to endpoint ENIs without application changes (Well-Architected SEC 6). |
| `open` | `false` | Always hard-coded — SG ingress is always explicit. |

## Recommended alarms

Sourced from the [AWS CloudWatch recommended-alarms reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints):

| Alarm | Metric | Default threshold |
| --- | --- | --- |
| `packetsDropped` | `AWS/PrivateLinkEndpoints PacketsDropped` (Sum, 1 min) | > 0 over 5 consecutive 1-min windows |

Configurable via \`.recommendedAlarms({...})\` / \`.addAlarm()\`. Threshold default of 0 signals any sustained drop; workloads sending packets > 8,500 bytes (PrivateLink MTU) should raise it.

## Use cases (see README for full examples)

### 1. Minimalist single service (managed shortcut)

```ts
ssm: createInterfaceEndpointBuilder()
  .vpc(ref<VpcBuilderResult>("network").get("vpc"))
  .service(InterfaceVpcEndpointAwsService.SSM)
  .subnets({ subnetType: SubnetType.PRIVATE_ISOLATED })
  .allowDefaultPortFrom(ref<SecurityGroupBuilderResult>("bastionSg").get("securityGroup")),
// result.ssm = { endpoint, securityGroup, alarms }
```

### 2. SSM access — multiple endpoints, one shared SG

One endpoint per builder; share a single \`SecurityGroupBuilder\`. The three SSM services (\`SSM\`, \`SSM_MESSAGES\`, \`EC2_MESSAGES\`) are declared explicitly — no \`SSM_ACCESS_SERVICES\` helper.

### 3. Complex / custom service (BYO SG, non-443, ingress + egress)

```ts
partner: createInterfaceEndpointBuilder()
  .vpc(ref<VpcBuilderResult>("network").get("vpc"))
  .service(new InterfaceVpcEndpointService("com.amazonaws.vpce.eu-west-1.vpce-svc-0abc123", 8443))
  .securityGroups([ref<SecurityGroupBuilderResult>("endpointSg").get("securityGroup")]),
// result.partner = { endpoint, alarms }  (no managed securityGroup in BYO mode)
```

## Changes

- \`packages/ec2/src/interface-endpoint-builder.ts\` — builder + alarm wiring
- \`packages/ec2/src/interface-endpoint-defaults.ts\` — Well-Architected defaults
- \`packages/ec2/src/interface-endpoint-alarm-config.ts\` — alarm config type
- \`packages/ec2/src/interface-endpoint-alarm-defaults.ts\` — alarm defaults const
- \`packages/ec2/src/interface-endpoint-alarms.ts\` — alarm creation
- \`packages/ec2/src/index.ts\` — exports (removed \`SSM_ACCESS_SERVICES\`)
- \`packages/ec2/README.md\` — full builder documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)