### PR TITLE
refactor(ec2/examples): InterfaceEndpointBuilder bidirectional wiring + Neptune example cleanup

### DIFF
--- a/packages/ec2/README.md
+++ b/packages/ec2/README.md
@@ -300,8 +300,9 @@ group modes:
 - **BYO** — `.securityGroups([...])` with SGs you fully manage (typically
   sibling `SecurityGroupBuilder`s): full ingress/egress/port control.
 - **Managed shortcut** — omit `.securityGroups()` and the builder auto-creates a
-  closed SG, exposes it on the result, and `.allowDefaultPortFrom(peer)` opens
-  ingress on the service's default port.
+  closed SG, exposes it on the result, and `.allowDefaultPortFrom(peer)` wires
+  bidirectionally: ingress on the managed SG from the peer **and** egress from
+  the peer's SG to the managed SG (on the service's default port, 443).
 
 The two are mutually exclusive (combining them throws). To group several
 endpoints under one access policy, point them at the same security group.
@@ -336,8 +337,10 @@ compose(
 // result.ssm = { endpoint: InterfaceVpcEndpoint, securityGroup: SecurityGroup }
 ```
 
-The managed `securityGroup` is on the result so the **peer's egress side** can
-reference it (`bastionSg.addEgressRule(ref("ssm").get("securityGroup"), Port.tcp(443))`).
+The managed `securityGroup` is present on the result for cases where another
+component needs a direct reference to it (e.g. BYO-mode builders that share
+one SG across several endpoints). The peer's egress rule is wired automatically
+by `.allowDefaultPortFrom()` — no manual `addEgressRule` call needed.
 
 ### SSM access (multiple endpoints, one shared SG)
 

--- a/packages/ec2/src/interface-endpoint-builder.ts
+++ b/packages/ec2/src/interface-endpoint-builder.ts
@@ -1,11 +1,10 @@
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import {
   InterfaceVpcEndpoint,
+  type IConnectable,
   type InterfaceVpcEndpointProps,
-  type IPeer,
   type ISecurityGroup,
   type IVpc,
-  Port,
   type SecurityGroup,
 } from "aws-cdk-lib/aws-ec2";
 import { type IConstruct } from "constructs";
@@ -50,9 +49,9 @@ export interface InterfaceEndpointBuilderProps extends Omit<
  *
  * `securityGroup` is present only in **managed mode** — i.e. when the caller
  * did *not* supply `.securityGroups(...)`, so the builder auto-created one. It
- * is exposed so a peer's *egress* rule can `ref` it. In **BYO mode** it is
- * `undefined`: the caller already holds refs to the security groups they
- * passed in.
+ * is exposed for cases where sibling builders need to reference the
+ * auto-created SG directly. In **BYO mode** it is `undefined`: the caller
+ * already holds refs to the security groups they passed in.
  */
 export interface InterfaceEndpointBuilderResult {
   endpoint: InterfaceVpcEndpoint;
@@ -61,7 +60,7 @@ export interface InterfaceEndpointBuilderResult {
 }
 
 interface AccessSpec {
-  readonly peer: Resolvable<IPeer>;
+  readonly peer: Resolvable<IConnectable>;
   readonly description?: string;
 }
 
@@ -80,9 +79,10 @@ interface AccessSpec {
  *   `SecurityGroupBuilder`s). Full ingress/egress/port control; the builder
  *   creates no SG and `securityGroup` is absent from the result.
  * - *Managed shortcut* — omit `.securityGroups()` and the builder auto-creates
- *   a closed SG, exposes it on the result, and opens ingress for the peers you
- *   pass to {@link IInterfaceEndpointBuilder.allowDefaultPortFrom} on the
- *   service's default port.
+ *   a closed SG, exposes it on the result, and for each peer you pass to
+ *   {@link IInterfaceEndpointBuilder.allowDefaultPortFrom} it opens ingress on
+ *   the managed SG **and** egress on the peer's SG — matching exactly what CDK's
+ *   `connections.allowDefaultPortFrom(...)` does bidirectionally.
  *
  * The two are mutually exclusive — combining BYO `.securityGroups()` with
  * `.allowDefaultPortFrom()` throws, since the rule would have nowhere it
@@ -136,17 +136,20 @@ class InterfaceEndpointBuilder implements Lifecycle<InterfaceEndpointBuilderResu
   }
 
   /**
-   * Managed-SG shortcut: opens ingress on the auto-created security group from
-   * `peer`, on the endpoint service's default port (443 for AWS services, or
-   * the port the custom service was declared with). Mirrors CDK's
-   * `endpoint.connections.allowDefaultPortFrom(...)`.
+   * Managed-SG shortcut: wires `peer` to the auto-created security group via
+   * CDK's `endpoint.connections.allowDefaultPortFrom(peer)` — opening ingress
+   * on the managed SG from `peer`'s SG **and** egress from `peer`'s SG to the
+   * managed SG, on the service's default port (443 for AWS services).
    *
-   * For an `open: true` equivalent, pass a VPC-CIDR peer
-   * (`Peer.ipv4(vpc.vpcCidrBlock)`). Mutually exclusive with
-   * {@link securityGroups}.
+   * Because this delegates to CDK connections, `peer` must be an
+   * {@link IConnectable} (e.g. a `SecurityGroup` or `Instance`), not a raw
+   * `IPeer` (e.g. `Peer.ipv4(...)`). For CIDR-based rules use BYO mode with
+   * an explicit `addIngressRule` on your own {@link SecurityGroupBuilder}.
+   *
+   * Mutually exclusive with {@link securityGroups}.
    */
-  allowDefaultPortFrom(peer: Resolvable<IPeer>, description?: string): this {
-    this.#access.push({ peer, ...(description !== undefined ? { description } : {}) });
+  allowDefaultPortFrom(peer: Resolvable<IConnectable>, description?: string): this {
+    this.#access.push({ peer, description });
     return this;
   }
 
@@ -212,14 +215,6 @@ class InterfaceEndpointBuilder implements Lifecycle<InterfaceEndpointBuilderResu
         .vpc(resolvedVpc)
         .description(`Interface endpoint ${id}`)
         .build(scope, `${id}Sg`).securityGroup;
-      const defaultPort = Port.tcp(service.port);
-      for (const rule of this.#access) {
-        managedSecurityGroup.addIngressRule(
-          resolve(rule.peer, context),
-          defaultPort,
-          rule.description,
-        );
-      }
       securityGroups = [managedSecurityGroup];
     }
 
@@ -232,6 +227,10 @@ class InterfaceEndpointBuilder implements Lifecycle<InterfaceEndpointBuilderResu
       // Always explicit: `open: true` would silently add a VPC-wide :443 rule.
       open: false,
     });
+
+    for (const rule of this.#access) {
+      endpoint.connections.allowDefaultPortFrom(resolve(rule.peer, context), rule.description);
+    }
 
     const alarms = createInterfaceEndpointAlarms(
       scope,

--- a/packages/ec2/test/interface-endpoint-builder.test.ts
+++ b/packages/ec2/test/interface-endpoint-builder.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import {
+  InterfaceVpcEndpointAwsService,
+  SecurityGroup,
+  SubnetType,
+  Vpc,
+  type IVpc,
+} from "aws-cdk-lib/aws-ec2";
+import { compose, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import {
+  createInterfaceEndpointBuilder,
+  type InterfaceEndpointBuilderResult,
+  type SecurityGroupBuilderResult,
+  type VpcBuilderResult,
+} from "../src/index.js";
+import { createSecurityGroupBuilder } from "../src/security-group-builder.js";
+import { createVpcBuilder } from "../src/vpc-builder.js";
+
+function freshScope(): { stack: Stack; vpc: Vpc } {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const vpc = new Vpc(stack, "TestVpc", {
+    maxAzs: 1,
+    natGateways: 0,
+    subnetConfiguration: [
+      { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+    ],
+  });
+  return { stack, vpc };
+}
+
+describe("InterfaceEndpointBuilder", () => {
+  describe("build", () => {
+    it("returns an InterfaceEndpointBuilderResult with endpoint and alarms properties", () => {
+      const { stack, vpc } = freshScope();
+      const result = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .build(stack, "Endpoint");
+
+      expect(result.endpoint).toBeDefined();
+      expect(result.alarms).toBeDefined();
+    });
+
+    it("creates exactly one VPC endpoint", () => {
+      const { stack, vpc } = freshScope();
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .build(stack, "Endpoint");
+
+      Template.fromStack(stack).resourceCountIs("AWS::EC2::VPCEndpoint", 1);
+    });
+
+    it("creates an Interface-type endpoint", () => {
+      const { stack, vpc } = freshScope();
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .build(stack, "Endpoint");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::VPCEndpoint", {
+        VpcEndpointType: "Interface",
+      });
+    });
+
+    it("throws a clear error when vpc is not provided", () => {
+      const { stack } = freshScope();
+      const builder = createInterfaceEndpointBuilder().service(InterfaceVpcEndpointAwsService.SSM);
+
+      expect(() => builder.build(stack, "Endpoint")).toThrow(/requires a VPC/);
+    });
+
+    it("throws a clear error when service is not provided", () => {
+      const { stack, vpc } = freshScope();
+      const builder = createInterfaceEndpointBuilder().vpc(vpc);
+
+      expect(() => builder.build(stack, "Endpoint")).toThrow(/requires a service/);
+    });
+  });
+
+  describe("well-architected defaults", () => {
+    it("enables private DNS by default", () => {
+      const { stack, vpc } = freshScope();
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .build(stack, "Endpoint");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::VPCEndpoint", {
+        PrivateDnsEnabled: true,
+      });
+    });
+
+    it("never adds an open 0.0.0.0/0 rule to the managed SG", () => {
+      const { stack, vpc } = freshScope();
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .build(stack, "Endpoint");
+
+      const sgs = Template.fromStack(stack).findResources("AWS::EC2::SecurityGroup");
+      const managedSg = Object.values(sgs)[0]?.Properties as {
+        SecurityGroupIngress?: { CidrIp?: string; IpProtocol?: string }[];
+      };
+      const openRule = managedSg.SecurityGroupIngress?.find(
+        (r) => r.CidrIp === "0.0.0.0/0" && r.IpProtocol === "-1",
+      );
+      expect(openRule).toBeUndefined();
+    });
+  });
+
+  describe("managed mode", () => {
+    it("auto-creates a managed SG exposed on result.securityGroup", () => {
+      const { stack, vpc } = freshScope();
+      const result = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .build(stack, "Endpoint");
+
+      expect(result.securityGroup).toBeDefined();
+      Template.fromStack(stack).resourceCountIs("AWS::EC2::SecurityGroup", 1);
+    });
+
+    it("allowDefaultPortFrom adds ingress on the managed SG from the peer", () => {
+      const { stack, vpc } = freshScope();
+      const peerSg = createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Peer")
+        .build(stack, "PeerSg").securityGroup;
+
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .allowDefaultPortFrom(peerSg, "SSM from peer")
+        .build(stack, "Endpoint");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+        IpProtocol: "tcp",
+        FromPort: 443,
+        ToPort: 443,
+        SourceSecurityGroupId: Match.objectLike({
+          "Fn::GetAtt": Match.arrayWith(["GroupId"]),
+        }),
+      });
+    });
+
+    it("allowDefaultPortFrom adds egress on the peer's SG (bidirectional wiring)", () => {
+      // This is the key behaviour introduced in this change: delegating to
+      // endpoint.connections.allowDefaultPortFrom() ensures the egress rule
+      // is added to the peer's SG so peers with allowAllOutbound:false (the
+      // SecurityGroupBuilder default) can actually reach the endpoint.
+      const { stack, vpc } = freshScope();
+      const peerSg = createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Peer")
+        .build(stack, "PeerSg").securityGroup;
+
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .allowDefaultPortFrom(peerSg)
+        .build(stack, "Endpoint");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::EC2::SecurityGroupEgress", {
+        IpProtocol: "tcp",
+        FromPort: 443,
+        ToPort: 443,
+        DestinationSecurityGroupId: Match.objectLike({
+          "Fn::GetAtt": Match.arrayWith(["GroupId"]),
+        }),
+      });
+    });
+
+    it("accepts multiple allowDefaultPortFrom peers", () => {
+      const { stack, vpc } = freshScope();
+      const peer1 = createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Peer 1")
+        .build(stack, "Peer1Sg").securityGroup;
+      const peer2 = createSecurityGroupBuilder()
+        .vpc(vpc)
+        .description("Peer 2")
+        .build(stack, "Peer2Sg").securityGroup;
+
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .allowDefaultPortFrom(peer1, "from peer 1")
+        .allowDefaultPortFrom(peer2, "from peer 2")
+        .build(stack, "Endpoint");
+
+      // One ingress rule per peer on the managed SG
+      const ingress = Template.fromStack(stack).findResources("AWS::EC2::SecurityGroupIngress");
+      const port443Rules = Object.values(ingress).filter(
+        (r) => (r.Properties as { FromPort: number }).FromPort === 443,
+      );
+      expect(port443Rules).toHaveLength(2);
+    });
+  });
+
+  describe("BYO mode", () => {
+    it("omits securityGroup from the result when securityGroups() is provided", () => {
+      const { stack, vpc } = freshScope();
+      const byoSg = new SecurityGroup(stack, "ByoSg", { vpc, description: "BYO" });
+
+      const result = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .securityGroups([byoSg])
+        .build(stack, "Endpoint");
+
+      expect(result.securityGroup).toBeUndefined();
+    });
+
+    it("does not create an additional managed SG in BYO mode", () => {
+      const { stack, vpc } = freshScope();
+      const byoSg = new SecurityGroup(stack, "ByoSg", { vpc, description: "BYO" });
+
+      createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .securityGroups([byoSg])
+        .build(stack, "Endpoint");
+
+      // Only the BYO SG — no auto-created managed SG
+      Template.fromStack(stack).resourceCountIs("AWS::EC2::SecurityGroup", 1);
+    });
+  });
+
+  describe("mutex", () => {
+    it("throws when allowDefaultPortFrom is combined with securityGroups", () => {
+      const { stack, vpc } = freshScope();
+      const byoSg = new SecurityGroup(stack, "ByoSg", { vpc, description: "BYO" });
+      const peerSg = new SecurityGroup(stack, "PeerSg", { vpc, description: "Peer" });
+
+      const builder = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .securityGroups([byoSg])
+        .allowDefaultPortFrom(peerSg);
+
+      expect(() => builder.build(stack, "Endpoint")).toThrow(/cannot be combined/);
+    });
+  });
+
+  describe("alarms", () => {
+    it("creates the packetsDropped recommended alarm by default", () => {
+      const { stack, vpc } = freshScope();
+      const result = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .build(stack, "Endpoint");
+
+      expect(result.alarms.packetsDropped).toBeDefined();
+      Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "PacketsDropped",
+      });
+    });
+
+    it("suppresses all alarms when recommendedAlarms is false", () => {
+      const { stack, vpc } = freshScope();
+      const result = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .recommendedAlarms(false)
+        .build(stack, "Endpoint");
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+      Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("suppresses an individual alarm when set to false in recommendedAlarms config", () => {
+      const { stack, vpc } = freshScope();
+      const result = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .recommendedAlarms({ packetsDropped: false })
+        .build(stack, "Endpoint");
+
+      expect(result.alarms.packetsDropped).toBeUndefined();
+      Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("compose integration", () => {
+    it("resolves a ref-based vpc at build time", () => {
+      const app = new App();
+      const stack = new Stack(app, "ComposedStack");
+
+      const system = compose(
+        {
+          network: createVpcBuilder()
+            .maxAzs(1)
+            .natGateways(0)
+            .subnetConfiguration([
+              { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+            ]),
+          endpoint: createInterfaceEndpointBuilder()
+            .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+            .service(InterfaceVpcEndpointAwsService.SSM),
+        },
+        { network: [], endpoint: ["network"] },
+      );
+
+      const result = system.build(stack, "App");
+      expect(result.endpoint.endpoint).toBeDefined();
+      Template.fromStack(stack).resourceCountIs("AWS::EC2::VPCEndpoint", 1);
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #vpc and #access across .copy() without leaking mutations to the original", () => {
+      const peer1Ref = ref<SecurityGroupBuilderResult>("peer1").get("securityGroup");
+      const peer2Ref = ref<SecurityGroupBuilderResult>("peer2").get("securityGroup");
+
+      assertCopyPreservesState({
+        factory: () =>
+          createInterfaceEndpointBuilder()
+            .vpc(ref<{ vpc: IVpc }>("network").get("vpc"))
+            .service(InterfaceVpcEndpointAwsService.SSM),
+        configure: (b) => {
+          b.allowDefaultPortFrom(peer1Ref, "from peer 1");
+        },
+        mutate: (b) => {
+          b.allowDefaultPortFrom(peer2Ref, "from peer 2");
+        },
+        build: (b) => {
+          const stack = new Stack(new App(), "S");
+          const vpc = new Vpc(stack, "Vpc", {
+            maxAzs: 1,
+            natGateways: 0,
+            subnetConfiguration: [
+              { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+            ],
+          });
+          const peer1 = new SecurityGroup(stack, "Peer1", { vpc, description: "peer 1" });
+          const peer2 = new SecurityGroup(stack, "Peer2", { vpc, description: "peer 2" });
+          return b.build(stack, "Ep", {
+            network: { vpc },
+            peer1: { securityGroup: peer1 },
+            peer2: { securityGroup: peer2 },
+          });
+        },
+        inspect: (r: InterfaceEndpointBuilderResult) => {
+          // Count the port-443 SecurityGroupIngress rules — one per allowDefaultPortFrom peer.
+          const template = Template.fromStack(Stack.of(r.endpoint));
+          const ingress = template.findResources("AWS::EC2::SecurityGroupIngress");
+          return Object.values(ingress).filter(
+            (res) => (res.Properties as { FromPort?: number }).FromPort === 443,
+          ).length;
+        },
+      });
+    });
+  });
+});

--- a/packages/examples/src/neptune-graph-app.ts
+++ b/packages/examples/src/neptune-graph-app.ts
@@ -6,14 +6,14 @@ import {
   InterfaceVpcEndpointAwsService,
   MachineImage,
   type ISecurityGroup,
-  type IVpc,
-  SubnetType,
   type Instance,
+  SubnetType,
   type Vpc,
 } from "aws-cdk-lib/aws-ec2";
 import { compose, ref } from "@composurecdk/core";
 import {
   createInstanceBuilder,
+  createInterfaceEndpointBuilder,
   createSecurityGroupBuilder,
   createVpcBuilder,
   type InstanceBuilderResult,
@@ -39,7 +39,13 @@ import { InstanceType as NeptuneInstanceType } from "@aws-cdk/aws-neptune-alpha"
  * - {@link createSecurityGroupBuilder} for the bastion's closed-egress SG.
  *   The only egress rules are the ones the cross-component wiring adds:
  *   `:8182` to Neptune (via `allowAccessFrom`) and `:443` to the SSM
- *   interface endpoints — least privilege, made visible.
+ *   interface endpoints (via `allowDefaultPortFrom`) — least privilege,
+ *   made visible.
+ * - Three {@link createInterfaceEndpointBuilder} components (`ssmEndpoint`,
+ *   `ssmMessagesEndpoint`, `ec2MessagesEndpoint`) that give the isolated
+ *   bastion SSM Session Manager reachability without a NAT gateway. Each
+ *   opens ingress `:443` from `bastionSg` and wires the matching egress
+ *   back onto `bastionSg` — entirely within `compose()`.
  * - A reachable, queryable Neptune in a cost-free isolated VPC (no NAT):
  *   SSM interface endpoints let Session Manager / `SendCommand` reach the
  *   bastion, and the bastion has a network path to the cluster's port. The
@@ -53,7 +59,13 @@ import { InstanceType as NeptuneInstanceType } from "@aws-cdk/aws-neptune-alpha"
 export function createNeptuneGraphApp(app = new App()) {
   const stack = new Stack(app, "ComposureCDK-NeptuneGraphStack");
 
-  const result = compose(
+  const ssmEndpointBase = createInterfaceEndpointBuilder()
+    .vpc(ref<VpcBuilderResult>("network").get("vpc"))
+    .subnets({ subnetType: SubnetType.PRIVATE_ISOLATED });
+
+  const bastionSgRef = ref<SecurityGroupBuilderResult>("bastionSg").get("securityGroup");
+
+  compose(
     {
       network: createVpcBuilder()
         .natGateways(0)
@@ -76,6 +88,21 @@ export function createNeptuneGraphApp(app = new App()) {
           ),
         ),
 
+      ssmEndpoint: ssmEndpointBase
+        .copy()
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .allowDefaultPortFrom(bastionSgRef, "SSM from Neptune bastion"),
+
+      ssmMessagesEndpoint: ssmEndpointBase
+        .copy()
+        .service(InterfaceVpcEndpointAwsService.SSM_MESSAGES)
+        .allowDefaultPortFrom(bastionSgRef, "SSM Messages from Neptune bastion"),
+
+      ec2MessagesEndpoint: ssmEndpointBase
+        .copy()
+        .service(InterfaceVpcEndpointAwsService.EC2_MESSAGES)
+        .allowDefaultPortFrom(bastionSgRef, "EC2 Messages from Neptune bastion"),
+
       graph: createClusterBuilder()
         .vpc(ref<VpcBuilderResult>("network").map((r: VpcBuilderResult): Vpc => r.vpc))
         .vpcSubnets({ subnetType: SubnetType.PRIVATE_ISOLATED })
@@ -91,35 +118,12 @@ export function createNeptuneGraphApp(app = new App()) {
       network: [],
       bastionSg: ["network"],
       bastion: ["network", "bastionSg"],
+      ssmEndpoint: ["network", "bastionSg"],
+      ssmMessagesEndpoint: ["network", "bastionSg"],
+      ec2MessagesEndpoint: ["network", "bastionSg"],
       graph: ["network", "bastion"],
     },
   ).build(stack, "NeptuneGraphApp");
 
-  // SSM Session Manager reachability without a NAT gateway: interface
-  // endpoints for the three services the agent needs. Each opens :443 to the
-  // bastion only, which also adds the matching egress rule on the bastion's
-  // closed-egress SG.
-  //
-  // NOTE: this is post-build glue — interface endpoints have no builder, so
-  // they can't yet be declared inside compose(). Tracked by #194 (a
-  // first-class endpoint builder); once it lands this folds into the graph.
-  addSsmEndpoints(result.network.vpc, result.bastion.instance);
-
   return { stack };
-}
-
-function addSsmEndpoints(vpc: IVpc, bastion: Instance): void {
-  const services = {
-    Ssm: InterfaceVpcEndpointAwsService.SSM,
-    SsmMessages: InterfaceVpcEndpointAwsService.SSM_MESSAGES,
-    Ec2Messages: InterfaceVpcEndpointAwsService.EC2_MESSAGES,
-  };
-  for (const [id, service] of Object.entries(services)) {
-    const endpoint = vpc.addInterfaceEndpoint(`${id}Endpoint`, {
-      service,
-      subnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
-      open: false,
-    });
-    endpoint.connections.allowDefaultPortFrom(bastion, `${id} from Neptune bastion`);
-  }
 }

--- a/packages/examples/test/__snapshots__/neptune-graph-app.test.ts.snap
+++ b/packages/examples/test/__snapshots__/neptune-graph-app.test.ts.snap
@@ -438,6 +438,27 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "NeptuneGraphAppbastionSgtoComposureCDKNeptuneGraphStackNeptuneGraphAppec2MessagesEndpointSgD6AA56264436614C9BC": {
+      "Properties": {
+        "Description": "EC2 Messages from Neptune bastion",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppec2MessagesEndpointSg84596DCD",
+            "GroupId",
+          ],
+        },
+        "FromPort": 443,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppbastionSgA2525585",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 443,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "NeptuneGraphAppbastionSgtoComposureCDKNeptuneGraphStackNeptuneGraphAppgraphSecurityGroupD151DD39IndirectPort57EB8748": {
       "Properties": {
         "Description": "to ComposureCDKNeptuneGraphStackNeptuneGraphAppgraphSecurityGroupD151DD39:{IndirectPort}",
@@ -469,12 +490,12 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "NeptuneGraphAppbastionSgtoComposureCDKNeptuneGraphStackNeptuneGraphAppnetworkEc2MessagesEndpointSecurityGroupEA3F3F7E4437C5FF002": {
+    "NeptuneGraphAppbastionSgtoComposureCDKNeptuneGraphStackNeptuneGraphAppssmEndpointSg7EDBC62B44311A4BBC4": {
       "Properties": {
-        "Description": "Ec2Messages from Neptune bastion",
+        "Description": "SSM from Neptune bastion",
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
-            "NeptuneGraphAppnetworkEc2MessagesEndpointSecurityGroup593DE067",
+            "NeptuneGraphAppssmEndpointSg66B90B9D",
             "GroupId",
           ],
         },
@@ -490,33 +511,12 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "NeptuneGraphAppbastionSgtoComposureCDKNeptuneGraphStackNeptuneGraphAppnetworkSsmEndpointSecurityGroup600CC412443273E81A5": {
+    "NeptuneGraphAppbastionSgtoComposureCDKNeptuneGraphStackNeptuneGraphAppssmMessagesEndpointSg03B17020443D15E64CF": {
       "Properties": {
-        "Description": "Ssm from Neptune bastion",
+        "Description": "SSM Messages from Neptune bastion",
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
-            "NeptuneGraphAppnetworkSsmEndpointSecurityGroup96376F45",
-            "GroupId",
-          ],
-        },
-        "FromPort": 443,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppbastionSgA2525585",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 443,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "NeptuneGraphAppbastionSgtoComposureCDKNeptuneGraphStackNeptuneGraphAppnetworkSsmMessagesEndpointSecurityGroupB3945BC44434D3EC25D": {
-      "Properties": {
-        "Description": "SsmMessages from Neptune bastion",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppnetworkSsmMessagesEndpointSecurityGroupA985331A",
+            "NeptuneGraphAppssmMessagesEndpointSg75696C9A",
             "GroupId",
           ],
         },
@@ -555,6 +555,107 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NeptuneGraphAppec2MessagesEndpoint17906E67": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "NeptuneGraphAppec2MessagesEndpointSg84596DCD",
+              "GroupId",
+            ],
+          },
+        ],
+        "ServiceName": {
+          "Fn::Join": [
+            "",
+            [
+              "com.amazonaws.",
+              {
+                "Ref": "AWS::Region",
+              },
+              ".ec2messages",
+            ],
+          ],
+        },
+        "SubnetIds": [
+          {
+            "Ref": "NeptuneGraphAppnetworkisolatedSubnet1SubnetBE50669E",
+          },
+          {
+            "Ref": "NeptuneGraphAppnetworkisolatedSubnet2Subnet1C86C7A4",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
+    "NeptuneGraphAppec2MessagesEndpointPacketsDroppedAlarm048BC171": {
+      "Properties": {
+        "AlarmDescription": "VPC interface endpoint is dropping packets — possible endpoint service unhealthy, security group blocking traffic, or packets exceeding the 8,500-byte PrivateLink MTU. Threshold: > 0 (sum) over 5 x 1 minute.",
+        "AlarmName": "composure-cdk-neptune-graph-stack/neptune-graph-app/ec2-messages-endpoint/packets-dropped",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": [
+          {
+            "Name": "VPC Endpoint Id",
+            "Value": {
+              "Ref": "NeptuneGraphAppec2MessagesEndpoint17906E67",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "PacketsDropped",
+        "Namespace": "AWS/PrivateLinkEndpoints",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NeptuneGraphAppec2MessagesEndpointSg84596DCD": {
+      "Properties": {
+        "GroupDescription": "Interface endpoint NeptuneGraphApp/ec2MessagesEndpoint",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "VpcId": {
+          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "NeptuneGraphAppec2MessagesEndpointSgfromComposureCDKNeptuneGraphStackNeptuneGraphAppbastionSg36AA71984430E1E46E5": {
+      "Properties": {
+        "Description": "EC2 Messages from Neptune bastion",
+        "FromPort": 443,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppec2MessagesEndpointSg84596DCD",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppbastionSgA2525585",
+            "GroupId",
+          ],
+        },
+        "ToPort": 443,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "NeptuneGraphAppgraph2EE8F381": {
       "DeletionPolicy": "Retain",
@@ -916,93 +1017,6 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "NeptuneGraphAppnetworkEc2MessagesEndpointB9744A5D": {
-      "Properties": {
-        "PrivateDnsEnabled": true,
-        "SecurityGroupIds": [
-          {
-            "Fn::GetAtt": [
-              "NeptuneGraphAppnetworkEc2MessagesEndpointSecurityGroup593DE067",
-              "GroupId",
-            ],
-          },
-        ],
-        "ServiceName": {
-          "Fn::Join": [
-            "",
-            [
-              "com.amazonaws.",
-              {
-                "Ref": "AWS::Region",
-              },
-              ".ec2messages",
-            ],
-          ],
-        },
-        "SubnetIds": [
-          {
-            "Ref": "NeptuneGraphAppnetworkisolatedSubnet1SubnetBE50669E",
-          },
-          {
-            "Ref": "NeptuneGraphAppnetworkisolatedSubnet2Subnet1C86C7A4",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network",
-          },
-        ],
-        "VpcEndpointType": "Interface",
-        "VpcId": {
-          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
-        },
-      },
-      "Type": "AWS::EC2::VPCEndpoint",
-    },
-    "NeptuneGraphAppnetworkEc2MessagesEndpointSecurityGroup593DE067": {
-      "Properties": {
-        "GroupDescription": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network/Ec2MessagesEndpoint/SecurityGroup",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network",
-          },
-        ],
-        "VpcId": {
-          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "NeptuneGraphAppnetworkEc2MessagesEndpointSecurityGroupfromComposureCDKNeptuneGraphStackNeptuneGraphAppbastionSg36AA71984435BFFF54F": {
-      "Properties": {
-        "Description": "Ec2Messages from Neptune bastion",
-        "FromPort": 443,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppnetworkEc2MessagesEndpointSecurityGroup593DE067",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppbastionSgA2525585",
-            "GroupId",
-          ],
-        },
-        "ToPort": 443,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
     "NeptuneGraphAppnetworkFlowLogsLogGroup24FFC645": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -1032,180 +1046,6 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
       },
       "Type": "Custom::VpcRestrictDefaultSG",
       "UpdateReplacePolicy": "Delete",
-    },
-    "NeptuneGraphAppnetworkSsmEndpointC2160135": {
-      "Properties": {
-        "PrivateDnsEnabled": true,
-        "SecurityGroupIds": [
-          {
-            "Fn::GetAtt": [
-              "NeptuneGraphAppnetworkSsmEndpointSecurityGroup96376F45",
-              "GroupId",
-            ],
-          },
-        ],
-        "ServiceName": {
-          "Fn::Join": [
-            "",
-            [
-              "com.amazonaws.",
-              {
-                "Ref": "AWS::Region",
-              },
-              ".ssm",
-            ],
-          ],
-        },
-        "SubnetIds": [
-          {
-            "Ref": "NeptuneGraphAppnetworkisolatedSubnet1SubnetBE50669E",
-          },
-          {
-            "Ref": "NeptuneGraphAppnetworkisolatedSubnet2Subnet1C86C7A4",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network",
-          },
-        ],
-        "VpcEndpointType": "Interface",
-        "VpcId": {
-          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
-        },
-      },
-      "Type": "AWS::EC2::VPCEndpoint",
-    },
-    "NeptuneGraphAppnetworkSsmEndpointSecurityGroup96376F45": {
-      "Properties": {
-        "GroupDescription": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network/SsmEndpoint/SecurityGroup",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network",
-          },
-        ],
-        "VpcId": {
-          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "NeptuneGraphAppnetworkSsmEndpointSecurityGroupfromComposureCDKNeptuneGraphStackNeptuneGraphAppbastionSg36AA7198443670183A7": {
-      "Properties": {
-        "Description": "Ssm from Neptune bastion",
-        "FromPort": 443,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppnetworkSsmEndpointSecurityGroup96376F45",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppbastionSgA2525585",
-            "GroupId",
-          ],
-        },
-        "ToPort": 443,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "NeptuneGraphAppnetworkSsmMessagesEndpoint50696562": {
-      "Properties": {
-        "PrivateDnsEnabled": true,
-        "SecurityGroupIds": [
-          {
-            "Fn::GetAtt": [
-              "NeptuneGraphAppnetworkSsmMessagesEndpointSecurityGroupA985331A",
-              "GroupId",
-            ],
-          },
-        ],
-        "ServiceName": {
-          "Fn::Join": [
-            "",
-            [
-              "com.amazonaws.",
-              {
-                "Ref": "AWS::Region",
-              },
-              ".ssmmessages",
-            ],
-          ],
-        },
-        "SubnetIds": [
-          {
-            "Ref": "NeptuneGraphAppnetworkisolatedSubnet1SubnetBE50669E",
-          },
-          {
-            "Ref": "NeptuneGraphAppnetworkisolatedSubnet2Subnet1C86C7A4",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network",
-          },
-        ],
-        "VpcEndpointType": "Interface",
-        "VpcId": {
-          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
-        },
-      },
-      "Type": "AWS::EC2::VPCEndpoint",
-    },
-    "NeptuneGraphAppnetworkSsmMessagesEndpointSecurityGroupA985331A": {
-      "Properties": {
-        "GroupDescription": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network/SsmMessagesEndpoint/SecurityGroup",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "ComposureCDK-NeptuneGraphStack/NeptuneGraphApp--network",
-          },
-        ],
-        "VpcId": {
-          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "NeptuneGraphAppnetworkSsmMessagesEndpointSecurityGroupfromComposureCDKNeptuneGraphStackNeptuneGraphAppbastionSg36AA71984439DE54F16": {
-      "Properties": {
-        "Description": "SsmMessages from Neptune bastion",
-        "FromPort": 443,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppnetworkSsmMessagesEndpointSecurityGroupA985331A",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "NeptuneGraphAppbastionSgA2525585",
-            "GroupId",
-          ],
-        },
-        "ToPort": 443,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "NeptuneGraphAppnetworkisolatedSubnet1RouteTableAD136CDE": {
       "Properties": {
@@ -1320,6 +1160,208 @@ exports[`neptune-graph-app > matches the expected synthesised template 1`] = `
         },
       },
       "Type": "AWS::EC2::Subnet",
