### PR TITLE
Lower Neptune aws-cdk-lib floor to its real value (2.190.0)

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Per-package aws-cdk-lib floors — the source of truth for each package's peerDependencies.aws-cdk-lib range. `node scripts/cdk-floors.mjs establish` discovers these (ladder-granular); the values here are refined to the exact introducing release and validated by loading each package against real installs. `apply` writes them to package.json; `check` asserts package.json matches. To grandfather older support, drop the requiring API, re-run establish to prove the lower floor, then apply.",
+  "$comment": "Per-package aws-cdk-lib floors — the source of truth for each package's peerDependencies.aws-cdk-lib range. `node scripts/cdk-floors.mjs establish` discovers these (ladder-granular); the values here are refined to the exact introducing release and validated by loading each package against real installs. `apply` writes them to package.json; `check` asserts package.json matches. To grandfather older support, drop the requiring API, re-run establish to prove the lower floor, then apply. An optional `peerFloors` map declares additional peerDependencies that move in lockstep with the aws-cdk-lib floor (e.g. a version-locked `@aws-cdk/aws-*-alpha` module); like `floor`, each value is the exact version — `apply` writes it as a `^` range, `check` asserts it, and `enforce` pins it (exact) alongside aws-cdk-lib when probing the floor.",
   "floors": {
     "cloudformation": {
       "floor": "2.1.0",
@@ -52,8 +52,11 @@
     },
     "lambda": { "floor": "2.168.0", "gatedBy": "aws-lambda.MetricType (introduced 2.168.0)" },
     "neptune": {
-      "floor": "2.257.0",
-      "gatedBy": "@aws-cdk/aws-neptune-alpha is version-locked to its matching aws-cdk-lib release (the 2.257.0-alpha.0 peer requires aws-cdk-lib 2.257.0), so the floor tracks that exact release rather than an introducing API"
+      "floor": "2.190.0",
+      "gatedBy": "ParameterGroupFamily.NEPTUNE_1_4 (used as the default parameter-group family in cluster-parameter-group-defaults.ts) and EngineVersion.V1_4_0_0 were introduced in @aws-cdk/aws-neptune-alpha 2.190.0-alpha.0, whose own aws-cdk-lib peer is ^2.190.0; the alpha just below (2.189.x-alpha.0) lacks both symbols so the package fails to compile. @aws-cdk/aws-neptune-alpha is version-locked to its matching aws-cdk-lib release, so the alpha peer (see peerFloors) tracks the same 2.190.0 line.",
+      "peerFloors": {
+        "@aws-cdk/aws-neptune-alpha": "2.190.0-alpha.0"
+      }
     },
     "route53": { "floor": "2.216.0", "gatedBy": "aws-route53.HttpsRecord (introduced 2.216.0)" }
   }

--- a/docs/adr/0008-aws-cdk-lib-version-floors.md
+++ b/docs/adr/0008-aws-cdk-lib-version-floors.md
@@ -114,6 +114,33 @@ This complements the static guard already in place: the
 blocks known version-gated APIs at lint time, so they can't be written into
 `src/` in the first place.
 
