### PR TITLE
chore: fill root package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "composurecdk",
-  "description": "",
+  "description": "Composable, lifecycle-managed AWS infrastructure built on AWS CDK — monorepo for the @composurecdk/* packages.",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
@@ -26,7 +26,15 @@
     "type": "git",
     "url": "git+https://github.com/laazyj/composureCDK.git"
   },
-  "keywords": [],
+  "keywords": [
+    "aws",
+    "cdk",
+    "aws-cdk",
+    "infrastructure-as-code",
+    "iac",
+    "composurecdk",
+    "monorepo"
+  ],
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## What

Populate the previously-empty `description` and `keywords` on the root `package.json`.

- `description`: "Composable, lifecycle-managed AWS infrastructure built on AWS CDK — monorepo for the @composurecdk/* packages."
- `keywords`: the shared base set (`aws`, `cdk`, `aws-cdk`, `infrastructure-as-code`, `iac`, `composurecdk`, `monorepo`).

## Why

Small repo-root polish ahead of the public unveiling. The root package is unpublished, so this is metadata only — no build or release impact.