### PR TITLE
fix: remove duplicate security entry from issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,3 @@
+# Security reports are surfaced automatically by GitHub from SECURITY.md, so no
+# contact_links entry is needed here (it would duplicate that built-in option).
 blank_issues_enabled: false
-contact_links:
-  - name: Security vulnerability
-    url: https://github.com/laazyj/composureCDK/security/advisories/new
-    about: Please report security issues privately, not as a public issue. See SECURITY.md.


### PR DESCRIPTION
## What

Remove the `contact_links` block from `.github/ISSUE_TEMPLATE/config.yml`.

## Why

GitHub automatically adds a **"Report a security vulnerability"** entry to the new-issue chooser whenever a `SECURITY.md` exists. Our `contact_links` entry pointed at the same place, so the chooser showed **two** near-identical security options (see below). Dropping our entry leaves GitHub's built-in one. `blank_issues_enabled: false` is retained.

Before:
- 🛡 Report a security vulnerability (GitHub built-in, from SECURITY.md)
- 🔗 Security vulnerability (our contact_link — duplicate)

After:
- 🛡 Report a security vulnerability (GitHub built-in)