### PR TITLE
test(examples): normalise CDK asset hashes in snapshots

### DIFF
--- a/packages/examples/test/__snapshots__/agent-volume-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/agent-volume-app.test.ts.snap
@@ -917,7 +917,7 @@ exports[`agent-volume-app > matches the expected synthesised template 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7fa1e366ee8a9ded01fc355f704cff92bfd179574e6f9cfee800a3541df1b200.zip",
+          "S3Key": "<asset-hash>.zip",
         },
         "Description": "Lambda function for removing all inbound/outbound rules from the VPC default security group",
         "Handler": "__entrypoint__.handler",

--- a/packages/examples/test/__snapshots__/ec2-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/ec2-app.test.ts.snap
@@ -23,7 +23,7 @@ exports[`ec2-app > matches the expected synthesised template 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7fa1e366ee8a9ded01fc355f704cff92bfd179574e6f9cfee800a3541df1b200.zip",
+          "S3Key": "<asset-hash>.zip",
         },
         "Description": "Lambda function for removing all inbound/outbound rules from the VPC default security group",
         "Handler": "__entrypoint__.handler",

--- a/packages/examples/test/__snapshots__/neptune-graph-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/neptune-graph-app.test.ts.snap
@@ -23,7 +23,7 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7fa1e366ee8a9ded01fc355f704cff92bfd179574e6f9cfee800a3541df1b200.zip",
+          "S3Key": "<asset-hash>.zip",
         },
         "Description": "Lambda function for removing all inbound/outbound rules from the VPC default security group",
         "Handler": "__entrypoint__.handler",
@@ -118,7 +118,7 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2819175352ad1ce0dae768e83fc328fb70fb5f10b4a8ff0ccbcb791f02b0716d.zip",
+          "S3Key": "<asset-hash>.zip",
         },
         "Handler": "index.handler",
         "Role": {

--- a/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/static-website-app.test.ts.snap
@@ -46,7 +46,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3423a042b818e31c1e34a19d6689ab2e5f9b70fcbe9e71df66f241b20a200bd9.zip",
+          "S3Key": "<asset-hash>.zip",
         },
         "Environment": {
           "Variables": {
@@ -961,7 +961,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e2659170a0721541efa761a8d5d04d5e36cbbf691c4b15a9053002b7c825055d.zip",
+          "S3Key": "<asset-hash>.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -994,7 +994,7 @@ exports[`static-website-app > stack > matches the expected synthesised template 
           },
         ],
         "SourceObjectKeys": [
-          "53bdfa46ffcb6cefd70edccc9965b2cb903abb80bace345f9f146251e2b8c25e.zip",
+          "<asset-hash>.zip",
         ],
         "WaitForDistributionInvalidation": true,
       },

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -11,6 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true
   },
-  "include": ["bin", "src", "test"],
+  "include": ["bin", "src", "test", "vitest.config.ts", "vitest.setup.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/examples/vitest.config.ts
+++ b/packages/examples/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});

--- a/packages/examples/vitest.setup.ts
+++ b/packages/examples/vitest.setup.ts
@@ -1,0 +1,24 @@
+import { expect } from "vitest";
+
+// CDK addresses its bundled assets by content hash, and every such hash is a
+// 64-char hex SHA-256. Two shapes show up in our synthesised example
+// templates:
+//
+//   - `S3Key`            — the framework's custom-resource provider Lambdas
+//                          (e.g. the VPC default-security-group cleanup
+//                          handler) and the awscli Lambda layer that backs the
+//                          static-website bucket deployment.
+//   - `SourceObjectKeys` — the bucket-deployment source archive.
+//
+// These provider/layer/deployment hashes churn on every aws-cdk-lib release
+// with no change to our own infrastructure, so they carry no signal in a
+// snapshot — they only make routine dependency bumps fail the suite. We
+// collapse every asset hash to a stable placeholder. These are the only
+// 64-hex strings the templates contain, so a value-based serializer
+// normalises both shapes without needing to inspect keys.
+const ASSET_HASH = /^[0-9a-f]{64}(\.zip)?$/;
+
+expect.addSnapshotSerializer({
+  test: (value: unknown): boolean => typeof value === "string" && ASSET_HASH.test(value),
+  serialize: (value: string) => (value.endsWith(".zip") ? '"<asset-hash>.zip"' : '"<asset-hash>"'),
+});


### PR DESCRIPTION
## What

Adds a vitest snapshot serializer to `packages/examples` that normalises CDK's bundled-asset content hashes to a stable `<asset-hash>` placeholder, so routine `aws-cdk-lib` bumps no longer break the example snapshot suite.

## Why

CDK addresses its bundled assets by 64-char hex SHA-256 content hash. Two shapes appear in our synthesised example templates:

- **`S3Key`** — the framework's custom-resource provider Lambdas (e.g. the VPC default-security-group cleanup handler) and the awscli Lambda layer behind the static-website bucket deployment.
- **`SourceObjectKeys`** — the bucket-deployment source archive.

These hashes churn on every aws-cdk-lib release with no change to our own infrastructure, so they carry no snapshot signal — they just make dependency bumps fail the suite. This is exactly what broke CI on #199 (the 2.258.1 bump shifted these vendored asset hashes; `lint`/`format`/`typecheck`/`build` all passed, only the four example snapshots mismatched).

## How

- `packages/examples/vitest.setup.ts` — a value-based serializer matching any string of the form `^[0-9a-f]{64}(\.zip)?$`. Matching on **value** rather than key normalises both the object-valued (`S3Key`) and array-element (`SourceObjectKeys`) shapes without inspecting keys. Adapted from the equivalent serializer in [`jasonduffett.net`](https://github.com/laazyj/jasonduffett.net/blob/main/packages/cdk/vitest.setup.ts).
- `packages/examples/vitest.config.ts` — registers the setup file via `setupFiles`. (The package previously ran bare `vitest run` with no config.)
- `packages/examples/tsconfig.json` — adds the two root-level files to `include` so `tsc --noEmit` and the type-checked ESLint rules cover them. They stay out of `tsconfig.build.json` (which only builds `bin`/`src`).
- Regenerated the four affected snapshots (`agent-volume`, `ec2`, `neptune-graph`, `static-website`); the only diff is hash → placeholder.

## Verification

- `nx run @composurecdk/examples:test` — 11 files / 102 tests pass
- `npm run lint` — clean
- `npm run format:check` — clean
- No raw 64-hex asset hashes remain in `test/__snapshots__`

https://claude.ai/code/session_01KRmLyz7RCJPr3eyVg1Scje

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRmLyz7RCJPr3eyVg1Scje)_