### PR TITLE
ci: serialise sandbox cleanup against deploys, raise deploy timeout

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -38,7 +38,9 @@ jobs:
     name: Deploy and Verify Examples
     needs: ci
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Neptune DB instance provisioning alone is a >15 min long pole; 30 min
+    # left too little slack for a clean deploy of the full example fleet.
+    timeout-minutes: 45
     environment: ${{ inputs.environment }}
 
     steps:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -23,7 +23,10 @@ permissions:
   id-token: write # Required for AWS OIDC
 
 concurrency:
-  group: deploy-test-${{ github.event.inputs.environment }}
+  # Shared with sandbox-cleanup.yml so a teardown can never run against the
+  # sandbox account while a deploy is in flight (and vice versa). Keep this
+  # group string identical in both workflows.
+  group: sandbox-account-${{ inputs.environment || 'sandbox' }}
   cancel-in-progress: false # Never cancel in-flight deployments
 
 jobs:

--- a/.github/workflows/sandbox-cleanup.yml
+++ b/.github/workflows/sandbox-cleanup.yml
@@ -26,7 +26,10 @@ permissions:
   id-token: write # AWS OIDC
 
 concurrency:
-  group: sandbox-cleanup
+  # Shared with deploy-test.yml — see the note there. A cleanup queues behind
+  # any in-flight deploy instead of tearing stacks down mid-deployment. Keep
+  # this group string identical in both workflows.
+  group: sandbox-account-${{ inputs.environment || 'sandbox' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Two small, independent CI hardening fixes, prompted by the timed-out deploy in [run 27897029728](https://github.com/laazyj/composureCDK/actions/runs/27897029728/job/82550686540).

> The GitHub-Release-gating change originally in this PR has been split out to #234 so these can land first.

## Root cause of that failure
A scheduled **Sandbox Cleanup** run (`27897554385`) fired mid-deploy and ran `cdk destroy --all` against the shared sandbox account while the release's **Deploy and Verify Examples** job was still creating the Neptune stack. The same resource (`NeptuneGraphApp--graph/Instance1`) appears in both logs at `07:43:23` — created by the deploy, deleted by the cleanup. The deploy then sat in an externally-induced rollback and was killed by its 30-minute timeout. Not a code defect.

## Changes (one commit each)
1. **Serialise sandbox cleanup against in-flight deploys** — `deploy-test.yml` and `sandbox-cleanup.yml` now share one concurrency group (`sandbox-account-<env>`, `cancel-in-progress: false`), so a cleanup queues behind any active deploy instead of colliding with it. Also fixes the deploy-test group key to use `inputs.environment` (the old `github.event.inputs.*` was empty when called from `release.yml`).
2. **Raise deploy-test timeout 30 → 45 min** — a clean full-fleet deploy is dominated by Neptune DB provisioning (>15 min); 30 min left too little slack.

## Validation
- `actionlint` 1.7.12 — clean
- `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)