### PR TITLE
docs: add pre-release warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-0f0d0c)](https://www.typescriptlang.org/)
 [![node >=20](https://img.shields.io/badge/node-%3E%3D20-0f0d0c)](https://nodejs.org/)
 
+> [!WARNING]
+> **Pre-release (0.x).** ComposureCDK is under active development. The public
+> API may change between minor versions until 1.0. Pin exact versions and
+> expect breaking changes. Early feedback is very welcome —
+> please [open an issue](https://github.com/laazyj/composureCDK/issues).
+
 ComposureCDK is a TypeScript library built on [AWS CDK](https://docs.aws.amazon.com/cdk/) that brings managed lifecycles, explicit dependency graphs, and builder patterns to cloud infrastructure definition. It is inspired by Stuart Sierra's [Component](https://github.com/stuartsierra/component) library for Clojure.
 
 ## The Problem


### PR DESCRIPTION
## What

Re-applies the 0.x pre-release `[!WARNING]` banner below the badge block.

## Why a second PR

The original banner PR (#210) was **stacked** on the badges branch (`docs/readme-badges`) and got merged into *that* branch rather than `main`. When the badges PR (#209) merged to `main`, it carried the badges but not the banner — so the banner never landed on `main`. This PR targets `main` directly to fix that.