### PR TITLE
feat(lambda): add dynamoEventSource() and stream IteratorAge alarm

### DIFF
--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -125,16 +125,19 @@ Opt back into CDK's auto-created role attached to `AWSLambdaBasicExecutionRole`.
 
 The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda) by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.
 
-| Alarm                    | Metric                            | Default threshold           | Created when                          |
-| ------------------------ | --------------------------------- | --------------------------- | ------------------------------------- |
-| `errors`                 | Errors (Sum, 1 min)               | > 0                         | Always                                |
-| `throttles`              | Throttles (Sum, 1 min)            | > 0                         | Always                                |
-| `duration`               | Duration (p99, 1 min)             | > 90% of configured timeout | `timeout` is set                      |
-| `concurrentExecutions`   | ConcurrentExecutions (Max, 1 min) | >= 80% of reserved limit    | `reservedConcurrentExecutions` is set |
-| `<key>FailedInvocations` | FailedInvokeEventCount (Sum)      | > 0                         | An SQS event source is attached       |
-| `<key>DroppedEvents`     | DroppedEventCount (Sum)           | > 0                         | An SQS event source is attached       |
+| Alarm                    | Metric                            | Default threshold           | Created when                           |
+| ------------------------ | --------------------------------- | --------------------------- | -------------------------------------- |
+| `errors`                 | Errors (Sum, 1 min)               | > 0                         | Always                                 |
+| `throttles`              | Throttles (Sum, 1 min)            | > 0                         | Always                                 |
+| `duration`               | Duration (p99, 1 min)             | > 90% of configured timeout | `timeout` is set                       |
+| `concurrentExecutions`   | ConcurrentExecutions (Max, 1 min) | >= 80% of reserved limit    | `reservedConcurrentExecutions` is set  |
+| `<key>FailedInvocations` | FailedInvokeEventCount (Sum)      | > 0                         | An SQS or DynamoDB source is attached  |
+| `<key>DroppedEvents`     | DroppedEventCount (Sum)           | > 0                         | An SQS or DynamoDB source is attached  |
+| `iteratorAge`            | IteratorAge (Max, 1 min)          | > 60000 ms for 3 min        | A stream source (DynamoDB) is attached |
 