+    },
+    "NeptuneGraphAppssmEndpointE1195B79": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "NeptuneGraphAppssmEndpointSg66B90B9D",
+              "GroupId",
+            ],
+          },
+        ],
+        "ServiceName": {
+          "Fn::Join": [
+            "",
+            [
+              "com.amazonaws.",
+              {
+                "Ref": "AWS::Region",
+              },
+              ".ssm",
+            ],
+          ],
+        },
+        "SubnetIds": [
+          {
+            "Ref": "NeptuneGraphAppnetworkisolatedSubnet1SubnetBE50669E",
+          },
+          {
+            "Ref": "NeptuneGraphAppnetworkisolatedSubnet2Subnet1C86C7A4",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
+    "NeptuneGraphAppssmEndpointPacketsDroppedAlarm064B700E": {
+      "Properties": {
+        "AlarmDescription": "VPC interface endpoint is dropping packets — possible endpoint service unhealthy, security group blocking traffic, or packets exceeding the 8,500-byte PrivateLink MTU. Threshold: > 0 (sum) over 5 x 1 minute.",
+        "AlarmName": "composure-cdk-neptune-graph-stack/neptune-graph-app/ssm-endpoint/packets-dropped",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": [
+          {
+            "Name": "VPC Endpoint Id",
+            "Value": {
+              "Ref": "NeptuneGraphAppssmEndpointE1195B79",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "PacketsDropped",
+        "Namespace": "AWS/PrivateLinkEndpoints",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NeptuneGraphAppssmEndpointSg66B90B9D": {
+      "Properties": {
+        "GroupDescription": "Interface endpoint NeptuneGraphApp/ssmEndpoint",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "VpcId": {
+          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "NeptuneGraphAppssmEndpointSgfromComposureCDKNeptuneGraphStackNeptuneGraphAppbastionSg36AA71984438E0E17D0": {
+      "Properties": {
+        "Description": "SSM from Neptune bastion",
+        "FromPort": 443,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppssmEndpointSg66B90B9D",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppbastionSgA2525585",
+            "GroupId",
+          ],
+        },
+        "ToPort": 443,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "NeptuneGraphAppssmMessagesEndpoint03FCEEC2": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "NeptuneGraphAppssmMessagesEndpointSg75696C9A",
+              "GroupId",
+            ],
+          },
+        ],
+        "ServiceName": {
+          "Fn::Join": [
+            "",
+            [
+              "com.amazonaws.",
+              {
+                "Ref": "AWS::Region",
+              },
+              ".ssmmessages",
+            ],
+          ],
+        },
+        "SubnetIds": [
+          {
+            "Ref": "NeptuneGraphAppnetworkisolatedSubnet1SubnetBE50669E",
+          },
+          {
+            "Ref": "NeptuneGraphAppnetworkisolatedSubnet2Subnet1C86C7A4",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
+    "NeptuneGraphAppssmMessagesEndpointPacketsDroppedAlarmC6C03A15": {
+      "Properties": {
+        "AlarmDescription": "VPC interface endpoint is dropping packets — possible endpoint service unhealthy, security group blocking traffic, or packets exceeding the 8,500-byte PrivateLink MTU. Threshold: > 0 (sum) over 5 x 1 minute.",
+        "AlarmName": "composure-cdk-neptune-graph-stack/neptune-graph-app/ssm-messages-endpoint/packets-dropped",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": [
+          {
+            "Name": "VPC Endpoint Id",
+            "Value": {
+              "Ref": "NeptuneGraphAppssmMessagesEndpoint03FCEEC2",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "PacketsDropped",
+        "Namespace": "AWS/PrivateLinkEndpoints",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NeptuneGraphAppssmMessagesEndpointSg75696C9A": {
+      "Properties": {
+        "GroupDescription": "Interface endpoint NeptuneGraphApp/ssmMessagesEndpoint",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "VpcId": {
+          "Ref": "NeptuneGraphAppnetwork6E4EC8BD",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "NeptuneGraphAppssmMessagesEndpointSgfromComposureCDKNeptuneGraphStackNeptuneGraphAppbastionSg36AA7198443BCC996F0": {
+      "Properties": {
+        "Description": "SSM Messages from Neptune bastion",
+        "FromPort": 443,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppssmMessagesEndpointSg75696C9A",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "NeptuneGraphAppbastionSgA2525585",
+            "GroupId",
+          ],
+        },
+        "ToPort": 443,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
   },
   "Rules": {


### PR DESCRIPTION
## Summary

Two commits:

1. **`refactor(ec2)`** — `allowDefaultPortFrom()` now accepts `IConnectable`
   instead of `IPeer`, delegating to `endpoint.connections.allowDefaultPortFrom()`.
   This wires both directions in one call: ingress on the managed SG from the peer,
   and egress from the peer's SG to the managed SG. Peers with
   `allowAllOutbound: false` (the `SecurityGroupBuilder` default) no longer need a
   manual `addEgressRule` on the result.

   Also includes unit tests (19 cases: build shape, well-architected defaults,
   bidirectional wiring, BYO mode, mutex, alarms, compose ref integration,
   copy-state isolation) and a README correction — the managed-mode section
   incorrectly described `allowDefaultPortFrom` as ingress-only.

   This is not a breaking change — `InterfaceEndpointBuilder` has not yet been
   included in a release.

2. **`refactor(examples)`** — Neptune graph example uses
   `createInterfaceEndpointBuilder` for the SSM endpoints instead of the
   post-build `addSsmEndpoints()` helper. Three endpoint components built via
   `.copy()` from a shared base; `bastionSg` egress rules are wired
   automatically by `allowDefaultPortFrom`.

## Test plan

- [ ] `npx nx test ec2` — 19 new tests all green
- [ ] `npx nx test examples` — Neptune snapshot updated to reflect new resource
      logical IDs and bidirectional egress rules
- [ ] `npm run lint && npm run format:check` — clean