### PR TITLE
docs: add 'Filing a good issue' guidance to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,25 @@ public API is fluid.
 - **Security issues** — please **do not** open a public issue. Follow the
   process in [SECURITY.md](SECURITY.md).
 
+### Filing a good issue
+
+The web UI offers issue templates, but the most useful reports — however they're
+filed, including via the API or a coding agent — include the same things. A good
+**bug report** has:
+
+- The **affected package and version** (e.g. `@composurecdk/s3@0.8.4`), taken
+  from your lockfile.
+- A **minimal reproduction**: the smallest `compose`/builder snippet that shows
+  the problem, plus any error or relevant `cdk synth` output.
+- **What you expected** to happen instead.
+- Your **environment**: Node version, `aws-cdk-lib` version, OS.
+
+A good **feature request** describes the **problem or use case** first (the
+friction you hit), then a **proposed solution** as a sketch of the builder or
+`compose` usage, and any **alternatives** or prior art you considered. Because
+the API is still stabilising, open these for discussion before writing a large
+PR.
+
 ## Development setup
 
 Prerequisites: **Node.js >= 20** and npm.


### PR DESCRIPTION
## What

Add a **Filing a good issue** subsection to `CONTRIBUTING.md` describing what a good bug report and feature request contain (affected package & version, minimal `compose`/builder repro, expected behaviour, environment; for features: problem-first, proposed solution sketch, alternatives).

## Why

Companion to the issue/PR templates (#213). Issue templates are a web-UI construct that reports filed via the API or a coding agent bypass entirely. This puts the substantive "good report" guidance in a file those reporters actually read, in prose they can follow into a free-form issue body.

Part of the documentation tidy-up ahead of a public (pre-release) unveiling.