### PR TITLE
ci: add Node 22 and 26 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Node 20 is the supported floor; 24 is current. Dual-published
-        # packages must resolve on both — see ADR-0007.
-        node-version: [20, 24]
+        # Node 20 is the supported floor; 24 is current LTS; 26 is next.
+        # Dual-published packages must resolve on all — see ADR-0007.
+        node-version: [20, 22, 24, 26]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds Node 22 and 26 to the `verify` job matrix, giving full coverage of all active LTS versions (20, 22, 24) plus the upcoming Node 26.
- Updates the inline comment to reflect the expanded set.

## Test plan

- [x] Ran `npm run verify` on Node 26 with a cold nx cache — all builds, export checks, lint, CDK floor checks, and 1,136 tests passed.
- [ ] CI matrix runs on all four versions (20, 22, 24, 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)