### PR TITLE
fix(lambda): guard token-valued alarm thresholds (#196)

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -6,8 +6,8 @@
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/assertions, aws-cdk-lib/aws-*) used by the suite. Src itself only needs the root entry (2.0.0), but the enforce model requires the suite to run, and `aws-cdk-lib/assertions` is table stakes for builder tests."
     },
     "cloudwatch": {
-      "floor": "2.1.0",
-      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch)"
+      "floor": "2.93.0",
+      "gatedBy": "Annotations.addWarningV2 used by alarm-threshold-basis.ts (introduced 2.93.0); also aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-cloudwatch, 2.1.0)"
     },
     "sns": {
       "floor": "2.178.0",
@@ -26,14 +26,17 @@
       "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs)"
     },
     "events": {
-      "floor": "2.85.0",
-      "gatedBy": "aws-stepfunctions.DefinitionBody used by target-helpers.test (introduced 2.85.0); also Match.stringLikeRegexp used by rule-alarms.test (2.9.0)"
+      "floor": "2.93.0",
+      "gatedBy": "Annotations.addWarningV2 reached transitively via @composurecdk/cloudwatch's alarm-threshold-basis.ts (introduced 2.93.0); also aws-stepfunctions.DefinitionBody used by target-helpers.test (2.85.0) and Match.stringLikeRegexp used by rule-alarms.test (2.9.0)"
     },
     "budgets": {
       "floor": "2.93.0",
       "gatedBy": "Annotations.addWarningV2 used by budget-alarm-builder.ts and currency.ts (introduced 2.93.0)"
     },
