### PR TITLE
fix(dynamodb): stabilise alarms test lint across Node matrix

### DIFF
--- a/packages/dynamodb/test/table-alarms.test.ts
+++ b/packages/dynamodb/test/table-alarms.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { type Lifecycle } from "@composurecdk/core";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
@@ -27,7 +28,16 @@ describe.each(builders)("$name table alarms", ({ create }) => {
     const stack = new Stack(app, "TestStack");
     const builder = create().partitionKey(PK);
     configureFn?.(builder);
-    const result = builder.build(stack, "TestTable");
+    // `builder` is a union of the two builder types, so `.build()` is a union of
+    // two call signatures. typescript-eslint's project service can intermittently
+    // fail to resolve that union (the file is the only test importing both
+    // builders), degrading it to an `error` type and tripping no-unsafe-call —
+    // flaky across the Node CI matrix. Both builders implement Lifecycle and
+    // every result carries `alarms`, so widen to that single signature.
+    const result = (builder as Lifecycle<{ alarms: Record<string, unknown> }>).build(
+      stack,
+      "TestTable",
+    );
     return { result, template: Template.fromStack(stack) };
   }
 


### PR DESCRIPTION
## Why

The `Lint` step intermittently fails on `packages/dynamodb/test/table-alarms.test.ts` across the Node CI matrix (seen on both Node 24 and Node 26), with:

```
30:11  error  Unsafe assignment of an error typed value         @typescript-eslint/no-unsafe-assignment
30:20  error  Unsafe call of a type that could not be resolved  @typescript-eslint/no-unsafe-call
31:14  error  Unsafe assignment of an error typed value         @typescript-eslint/no-unsafe-assignment
```

It is **not** a real type error and **not** Node-version-specific:

- `tsc --noEmit` (Typecheck) passes everywhere.
- Linting the file on its own, or its package directory, passes.
- It only fails when the whole repo is linted (`eslint .`) and depends on the order files are fed to typescript-eslint's **project service** — which shifts with the runner's Node build, so it surfaces flakily on different matrix jobs.

`table-alarms.test.ts` is the only test importing **both** builders, so its `build()` helper calls `.build()` on the `ITableBuilder | ITableV2Builder` union — a union of two call signatures. When the project service fails to associate the file with `packages/dynamodb/tsconfig.json` it degrades the union to an `error` type, tripping the `no-unsafe-*` rules.

## Fix

Both builders implement `Lifecycle` and every result carries `alarms`, so the helper widens the builder to `Lifecycle<{ alarms: Record<string, unknown> }>` at the build call. That collapses the union method call to a single signature, removing the resolution ambiguity regardless of project-service file ordering.

## Verification (on Node 26.3.1, the CI version that reproduced it)

- `eslint .` — clean
- `eslint packages/dynamodb/test/*.test.ts` (the reliable repro) — clean
- `tsc --noEmit` — clean
- `vitest run table-alarms.test.ts` — 18/18 pass
- `prettier --check .` — clean