+### Lockstep alpha peers
+
+`@composurecdk/neptune` also depends on `@aws-cdk/aws-neptune-alpha`, an L2 module
+AWS publishes one-per-`aws-cdk-lib`-release: `@aws-cdk/aws-neptune-alpha@X.Y.Z-alpha.0`
+declares `peerDependencies.aws-cdk-lib` of `^X.Y.Z`. The two move in lockstep, so
+the package's real floor is "the lowest alpha that still carries every symbol the
+builder uses" and its matching aws-cdk-lib release. Neptune's floor is **2.190.0**:
+`ParameterGroupFamily.NEPTUNE_1_4` (the default parameter-group family) and
+`EngineVersion.V1_4_0_0` first ship in `@aws-cdk/aws-neptune-alpha@2.190.0-alpha.0`;
+the alpha immediately below (`2.189.x-alpha.0`) lacks both and the package fails to
+compile.
+
+A manifest entry may therefore carry an optional **`peerFloors`** map of lockstep
+peers, each stored as an exact version exactly like `floor`
+(here `{ "@aws-cdk/aws-neptune-alpha": "2.190.0-alpha.0" }`). `apply` writes it to
+`peerDependencies` as a `^` range and `check` asserts it, while `enforce` pins the
+exact version in the same `overrides` block it uses for aws-cdk-lib — otherwise a
+lowered aws-cdk-lib floor would be probed against the still-latest alpha
+devDependency, and the run would prove nothing.
+
+A subtlety drives the range shape: because alpha versions are prerelease-tagged,
+`^2.190.0-alpha.0` only matches the `2.190.x` alpha line under default semver — no
+single caret/`>=` range spans an arbitrary span of `-alpha.0` minors. The
+`aws-cdk-lib` peer stays a clean stable range (`^2.190.0`, satisfied by the latest
+devDependency), so the package still tests at the latest CDK; the alpha peer is the
+narrow lockstep pin, matching how the alpha ecosystem is consumed in practice.
+
 ## Consequences
 
 - Consumers get honest, per-package ranges; low-floor packages stay broadly

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -37,11 +37,11 @@
     }
   },
   "peerDependencies": {
-    "@aws-cdk/aws-neptune-alpha": "^2.257.0-alpha.0",
+    "@aws-cdk/aws-neptune-alpha": "^2.190.0-alpha.0",
     "@composurecdk/cloudformation": "^0.8.0",
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.257.0",
+    "aws-cdk-lib": "^2.190.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -71,7 +71,7 @@ function readFloors() {
 
 /** Writes each package's peerDependencies.aws-cdk-lib from the curated manifest. */
 function apply() {
-  for (const [pkg, { floor }] of Object.entries(readFloors())) {
+  for (const [pkg, { floor, peerFloors }] of Object.entries(readFloors())) {
     const path = pkgJsonPath(pkg);
     const json = JSON.parse(readFileSync(path, "utf8"));
     if (json.peerDependencies?.["aws-cdk-lib"] === undefined) {
@@ -79,8 +79,17 @@ function apply() {
       continue;
     }
     json.peerDependencies["aws-cdk-lib"] = `^${floor}`;
+    // Lockstep peers (e.g. a version-locked @aws-cdk/aws-*-alpha) are stored exact
+    // in the manifest, like `floor`, and written as a caret range here.
+    const extras = [];
+    for (const [name, version] of Object.entries(peerFloors ?? {})) {
+      json.peerDependencies[name] = `^${version}`;
+      extras.push(`${name} ^${version}`);
+    }
     writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
-    console.log(`  ${pkg.padEnd(16)} aws-cdk-lib ^${floor}`);
+    console.log(
+      `  ${pkg.padEnd(16)} aws-cdk-lib ^${floor}${extras.length > 0 ? ` + ${extras.join(", ")}` : ""}`,
+    );
   }
   console.log("\nApplied to package.json files (run `npm run format` to normalise).");
 }
@@ -89,14 +98,19 @@ function apply() {
 function check() {
   const floors = readFloors();
   const mismatches = [];
-  for (const [pkg, { floor }] of Object.entries(floors)) {
-    const actual = JSON.parse(readFileSync(pkgJsonPath(pkg), "utf8")).peerDependencies?.[
-      "aws-cdk-lib"
-    ];
-    if (actual !== `^${floor}`) {
+  for (const [pkg, { floor, peerFloors }] of Object.entries(floors)) {
+    const peers = JSON.parse(readFileSync(pkgJsonPath(pkg), "utf8")).peerDependencies ?? {};
+    if (peers["aws-cdk-lib"] !== `^${floor}`) {
       mismatches.push(
-        `  ${pkg}: package.json has "${actual ?? "(unset)"}", manifest expects "^${floor}"`,
+        `  ${pkg}: package.json has aws-cdk-lib "${peers["aws-cdk-lib"] ?? "(unset)"}", manifest expects "^${floor}"`,
       );
+    }
+    for (const [name, version] of Object.entries(peerFloors ?? {})) {
+      if (peers[name] !== `^${version}`) {
+        mismatches.push(
+          `  ${pkg}: package.json has ${name} "${peers[name] ?? "(unset)"}", manifest expects "^${version}"`,
+        );
+      }
     }
   }
   if (mismatches.length > 0) {
@@ -119,12 +133,27 @@ function groupByFloor(floors) {
   return byFloor;
 }
 
-/** The aws-cdk-lib version `pkgName` actually resolves, from inside its own dir. */
-function resolvedVersionFor(pkgName) {
+/**
+ * Lockstep peer overrides (e.g. a version-locked `@aws-cdk/aws-*-alpha`) for each
+ * floor, as `{ [floor]: { [peer]: exactVersion } }`. The manifest stores each peer
+ * exact (like `floor`), which is exactly what `enforce` pins — without pinning the
+ * alpha too, a lowered aws-cdk-lib floor would be probed against a mismatched
+ * (latest) alpha and the result would be meaningless.
+ */
+function peerOverridesByFloor(floors) {
+  const byFloor = {};
+  for (const { floor, peerFloors } of Object.values(floors)) {
+    byFloor[floor] = { ...byFloor[floor], ...peerFloors };
+  }
+  return byFloor;
+}
+
+/** The version of `dep` that `pkgName` actually resolves, from inside its own dir. */
+function resolvedVersionFor(pkgName, dep = "aws-cdk-lib") {
   const cwd = join(PACKAGES_DIR, pkgName.replace("@composurecdk/", ""));
   return execFileSync(
     process.execPath,
-    ["-e", "process.stdout.write(require('aws-cdk-lib/package.json').version)"],
+    ["-e", `process.stdout.write(require(${JSON.stringify(`${dep}/package.json`)}).version)`],
     { cwd, encoding: "utf8" },
   ).trim();
 }
@@ -143,7 +172,9 @@ function resolvedVersionFor(pkgName) {
 function enforce() {
   const requested = process.env.CDK_FLOORS_FLOOR ?? process.argv[3];
   const hasRequested = requested !== undefined && requested !== "" && requested !== "--force";
-  const byFloor = groupByFloor(readFloors());
+  const floors = readFloors();
+  const byFloor = groupByFloor(floors);
+  const peerByFloor = peerOverridesByFloor(floors);
   if (hasRequested && !byFloor.has(requested)) {
     console.error(
       `cdk-floors enforce: no packages declare aws-cdk-lib floor ${requested}.\n` +
@@ -196,9 +227,15 @@ function enforce() {
 
       // Derive the override from the pristine backup each time (so floors don't
       // compound) and install from scratch — overrides only bind on a clean tree.
+      // Lockstep peers (e.g. a version-locked alpha module) are pinned in the same
+      // override so the floor is probed against a coherent peer graph.
+      const peerOverrides = peerByFloor[floor] ?? {};
       const manifest = JSON.parse(pkgBackup);
-      manifest.overrides = { ...manifest.overrides, "aws-cdk-lib": floor };
+      manifest.overrides = { ...manifest.overrides, "aws-cdk-lib": floor, ...peerOverrides };
       writeFileSync(PKG, `${JSON.stringify(manifest, null, 2)}\n`);
+      for (const [name, version] of Object.entries(peerOverrides)) {
+        console.log(`  pinning lockstep peer ${name}@${version}`);
+      }
       // Both must go for npm to re-resolve under the override: with node_modules
       // present npm reports "up to date", and with the lockfile present it
       // installs the locked (latest) version regardless of the override.
@@ -209,17 +246,19 @@ function enforce() {
         stdio: "inherit",
       });
 
-      // Hard gate: confirm the floor bound for this group (not a nested latest
-      // copy), so the run can never silently pass against the wrong version.
+      // Hard gate: confirm every pinned version bound for this group (not a nested
+      // latest copy), so the run can never silently pass against the wrong version.
       const sample = group[0];
-      const got = resolvedVersionFor(sample);
-      if (got !== floor) {
-        throw new Error(
-          `floor pin failed: ${sample} resolves aws-cdk-lib ${got}, expected ${floor} — ` +
-            "the override did not bind (stale node_modules?).",
-        );
+      for (const [dep, want] of Object.entries({ "aws-cdk-lib": floor, ...peerOverrides })) {
+        const got = resolvedVersionFor(sample, dep);
+        if (got !== want) {
+          throw new Error(
+            `pin failed: ${sample} resolves ${dep} ${got}, expected ${want} — ` +
+              "the override did not bind (stale node_modules?).",
+          );
+        }
+        console.log(`  ${sample} resolves ${dep} ${got} ✓`);
       }
-      console.log(`  ${sample} resolves aws-cdk-lib ${got} ✓`);
 
       try {
         execFileSync(


### PR DESCRIPTION
Closes #203.

## What

The Neptune package declared an `aws-cdk-lib` floor of **2.257.0**, justified only by "`@aws-cdk/aws-neptune-alpha` is version-locked to its matching aws-cdk-lib release, so the floor tracks that exact release rather than an introducing API." That pinned the floor to whatever happened to be latest when the package was authored — not to its actual minimum.

Testing the source against a descending ladder of matched `(aws-cdk-lib, @aws-cdk/aws-neptune-alpha)` pairs shows the **real floor is 2.190.0**.

## Evidence

The newest alpha symbols the builder uses are `ParameterGroupFamily.NEPTUNE_1_4` (the default parameter-group family in `cluster-parameter-group-defaults.ts`) and `EngineVersion.V1_4_0_0`. Both first ship in `@aws-cdk/aws-neptune-alpha@2.190.0-alpha.0`, whose own `aws-cdk-lib` peer is `^2.190.0`. The alpha immediately below (`2.189.x-alpha.0`) lacks both symbols and the package fails to compile:

```
src/cluster-parameter-group-defaults.ts(48,35): error TS2551: Property 'NEPTUNE_1_4' does not exist on type 'typeof ParameterGroupFamily'.
test/cluster-builder.test.ts(172,56): error TS2551: Property 'V1_4_0_0' does not exist on type 'typeof EngineVersion'.
```

Verified with the repo's own gate — the Neptune unit suite (typecheck + 21 tests) passes at `2.190.0 / 2.190.0-alpha.0` and breaches at `2.189.1`:

```
=== Enforcing aws-cdk-lib@2.190.0 for 1 package(s) ===
  pinning lockstep peer @aws-cdk/aws-neptune-alpha@2.190.0-alpha.0
  @composurecdk/neptune resolves aws-cdk-lib 2.190.0 ✓
  @composurecdk/neptune resolves @aws-cdk/aws-neptune-alpha 2.190.0-alpha.0 ✓
  Tests  21 passed (21)
cdk-floors enforce passed
```

## Changes

- **`cdk-floors.json`** — Neptune floor `2.257.0` → `2.190.0` with the measured `gatedBy` rationale, plus a new optional **`peerFloors`** map declaring the lockstep alpha peer (stored exact, like `floor`).
- **`packages/neptune/package.json`** — peer ranges lowered to `aws-cdk-lib ^2.190.0` and `@aws-cdk/aws-neptune-alpha ^2.190.0-alpha.0` (via `apply`). `devDependencies` stay at latest, so the package still tests at the latest CDK.
- **`scripts/cdk-floors.mjs`** — `apply`/`check` now keep `peerFloors` in sync with the floor, and `enforce` pins lockstep peers alongside `aws-cdk-lib` (asserting each binds) so the floor is probed against a coherent peer graph rather than a mismatched latest alpha. Without this, `enforce` at a lowered floor would run the suite against the still-latest devDependency alpha and prove nothing.
- **`docs/adr/0008`** — documents lockstep alpha peers and the prerelease-range reasoning (a caret range on a prerelease only spans one `-alpha.0` minor under default semver, so the alpha peer is a narrow lockstep pin while the `aws-cdk-lib` peer stays a clean stable range).

## Notes for review

- The `aws-cdk-lib` peer (`^2.190.0`) is a normal stable caret range, satisfied by any 2.190+, so existing consumers on newer CDK are unaffected.
- `peerFloors` is generic (not Neptune-specific) and threads through the existing `apply`/`check`/`enforce` modes, ready for the next version-locked `@aws-cdk/aws-*-alpha` consumer.

https://claude.ai/code/session_01HdDC2PN4gwtEnWKMgGfp5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdDC2PN4gwtEnWKMgGfp5Y)_