-The event-source alarms are contextual: one pair is created per event source attached via `addEventSource` (see [Event sources](#event-sources)) whose kind emits per-mapping ESM metrics. Each alarm's key is the event source's key suffixed with `FailedInvocations` / `DroppedEvents` — e.g. an event source added as `"orders"` produces `ordersFailedInvocations` and `ordersDroppedEvents`. The `eventSourceFailedInvocations` / `eventSourceDroppedEvents` fields on `recommendedAlarms` tune every such alarm.
+The per-mapping event-source alarms are contextual: one pair is created per event source attached via `addEventSource` (see [Event sources](#event-sources)) whose kind emits per-mapping ESM metrics. Each alarm's key is the event source's key suffixed with `FailedInvocations` / `DroppedEvents` — e.g. an event source added as `"orders"` produces `ordersFailedInvocations` and `ordersDroppedEvents`. The `eventSourceFailedInvocations` / `eventSourceDroppedEvents` fields on `recommendedAlarms` tune every such alarm.
+
+`iteratorAge` is different: `IteratorAge` is a function-level metric, so a single alarm (keyed `iteratorAge`) is created whenever at least one stream source (currently DynamoDB streams) is attached, regardless of how many. It warns when the consumer falls behind its stream. Tune or disable it via the `eventSourceIteratorAge` field on `recommendedAlarms`.
 
 The defaults are exported as `FUNCTION_ALARM_DEFAULTS` for visibility and testing:
 
@@ -226,9 +229,10 @@ for (const alarm of Object.values(result.alarms)) {
 function can have many event sources of mixed types, so the hook is repeatable
 and keyed — the resolved sources are exposed on `result.eventSources`.
 
-Pass a `ComposureEventSource` from a factory (`sqsEventSource`), which carries
-its own `Resolvable` so the source queue can be a `ref()` to a sibling
-component, or a bare CDK `IEventSource` as an escape hatch.
+Pass a `ComposureEventSource` from a factory (`sqsEventSource`,
+`dynamoEventSource`), which carries its own `Resolvable` so the source queue or
+table can be a `ref()` to a sibling component, or a bare CDK `IEventSource` as
+an escape hatch.
 
 ```ts
 import { compose, ref } from "@composurecdk/core";
@@ -250,7 +254,44 @@ const system = compose(
 
 The source is attached _after_ the function and its least-privilege execution
 role exist, so the `source.bind(fn)` that `addEventSource` performs grants the
-queue-consume permission onto the builder's role rather than CDK's auto-role.
+consume permission (SQS `ReceiveMessage`, or DynamoDB `grantStreamRead`) onto
+the builder's role rather than CDK's auto-role.
+
+`dynamoEventSource(table, props?)` mirrors the SQS factory for DynamoDB streams.
+The table must have a stream enabled (via the [DynamoDB builder](../dynamodb)'s
+`.dynamoStream(...)` / `.stream(...)`, or `TableProps.stream`); otherwise CDK
+throws `DynamoDB Streams must be enabled` at build time. `startingPosition`
+defaults to `LATEST` and is overridable via `props`:
+
+```ts
+import { StartingPosition } from "aws-cdk-lib/aws-lambda";
+import { StreamViewType } from "aws-cdk-lib/aws-dynamodb";
+import { compose, ref } from "@composurecdk/core";
+import { createFunctionBuilder, dynamoEventSource } from "@composurecdk/lambda";
+import { createTableV2Builder } from "@composurecdk/dynamodb";
+
+compose(
+  {
+    orders: createTableV2Builder()
+      .partitionKey({ name: "pk", type: AttributeType.STRING })
+      .dynamoStream(StreamViewType.NEW_AND_OLD_IMAGES),
+    processor: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_22_X)
+      .handler("index.handler")
+      .code(Code.fromAsset("lambda"))
+      .addEventSource(
+        "orders",
+        dynamoEventSource(
+          ref("orders", (r) => r.table),
+          {
+            startingPosition: StartingPosition.TRIM_HORIZON,
+          },
+        ),
+      ),
+  },
+  { orders: [], processor: ["orders"] },
+);
+```
 
 ### Secure defaults
 
@@ -262,6 +303,15 @@ second `props` argument and exported as `DEFAULT_SQS_EVENT_SOURCE_PROPS`:
 | `reportBatchItemFailures` | `true`                      | A single poison message fails only its own record, not the whole batch. CDK defaults this `false`. |
 | `metricsConfig`           | `{ metrics: [EventCount] }` | Enables the per-mapping ESM metrics that back the event-source contextual alarms.                  |
 
+`dynamoEventSource` applies the same defaults plus `startingPosition`, exported
+as `DEFAULT_DYNAMO_EVENT_SOURCE_PROPS`:
+
+| Property                  | Default                     | Rationale                                                                                         |
+| ------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------- |
+| `startingPosition`        | `LATEST`                    | A newly-attached consumer reads from the stream tip, not the table's existing change history.     |
+| `reportBatchItemFailures` | `true`                      | A single poison record fails only its own record, not the whole batch. CDK defaults this `false`. |
+| `metricsConfig`           | `{ metrics: [EventCount] }` | Enables the per-mapping ESM metrics that back the event-source contextual alarms.                 |
+
 ### Cross-component invariants
 
 AWS Well-Architected guidance spans the queue and the function — the source
@@ -271,9 +321,8 @@ today (the queue often arrives as an unresolved `ref()`); they are tracked in
 [#123](https://github.com/laazyj/composureCDK/issues/123) and
 [#124](https://github.com/laazyj/composureCDK/issues/124).
 
-`kinesisEventSource` / `dynamoEventSource` and the stream-only `IteratorAge`
-alarm are deferred — see [#120](https://github.com/laazyj/composureCDK/issues/120)
-and [#121](https://github.com/laazyj/composureCDK/issues/121).
+`kinesisEventSource` is still deferred — see
+[#120](https://github.com/laazyj/composureCDK/issues/120).
 
 ## Examples
 

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -133,7 +133,9 @@ The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.
 | `concurrentExecutions`   | ConcurrentExecutions (Max, 1 min) | >= 80% of reserved limit    | `reservedConcurrentExecutions` is set  |
 | `<key>FailedInvocations` | FailedInvokeEventCount (Sum)      | > 0                         | An SQS or DynamoDB source is attached  |
 | `<key>DroppedEvents`     | DroppedEventCount (Sum)           | > 0                         | An SQS or DynamoDB source is attached  |
-| `iteratorAge`            | IteratorAge (Max, 1 min)          | > 60000 ms for 3 min        | A stream source (DynamoDB) is attached |
+| `iteratorAge`            | IteratorAge (Max, 1 min)          | > 60000 ms for 3 min¹       | A stream source (DynamoDB) is attached |
+
+¹ AWS recommends alarming on `IteratorAge` for stream consumers but prescribes no fixed threshold — it is workload dependent. The 60s/3-minute default is deliberately conservative; tune it per workload via `eventSourceIteratorAge`.
 
 The per-mapping event-source alarms are contextual: one pair is created per event source attached via `addEventSource` (see [Event sources](#event-sources)) whose kind emits per-mapping ESM metrics. Each alarm's key is the event source's key suffixed with `FailedInvocations` / `DroppedEvents` — e.g. an event source added as `"orders"` produces `ordersFailedInvocations` and `ordersDroppedEvents`. The `eventSourceFailedInvocations` / `eventSourceDroppedEvents` fields on `recommendedAlarms` tune every such alarm.
 

--- a/packages/lambda/src/alarm-config.ts
+++ b/packages/lambda/src/alarm-config.ts
@@ -119,4 +119,24 @@ export interface FunctionAlarmConfig {
    * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
    */
   eventSourceDroppedEvents?: AlarmConfig | false;
+
+  /**
+   * Alarm when the function is falling behind a stream event source.
+   *
+   * Contextual: a single alarm is created when at least one stream event
+   * source (currently DynamoDB streams) is attached via
+   * {@link IFunctionBuilder.addEventSource}. Unlike the per-mapping alarms
+   * above, `IteratorAge` is a function-level metric, so there is one alarm per
+   * function (keyed `iteratorAge`) regardless of how many stream sources are
+   * attached.
+   *
+   * The threshold is an absolute age in milliseconds (not a percentage).
+   *
+   * Metric: `AWS/Lambda IteratorAge`, statistic Maximum, period 1 minute,
+   * dimensioned on `FunctionName`. Default threshold: > 60000 ms (60s) for 3
+   * consecutive minutes.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda
+   */
+  eventSourceIteratorAge?: AlarmConfig | false;
 }

--- a/packages/lambda/src/alarm-config.ts
+++ b/packages/lambda/src/alarm-config.ts
@@ -125,18 +125,21 @@ export interface FunctionAlarmConfig {
    *
    * Contextual: a single alarm is created when at least one stream event
    * source (currently DynamoDB streams) is attached via
-   * {@link IFunctionBuilder.addEventSource}. Unlike the per-mapping alarms
-   * above, `IteratorAge` is a function-level metric, so there is one alarm per
-   * function (keyed `iteratorAge`) regardless of how many stream sources are
-   * attached.
+   * {@link IFunctionBuilder.addEventSource}. Unlike the per-mapping
+   * {@link FunctionAlarmConfig.eventSourceFailedInvocations} /
+   * {@link FunctionAlarmConfig.eventSourceDroppedEvents} alarms, `IteratorAge`
+   * is a function-level metric, so there is one alarm per function (keyed
+   * `iteratorAge`) regardless of how many stream sources are attached.
    *
    * The threshold is an absolute age in milliseconds (not a percentage).
    *
    * Metric: `AWS/Lambda IteratorAge`, statistic Maximum, period 1 minute,
-   * dimensioned on `FunctionName`. Default threshold: > 60000 ms (60s) for 3
-   * consecutive minutes.
+   * dimensioned on `FunctionName`. AWS recommends alarming on this metric for
+   * stream consumers but does not prescribe a threshold (it is workload
+   * dependent); the default is a deliberately conservative > 60000 ms (60s) for
+   * 3 consecutive minutes.
    *
-   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#Lambda
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html
    */
   eventSourceIteratorAge?: AlarmConfig | false;
 }

--- a/packages/lambda/src/alarm-defaults.ts
+++ b/packages/lambda/src/alarm-defaults.ts
@@ -77,9 +77,12 @@ export const FUNCTION_ALARM_DEFAULTS: FunctionAlarmDefaults = {
 
   /**
    * The consumer falling behind the stream risks data loss once records age
-   * past the stream's 24h retention. Alarm on sustained lag — 60s of iterator
-   * age for 3 consecutive minutes. Idle functions emit no datapoints and stay
-   * OK (`NOT_BREACHING`).
+   * past the stream's 24h retention. AWS recommends alarming on `IteratorAge`
+   * for stream consumers but publishes no fixed threshold — the right value is
+   * workload dependent. 60s of sustained lag for 3 consecutive minutes is a
+   * deliberately conservative default; tune via `eventSourceIteratorAge`. Idle
+   * functions emit no datapoints and stay OK (`NOT_BREACHING`).
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html
    */
   eventSourceIteratorAge: {
     threshold: 60_000,

--- a/packages/lambda/src/alarm-defaults.ts
+++ b/packages/lambda/src/alarm-defaults.ts
@@ -10,6 +10,7 @@ interface FunctionAlarmDefaults {
   concurrentExecutions: PercentageAlarmConfigDefaults;
   eventSourceFailedInvocations: AlarmConfigDefaults;
   eventSourceDroppedEvents: AlarmConfigDefaults;
+  eventSourceIteratorAge: AlarmConfigDefaults;
 }
 
 /**
@@ -71,6 +72,19 @@ export const FUNCTION_ALARM_DEFAULTS: FunctionAlarmDefaults = {
     threshold: 0,
     evaluationPeriods: 1,
     datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /**
+   * The consumer falling behind the stream risks data loss once records age
+   * past the stream's 24h retention. Alarm on sustained lag — 60s of iterator
+   * age for 3 consecutive minutes. Idle functions emit no datapoints and stay
+   * OK (`NOT_BREACHING`).
+   */
+  eventSourceIteratorAge: {
+    threshold: 60_000,
+    evaluationPeriods: 3,
+    datapointsToAlarm: 3,
     treatMissingData: TreatMissingData.NOT_BREACHING,
   },
 };

--- a/packages/lambda/src/event-sources/composure-event-source.ts
+++ b/packages/lambda/src/event-sources/composure-event-source.ts
@@ -1,5 +1,5 @@
 import type { IEventSource } from "aws-cdk-lib/aws-lambda";
-import type { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import type { DynamoEventSource, SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import type { Resolvable } from "@composurecdk/core";
 
 /**
@@ -11,7 +11,7 @@ import type { Resolvable } from "@composurecdk/core";
  * straight to {@link IFunctionBuilder.addEventSource} as an escape hatch —
  * the builder still attaches it, but cannot reason about it.
  */
-export type EventSourceKind = "sqs" | "unknown";
+export type EventSourceKind = "sqs" | "dynamodb" | "unknown";
 
 /** @internal — brands {@link ComposureEventSource} so the guard is unambiguous. */
 const COMPOSURE_EVENT_SOURCE = Symbol.for("composurecdk.lambda.eventSource");
@@ -53,9 +53,9 @@ export function composureEventSource(
 /**
  * Reads the event source mapping UUID off a bound CDK source, keyed by
  * {@link EventSourceKind}. Defined only for kinds whose per-mapping ESM
- * metrics back contextual alarms (currently SQS); `FunctionBuilder` invokes
- * the reader after `addEventSource` so the binding exists. Keying off `kind`
- * — like {@link EVENT_SOURCE_ALARM_SPECS} — keeps the builder from
+ * metrics back contextual alarms (SQS and DynamoDB streams); `FunctionBuilder`
+ * invokes the reader after `addEventSource` so the binding exists. Keying off
+ * `kind` — like {@link EVENT_SOURCE_ALARM_SPECS} — keeps the builder from
  * `instanceof`-ing CDK source classes.
  *
  * @internal
@@ -68,6 +68,10 @@ export const EVENT_SOURCE_MAPPING_ID_READERS: Record<
   // constructs the `SqsEventSource` in the same call — kind and concrete class
   // move in lockstep.
   sqs: (bound) => (bound as SqsEventSource).eventSourceMappingId,
+  // Safe: the `"dynamodb"` kind is only ever assigned by `dynamoEventSource()`,
+  // which constructs the `DynamoEventSource` in the same call — kind and
+  // concrete class move in lockstep.
+  dynamodb: (bound) => (bound as DynamoEventSource).eventSourceMappingId,
   unknown: undefined,
 };
 

--- a/packages/lambda/src/event-sources/dynamodb-event-source.ts
+++ b/packages/lambda/src/event-sources/dynamodb-event-source.ts
@@ -1,0 +1,98 @@
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import type { IEventSource } from "aws-cdk-lib/aws-lambda";
+import { MetricType, StartingPosition } from "aws-cdk-lib/aws-lambda";
+import {
+  DynamoEventSource,
+  type DynamoEventSourceProps,
+} from "aws-cdk-lib/aws-lambda-event-sources";
+import { isRef, type Resolvable } from "@composurecdk/core";
+import { type ComposureEventSource, composureEventSource } from "./composure-event-source.js";
+
+/**
+ * Secure, AWS-recommended defaults applied to every DynamoDB stream event
+ * source built with {@link dynamoEventSource}. Each property can be overridden
+ * via the factory's `props` argument.
+ */
+export const DEFAULT_DYNAMO_EVENT_SOURCE_PROPS: Pick<
+  DynamoEventSourceProps,
+  "startingPosition" | "reportBatchItemFailures" | "metricsConfig"
+> = {
+  /**
+   * Start reading from the tip of the stream so a newly-attached consumer does
+   * not replay the table's existing change history on first deploy. Override
+   * with {@link StartingPosition.TRIM_HORIZON} to reprocess from the oldest
+   * record in the stream.
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
+   */
+  startingPosition: StartingPosition.LATEST,
+
+  /**
+   * Report partial batch failures so a single poison record does not fail the
+   * whole batch and force redelivery of already-processed records. CDK
+   * defaults this to `false`.
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting
+   */
+  reportBatchItemFailures: true,
+
+  /**
+   * Enable the per-mapping `EventCount` ESM metrics (`FailedInvokeEventCount`,
+   * `DroppedEventCount`, …). They emit only when opted in, and the
+   * event-source contextual alarms on {@link IFunctionBuilder} depend on them.
+   * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
+   */
+  metricsConfig: { metrics: [MetricType.EVENT_COUNT] },
+};
+
+/**
+ * Wraps a DynamoDB table's change stream as a Lambda {@link IEventSource},
+ * deferring resolution when the table is a `ref()` to a sibling component's
+ * output.
+ *
+ * Follows the `events/targets` factory shape: register the result with
+ * {@link IFunctionBuilder.addEventSource} and the builder resolves the
+ * `ref()`, attaches the source, and (because `addEventSource` calls
+ * `source.bind(fn)`) grants the function's least-privilege execution role
+ * permission to read the stream via `grantStreamRead`.
+ *
+ * Applies {@link DEFAULT_DYNAMO_EVENT_SOURCE_PROPS}; pass `props` to override.
+ *
+ * ## Cross-component invariant (enforced by CDK at bind time)
+ *
+ * The table must have a stream enabled (via the table builder's
+ * `.dynamoStream(...)` / `.stream(...)`, or `TableProps.stream`). If it does
+ * not, CDK's `DynamoEventSource.bind()` throws `DynamoDB Streams must be
+ * enabled on the table` when the function is built — the table often arrives
+ * as a `ref()` that is not resolvable at configuration time, so this is not
+ * validated earlier.
+ *
+ * @param table - The source table, concrete or a `ref()` to a sibling.
+ * @param props - Overrides for {@link DEFAULT_DYNAMO_EVENT_SOURCE_PROPS} and
+ *   any other {@link DynamoEventSourceProps}.
+ *
+ * @example
+ * ```ts
+ * compose(
+ *   {
+ *     orders: createTableV2Builder()
+ *       .partitionKey({ name: "pk", type: AttributeType.STRING })
+ *       .dynamoStream(StreamViewType.NEW_AND_OLD_IMAGES),
+ *     processor: createFunctionBuilder()
+ *       .runtime(Runtime.NODEJS_22_X)
+ *       .handler("index.handler")
+ *       .code(Code.fromAsset("lambda"))
+ *       .addEventSource("orders", dynamoEventSource(ref("orders", (r) => r.table))),
+ *   },
+ *   { orders: [], processor: ["orders"] },
+ * );
+ * ```
+ */
+export function dynamoEventSource(
+  table: Resolvable<ITable>,
+  props?: DynamoEventSourceProps,
+): ComposureEventSource {
+  const merged: DynamoEventSourceProps = { ...DEFAULT_DYNAMO_EVENT_SOURCE_PROPS, ...props };
+  const source: Resolvable<IEventSource> = isRef(table)
+    ? table.map((resolved) => new DynamoEventSource(resolved, merged))
+    : new DynamoEventSource(table, merged);
+  return composureEventSource("dynamodb", source);
+}

--- a/packages/lambda/src/function-alarms.ts
+++ b/packages/lambda/src/function-alarms.ts
@@ -42,27 +42,41 @@ interface EventSourceAlarmSpec {
  *
  * @see https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/
  */
+/**
+ * Per-mapping ESM alarms shared by every kind that emits the `EventCount`
+ * metrics — both SQS and DynamoDB streams report `FailedInvokeEventCount` and
+ * `DroppedEventCount` when the mapping opts into `MetricType.EVENT_COUNT`.
+ */
+const ESM_EVENT_COUNT_SPECS: EventSourceAlarmSpec[] = [
+  {
+    keySuffix: "FailedInvocations",
+    configKey: "eventSourceFailedInvocations",
+    metricName: "FailedInvokeEventCount",
+    describe: (key, threshold) =>
+      `Lambda event source "${key}" is failing to invoke the function. ` +
+      `Threshold: > ${String(threshold)} failed invocations in ${METRIC_PERIOD_LABEL}.`,
+  },
+  {
+    keySuffix: "DroppedEvents",
+    configKey: "eventSourceDroppedEvents",
+    metricName: "DroppedEventCount",
+    describe: (key, threshold) =>
+      `Lambda event source "${key}" is dropping events after exhausting retries or TTL. ` +
+      `Threshold: > ${String(threshold)} dropped events in ${METRIC_PERIOD_LABEL}.`,
+  },
+];
+
 const EVENT_SOURCE_ALARM_SPECS: Record<AttachedEventSource["kind"], EventSourceAlarmSpec[]> = {
-  sqs: [
-    {
-      keySuffix: "FailedInvocations",
-      configKey: "eventSourceFailedInvocations",
-      metricName: "FailedInvokeEventCount",
-      describe: (key, threshold) =>
-        `Lambda event source "${key}" is failing to invoke the function. ` +
-        `Threshold: > ${String(threshold)} failed invocations in ${METRIC_PERIOD_LABEL}.`,
-    },
-    {
-      keySuffix: "DroppedEvents",
-      configKey: "eventSourceDroppedEvents",
-      metricName: "DroppedEventCount",
-      describe: (key, threshold) =>
-        `Lambda event source "${key}" is dropping events after exhausting retries or TTL. ` +
-        `Threshold: > ${String(threshold)} dropped events in ${METRIC_PERIOD_LABEL}.`,
-    },
-  ],
+  sqs: ESM_EVENT_COUNT_SPECS,
+  dynamodb: ESM_EVENT_COUNT_SPECS,
   unknown: [],
 };
+
+/**
+ * Source kinds backed by a stream, for which the function-level `IteratorAge`
+ * alarm is created. Extensible to `"kinesis"` when that source lands.
+ */
+const STREAM_EVENT_SOURCE_KINDS: ReadonlySet<AttachedEventSource["kind"]> = new Set(["dynamodb"]);
 
 /**
  * Resolves the recommended alarm configuration into fully-resolved
@@ -199,6 +213,38 @@ export function resolveFunctionAlarmDefinitions(
         description: spec.describe(eventSource.key, cfg.threshold),
       });
     }
+  }
+
+  // `IteratorAge` is a function-level metric (dimensioned on `FunctionName`,
+  // not the mapping UUID), so it cannot ride the per-mapping loop above: one
+  // alarm covers the function whenever any stream source is attached.
+  if (
+    config?.eventSourceIteratorAge !== false &&
+    eventSources.some((es) => STREAM_EVENT_SOURCE_KINDS.has(es.kind))
+  ) {
+    const cfg = resolveAlarmConfig(
+      config?.eventSourceIteratorAge,
+      FUNCTION_ALARM_DEFAULTS.eventSourceIteratorAge,
+    );
+    definitions.push({
+      key: "iteratorAge",
+      alarmName: cfg.alarmName,
+      metric: new Metric({
+        namespace: "AWS/Lambda",
+        metricName: "IteratorAge",
+        dimensionsMap: { FunctionName: fn.functionName },
+        statistic: Stats.MAXIMUM,
+        period: METRIC_PERIOD,
+      }),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `Lambda function is falling behind its stream event source (IteratorAge). ` +
+        `Threshold: > ${String(cfg.threshold)}ms for ${String(cfg.evaluationPeriods)} consecutive ${METRIC_PERIOD_LABEL} periods.`,
+    });
   }
 
   return definitions;

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -15,3 +15,7 @@ export {
   sqsEventSource,
   DEFAULT_SQS_EVENT_SOURCE_PROPS,
 } from "./event-sources/sqs-event-source.js";
+export {
+  dynamoEventSource,
+  DEFAULT_DYNAMO_EVENT_SOURCE_PROPS,
+} from "./event-sources/dynamodb-event-source.js";

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { Code, type IEventSource, Runtime } from "aws-cdk-lib/aws-lambda";
-import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import { AttributeType, type ITable, StreamViewType, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Code, type IEventSource, Runtime, StartingPosition } from "aws-cdk-lib/aws-lambda";
+import { DynamoEventSource, SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import { isRef, ref } from "@composurecdk/core";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
@@ -11,6 +12,18 @@ import {
   DEFAULT_SQS_EVENT_SOURCE_PROPS,
   sqsEventSource,
 } from "../src/event-sources/sqs-event-source.js";
+import {
+  DEFAULT_DYNAMO_EVENT_SOURCE_PROPS,
+  dynamoEventSource,
+} from "../src/event-sources/dynamodb-event-source.js";
+
+/** A table with a stream enabled, as `DynamoEventSource.bind` requires. */
+function streamTable(stack: Stack, id = "T"): Table {
+  return new Table(stack, id, {
+    partitionKey: { name: "pk", type: AttributeType.STRING },
+    stream: StreamViewType.NEW_AND_OLD_IMAGES,
+  });
+}
 
 function baseBuilder(): ReturnType<typeof createFunctionBuilder> {
   return createFunctionBuilder()
@@ -43,6 +56,94 @@ describe("sqsEventSource", () => {
   it("exposes its secure defaults for visibility", () => {
     expect(DEFAULT_SQS_EVENT_SOURCE_PROPS.reportBatchItemFailures).toBe(true);
     expect(DEFAULT_SQS_EVENT_SOURCE_PROPS.metricsConfig).toEqual({ metrics: ["EventCount"] });
+  });
+});
+
+describe("dynamoEventSource", () => {
+  it("returns a ComposureEventSource of kind 'dynamodb'", () => {
+    const stack = new Stack(new App(), "S");
+    const source = dynamoEventSource(streamTable(stack));
+
+    expect(source.kind).toBe("dynamodb");
+  });
+
+  it("holds a concrete source for a concrete table", () => {
+    const stack = new Stack(new App(), "S");
+    const source = dynamoEventSource(streamTable(stack));
+
+    expect(isRef(source.source)).toBe(false);
+  });
+
+  it("holds a Ref source for a Ref table", () => {
+    const source = dynamoEventSource(ref("orders", (r: { table: ITable }) => r.table));
+
+    expect(isRef(source.source)).toBe(true);
+  });
+
+  it("exposes its secure defaults for visibility", () => {
+    expect(DEFAULT_DYNAMO_EVENT_SOURCE_PROPS.startingPosition).toBe("LATEST");
+    expect(DEFAULT_DYNAMO_EVENT_SOURCE_PROPS.reportBatchItemFailures).toBe(true);
+    expect(DEFAULT_DYNAMO_EVENT_SOURCE_PROPS.metricsConfig).toEqual({ metrics: ["EventCount"] });
+  });
+});
+
+describe("FunctionBuilder.addEventSource (DynamoDB)", () => {
+  it("synthesises an event source mapping and grants stream read", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .build(stack, "Fn");
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::Lambda::EventSourceMapping", 1);
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(["dynamodb:GetRecords", "dynamodb:GetShardIterator"]),
+            Effect: "Allow",
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("applies the secure DynamoDB defaults to the mapping", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::EventSourceMapping", {
+      StartingPosition: "LATEST",
+      FunctionResponseTypes: ["ReportBatchItemFailures"],
+      MetricsConfig: { Metrics: ["EventCount"] },
+    });
+  });
+
+  it("lets props override the secure defaults", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource(
+        "orders",
+        dynamoEventSource(streamTable(stack), { startingPosition: StartingPosition.TRIM_HORIZON }),
+      )
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::EventSourceMapping", {
+      StartingPosition: "TRIM_HORIZON",
+    });
+  });
+
+  it("resolves a Ref table against the build context", () => {
+    const stack = new Stack(new App(), "S");
+    const table = streamTable(stack);
+
+    baseBuilder()
+      .addEventSource("orders", dynamoEventSource(ref("orders", (r: { table: ITable }) => r.table)))
+      .build(stack, "Fn", { orders: { table } });
+
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::EventSourceMapping", 1);
   });
 });
 
@@ -246,5 +347,99 @@ describe("event-source contextual alarms", () => {
 
     expect(result.alarms).not.toHaveProperty("ordersFailedInvocations");
     expect(result.alarms).toHaveProperty("ordersDroppedEvents");
+  });
+
+  it("creates per-mapping alarms for a DynamoDB stream source too", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .build(stack, "Fn");
+
+    expect(result.alarms).toHaveProperty("ordersFailedInvocations");
+    expect(result.alarms).toHaveProperty("ordersDroppedEvents");
+  });
+});
+
+describe("stream IteratorAge contextual alarm", () => {
+  it("creates a single iteratorAge alarm when a DynamoDB stream source is attached", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .build(stack, "Fn");
+
+    expect(result.alarms).toHaveProperty("iteratorAge");
+  });
+
+  it("dimensions the iteratorAge metric on the function with Maximum statistic", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/Lambda",
+      MetricName: "IteratorAge",
+      Statistic: "Maximum",
+      Dimensions: [{ Name: "FunctionName", Value: Match.anyValue() }],
+      Threshold: 60_000,
+      ComparisonOperator: "GreaterThanThreshold",
+    });
+  });
+
+  it("creates one iteratorAge alarm regardless of how many stream sources are attached", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack, "Orders")))
+      .addEventSource("audit", dynamoEventSource(streamTable(stack, "Audit")))
+      .build(stack, "Fn");
+
+    const iteratorAgeKeys = Object.keys(result.alarms).filter((k) => k === "iteratorAge");
+    expect(iteratorAgeKeys).toEqual(["iteratorAge"]);
+  });
+
+  it("does not create an iteratorAge alarm for an SQS-only function", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    expect(result.alarms).not.toHaveProperty("iteratorAge");
+  });
+
+  it("does not create an iteratorAge alarm for a bare escape-hatch stream source", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource(
+        "orders",
+        new DynamoEventSource(streamTable(stack), {
+          startingPosition: StartingPosition.LATEST,
+        }),
+      )
+      .build(stack, "Fn");
+
+    expect(result.alarms).not.toHaveProperty("iteratorAge");
+  });
+
+  it("disables the iteratorAge alarm via recommendedAlarms", () => {
+    const stack = new Stack(new App(), "S");
+    const result = baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .recommendedAlarms({ eventSourceIteratorAge: false })
+      .build(stack, "Fn");
+
+    expect(result.alarms).not.toHaveProperty("iteratorAge");
+  });
+
+  it("tunes the iteratorAge threshold via recommendedAlarms", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .recommendedAlarms({ eventSourceIteratorAge: { threshold: 120_000 } })
+      .build(stack, "Fn");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "IteratorAge",
+      Threshold: 120_000,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Completes the DynamoDB event-source remainder deferred from #118. The SQS half
(`sqsEventSource()` + `FunctionBuilder.addEventSource()`) shipped there;
`dynamoEventSource()` and the stream-only `IteratorAge` alarm were parked until
a DynamoDB builder existed to `ref()` against. #121 (merged as #221) landed
`@composurecdk/dynamodb`, unblocking this. Kinesis (#120) remains.

The source-`kind` seam built for the SQS work made this almost entirely
additive — the compiler forced the new kind into the dispatch maps.

## What's included

- **`dynamoEventSource(table, props?)`** — a `Resolvable`-aware factory mirroring
  `sqsEventSource`: accepts a concrete `ITable` or a `ref()` to a sibling, and
  applies secure defaults via `DEFAULT_DYNAMO_EVENT_SOURCE_PROPS`
  (`startingPosition: LATEST`, `reportBatchItemFailures: true`, `EventCount` ESM
  metrics), each overridable through `props`. At build time the source binds onto
  the function's least-privilege role (`grantStreamRead`).
- **Per-mapping alarms reused** — DynamoDB streams emit the same
  `FailedInvokeEventCount` / `DroppedEventCount` as SQS, so both kinds now share
  one `ESM_EVENT_COUNT_SPECS` array.
- **New `iteratorAge` contextual alarm** — `AWS/Lambda IteratorAge` (Maximum,
  dimensioned on `FunctionName`), created once whenever a stream source is
  attached. Unlike the per-mapping alarms it is function-level, so it sits in its
  own branch alongside `duration` / `concurrentExecutions`, not the per-mapping
  loop. Default `> 60000 ms` for 3 consecutive minutes; tune/disable via the new
  `eventSourceIteratorAge` field.

## Notable details

- **No `aws-cdk-lib` floor change** — `DynamoEventSource` and the `metricsConfig`
  prop are gated by the same `MetricType` feature already at the lambda floor
  (2.168.0); `cdk-floors:check` is unchanged.
- **No new package dependency** — the factory takes `Resolvable<ITable>` from
  `aws-cdk-lib/aws-dynamodb`, not `@composurecdk/dynamodb`, keeping lambda
  decoupled (exactly as `sqsEventSource` depends on `IQueue`, not
  `@composurecdk/sqs`).
- The table must have a stream enabled or CDK's `DynamoEventSource.bind()` throws
  at build time; documented in the factory JSDoc and README.
- `module-compat` unaffected — new exports are additive.

## Testing

- `packages/lambda/test/event-sources.test.ts`: factory defaults (`LATEST`,
  batch-failure, EventCount), `props` override, `ref` deferral, synth of the
  event source mapping + `grantStreamRead`, per-mapping alarms for DynamoDB, and
  the `iteratorAge` alarm (present for a stream source; absent for SQS-only and
  bare escape-hatch sources; one per function; threshold override; disable).
- Full gate green on the new base (`origin/main` incl. the dynamodb lint fix):
  build, `check:exports`, lint, format, `cdk-floors:check`, tests across all 21
  projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jYSQRVE7HSoWH3HfMNbsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jYSQRVE7HSoWH3HfMNbsQ)_