### PR TITLE
docs(ci): add --allow-publish to npm trust command

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -113,8 +113,10 @@ Publishing uses [trusted publishers](https://docs.npmjs.com/trusted-publishers/)
 4. Configure a trusted publisher for each package:
 
    ```sh
-   npm trust github @composurecdk/<name> --file release.yml --repo laazyj/composureCDK --env npm
+   npm trust github @composurecdk/<name> --file release.yml --repo laazyj/composureCDK --env npm --allow-publish
    ```
+
+   `--allow-publish` is required by npm 11.6+ (`npm trust` no longer defaults to a permission). Use `--allow-publish` to match the release flow, which publishes immediately-installable versions; `--allow-stage-publish` would only permit staged publishes that need a separate promotion step.
 
 **Adding a new package:**
 


### PR DESCRIPTION
## Summary

The `npm trust` command documented in `docs/ci.md` fails on npm 11.6+ with:

```
npm error At least one permission flag is required (--allow-publish, --allow-stage-publish)
```

npm no longer defaults `npm trust` to a permission — a flag is now mandatory. This adds `--allow-publish` to the documented command (matching the release flow, which publishes immediately-installable versions) and notes the `--allow-stage-publish` alternative for staged publishes.

## Test plan

- Docs-only change; pre-push `verify` gate passed (format, build, exports, lint, test).