-    "apigateway": { "floor": "2.54.0", "gatedBy": "aws-cloudwatch.Stats (introduced 2.54.0)" },
+    "apigateway": {
+      "floor": "2.93.0",
+      "gatedBy": "Annotations.addWarningV2 reached transitively via @composurecdk/cloudwatch's alarm-threshold-basis.ts (introduced 2.93.0); also aws-cloudwatch.Stats (2.54.0)"
+    },
     "ec2": {
       "floor": "2.140.0",
       "gatedBy": "aws-ec2.InstanceProps.ebsOptimized (introduced 2.140.0); also IKeyPair / InstanceProps.keyPair (2.116.0)"

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -41,7 +41,7 @@
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
     "@composurecdk/logs": "^0.8.0",
-    "aws-cdk-lib": "^2.54.0",
+    "aws-cdk-lib": "^2.93.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@composurecdk/cloudformation": "^0.8.0",
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.93.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/cloudwatch/src/alarm-threshold-basis.ts
+++ b/packages/cloudwatch/src/alarm-threshold-basis.ts
@@ -1,0 +1,97 @@
+import { Annotations, Token } from "aws-cdk-lib";
+import type { IConstruct } from "constructs";
+
+/**
+ * Inputs to {@link resolveAlarmThresholdBasis}.
+ *
+ * @typeParam T - The input value's type (e.g. `Duration`, `number`).
+ */
+export interface AlarmThresholdBasisOptions<T> {
+  /** Construct to annotate when the alarm is skipped. */
+  scope: IConstruct;
+
+  /**
+   * The value the alarm threshold is derived from. May be `undefined` (the
+   * input was simply not configured) or an unresolved token (e.g. threaded
+   * through a `CfnParameter`).
+   */
+  value: T | undefined;
+
+  /**
+   * Converts a known-resolved `value` into the numeric basis for the threshold
+   * (e.g. `(d) => d.toMilliseconds()`, or the identity for a raw number). Only
+   * invoked once `value` is confirmed present and resolved, so it is safe to
+   * call conversions that throw on tokens.
+   */
+  resolve: (value: T) => number;
+
+  /**
+   * Predicate deciding whether `value` is an unresolved token. Defaults to
+   * {@link Token.isUnresolved}. Override for wrapper types that carry their own
+   * check rather than being a token directly — notably a CDK `Duration`, whose
+   * token state is exposed via `value.isUnresolved()`.
+   */
+  isUnresolved?: (value: T) => boolean;
+
+  /**
+   * Stable warning identifier, also the handle callers pass to
+   * `Annotations.of(scope).acknowledgeWarning(...)` to suppress it. By
+   * convention `@composurecdk/<package>:<slug>`.
+   */
+  warningId: string;
+
+  /**
+   * Human-readable name of the alarm being skipped, interpolated into the
+   * warning (e.g. `"Lambda duration"`). Phrase it to read after
+   * "Skipping the recommended ".
+   */
+  alarmLabel: string;
+
+  /**
+   * How a caller can intentionally suppress the warning, interpolated into the
+   * warning's closing sentence (e.g. `"recommendedAlarms({ duration: false })"`).
+   */
+  suppressHint: string;
+}
+
+/**
+ * Resolves the numeric basis for a derived-threshold alarm, short-circuiting
+ * when the basis cannot be known at synth time.
+ *
+ * Recommended alarms whose threshold is a function of a configured input (a
+ * percentage of a timeout, of a reserved-concurrency limit, etc.) can only be
+ * rendered when that input is concrete. When the input is an unresolved token —
+ * e.g. a value threaded through a `CfnParameter` — there is no number to derive
+ * from at synth time, and unit-converting it would either throw or silently
+ * produce a meaningless threshold. In that case this annotates `scope` with a
+ * standardized, acknowledgeable warning and returns `undefined`, signalling the
+ * caller to omit the alarm.
+ *
+ * Returns `undefined` (without warning) when `value` is `undefined`, since an
+ * unconfigured input is not a skipped guardrail. The escape hatch that disables
+ * the alarm entirely (e.g. `recommendedAlarms({ duration: false })`) belongs at
+ * the call site, ahead of this call.
+ *
+ * @returns The resolved numeric basis, or `undefined` when the alarm should be
+ *   omitted.
+ * @see https://github.com/laazyj/composureCDK/issues/196
+ */
+export function resolveAlarmThresholdBasis<T>(
+  opts: AlarmThresholdBasisOptions<T>,
+): number | undefined {
+  if (opts.value === undefined) return undefined;
+
+  const isUnresolved = opts.isUnresolved ?? Token.isUnresolved;
+  if (isUnresolved(opts.value)) {
+    Annotations.of(opts.scope).addWarningV2(
+      opts.warningId,
+      `Skipping the recommended ${opts.alarmLabel} alarm: its threshold is derived from a ` +
+        `value that is an unresolved token and cannot be resolved to a concrete threshold at ` +
+        `synth time. Set a literal value, add the alarm explicitly via addAlarm() with a fixed ` +
+        `threshold, or suppress this warning with ${opts.suppressHint}.`,
+    );
+    return undefined;
+  }
+
+  return opts.resolve(opts.value);
+}

--- a/packages/cloudwatch/src/index.ts
+++ b/packages/cloudwatch/src/index.ts
@@ -5,6 +5,10 @@ export type { AlarmConfig, AlarmConfigDefaults } from "./alarm-config.js";
 export type { AlarmDefinition, AlarmMetric } from "./alarm-definition.js";
 export { AlarmDefinitionBuilder } from "./alarm-definition-builder.js";
 export { type AlarmName, alarmName } from "./alarm-name.js";
+export {
+  type AlarmThresholdBasisOptions,
+  resolveAlarmThresholdBasis,
+} from "./alarm-threshold-basis.js";
 export { defaultAlarmName } from "./default-alarm-name.js";
 export { createAlarms } from "./create-alarms.js";
 export { resolveAlarmConfig, type ResolvedAlarmConfig } from "./resolve-alarm-config.js";

--- a/packages/cloudwatch/test/alarm-threshold-basis.test.ts
+++ b/packages/cloudwatch/test/alarm-threshold-basis.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { App, CfnParameter, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match } from "aws-cdk-lib/assertions";
+import { resolveAlarmThresholdBasis } from "../src/alarm-threshold-basis.js";
+
+function testScope() {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  return { stack };
+}
+
+const WARNING_ID = "@composurecdk/test:token-threshold";
+
+describe("resolveAlarmThresholdBasis", () => {
+  it("returns the resolved basis for a concrete value", () => {
+    const { stack } = testScope();
+
+    const basis = resolveAlarmThresholdBasis({
+      scope: stack,
+      value: 100,
+      resolve: (n) => n,
+      warningId: WARNING_ID,
+      alarmLabel: "test",
+      suppressHint: "recommendedAlarms({ test: false })",
+    });
+
+    expect(basis).toBe(100);
+    expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+  });
+
+  it("applies the resolve conversion to a concrete value", () => {
+    const { stack } = testScope();
+
+    const basis = resolveAlarmThresholdBasis({
+      scope: stack,
+      value: Duration.seconds(30),
+      isUnresolved: (d) => d.isUnresolved(),
+      resolve: (d) => d.toMilliseconds(),
+      warningId: WARNING_ID,
+      alarmLabel: "test",
+      suppressHint: "recommendedAlarms({ test: false })",
+    });
+
+    expect(basis).toBe(30_000);
+  });
+
+  it("returns undefined without warning for an unconfigured (undefined) value", () => {
+    const { stack } = testScope();
+
+    const basis = resolveAlarmThresholdBasis({
+      scope: stack,
+      value: undefined,
+      resolve: (n: number) => n,
+      warningId: WARNING_ID,
+      alarmLabel: "test",
+      suppressHint: "recommendedAlarms({ test: false })",
+    });
+
+    expect(basis).toBeUndefined();
+    expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+  });
+
+  it("skips and warns for a token-valued number (default Token.isUnresolved guard)", () => {
+    const { stack } = testScope();
+    const param = new CfnParameter(stack, "Concurrency", { type: "Number", default: 100 });
+
+    const basis = resolveAlarmThresholdBasis({
+      scope: stack,
+      value: param.valueAsNumber,
+      resolve: (n) => n,
+      warningId: WARNING_ID,
+      alarmLabel: "test concurrency",
+      suppressHint: "recommendedAlarms({ test: false })",
+    });
+
+    expect(basis).toBeUndefined();
+    Annotations.fromStack(stack).hasWarning(
+      "*",
+      Match.stringLikeRegexp(
+        "Skipping the recommended test concurrency alarm.*" +
+          "recommendedAlarms\\(\\{ test: false \\}\\).*" +
+          `\\[ack: ${WARNING_ID}\\]`,
+      ),
+    );
+  });
+
+  it("skips and warns for a token-valued Duration via the custom guard", () => {
+    const { stack } = testScope();
+    const param = new CfnParameter(stack, "TimeoutSeconds", { type: "Number", default: 30 });
+
+    // toMilliseconds() throws on a token-valued seconds Duration; the guard must
+    // short-circuit before resolve() is ever called.
+    const basis = resolveAlarmThresholdBasis({
+      scope: stack,
+      value: Duration.seconds(param.valueAsNumber),
+      isUnresolved: (d) => d.isUnresolved(),
+      resolve: (d) => d.toMilliseconds(),
+      warningId: WARNING_ID,
+      alarmLabel: "test duration",
+      suppressHint: "recommendedAlarms({ test: false })",
+    });
+
+    expect(basis).toBeUndefined();
+    Annotations.fromStack(stack).hasWarning(
+      "*",
+      Match.stringLikeRegexp(
+        `Skipping the recommended test duration alarm.*\\[ack: ${WARNING_ID}\\]`,
+      ),
+    );
+  });
+});

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@composurecdk/cloudwatch": "^0.8.0",
     "@composurecdk/core": "^0.8.0",
-    "aws-cdk-lib": "^2.85.0",
+    "aws-cdk-lib": "^2.93.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/lambda/src/function-alarms.ts
+++ b/packages/lambda/src/function-alarms.ts
@@ -9,7 +9,12 @@ import {
 import type { Function as LambdaFunction, FunctionProps } from "aws-cdk-lib/aws-lambda";
 import type { IConstruct } from "constructs";
 import type { AlarmDefinition, AlarmName } from "@composurecdk/cloudwatch";
-import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import {
+  AlarmDefinitionBuilder,
+  createAlarms,
+  resolveAlarmConfig,
+  resolveAlarmThresholdBasis,
+} from "@composurecdk/cloudwatch";
 import type {
   FunctionAlarmConfig,
   PercentageAlarmConfig,
@@ -104,44 +109,71 @@ export function resolveFunctionAlarmDefinitions(
     });
   }
 
-  const timeoutMs = props.timeout?.toMilliseconds();
-  if (config?.duration !== false && timeoutMs !== undefined) {
-    const cfg = resolvePercentageAlarmConfig(config?.duration, FUNCTION_ALARM_DEFAULTS.duration);
-    const threshold = Math.round(timeoutMs * cfg.thresholdPercent);
-    definitions.push({
-      key: "duration",
-      alarmName: cfg.alarmName,
-      metric: fn.metricDuration({ period: METRIC_PERIOD, statistic: Stats.percentile(99) }),
-      threshold,
-      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: cfg.evaluationPeriods,
-      datapointsToAlarm: cfg.datapointsToAlarm,
-      treatMissingData: cfg.treatMissingData,
-      description: `Lambda function p99 duration is approaching the configured timeout. Threshold: > ${String(threshold)}ms (${String(cfg.thresholdPercent * 100)}% of ${String(timeoutMs)}ms timeout).`,
+  // Threshold is a percentage of the timeout, so it needs a concrete `Duration`.
+  // Check the `duration !== false` escape hatch *before* touching the timeout, so
+  // disabling always works even when the conversion below would throw. The shared
+  // helper then omits the alarm (and warns) for a token-valued timeout, which has
+  // no millisecond threshold at synth time.
+  if (config?.duration !== false) {
+    const timeoutMs = resolveAlarmThresholdBasis({
+      scope: fn,
+      value: props.timeout,
+      isUnresolved: (timeout) => timeout.isUnresolved(),
+      resolve: (timeout) => timeout.toMilliseconds(),
+      warningId: "@composurecdk/lambda:token-timeout-duration-alarm",
+      alarmLabel: "Lambda duration",
+      suppressHint: "recommendedAlarms({ duration: false })",
     });
+    if (timeoutMs !== undefined) {
+      const cfg = resolvePercentageAlarmConfig(config?.duration, FUNCTION_ALARM_DEFAULTS.duration);
+      const threshold = Math.round(timeoutMs * cfg.thresholdPercent);
+      definitions.push({
+        key: "duration",
+        alarmName: cfg.alarmName,
+        metric: fn.metricDuration({ period: METRIC_PERIOD, statistic: Stats.percentile(99) }),
+        threshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: cfg.evaluationPeriods,
+        datapointsToAlarm: cfg.datapointsToAlarm,
+        treatMissingData: cfg.treatMissingData,
+        description: `Lambda function p99 duration is approaching the configured timeout. Threshold: > ${String(threshold)}ms (${String(cfg.thresholdPercent * 100)}% of ${String(timeoutMs)}ms timeout).`,
+      });
+    }
   }
 
-  const reservedConcurrency = props.reservedConcurrentExecutions;
-  if (config?.concurrentExecutions !== false && reservedConcurrency !== undefined) {
-    const cfg = resolvePercentageAlarmConfig(
-      config?.concurrentExecutions,
-      FUNCTION_ALARM_DEFAULTS.concurrentExecutions,
-    );
-    const threshold = Math.round(reservedConcurrency * cfg.thresholdPercent);
-    definitions.push({
-      key: "concurrentExecutions",
-      alarmName: cfg.alarmName,
-      metric: fn.metric("ConcurrentExecutions", {
-        period: METRIC_PERIOD,
-        statistic: Stats.MAXIMUM,
-      }),
-      threshold,
-      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      evaluationPeriods: cfg.evaluationPeriods,
-      datapointsToAlarm: cfg.datapointsToAlarm,
-      treatMissingData: cfg.treatMissingData,
-      description: `Lambda function concurrent executions approaching reserved concurrency limit. Threshold: >= ${String(threshold)} (${String(cfg.thresholdPercent * 100)}% of ${String(reservedConcurrency)} reserved).`,
+  // Same shape, against a raw number. A token-valued `reservedConcurrentExecutions`
+  // wouldn't throw but would yield a meaningless threshold, so the helper skips it
+  // (default `Token.isUnresolved` guard).
+  if (config?.concurrentExecutions !== false) {
+    const reservedConcurrency = resolveAlarmThresholdBasis({
+      scope: fn,
+      value: props.reservedConcurrentExecutions,
+      resolve: (reserved) => reserved,
+      warningId: "@composurecdk/lambda:token-reserved-concurrency-alarm",
+      alarmLabel: "Lambda concurrent-executions",
+      suppressHint: "recommendedAlarms({ concurrentExecutions: false })",
     });
+    if (reservedConcurrency !== undefined) {
+      const cfg = resolvePercentageAlarmConfig(
+        config?.concurrentExecutions,
+        FUNCTION_ALARM_DEFAULTS.concurrentExecutions,
+      );
+      const threshold = Math.round(reservedConcurrency * cfg.thresholdPercent);
+      definitions.push({
+        key: "concurrentExecutions",
+        alarmName: cfg.alarmName,
+        metric: fn.metric("ConcurrentExecutions", {
+          period: METRIC_PERIOD,
+          statistic: Stats.MAXIMUM,
+        }),
+        threshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        evaluationPeriods: cfg.evaluationPeriods,
+        datapointsToAlarm: cfg.datapointsToAlarm,
+        treatMissingData: cfg.treatMissingData,
+        description: `Lambda function concurrent executions approaching reserved concurrency limit. Threshold: >= ${String(threshold)} (${String(cfg.thresholdPercent * 100)}% of ${String(reservedConcurrency)} reserved).`,
+      });
+    }
   }
 
   for (const eventSource of eventSources) {

--- a/packages/lambda/test/function-alarms.test.ts
+++ b/packages/lambda/test/function-alarms.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { App, Duration, Stack } from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
+import { App, CfnParameter, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
 import { alarmName } from "@composurecdk/cloudwatch";
+import type { FunctionAlarmConfig } from "../src/alarm-config.js";
 import { createFunctionBuilder } from "../src/function-builder.js";
 
 function buildResult(configureFn: (builder: ReturnType<typeof createFunctionBuilder>) => void) {
@@ -130,6 +131,89 @@ describe("recommended alarms", () => {
       expect(result.alarms.duration).toBeDefined();
       expect(result.alarms.concurrentExecutions).toBeDefined();
       template.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+    });
+  });
+
+  describe("token-valued props", () => {
+    // A timeout threaded through a CfnParameter is an unresolved token: the
+    // duration alarm cannot derive a millisecond threshold from it. build()
+    // must still succeed (the conversion previously threw — see #196), the
+    // alarm must be omitted, and a warning must explain the skip.
+    function buildWithTokenTimeout(config?: FunctionAlarmConfig | false) {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const param = new CfnParameter(stack, "TimeoutSeconds", { type: "Number", default: 30 });
+      const builder = createFunctionBuilder();
+      minimalFunction(builder);
+      builder.timeout(Duration.seconds(param.valueAsNumber));
+      if (config !== undefined) builder.recommendedAlarms(config);
+      const result = builder.build(stack, "TestFunction");
+      return { result, stack };
+    }
+
+    it("builds successfully and omits the duration alarm for a token-valued timeout", () => {
+      const { result } = buildWithTokenTimeout();
+
+      expect(result.alarms.duration).toBeUndefined();
+      expect(result.alarms.errors).toBeDefined();
+      expect(result.alarms.throttles).toBeDefined();
+    });
+
+    it("warns when the duration alarm is skipped for a token-valued timeout", () => {
+      const { stack } = buildWithTokenTimeout();
+
+      // The ack tag is the public suppression handle, so it is asserted here to
+      // guard against an accidental rename.
+      Annotations.fromStack(stack).hasWarning(
+        "*",
+        Match.stringLikeRegexp(
+          "Skipping the recommended Lambda duration alarm.*" +
+            "\\[ack: @composurecdk/lambda:token-timeout-duration-alarm\\]",
+        ),
+      );
+    });
+
+    it("does not warn when duration is disabled, even with a token-valued timeout", () => {
+      // recommendedAlarms({ duration: false }) must short-circuit before the
+      // token is inspected, so it is a reliable escape hatch.
+      const { result, stack } = buildWithTokenTimeout({ duration: false });
+
+      expect(result.alarms.duration).toBeUndefined();
+      expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
+    });
+
+    function buildWithTokenConcurrency(config?: FunctionAlarmConfig | false) {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const param = new CfnParameter(stack, "Concurrency", { type: "Number", default: 100 });
+      const builder = createFunctionBuilder();
+      minimalFunction(builder);
+      builder.reservedConcurrentExecutions(param.valueAsNumber);
+      if (config !== undefined) builder.recommendedAlarms(config);
+      const result = builder.build(stack, "TestFunction");
+      return { result, stack };
+    }
+
+    it("omits the concurrentExecutions alarm for a token-valued reservedConcurrentExecutions", () => {
+      // A token value would not throw but would silently round to a garbage
+      // threshold, so the alarm is skipped rather than rendered wrong.
+      const { result, stack } = buildWithTokenConcurrency();
+
+      expect(result.alarms.concurrentExecutions).toBeUndefined();
+      Annotations.fromStack(stack).hasWarning(
+        "*",
+        Match.stringLikeRegexp(
+          "Skipping the recommended Lambda concurrent-executions alarm.*" +
+            "\\[ack: @composurecdk/lambda:token-reserved-concurrency-alarm\\]",
+        ),
+      );
+    });
+
+    it("does not warn when concurrentExecutions is disabled, even with a token value", () => {
+      const { result, stack } = buildWithTokenConcurrency({ concurrentExecutions: false });
+
+      expect(result.alarms.concurrentExecutions).toBeUndefined();
+      expect(Annotations.fromStack(stack).findWarning("*", Match.anyValue())).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

`FunctionBuilder.build()` threw when `timeout` was a token-valued `Duration` (e.g. derived from `CfnParameter.valueAsNumber`): the recommended duration alarm called `toMilliseconds()` **unconditionally, ahead of the `duration !== false` escape hatch**, and that conversion throws on a cross-unit token. Closes #196.

Rather than patch the one call site, this generalises the underlying mechanism and sweeps every alarm builder in the library for the same shape.

## What changed

**`feat(cloudwatch)` — new shared guard.** `resolveAlarmThresholdBasis` resolves the numeric basis for any alarm whose threshold is *derived* from a possibly-token input. When the input is an unresolved token it annotates the scope with a standardized, acknowledgeable warning and returns `undefined` (signalling the caller to omit the alarm) instead of throwing or rendering a garbage threshold. The token predicate defaults to `Token.isUnresolved` and is overridable for wrapper types like `Duration` that carry their own check. It lives in `@composurecdk/cloudwatch` because every alarm builder already depends on it.

**`fix(lambda)` — adopt the guard + fix ordering.** Both derived-threshold alarms now:
1. evaluate their enabling boolean (`config?.x !== false`) **before** any per-alarm computation, so `recommendedAlarms({ duration: false })` is a reliable escape hatch even when the conversion would throw; and
2. route the `timeout` / `reservedConcurrentExecutions` derivation through the shared guard. A token-valued input omits the alarm and warns (the concurrency alarm previously wouldn't throw but would silently `Math.round(token * pct)` into a meaningless threshold — also fixed).

## Holistic coverage

I audited **every** alarm-producing file across all packages for both failure modes — (1) escape-hatch misordering, (2) threshold arithmetic/unit-conversion on a token-capable builder prop:

| Package | Result |
|---|---|
| lambda | **Fixed** (this PR) |
| acm, apigateway, budgets, cloudfront, ec2, events, route53, s3, sns, sqs | **Clean** — all thresholds are verbatim config pass-throughs (no arithmetic on props); enabling booleans correctly precede computation |
| neptune | **Considered, no change** — the `serverlessDatabaseCapacity` default does `maxCapacity * fraction`, but `@aws-cdk/aws-neptune-alpha` validates `maxCapacity`'s range **without** a token guard, so a token `maxCapacity` throws during cluster construction — the arithmetic is unreachable through the supported API. Adding a guard would be untestable dead code, so it was left alone. |

So lambda was the only genuinely token-exposed site; the shared helper is in place for the next derived-threshold alarm (e.g. the SQS visibility-timeout work in #123).

## Tests

- `cloudwatch`: unit tests for the helper — concrete / converted / undefined / token-number / token-`Duration`, including that the guard short-circuits before `resolve()` runs.
- `lambda`: `build()` succeeds with a token-valued timeout and the duration alarm is omitted + warns; the `duration: false` / `concurrentExecutions: false` escape hatches suppress without warning; same for token-valued `reservedConcurrentExecutions`.

Full `verify` gate (build, `check:exports`, lint, test across all packages) passes.