### PR TITLE
fix(ci): grant deploy-test role Neptune smoke-test permissions

### DIFF
--- a/.github/cloudformation/github-oidc-role.yml
+++ b/.github/cloudformation/github-oidc-role.yml
@@ -152,6 +152,48 @@ Resources:
               - ec2:DescribeSecurityGroups
             Resource: "*"
 
+          # Neptune — read-only describe for the smoke test against
+          # ComposureCDK-NeptuneGraphStack. Neptune's control plane shares the
+          # RDS API namespace, so describing the cluster is an `rds:` action.
+          # RDS Describe* actions do not support resource-level permissions, so
+          # Resource is "*" (same constraint as EC2Read above). Cluster
+          # creation/mutation runs under the CDK cfn-exec role (not this OIDC
+          # role) via AssumeRole below.
+          - Sid: NeptuneRead
+            Effect: Allow
+            Action:
+              - rds:DescribeDBClusters
+            Resource: "*"
+
+          # SSM Run Command — the Neptune smoke test SSMs to the bastion and
+          # runs a SigV4-signed OpenCypher health query against the cluster.
+          # SendCommand is granted across two resource scopes: the AWS-managed
+          # `AWS-RunShellScript` document (public, carries no tag) and the
+          # target instances, restricted to ComposureCDK-* stacks via the
+          # CloudFormation stack-name tag on the bastion. GetCommandInvocation
+          # does not support resource-level permissions, so it is granted on
+          # "*" (read-only command status).
+          - Sid: SSMSendCommandDocument
+            Effect: Allow
+            Action:
+              - ssm:SendCommand
+            Resource:
+              - !Sub arn:${AWS::Partition}:ssm:*::document/AWS-RunShellScript
+          - Sid: SSMSendCommandInstances
+            Effect: Allow
+            Action:
+              - ssm:SendCommand
+            Resource:
+              - !Sub arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*
+            Condition:
+              StringLike:
+                ssm:resourceTag/aws:cloudformation:stack-name: ComposureCDK-*
+          - Sid: SSMCommandStatus
+            Effect: Allow
+            Action:
+              - ssm:GetCommandInvocation
+            Resource: "*"
+
           # Lambda — scoped by CloudFormation stack-name tag.
           # CreateFunction accepts Tags, so aws:RequestTag works at
           # creation time. Mutations use aws:ResourceTag on the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -254,7 +254,7 @@ npx nx cdk examples -- destroy --all
 
 - **OIDC everywhere** — both AWS and npm. No long-lived credentials in GitHub.
 - **Environment-scoped trust** — the AWS role restricts assumption to the `sandbox` environment; npm trusted publishers restrict publishing to `release.yml` in the `npm` environment.
-- **Tag-based resource scoping** — Lambda, CloudWatch Logs, and IAM permissions use `aws:cloudformation:stack-name` tag conditions limited to `ComposureCDK-*`. SQS smoke-test access is ARN-scoped to the sandbox account (CloudFormation system tags don't propagate to SQS in a form IAM evaluates).
+- **Tag-based resource scoping** — Lambda, CloudWatch Logs, and IAM permissions use `aws:cloudformation:stack-name` tag conditions limited to `ComposureCDK-*`. The Neptune smoke test's `ssm:SendCommand` is likewise scoped to bastion instances carrying that tag (the `AWS-RunShellScript` document is granted separately). SQS smoke-test access is ARN-scoped to the sandbox account (CloudFormation system tags don't propagate to SQS in a form IAM evaluates). Read-only describes that AWS does not support resource-level permissions for — EC2 `Describe*`, `rds:DescribeDBClusters`, `ssm:GetCommandInvocation`, `cloudformation:ListStacks` — are granted on `*`.
 - **npm provenance** — published packages include provenance attestations linking them to this repo and workflow run.
 - **Action pinning** — all GitHub Actions are pinned by commit SHA, kept current by Dependabot.
 - **Concurrency** — deploy-test uses `cancel-in-progress: false` so an in-flight deployment cannot be interrupted into an inconsistent state.


### PR DESCRIPTION
## Problem

The `deploy-test` workflow's post-deploy smoke test was failing on the Neptune graph example ([run 27261831134](https://github.com/laazyj/composureCDK/actions/runs/27261831134/job/80509930758#step:9:1)). The Neptune stack deploys fine — CDK creates its resources under the bootstrap cfn-exec role — but the `github-actions-composurecdk-deploy` OIDC role that the smoke test itself runs under lacked the permissions the `neptune-graph.smoke.mjs` check needs:

```
AccessDenied ... not authorized to perform: rds:DescribeDBClusters on resource:
arn:aws:rds:eu-west-2:...:cluster:neptunedbcluster-zw7kxgkl5jni
```

That was just the first call to fail. The check then SSMs to the bastion and polls a Run Command — neither of which the role could do either.

## Fix

Added three smoke-test permissions to the managed policy in `.github/cloudformation/github-oidc-role.yml`:

| Permission | Scope | Why |
| --- | --- | --- |
| `rds:DescribeDBClusters` | `*` | Neptune's control plane shares the RDS API namespace. RDS `Describe*` actions have no resource-level permissions, so `*` — same constraint as the existing `EC2Read` block. |
| `ssm:SendCommand` | `AWS-RunShellScript` document + instances tagged `aws:cloudformation:stack-name=ComposureCDK-*` | Run the SigV4-signed OpenCypher health query on the bastion. Split across two statements so the public document and the tag-scoped instances are each covered. |
| `ssm:GetCommandInvocation` | `*` | Poll command status; no resource-level support. |

The instance-tag condition keeps `SendCommand` within the same `ComposureCDK-*` security boundary used everywhere else in the policy.

Also documented the new scoping in the `docs/ci.md` security notes.

## Verification

`npm run lint` and `npm run format:check` pass; the `pre-push` hook ran the full `verify` gate (build + tests) successfully. The IAM change can only be exercised end-to-end by re-running the `deploy-test` workflow after the sandbox role's managed policy is redeployed from this template.

https://claude.ai/code/session_01K2s69oehh7Eo15VyrphkCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2s69oehh7Eo15VyrphkCN)_