### PR TITLE
chore: add npm keywords to public packages

### DIFF
--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -20,7 +20,19 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "acm",
+    "certificate",
+    "tls",
+    "ssl",
+    "https"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -20,7 +20,17 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "api-gateway",
+    "rest-api",
+    "api"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -20,7 +20,17 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "budgets",
+    "cost-management",
+    "billing"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -20,7 +20,16 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "cloudformation",
+    "stack"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -20,7 +20,17 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "cloudfront",
+    "cdn",
+    "distribution"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -20,7 +20,19 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "cloudwatch",
+    "alarm",
+    "monitoring",
+    "metrics",
+    "observability"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,19 @@
       "prettier --write"
     ]
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "lifecycle",
+    "dependency-injection",
+    "component",
+    "builder",
+    "composition"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -20,7 +20,18 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "ec2",
+    "vpc",
+    "networking",
+    "compute"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -20,7 +20,17 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "eventbridge",
+    "events",
+    "event-driven"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -20,7 +20,19 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "iam",
+    "role",
+    "policy",
+    "permissions",
+    "least-privilege"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -20,7 +20,17 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "lambda",
+    "serverless",
+    "function"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -20,7 +20,18 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "cloudwatch-logs",
+    "logs",
+    "log-group",
+    "logging"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -20,7 +20,18 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "neptune",
+    "graph-database",
+    "gremlin",
+    "database"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -20,7 +20,17 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "route53",
+    "dns",
+    "hosted-zone"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -20,7 +20,18 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "s3",
+    "bucket",
+    "storage",
+    "object-storage"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -20,7 +20,19 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "sns",
+    "notifications",
+    "pub-sub",
+    "messaging",
+    "topic"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -20,7 +20,18 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "sqs",
+    "queue",
+    "message-queue",
+    "messaging"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## What

Populate the previously-empty `keywords` array on all 17 public `@composurecdk/*` packages.

Each gets a shared base set — `aws`, `cdk`, `aws-cdk`, `infrastructure-as-code`, `iac`, `composurecdk` — plus service-specific terms (e.g. s3 → `s3`, `bucket`, `storage`, `object-storage`; sns → `sns`, `notifications`, `pub-sub`, `messaging`, `topic`).

## Why

Empty keywords hurt npm search discoverability. With the blog unveiling driving traffic, packages should surface both for people searching "composurecdk" and for per-service searches. No code or build impact — metadata only.