### PR TITLE
ci: gate GitHub Release on a successful deploy

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   tag:
-    name: Tag and create GitHub Release
+    name: Create and push release tag
     # Cheap workflow-level filter so non-release pushes never spin up a runner.
     # Assumes squash-merge of the release PR — the strict regex parse below is
     # the authoritative validation.
@@ -65,28 +65,6 @@ jobs:
           fi
           git tag -a "$tag" -m "Release $tag"
           git push origin "$tag"
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.parse.outputs.version }}
-        run: |
-          tag="v${VERSION}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "Release $tag already exists; nothing to do."
-            exit 0
-          fi
-          # Notes are extracted from the workspace CHANGELOG.md section for this version.
-          # The section header format is set by nx release: `## VERSION` followed by content
-          # until the next `## ` heading.
-          notes=$(awk -v ver="$VERSION" '
-            $0 ~ "^## "ver"( |$|\\()" { found=1; next }
-            found && /^## / { exit }
-            found { print }
-          ' CHANGELOG.md)
-          if [ -z "$notes" ]; then
-            echo "::warning::Could not extract notes for $tag from CHANGELOG.md; using auto-generated notes."
-            gh release create "$tag" --title "$tag" --generate-notes
-          else
-            printf '%s' "$notes" | gh release create "$tag" --title "$tag" --notes-file -
-          fi
+          # The GitHub Release itself is created by release.yml, gated behind a
+          # successful deploy-test (just before npm publish), so we never
+          # advertise a release whose artefacts failed to deploy.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 15
     environment: npm
     permissions:
-      contents: read
+      contents: write # Create the GitHub Release once the deploy has passed
       id-token: write
 
     steps:
@@ -44,6 +44,34 @@ jobs:
         run: npm run build
         env:
           NX_DAEMON: false
+
+      # Created here, after deploy-test has passed, rather than at tag time —
+      # so a release is only published once its artefacts have deployed cleanly.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          tag="$REF_NAME"
+          version="${tag#v}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists; nothing to do."
+            exit 0
+          fi
+          # Notes are extracted from the workspace CHANGELOG.md section for this version.
+          # The section header format is set by nx release: `## VERSION` followed by content
+          # until the next `## ` heading.
+          notes=$(awk -v ver="$version" '
+            $0 ~ "^## "ver"( |$|\\()" { found=1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$notes" ]; then
+            echo "::warning::Could not extract notes for $tag from CHANGELOG.md; using auto-generated notes."
+            gh release create "$tag" --title "$tag" --generate-notes
+          else
+            printf '%s' "$notes" | gh release create "$tag" --title "$tag" --notes-file -
+          fi
 
       - name: Publish to npm
         run: npx nx release publish


### PR DESCRIPTION
Split out from #233 so the concurrency + timeout fixes can land first; this change is independent (touches only `release.yml` / `release-tag.yml`).

## Problem
The GitHub Release was created in `release-tag.yml` the moment the version tag was pushed — before `release.yml` had run `deploy-test` or published to npm. A deploy failure therefore still left a published GitHub Release advertising artefacts that never deployed.

## Change
Move release creation into `release.yml`'s publish job, immediately before the npm publish step. Because that job `needs: deploy-test`, the release is now only cut once the deploy passes:

- `release-tag.yml` still creates and pushes the tag (which triggers `release.yml`); it no longer creates the Release.
- The version is derived from the tag ref (`github.ref_name`); CHANGELOG note extraction is unchanged.
- The publish job gains `contents: write` to create the Release.

Trade-off (intended): on a deploy failure the tag exists but no Release/npm publish happens. Re-running `release.yml` is idempotent (`gh release view` guard).

## Validation
- `actionlint` 1.7.12 — clean
- `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)