### PR TITLE
docs: add ComposureCDK vs idiomatic CDK static-website comparison report

### DIFF
--- a/docs/comparison-report.md
+++ b/docs/comparison-report.md
@@ -1,9 +1,8 @@
 # ComposureCDK vs. idiomatic CDK — static-website comparison
 
-> **Status:** draft research report for maintainers. Not yet part of the published docs.
-> Purpose: evaluate how the ComposureCDK static-website showcase reads against the
-> canonical AWS / community CDK examples, and decide what (if anything) to lift into
-> public documentation.
+> A deep-dive companion to the [Showcase](showcase.md). It compares the ComposureCDK
+> static-website pattern against the canonical AWS and community CDK examples for the
+> same architecture — what each builds, and how they read at equal functionality.
 
 ## 1. Why this comparison
 
@@ -147,18 +146,67 @@ that part overlaps the showcase's _defaults_ closely, which is a useful external
 ComposureCDK's baked-in baseline matches AWS's own opinion. **Absent and not its job:** ACM, custom
 domain/DNS, alarms, SNS, health checks, budgets, content deployment, CloudFront functions.
 
-**Code coherence.** Highest of all references — one construct, one identity, nothing to wire. But it's
-coherent because it's _closed_: customisation happens through a wide `...Props` override surface, and
-once you need a custom-domain cert, a second origin, or your own alarm thresholds you're back to passing
-raw L2 props into the construct — the readability gain erodes exactly where the showcase adds value.
+**Is it production-capable for even a trivial site? Not really.** The bare `{}` form serves only the
+generated `*.cloudfront.net` name — no custom domain, no ACM certificate, no DNS. The first thing any
+real site needs is its own domain, and that is exactly where the three-line story ends. To add one you
+pass a `cloudFrontDistributionProps` object and spread raw L2 `DistributionProps` into it:
 
-**Conciseness.** Unbeatable at three lines, but it's three lines for a strictly smaller scope. It's the
-right comparison for "do I even need a builder library for a trivial private bucket + CDN?" and an honest
-report should concede B wins that narrow case. It is _not_ a comparison for the production shape.
+```typescript
+new CloudFrontToS3(this, "site", {
+  cloudFrontDistributionProps: {
+    domainNames: ["example.com"],
+    certificate: siteCert, // you still create + DNS-validate this yourself, in us-east-1
+    defaultRootObject: "index.html",
+    errorResponses: [
+      { httpStatus: 403, responsePagePath: "/error.html", ttl: Duration.minutes(30) },
+    ],
+  },
+});
+```
+
+— and you _still_ hand-write the `acm.Certificate` (in `us-east-1`) and the `route53.ARecord` yourself,
+because the construct creates neither. So for even a trivial _real_ site you are back to A's
+certificate/DNS code plus a nested props bag, with no alarms, health checks or budget. B is genuinely
+concise only for an internal/throwaway distribution on the default CloudFront domain.
+
+**Code coherence.** Highest of all references _while you stay inside its defaults_ — one construct, one
+identity, nothing to wire. But it's coherent because it's _closed_: customisation happens through the
+`cloudFrontDistributionProps` / `bucketProps` override surface, so the readability gain erodes exactly
+where the showcase adds value (custom domain, second origin, alarm thresholds).
+
+**Conciseness.** Three lines — but only for the domainless throwaway above. As soon as a custom domain
+is required the count jumps to A's cert/DNS code plus a nested props bag. The honest concession is narrow:
+B wins _only_ the "internal distribution on the default CloudFront domain" case, not the production shape.
 
 **Readability.** Maximal at first glance, lower under modification — the meaning of a `CloudFrontToS3`
-depends on knowing its (large) default set, and overrides are positional props rather than a fluent,
+depends on knowing its (large) default set, and overrides are nested raw-L2 props rather than a fluent,
 self-documenting chain.
+
+**A minimal, functionally-comparable ComposureCDK version.** Matching B's realistic trivial case — a
+private bucket behind a CDN _on a custom domain, with TLS and DNS_ — is itself only a handful of
+components, and unlike B it actually provisions the certificate and DNS records and ships secure defaults
+(versioned/RETAIN bucket, access logging) without extra lines:
+
+```typescript
+const bucket = ref<BucketBuilderResult>("bucket").get("bucket");
+const distribution = ref<DistributionBuilderResult>("cdn").get("distribution");
+
+compose(
+  {
+    cert: createCertificateBuilder().domainName(domain).validationZone(hostedZone), // us-east-1, DNS-validated
+    bucket: createBucketBuilder(), // private, versioned/RETAIN, access-logged by default
+    cdn: createDistributionBuilder()
+      .domainNames([domain])
+      .certificate(ref("cert", (r: CertificateBuilderResult) => r.certificate))
+      .origin(bucket.map((b) => S3BucketOrigin.withOriginAccessControl(b))),
+    dns: zoneRecords([ALIAS("@", cloudfrontAliasTarget(distribution))]).zone(hostedZone),
+  },
+  { cert: [], bucket: [], cdn: ["cert", "bucket"], dns: ["cdn"] },
+);
+```
+
+Same output surface as B's _customised_ form, fewer moving parts than B-plus-hand-rolled-cert/DNS, and
+the secure baseline is free rather than spread into a props bag.
 
 ## 5. Reference C — the "add monitoring yourself" reality
 
@@ -211,12 +259,16 @@ the AWS-recommended metric set reads as intent; a hand-built `new Alarm(this, 'C
 
 A credible public-doc comparison should pre-empt the obvious rebuttals:
 
-1. **Trivial scope favours B.** For "a private bucket behind a CDN, nothing else," `CloudFrontToS3` in
-   three lines beats anything. Lead with the production shape, not the toy, or the conciseness claim
-   looks cherry-picked.
+1. **The domainless throwaway favours B.** For an internal distribution on the default
+   `*.cloudfront.net` name — no custom domain, cert, DNS or alarms — `CloudFrontToS3` in three lines
+   beats anything (see §4). That's the one case to concede, and it evaporates the moment a real domain
+   is added. Lead with the production shape, not the toy, or the conciseness claim looks cherry-picked.
 2. **A is doing less, so its line count is unfairly flattering.** Always normalise: compare _at equal
-   functionality_. The fair statement is "ComposureCDK reaches A's output in ~20 lines with more secure
-   defaults, and reaches the _full_ showcase in ~110 where A would need ~250+."
+   functionality_. A's resource + output code is ~46 lines (excluding imports and class scaffolding);
+   the ComposureCDK equivalent for byte-identical output is ~20 — **roughly 43% of the code, a ~57%
+   reduction** (≈22% of the full ~90-line file once imports/scaffolding are counted), and that is
+   _before_ crediting the secure defaults A omits. At the _full_ showcase scope ComposureCDK is ~110
+   lines where A-plus-C would need ~250+.
 3. **Learning curve.** A and B use only stock CDK; ComposureCDK adds `compose` / `ref` / builders concepts.
    The payoff is real but non-zero to learn — worth stating plainly rather than hiding.
 4. **Library/version surface.** ComposureCDK is a set of `@composurecdk/*` packages to adopt and track;
@@ -224,21 +276,20 @@ A credible public-doc comparison should pre-empt the obvious rebuttals:
 5. **Don't overclaim on functional difference.** Where ComposureCDK's _output_ matches B's defaults
    (logging, OAC, SSL), the win is authoring ergonomics and override visibility, not capability. Say so.
 
-## 8. Recommendation for public documentation
+## 8. Takeaways
 
-1. **Add a "Compared to idiomatic CDK" section** (in `showcase.md` or a sibling page) built around the
-   **feature matrix in §6** — it's the most defensible, skimmable artefact and makes the "no single
-   example does all this" point immediately.
-2. **Use one head-to-head snippet at equal functionality**: the canonical `aws-cdk-examples/static-site`
-   beside the equivalent ComposureCDK `bucket`/`cdn`/`deploy` components, annotated to show which lines
-   ComposureCDK _removes_ (they become defaults). This is the strongest single image.
-3. **Frame the alarm/health/budget story as the differentiator**, since that's where reference examples
-   genuinely run out — "from secure CDN to fully-alarmed, budget-guarded site is one
-   `.recommendedAlarms()` and one `alarmActionsPolicy()` away, not 150 lines of `new Alarm(...)`."
-4. **Keep the caveats from §7 in the published version.** A comparison that concedes B's three-line win
-   and normalises for scope reads as confident and trustworthy; one that doesn't invites the rebuttal.
-5. **Attribute and link** every reference example, and pin the AWS sample to a commit — it tracks the
-   live `Distribution`/OAC API and will drift.
+- **No reference example covers the showcase's scope in one place.** A and B stop at a secure CDN; the
+  alarms, SNS routing, health checks and budget guard that make a site _operable_ are left to you.
+- **Normalise before comparing lines.** At equal output ComposureCDK is well under half of A's code
+  (§7.2); the larger win is everything A doesn't do.
+- **B's three-line headline is a domainless throwaway.** A custom domain pulls back the raw-L2 props
+  spread plus hand-written cert/DNS (§4) — B is production-capable only on the default CloudFront domain.
+- **The differentiator is the operability layer.** Going from "secure CDN" to "fully-alarmed,
+  budget-guarded, multi-stack site" is a `.recommendedAlarms()` and one `alarmActionsPolicy()` in
+  ComposureCDK, versus ~120–180 lines of `new Alarm(...)` and third-party wiring in idiomatic CDK.
+
+This page is the long-form companion to the [Showcase](showcase.md), which carries the short canonical
+example and the list of real-world consumers.
 
 ## Sources
 

--- a/docs/comparison-report.md
+++ b/docs/comparison-report.md
@@ -174,18 +174,18 @@ The showcase collapses that into `.recommendedAlarms({ errorRate: { threshold: 2
 Being straight about the trade-offs:
 
 - **It's a dependency, and a new vocabulary.** ComposureCDK is a set of `@composurecdk/*` packages to adopt and track, and `compose` / `ref` / builders are concepts your team has to learn. That cost is real and front-loaded. (Note that B and C's monitoring libraries are dependencies too — the honest question isn't "deps vs. no deps," it's which dependency buys the most.)
-- **For a true throwaway, reach for B.** An internal distribution on the default `*.cloudfront.net` domain, with no custom domain and nothing operational, is three lines of `CloudFrontToS3` and that's the right tool. ComposureCDK starts paying off once the site is real — a custom domain, alarms, a budget — which, as §4 shows, arrives almost immediately.
+- **For a true throwaway, reach for B.** An internal distribution on the default `*.cloudfront.net` domain, with no custom domain and nothing operational, is three lines of `CloudFrontToS3` and that's the right tool. ComposureCDK starts paying off once the site is real — a custom domain, alarms, a budget — which, as [§4](#4-reference-b--cloudfronttos3-aws-solutions-constructs) shows, arrives almost immediately.
 - **On the shared core, the win is ergonomics, not capability.** Where ComposureCDK's output matches B's defaults (private/OAC bucket, logging, SSL, security headers), it isn't doing anything B can't — the difference is that the baseline is a default you can't forget rather than props you maintain, and overrides read as a fluent chain rather than a nested bag.
 
 ## 8. Takeaways
 
 If you're building and _operating_ a real static site on S3 + CloudFront, ComposureCDK is the higher-leverage choice — and the reasons are concrete:
 
-- **The well-architected baseline is free and unforgettable.** Versioned/RETAIN buckets, OAC, SSL enforcement, access logging and the recommended alarm set are defaults, so they can't be omitted by accident and don't cost you a line. At equal functionality the stack is roughly half the code of the canonical AWS example (§3), and the parts that vanish are exactly the parts you'd otherwise copy-paste and have to keep correct.
-- **The operational layer is the real differentiator.** Going from "secure CDN" to "fully-alarmed, budget-guarded, multi-stack site" is a `.recommendedAlarms()` per resource and one `alarmActionsPolicy()` — versus the ~120–180 lines of `new Alarm(...)` and third-party wiring that no off-the-shelf example gives you (§5).
+- **The well-architected baseline is free and unforgettable.** Versioned/RETAIN buckets, OAC, SSL enforcement, access logging and the recommended alarm set are defaults, so they can't be omitted by accident and don't cost you a line. At equal functionality the stack is roughly half the code of the canonical AWS example ([§3](#3-reference-a--aws-cdk-examplesstatic-site)), and the parts that vanish are exactly the parts you'd otherwise copy-paste and have to keep correct.
+- **The operational layer is the real differentiator.** Going from "secure CDN" to "fully-alarmed, budget-guarded, multi-stack site" is a `.recommendedAlarms()` per resource and one `alarmActionsPolicy()` — versus the ~120–180 lines of `new Alarm(...)` and third-party wiring that no off-the-shelf example gives you ([§5](#5-reference-c--assembling-the-operational-layer-yourself)).
 - **The code reads as intent.** Defaults are invisible; only your decisions show. Dependencies are declared as data via `compose`/`ref` instead of implied by statement order, which is what keeps the stack legible as the surface grows.
 
-The honest counterweight: you're taking on a dependency and a small learning curve, and for a genuine throwaway a single-construct option is simpler (§7). For anything you intend to run in production, that trade goes ComposureCDK's way — and the [showcase](showcase.md) consumers are the working proof.
+The honest counterweight: you're taking on a dependency and a small learning curve, and for a genuine throwaway a single-construct option is simpler ([§7](#7-where-composurecdk-isnt-the-right-call)). For anything you intend to run in production, that trade goes ComposureCDK's way — and the [showcase](showcase.md) consumers are the working proof.
 
 ## Sources
 

--- a/docs/comparison-report.md
+++ b/docs/comparison-report.md
@@ -1,0 +1,250 @@
+# ComposureCDK vs. idiomatic CDK — static-website comparison
+
+> **Status:** draft research report for maintainers. Not yet part of the published docs.
+> Purpose: evaluate how the ComposureCDK static-website showcase reads against the
+> canonical AWS / community CDK examples, and decide what (if anything) to lift into
+> public documentation.
+
+## 1. Why this comparison
+
+The [showcase](showcase.md) and the [`ComposureCDK-StaticWebsiteStack`](../packages/examples/src/static-website/app.ts)
+example both center on the same well-trodden architecture: **a static site on S3, fronted
+by CloudFront, with TLS, DNS, content deployment, alarms, health checks and a budget guard.**
+This is the single most common "hello world plus production hardening" shape in the CDK
+ecosystem, which makes it the fairest place to put ComposureCDK's conciseness/readability
+claims next to what an engineer would otherwise copy from AWS.
+
+The comparison targets three reference points, chosen to span the realistic spectrum of
+"what would I reach for instead":
+
+| #   | Reference                                                                                                                                                                                                                                                                                                                                                                                                | What it represents                                                                       |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| A   | [`aws-samples/aws-cdk-examples` → `typescript/static-site`](https://github.com/aws-samples/aws-cdk-examples/blob/main/typescript/static-site/static-site.ts)                                                                                                                                                                                                                                             | The **canonical, hand-written L2** example AWS itself ships and most blogs clone.        |
+| B   | [`@aws-solutions-constructs/aws-cloudfront-s3` (`CloudFrontToS3`)](https://docs.aws.amazon.com/solutions/latest/constructs/aws-cloudfront-s3.html)                                                                                                                                                                                                                                                       | The **opinionated L3 pattern** — maximum concision, fixed scope.                         |
+| C   | Community / AWS-blog hand-rolled stacks (e.g. the [APN "secure & scalable" CDK post](https://aws.amazon.com/blogs/apn/automating-secure-and-scalable-website-deployment-on-aws-with-amazon-cloudfront-and-aws-cdk/), [pepperize `cdk-route53-health-check`](https://github.com/pepperize/cdk-route53-health-check), [`cdk-monitoring-constructs`](https://github.com/cdklabs/cdk-monitoring-constructs)) | What people actually assemble when they need **monitoring + health checks** on top of A. |
+
+The headline finding up front: **no canonical example covers the same feature set as the
+ComposureCDK showcase in one place.** A and B stop well short of alarms, health checks and
+cost guards; reaching parity means hand-assembling C's pieces. So the comparison is partly
+"same job, fewer lines" (A, B) and partly "a job no single reference example actually does" (C).
+
+## 2. The ComposureCDK baseline
+
+Two artefacts make up the showcase:
+
+- **The runnable example** — [`static-website/app.ts`](../packages/examples/src/static-website/app.ts),
+  ~110 lines including generous doc comments and _two_ inline CloudFront functions. Synth-verified
+  (see [`static-website-app.test.ts`](../packages/examples/test/static-website-app.test.ts)) to produce:
+  3 buckets (content + S3 access-log + CloudFront access-log), all private/encrypted/SSL-enforced;
+  OAC; security-headers response policy; HTTP/2+3; PriceClass_100; HTTP→HTTPS; custom 403/404 error
+  pages; a multi-behavior distribution (`/api/*` → HTTP origin); and **recommended CloudWatch alarms**
+  for CloudFront (5xx error rate, origin latency), S3 (4xx/5xx) and each CloudFront function
+  (execution errors / validation errors / throttles), all routed to an SNS topic via one
+  `alarmActionsPolicy(...)` call.
+- **The case studies** ([jasonduffett.net](https://github.com/laazyj/jasonduffett.net), ukehoot.net,
+  uke-o-ono.com) — the _full_ production shape: Route 53 zone, `us-east-1` ACM cert with `www` SAN,
+  health-check alarms, a hard monthly **AWS Budgets** guard, GitHub-OIDC deploy role, multi-stack split.
+
+The defining property of both: **the well-architected baseline is the default, not the code.**
+Versioned/RETAIN buckets, server access logging, DNS query logging, OAC, SSL enforcement, scoped
+IAM and the recommended alarm set come from builder defaults ([architecture.md](architecture.md#defaults)),
+so the source reads as _only the site-specific decisions_ — redirects, the cross-region cert,
+alarm thresholds — rather than restating boilerplate.
+
+## 3. Reference A — `aws-cdk-examples/static-site`
+
+The canonical example, in full, is a single ~90-line `Construct`:
+
+```typescript
+const zone = route53.HostedZone.fromLookup(this, "Zone", { domainName: props.domainName });
+const siteDomain = props.siteSubDomain + "." + props.domainName;
+
+const siteBucket = new s3.Bucket(this, "SiteBucket", {
+  blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const certificate = new acm.Certificate(this, "SiteCertificate", {
+  domainName: siteDomain,
+  validation: acm.CertificateValidation.fromDns(zone),
+});
+
+const distribution = new cloudfront.Distribution(this, "SiteDistribution", {
+  certificate,
+  defaultRootObject: "index.html",
+  domainNames: [siteDomain],
+  minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
+  errorResponses: [
+    {
+      httpStatus: 403,
+      responseHttpStatus: 403,
+      responsePagePath: "/error.html",
+      ttl: Duration.minutes(30),
+    },
+  ],
+  defaultBehavior: {
+    origin: cloudfront_origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+    compress: true,
+    allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+    viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+  },
+});
+
+new route53.ARecord(this, "SiteAliasRecord", {
+  recordName: siteDomain,
+  target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+  zone,
+});
+
+new s3deploy.BucketDeployment(this, "DeployWithInvalidation", {
+  sources: [s3deploy.Source.asset(path.join(__dirname, "./site-contents"))],
+  destinationBucket: siteBucket,
+  distribution,
+  distributionPaths: ["/*"],
+});
+```
+
+**Functionality vs. showcase.** Covers S3 + OAC + CloudFront + DNS-validated ACM + Route 53 alias +
+content deploy with invalidation. **Absent:** any CloudWatch alarm, SNS topic, Route 53 health check,
+budget guard, CloudFront/S3 access logging, security-headers policy, `www` SAN, second behavior, and
+CloudFront functions. It also makes two choices a production site usually reverses: a `DESTROY` +
+`autoDeleteObjects` content bucket (ComposureCDK defaults to versioned/RETAIN), and an unlogged
+distribution.
+
+**Code coherence.** Good, within its scope. It's a flat procedural sequence; the dependency order
+(bucket → cert → distribution → record → deploy) is implicit in line order — exactly the "dependencies
+as execution order, not data" pattern [architecture.md](architecture.md#design-drivers) calls out.
+Wiring is by local variable (`siteBucket`, `distribution` threaded by hand). Fine at this size; it's
+the thing that doesn't scale as the alarm/health-check/budget surface grows.
+
+**Conciseness.** Genuinely compact **for what it does** — but it does perhaps 40% of the showcase's job.
+Normalising for functionality, ComposureCDK is far ahead: reaching this example's _exact_ output in
+ComposureCDK is the `bucket` + `cdn` + `deploy` components (≈20 lines), and the defaults it omits
+(logging, SSL enforcement, security headers, RETAIN) come for free rather than as extra lines.
+
+**Readability.** Very approachable for a newcomer — plain constructs, no framework concepts. The cost
+is that _intent_ and _boilerplate_ sit at the same altitude: `minimumProtocolVersion`, `allowedMethods`,
+`compress` are restated every time, and nothing signals which values are deliberate vs. inherited.
+ComposureCDK inverts this — defaults are invisible, deviations are loud.
+
+## 4. Reference B — `CloudFrontToS3` (AWS Solutions Constructs)
+
+The opposite extreme. The minimal deployment is:
+
+```typescript
+import { CloudFrontToS3 } from "@aws-solutions-constructs/aws-cloudfront-s3";
+
+new CloudFrontToS3(this, "static-site", {});
+```
+
+Out of the box it provisions a private content bucket, an S3 access-log bucket, a CloudFront
+distribution with OAC, a CloudFront access-log bucket, HTTP→HTTPS, and (by default) injected HTTP
+security headers.
+
+**Functionality vs. showcase.** Strong on the S3/CloudFront/logging/OAC/security-headers core —
+that part overlaps the showcase's _defaults_ closely, which is a useful external corroboration that
+ComposureCDK's baked-in baseline matches AWS's own opinion. **Absent and not its job:** ACM, custom
+domain/DNS, alarms, SNS, health checks, budgets, content deployment, CloudFront functions.
+
+**Code coherence.** Highest of all references — one construct, one identity, nothing to wire. But it's
+coherent because it's _closed_: customisation happens through a wide `...Props` override surface, and
+once you need a custom-domain cert, a second origin, or your own alarm thresholds you're back to passing
+raw L2 props into the construct — the readability gain erodes exactly where the showcase adds value.
+
+**Conciseness.** Unbeatable at three lines, but it's three lines for a strictly smaller scope. It's the
+right comparison for "do I even need a builder library for a trivial private bucket + CDN?" and an honest
+report should concede B wins that narrow case. It is _not_ a comparison for the production shape.
+
+**Readability.** Maximal at first glance, lower under modification — the meaning of a `CloudFrontToS3`
+depends on knowing its (large) default set, and overrides are positional props rather than a fluent,
+self-documenting chain.
+
+## 5. Reference C — the "add monitoring yourself" reality
+
+There is **no single canonical example** that matches the showcase's full feature set (verified by
+search across aws-samples, awslabs, Constructs Hub and the AWS blogs). To get there from A you bolt on:
+
+- an **SNS topic** + subscription;
+- **CloudWatch alarms** — CloudFront `5xxErrorRate` and `OriginLatency`, S3 `4xx/5xxErrors` (needs the
+  request-metrics filter enabled), and per-function error/throttle alarms — each with `alarmActions`;
+- a **Route 53 health check** + its companion alarm (commonly via [`pepperize/cdk-route53-health-check`](https://github.com/pepperize/cdk-route53-health-check)
+  or [`cdk-monitoring-constructs`](https://github.com/cdklabs/cdk-monitoring-constructs));
+- an **AWS Budgets** monthly guard.
+
+In idiomatic CDK each alarm is ~6–10 lines (metric → alarm → `addAlarmAction`), repeated per metric,
+so parity with the showcase is realistically **+120–180 lines** of mechanical, easy-to-get-subtly-wrong
+code (right metric namespace, statistic, period, missing-data handling) on top of A's ~90.
+
+**Functionality.** This is the only reference that _can_ reach parity — by composition of third-party
+libraries the team must select, version and wire themselves.
+
+**Code coherence.** This is where hand-rolled CDK is weakest and the showcase strongest. Alarms live far
+from the resource they watch; the SNS action is repeated on every alarm; thresholds are scattered. The
+showcase collapses all of that into `.recommendedAlarms({ errorRate: { threshold: 2 } })` on the resource
+itself, plus **one** `alarmActionsPolicy(stack, { defaults: { alarmActions: [new SnsAction(alerts.topic)] } })`
+that routes _every_ alarm in the stack — a genuinely different coherence story, not just fewer characters.
+
+**Conciseness / readability.** No contest at parity scope: a fluent `.recommendedAlarms(...)` that encodes
+the AWS-recommended metric set reads as intent; a hand-built `new Alarm(this, 'Cf5xx', { metric: distribution.metric5xxErrorRate(...), threshold, evaluationPeriods, ... })` repeated six times reads as plumbing.
+
+## 6. Feature matrix
+
+| Capability                                 | A · aws-cdk-examples | B · CloudFrontToS3 | C · hand-rolled + libs | **ComposureCDK showcase** |
+| ------------------------------------------ | :------------------: | :----------------: | :--------------------: | :-----------------------: |
+| S3 content bucket (private, OAC)           |          ✅          |         ✅         |           ✅           |            ✅             |
+| Versioned / RETAIN by default              |     ❌ (DESTROY)     |     ⚠️ partial     |         manual         |        ✅ default         |
+| S3 + CloudFront access logging             |          ❌          |         ✅         |         manual         |        ✅ default         |
+| Security-headers policy                    |          ❌          |         ✅         |         manual         |        ✅ default         |
+| ACM cert (DNS-validated, `us-east-1`, SAN) |     ✅ (no SAN)      |         ❌         |         manual         |            ✅             |
+| Route 53 alias records                     |          ✅          |         ❌         |         manual         |            ✅             |
+| Content deploy + invalidation              |          ✅          |         ❌         |         manual         |            ✅             |
+| CloudFront functions / multi-behavior      |          ❌          |         ❌         |         manual         |            ✅             |
+| CloudWatch alarms (recommended set)        |          ❌          |         ❌         |  manual (~per metric)  |     ✅ one call each      |
+| SNS routing for all alarms                 |          ❌          |         ❌         |   repeated per alarm   |    ✅ one policy call     |
+| Route 53 health-check alarm                |          ❌          |         ❌         |     3rd-party lib      |            ✅             |
+| AWS Budgets guard                          |          ❌          |         ❌         |         manual         |            ✅             |
+| Multi-stack / cross-region split           |          ❌          |         ❌         |         manual         |    ✅ `.withStacks()`     |
+| **Well-architected baseline as default**   |          ❌          |     ⚠️ partial     |           ❌           |            ✅             |
+
+## 7. Honest caveats (where the comparison is _not_ one-sided)
+
+A credible public-doc comparison should pre-empt the obvious rebuttals:
+
+1. **Trivial scope favours B.** For "a private bucket behind a CDN, nothing else," `CloudFrontToS3` in
+   three lines beats anything. Lead with the production shape, not the toy, or the conciseness claim
+   looks cherry-picked.
+2. **A is doing less, so its line count is unfairly flattering.** Always normalise: compare _at equal
+   functionality_. The fair statement is "ComposureCDK reaches A's output in ~20 lines with more secure
+   defaults, and reaches the _full_ showcase in ~110 where A would need ~250+."
+3. **Learning curve.** A and B use only stock CDK; ComposureCDK adds `compose` / `ref` / builders concepts.
+   The payoff is real but non-zero to learn — worth stating plainly rather than hiding.
+4. **Library/version surface.** ComposureCDK is a set of `@composurecdk/*` packages to adopt and track;
+   A is copy-paste, B is one dependency. The trade is "more deps, less bespoke code."
+5. **Don't overclaim on functional difference.** Where ComposureCDK's _output_ matches B's defaults
+   (logging, OAC, SSL), the win is authoring ergonomics and override visibility, not capability. Say so.
+
+## 8. Recommendation for public documentation
+
+1. **Add a "Compared to idiomatic CDK" section** (in `showcase.md` or a sibling page) built around the
+   **feature matrix in §6** — it's the most defensible, skimmable artefact and makes the "no single
+   example does all this" point immediately.
+2. **Use one head-to-head snippet at equal functionality**: the canonical `aws-cdk-examples/static-site`
+   beside the equivalent ComposureCDK `bucket`/`cdn`/`deploy` components, annotated to show which lines
+   ComposureCDK _removes_ (they become defaults). This is the strongest single image.
+3. **Frame the alarm/health/budget story as the differentiator**, since that's where reference examples
+   genuinely run out — "from secure CDN to fully-alarmed, budget-guarded site is one
+   `.recommendedAlarms()` and one `alarmActionsPolicy()` away, not 150 lines of `new Alarm(...)`."
+4. **Keep the caveats from §7 in the published version.** A comparison that concedes B's three-line win
+   and normalises for scope reads as confident and trustworthy; one that doesn't invites the rebuttal.
+5. **Attribute and link** every reference example, and pin the AWS sample to a commit — it tracks the
+   live `Distribution`/OAC API and will drift.
+
+## Sources
+
+- [aws-samples/aws-cdk-examples — typescript/static-site](https://github.com/aws-samples/aws-cdk-examples/blob/main/typescript/static-site/static-site.ts)
+- [AWS Solutions Constructs — aws-cloudfront-s3](https://docs.aws.amazon.com/solutions/latest/constructs/aws-cloudfront-s3.html)
+- [AWS APN blog — Automating Secure and Scalable Website Deployment with CloudFront and CDK](https://aws.amazon.com/blogs/apn/automating-secure-and-scalable-website-deployment-on-aws-with-amazon-cloudfront-and-aws-cdk/)
+- [pepperize/cdk-route53-health-check](https://github.com/pepperize/cdk-route53-health-check)
+- [cdklabs/cdk-monitoring-constructs](https://github.com/cdklabs/cdk-monitoring-constructs)
+- ComposureCDK: [`static-website/app.ts`](../packages/examples/src/static-website/app.ts), [`showcase.md`](showcase.md), [`architecture.md`](architecture.md)

--- a/docs/comparison-report.md
+++ b/docs/comparison-report.md
@@ -1,54 +1,32 @@
 # ComposureCDK vs. idiomatic CDK — static-website comparison
 
-> A deep-dive companion to the [Showcase](showcase.md). It compares the ComposureCDK
-> static-website pattern against the canonical AWS and community CDK examples for the
-> same architecture — what each builds, and how they read at equal functionality.
+> A deep-dive companion to the [Showcase](showcase.md). If you're building a static site on
+> S3 + CloudFront and weighing ComposureCDK against the examples you'd otherwise copy, this
+> page lays the realistic options side by side — what each one builds, how the code reads, and
+> where ComposureCDK is _not_ the better choice.
 
-## 1. Why this comparison
+## 1. The options you're actually choosing between
 
-The [showcase](showcase.md) and the [`ComposureCDK-StaticWebsiteStack`](../packages/examples/src/static-website/app.ts)
-example both center on the same well-trodden architecture: **a static site on S3, fronted
-by CloudFront, with TLS, DNS, content deployment, alarms, health checks and a budget guard.**
-This is the single most common "hello world plus production hardening" shape in the CDK
-ecosystem, which makes it the fairest place to put ComposureCDK's conciseness/readability
-claims next to what an engineer would otherwise copy from AWS.
+The [showcase](showcase.md) and the [`ComposureCDK-StaticWebsiteStack`](../packages/examples/src/static-website/app.ts) example both target the same well-trodden architecture: **a static site on S3, fronted by CloudFront, with TLS, DNS, content deployment, alarms, health checks and a budget guard.** It's the most common "simple until it isn't" shape in the CDK ecosystem, which makes it a good place to compare honestly.
 
-The comparison targets three reference points, chosen to span the realistic spectrum of
-"what would I reach for instead":
+Three reference points span what an engineer realistically reaches for instead:
 
-| #   | Reference                                                                                                                                                                                                                                                                                                                                                                                                | What it represents                                                                       |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| A   | [`aws-samples/aws-cdk-examples` → `typescript/static-site`](https://github.com/aws-samples/aws-cdk-examples/blob/main/typescript/static-site/static-site.ts)                                                                                                                                                                                                                                             | The **canonical, hand-written L2** example AWS itself ships and most blogs clone.        |
-| B   | [`@aws-solutions-constructs/aws-cloudfront-s3` (`CloudFrontToS3`)](https://docs.aws.amazon.com/solutions/latest/constructs/aws-cloudfront-s3.html)                                                                                                                                                                                                                                                       | The **opinionated L3 pattern** — maximum concision, fixed scope.                         |
-| C   | Community / AWS-blog hand-rolled stacks (e.g. the [APN "secure & scalable" CDK post](https://aws.amazon.com/blogs/apn/automating-secure-and-scalable-website-deployment-on-aws-with-amazon-cloudfront-and-aws-cdk/), [pepperize `cdk-route53-health-check`](https://github.com/pepperize/cdk-route53-health-check), [`cdk-monitoring-constructs`](https://github.com/cdklabs/cdk-monitoring-constructs)) | What people actually assemble when they need **monitoring + health checks** on top of A. |
+| #   | Reference                                                                                                                                                                                                                                                                                                                                                                                                | What it is                                                                  |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| A   | [`aws-samples/aws-cdk-examples` → `typescript/static-site`](https://github.com/aws-samples/aws-cdk-examples/blob/main/typescript/static-site/static-site.ts)                                                                                                                                                                                                                                             | The **canonical, hand-written L2** example AWS ships and most blogs clone.  |
+| B   | [`@aws-solutions-constructs/aws-cloudfront-s3` (`CloudFrontToS3`)](https://docs.aws.amazon.com/solutions/latest/constructs/aws-cloudfront-s3.html)                                                                                                                                                                                                                                                       | The **opinionated L3 pattern** — maximum concision, fixed scope.            |
+| C   | Community / AWS-blog hand-rolled stacks (e.g. the [APN "secure & scalable" CDK post](https://aws.amazon.com/blogs/apn/automating-secure-and-scalable-website-deployment-on-aws-with-amazon-cloudfront-and-aws-cdk/), [pepperize `cdk-route53-health-check`](https://github.com/pepperize/cdk-route53-health-check), [`cdk-monitoring-constructs`](https://github.com/cdklabs/cdk-monitoring-constructs)) | What you assemble when you need **monitoring + health checks** on top of A. |
 
-The headline finding up front: **no canonical example covers the same feature set as the
-ComposureCDK showcase in one place.** A and B stop well short of alarms, health checks and
-cost guards; reaching parity means hand-assembling C's pieces. So the comparison is partly
-"same job, fewer lines" (A, B) and partly "a job no single reference example actually does" (C).
+The single most important finding: **no off-the-shelf example covers the showcase's feature set in one place.** A and B stop well short of alarms, health checks and cost guards; reaching that point means hand-assembling C's pieces yourself. So part of this is "same job, fewer lines" (A, B) and part is "a job no single reference example actually does" (C).
 
-## 2. The ComposureCDK baseline
+## 2. What the ComposureCDK showcase builds
 
 Two artefacts make up the showcase:
 
-- **The runnable example** — [`static-website/app.ts`](../packages/examples/src/static-website/app.ts),
-  ~110 lines including generous doc comments and _two_ inline CloudFront functions. Synth-verified
-  (see [`static-website-app.test.ts`](../packages/examples/test/static-website-app.test.ts)) to produce:
-  3 buckets (content + S3 access-log + CloudFront access-log), all private/encrypted/SSL-enforced;
-  OAC; security-headers response policy; HTTP/2+3; PriceClass_100; HTTP→HTTPS; custom 403/404 error
-  pages; a multi-behavior distribution (`/api/*` → HTTP origin); and **recommended CloudWatch alarms**
-  for CloudFront (5xx error rate, origin latency), S3 (4xx/5xx) and each CloudFront function
-  (execution errors / validation errors / throttles), all routed to an SNS topic via one
-  `alarmActionsPolicy(...)` call.
-- **The case studies** ([jasonduffett.net](https://github.com/laazyj/jasonduffett.net), ukehoot.net,
-  uke-o-ono.com) — the _full_ production shape: Route 53 zone, `us-east-1` ACM cert with `www` SAN,
-  health-check alarms, a hard monthly **AWS Budgets** guard, GitHub-OIDC deploy role, multi-stack split.
+- **The runnable example** — [`static-website/app.ts`](../packages/examples/src/static-website/app.ts), ~110 lines including generous doc comments and _two_ inline CloudFront functions. Synth-verified (see [`static-website-app.test.ts`](../packages/examples/test/static-website-app.test.ts)) to produce: 3 buckets (content + S3 access-log + CloudFront access-log), all private/encrypted/SSL-enforced; OAC; security-headers response policy; HTTP/2+3; PriceClass_100; HTTP→HTTPS; custom 403/404 error pages; a multi-behavior distribution (`/api/*` → HTTP origin); and **recommended CloudWatch alarms** for CloudFront (5xx error rate, origin latency), S3 (4xx/5xx) and each CloudFront function, all routed to an SNS topic via one `alarmActionsPolicy(...)` call.
+- **The case studies** ([jasonduffett.net](https://github.com/laazyj/jasonduffett.net), ukehoot.net, uke-o-ono.com) — the _full_ production shape: Route 53 zone, `us-east-1` ACM cert with `www` SAN, health-check alarms, a hard monthly **AWS Budgets** guard, GitHub-OIDC deploy role, multi-stack split.
 
-The defining property of both: **the well-architected baseline is the default, not the code.**
-Versioned/RETAIN buckets, server access logging, DNS query logging, OAC, SSL enforcement, scoped
-IAM and the recommended alarm set come from builder defaults ([architecture.md](architecture.md#defaults)),
-so the source reads as _only the site-specific decisions_ — redirects, the cross-region cert,
-alarm thresholds — rather than restating boilerplate.
+The property that matters for the comparison: **the well-architected baseline is the default, not the code.** Versioned/RETAIN buckets, server access logging, DNS query logging, OAC, SSL enforcement, scoped IAM and the recommended alarm set come from builder defaults ([architecture.md](architecture.md#defaults)), so the source reads as _only the site-specific decisions_ — redirects, the cross-region cert, alarm thresholds — rather than restating baselines on every resource.
 
 ## 3. Reference A — `aws-cdk-examples/static-site`
 
@@ -104,32 +82,15 @@ new s3deploy.BucketDeployment(this, "DeployWithInvalidation", {
 });
 ```
 
-**Functionality vs. showcase.** Covers S3 + OAC + CloudFront + DNS-validated ACM + Route 53 alias +
-content deploy with invalidation. **Absent:** any CloudWatch alarm, SNS topic, Route 53 health check,
-budget guard, CloudFront/S3 access logging, security-headers policy, `www` SAN, second behavior, and
-CloudFront functions. It also makes two choices a production site usually reverses: a `DESTROY` +
-`autoDeleteObjects` content bucket (ComposureCDK defaults to versioned/RETAIN), and an unlogged
-distribution.
+It covers S3 + OAC + CloudFront + DNS-validated ACM + Route 53 alias + content deploy with invalidation — and nothing operational. No CloudWatch alarm, SNS topic, Route 53 health check or budget guard; no CloudFront/S3 access logging, security-headers policy, `www` SAN, second behavior or CloudFront functions. Two of its defaults are ones a production site usually reverses: a `DESTROY` + `autoDeleteObjects` content bucket (ComposureCDK defaults to versioned/RETAIN) and an unlogged distribution.
 
-**Code coherence.** Good, within its scope. It's a flat procedural sequence; the dependency order
-(bucket → cert → distribution → record → deploy) is implicit in line order — exactly the "dependencies
-as execution order, not data" pattern [architecture.md](architecture.md#design-drivers) calls out.
-Wiring is by local variable (`siteBucket`, `distribution` threaded by hand). Fine at this size; it's
-the thing that doesn't scale as the alarm/health-check/budget surface grows.
+For what it does, it's clear and approachable — plain constructs, no framework to learn. The two things that don't scale are visible even here: the components are wired by hand through local variables (`siteBucket`, `distribution`), so dependency order lives in line order rather than as data; and intent sits at the same altitude as boilerplate — `minimumProtocolVersion`, `allowedMethods` and `compress` are restated in full, with nothing marking which values are deliberate and which are just the recommended default. ComposureCDK inverts that last point: the defaults are invisible and only your deviations show.
 
-**Conciseness.** Genuinely compact **for what it does** — but it does perhaps 40% of the showcase's job.
-Normalising for functionality, ComposureCDK is far ahead: reaching this example's _exact_ output in
-ComposureCDK is the `bucket` + `cdn` + `deploy` components (≈20 lines), and the defaults it omits
-(logging, SSL enforcement, security headers, RETAIN) come for free rather than as extra lines.
-
-**Readability.** Very approachable for a newcomer — plain constructs, no framework concepts. The cost
-is that _intent_ and _boilerplate_ sit at the same altitude: `minimumProtocolVersion`, `allowedMethods`,
-`compress` are restated every time, and nothing signals which values are deliberate vs. inherited.
-ComposureCDK inverts this — defaults are invisible, deviations are loud.
+The honest size comparison is at _equal functionality_. A's resource + output code is ~46 lines (excluding imports and class scaffolding); the ComposureCDK equivalent for byte-identical output is ~20 — **roughly 43% of the code, a ~57% reduction** — and that's before crediting the secure defaults A leaves out. The reduction comes mostly from those defaults (logging, SSL enforcement, security headers, RETAIN) being free rather than hand-typed.
 
 ## 4. Reference B — `CloudFrontToS3` (AWS Solutions Constructs)
 
-The opposite extreme. The minimal deployment is:
+The opposite extreme — a single L3 construct. The minimal deployment really is three lines:
 
 ```typescript
 import { CloudFrontToS3 } from "@aws-solutions-constructs/aws-cloudfront-s3";
@@ -137,19 +98,9 @@ import { CloudFrontToS3 } from "@aws-solutions-constructs/aws-cloudfront-s3";
 new CloudFrontToS3(this, "static-site", {});
 ```
 
-Out of the box it provisions a private content bucket, an S3 access-log bucket, a CloudFront
-distribution with OAC, a CloudFront access-log bucket, HTTP→HTTPS, and (by default) injected HTTP
-security headers.
+Out of the box it provisions a private content bucket, an S3 access-log bucket, a CloudFront distribution with OAC, a CloudFront access-log bucket, HTTP→HTTPS, and injected HTTP security headers. That core overlaps the showcase's _defaults_ closely — useful external corroboration that ComposureCDK's baked-in baseline matches AWS's own opinion. What it deliberately doesn't do: ACM, custom domain/DNS, alarms, SNS, health checks, budgets, content deployment, CloudFront functions.
 
-**Functionality vs. showcase.** Strong on the S3/CloudFront/logging/OAC/security-headers core —
-that part overlaps the showcase's _defaults_ closely, which is a useful external corroboration that
-ComposureCDK's baked-in baseline matches AWS's own opinion. **Absent and not its job:** ACM, custom
-domain/DNS, alarms, SNS, health checks, budgets, content deployment, CloudFront functions.
-
-**Is it production-capable for even a trivial site? Not really.** The bare `{}` form serves only the
-generated `*.cloudfront.net` name — no custom domain, no ACM certificate, no DNS. The first thing any
-real site needs is its own domain, and that is exactly where the three-line story ends. To add one you
-pass a `cloudFrontDistributionProps` object and spread raw L2 `DistributionProps` into it:
+The three-line figure holds for exactly one situation, and it's worth being precise about which. The bare `{}` form serves only the generated `*.cloudfront.net` name — no custom domain, certificate or DNS. The first thing a real site needs is its own domain, and adding it means handing the construct a `cloudFrontDistributionProps` object with raw L2 `DistributionProps` spread into it:
 
 ```typescript
 new CloudFrontToS3(this, "site", {
@@ -164,28 +115,9 @@ new CloudFrontToS3(this, "site", {
 });
 ```
 
-— and you _still_ hand-write the `acm.Certificate` (in `us-east-1`) and the `route53.ARecord` yourself,
-because the construct creates neither. So for even a trivial _real_ site you are back to A's
-certificate/DNS code plus a nested props bag, with no alarms, health checks or budget. B is genuinely
-concise only for an internal/throwaway distribution on the default CloudFront domain.
+— and you _still_ write the `acm.Certificate` (in `us-east-1`) and the `route53.ARecord` yourself, because the construct creates neither. So for even a trivial _real_ site you're back to A's certificate/DNS code plus a nested props bag, still with no alarms, health checks or budget. The construct stays maximally readable while you live inside its defaults, but it's a _closed_ shape: customisation flows through the `cloudFrontDistributionProps` / `bucketProps` override surface, so the concision fades exactly where the showcase adds value (custom domain, a second origin, your own alarm thresholds). **B is genuinely the smallest option for one case: an internal/throwaway distribution on the default CloudFront domain.**
 
-**Code coherence.** Highest of all references _while you stay inside its defaults_ — one construct, one
-identity, nothing to wire. But it's coherent because it's _closed_: customisation happens through the
-`cloudFrontDistributionProps` / `bucketProps` override surface, so the readability gain erodes exactly
-where the showcase adds value (custom domain, second origin, alarm thresholds).
-
-**Conciseness.** Three lines — but only for the domainless throwaway above. As soon as a custom domain
-is required the count jumps to A's cert/DNS code plus a nested props bag. The honest concession is narrow:
-B wins _only_ the "internal distribution on the default CloudFront domain" case, not the production shape.
-
-**Readability.** Maximal at first glance, lower under modification — the meaning of a `CloudFrontToS3`
-depends on knowing its (large) default set, and overrides are nested raw-L2 props rather than a fluent,
-self-documenting chain.
-
-**A minimal, functionally-comparable ComposureCDK version.** Matching B's realistic trivial case — a
-private bucket behind a CDN _on a custom domain, with TLS and DNS_ — is itself only a handful of
-components, and unlike B it actually provisions the certificate and DNS records and ships secure defaults
-(versioned/RETAIN bucket, access logging) without extra lines:
+For comparison, matching B's _realistic_ trivial case in ComposureCDK — a private bucket behind a CDN on a custom domain, with TLS and DNS — is a handful of components, and unlike B it actually provisions the certificate and DNS records and ships the secure baseline for free rather than spread into a props bag:
 
 ```typescript
 const bucket = ref<BucketBuilderResult>("bucket").get("bucket");
@@ -205,36 +137,18 @@ compose(
 );
 ```
 
-Same output surface as B's _customised_ form, fewer moving parts than B-plus-hand-rolled-cert/DNS, and
-the secure baseline is free rather than spread into a props bag.
+## 5. Reference C — assembling the operational layer yourself
 
-## 5. Reference C — the "add monitoring yourself" reality
-
-There is **no single canonical example** that matches the showcase's full feature set (verified by
-search across aws-samples, awslabs, Constructs Hub and the AWS blogs). To get there from A you bolt on:
+There is **no single canonical example** that matches the showcase's full feature set (verified across aws-samples, awslabs, Constructs Hub and the AWS blogs). To reach it from A you bolt on, by hand:
 
 - an **SNS topic** + subscription;
-- **CloudWatch alarms** — CloudFront `5xxErrorRate` and `OriginLatency`, S3 `4xx/5xxErrors` (needs the
-  request-metrics filter enabled), and per-function error/throttle alarms — each with `alarmActions`;
-- a **Route 53 health check** + its companion alarm (commonly via [`pepperize/cdk-route53-health-check`](https://github.com/pepperize/cdk-route53-health-check)
-  or [`cdk-monitoring-constructs`](https://github.com/cdklabs/cdk-monitoring-constructs));
+- **CloudWatch alarms** — CloudFront `5xxErrorRate` and `OriginLatency`, S3 `4xx/5xxErrors` (which needs the request-metrics filter enabled), and per-function error/throttle alarms — each with its own `alarmActions`;
+- a **Route 53 health check** + companion alarm (commonly via [`pepperize/cdk-route53-health-check`](https://github.com/pepperize/cdk-route53-health-check) or [`cdk-monitoring-constructs`](https://github.com/cdklabs/cdk-monitoring-constructs));
 - an **AWS Budgets** monthly guard.
 
-In idiomatic CDK each alarm is ~6–10 lines (metric → alarm → `addAlarmAction`), repeated per metric,
-so parity with the showcase is realistically **+120–180 lines** of mechanical, easy-to-get-subtly-wrong
-code (right metric namespace, statistic, period, missing-data handling) on top of A's ~90.
+This is the only route that _reaches_ parity — by composing third-party libraries you select, version and wire yourself. It's also where the readability gap is widest. In idiomatic CDK each alarm is ~6–10 lines (metric → alarm → `addAlarmAction`), repeated per metric, so the operational layer alone is realistically **+120–180 lines** on top of A's ~90 — and it's the easy-to-get-subtly-wrong kind (right metric namespace, statistic, period, missing-data handling). The alarms also end up living far from the resources they watch, with the SNS action restated on each one.
 
-**Functionality.** This is the only reference that _can_ reach parity — by composition of third-party
-libraries the team must select, version and wire themselves.
-
-**Code coherence.** This is where hand-rolled CDK is weakest and the showcase strongest. Alarms live far
-from the resource they watch; the SNS action is repeated on every alarm; thresholds are scattered. The
-showcase collapses all of that into `.recommendedAlarms({ errorRate: { threshold: 2 } })` on the resource
-itself, plus **one** `alarmActionsPolicy(stack, { defaults: { alarmActions: [new SnsAction(alerts.topic)] } })`
-that routes _every_ alarm in the stack — a genuinely different coherence story, not just fewer characters.
-
-**Conciseness / readability.** No contest at parity scope: a fluent `.recommendedAlarms(...)` that encodes
-the AWS-recommended metric set reads as intent; a hand-built `new Alarm(this, 'Cf5xx', { metric: distribution.metric5xxErrorRate(...), threshold, evaluationPeriods, ... })` repeated six times reads as plumbing.
+The showcase collapses that into `.recommendedAlarms({ errorRate: { threshold: 2 } })` on the resource itself — the AWS-recommended metric set encoded once — plus a single `alarmActionsPolicy(stack, { defaults: { alarmActions: [new SnsAction(alerts.topic)] } })` that routes _every_ alarm in the stack. That's a different model, not just fewer characters: the intent lives next to the resource, and the wiring is declared once.
 
 ## 6. Feature matrix
 
@@ -255,41 +169,23 @@ the AWS-recommended metric set reads as intent; a hand-built `new Alarm(this, 'C
 | Multi-stack / cross-region split           |          ❌          |         ❌         |         manual         |    ✅ `.withStacks()`     |
 | **Well-architected baseline as default**   |          ❌          |     ⚠️ partial     |           ❌           |            ✅             |
 
-## 7. Honest caveats (where the comparison is _not_ one-sided)
+## 7. Where ComposureCDK isn't the right call
 
-A credible public-doc comparison should pre-empt the obvious rebuttals:
+Being straight about the trade-offs:
 
-1. **The domainless throwaway favours B.** For an internal distribution on the default
-   `*.cloudfront.net` name — no custom domain, cert, DNS or alarms — `CloudFrontToS3` in three lines
-   beats anything (see §4). That's the one case to concede, and it evaporates the moment a real domain
-   is added. Lead with the production shape, not the toy, or the conciseness claim looks cherry-picked.
-2. **A is doing less, so its line count is unfairly flattering.** Always normalise: compare _at equal
-   functionality_. A's resource + output code is ~46 lines (excluding imports and class scaffolding);
-   the ComposureCDK equivalent for byte-identical output is ~20 — **roughly 43% of the code, a ~57%
-   reduction** (≈22% of the full ~90-line file once imports/scaffolding are counted), and that is
-   _before_ crediting the secure defaults A omits. At the _full_ showcase scope ComposureCDK is ~110
-   lines where A-plus-C would need ~250+.
-3. **Learning curve.** A and B use only stock CDK; ComposureCDK adds `compose` / `ref` / builders concepts.
-   The payoff is real but non-zero to learn — worth stating plainly rather than hiding.
-4. **Library/version surface.** ComposureCDK is a set of `@composurecdk/*` packages to adopt and track;
-   A is copy-paste, B is one dependency. The trade is "more deps, less bespoke code."
-5. **Don't overclaim on functional difference.** Where ComposureCDK's _output_ matches B's defaults
-   (logging, OAC, SSL), the win is authoring ergonomics and override visibility, not capability. Say so.
+- **It's a dependency, and a new vocabulary.** ComposureCDK is a set of `@composurecdk/*` packages to adopt and track, and `compose` / `ref` / builders are concepts your team has to learn. That cost is real and front-loaded. (Note that B and C's monitoring libraries are dependencies too — the honest question isn't "deps vs. no deps," it's which dependency buys the most.)
+- **For a true throwaway, reach for B.** An internal distribution on the default `*.cloudfront.net` domain, with no custom domain and nothing operational, is three lines of `CloudFrontToS3` and that's the right tool. ComposureCDK starts paying off once the site is real — a custom domain, alarms, a budget — which, as §4 shows, arrives almost immediately.
+- **On the shared core, the win is ergonomics, not capability.** Where ComposureCDK's output matches B's defaults (private/OAC bucket, logging, SSL, security headers), it isn't doing anything B can't — the difference is that the baseline is a default you can't forget rather than props you maintain, and overrides read as a fluent chain rather than a nested bag.
 
 ## 8. Takeaways
 
-- **No reference example covers the showcase's scope in one place.** A and B stop at a secure CDN; the
-  alarms, SNS routing, health checks and budget guard that make a site _operable_ are left to you.
-- **Normalise before comparing lines.** At equal output ComposureCDK is well under half of A's code
-  (§7.2); the larger win is everything A doesn't do.
-- **B's three-line headline is a domainless throwaway.** A custom domain pulls back the raw-L2 props
-  spread plus hand-written cert/DNS (§4) — B is production-capable only on the default CloudFront domain.
-- **The differentiator is the operability layer.** Going from "secure CDN" to "fully-alarmed,
-  budget-guarded, multi-stack site" is a `.recommendedAlarms()` and one `alarmActionsPolicy()` in
-  ComposureCDK, versus ~120–180 lines of `new Alarm(...)` and third-party wiring in idiomatic CDK.
+If you're building and _operating_ a real static site on S3 + CloudFront, ComposureCDK is the higher-leverage choice — and the reasons are concrete:
 
-This page is the long-form companion to the [Showcase](showcase.md), which carries the short canonical
-example and the list of real-world consumers.
+- **The well-architected baseline is free and unforgettable.** Versioned/RETAIN buckets, OAC, SSL enforcement, access logging and the recommended alarm set are defaults, so they can't be omitted by accident and don't cost you a line. At equal functionality the stack is roughly half the code of the canonical AWS example (§3), and the parts that vanish are exactly the parts you'd otherwise copy-paste and have to keep correct.
+- **The operational layer is the real differentiator.** Going from "secure CDN" to "fully-alarmed, budget-guarded, multi-stack site" is a `.recommendedAlarms()` per resource and one `alarmActionsPolicy()` — versus the ~120–180 lines of `new Alarm(...)` and third-party wiring that no off-the-shelf example gives you (§5).
+- **The code reads as intent.** Defaults are invisible; only your decisions show. Dependencies are declared as data via `compose`/`ref` instead of implied by statement order, which is what keeps the stack legible as the surface grows.
+
+The honest counterweight: you're taking on a dependency and a small learning curve, and for a genuine throwaway a single-construct option is simpler (§7). For anything you intend to run in production, that trade goes ComposureCDK's way — and the [showcase](showcase.md) consumers are the working proof.
 
 ## Sources
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,6 +1,6 @@
 # Showcase
 
-Real-world projects built with ComposureCDK. The case studies here extend the smaller, pattern-focused stacks in [`packages/examples/`](../packages/examples/README.md) — they show what a complete system looks like once ComposureCDK's defaults, lifecycles, and builders are in production.
+Real-world projects and patterns built with ComposureCDK, grouped by the kind of system they build. Each category opens with what ComposureCDK gives you for that use case, a short canonical example, a link to a runnable example app, a deep-dive comparison against idiomatic CDK, and the real-world projects that run it in production. More categories will be added as the library grows.
 
 ## Add the badge
 
@@ -14,26 +14,11 @@ It renders as:
 
 [![Built with ComposureCDK](https://img.shields.io/badge/built%20with-ComposureCDK-0f0d0c?labelColor=b85416)](https://github.com/laazyj/composureCDK)
 
-## Case studies
+## Categories
 
-<!--
-Skeleton for new entries. Copy below the closing `-->`, fill in, and remove the comment.
+### Static sites on S3 + CloudFront
 
-### [Project Name](https://github.com/your-org/your-repo)
-
-Two to four sentences describing the project — what it does, the AWS surface it runs on, and how it uses ComposureCDK. Mention which packages it leans on most (e.g. `@composurecdk/lambda` + `@composurecdk/apigateway`) and any pattern that's specific to this deployment.
-
-```ts
-// Optional: a representative excerpt (≤ ~15 lines) showing the project's
-// composureCDK use. Aim for a snippet that wouldn't fit as a generic example
-// — something that captures *this* project's shape.
-```
-
--->
-
-### [jasonduffett.net](https://github.com/laazyj/jasonduffett.net)
-
-A static personal site (Eleventy) hosted on S3 + CloudFront with Route 53 DNS, an ACM certificate, health-check alarms, and a hard monthly budget guard — the whole stack composed from ComposureCDK builders. It exercises most of the surface area: `@composurecdk/cloudfront`, `@composurecdk/s3`, `@composurecdk/route53`, `@composurecdk/acm`, `@composurecdk/budgets`, `@composurecdk/sns`, plus `@composurecdk/iam` for the GitHub OIDC deploy role. The builder defaults do most of the heavy lifting — versioned/RETAIN buckets, server access logging, DNS query logging, and scoped IAM — so the stack code stays focused on what's specific to the site (redirects, the `us-east-1` certificate, alarm wiring) instead of restating well-architected baselines.
+A static site fronted by CloudFront over a private S3 origin is the canonical "simple until it isn't" deployment: the happy path is a bucket and a distribution, but a production site also wants TLS on a custom domain, DNS, content deployment, alarms, a health check and a cost guard — and in idiomatic CDK each of those is more boilerplate to write and keep correct. ComposureCDK collapses that: the well-architected baseline (private/OAC bucket, versioned + RETAIN, S3 and CloudFront access logging, SSL enforcement, security-headers policy, scoped IAM, the recommended alarm set) comes from builder **defaults**, so the stack code reads as only the decisions specific to _your_ site. Going from a secure CDN to a fully-alarmed, budget-guarded, multi-stack deployment is a `.recommendedAlarms()` on each resource and one `alarmActionsPolicy()` to route every alarm — not 150 lines of `new Alarm(...)`.
 
 ```ts
 const hostedZone = ref<HostedZoneBuilderResult>("zone").get("hostedZone");
@@ -47,39 +32,38 @@ return compose({
     .domainName(domain)
     .subjectAlternativeNames([www])
     .validationZone(hostedZone),
-  bucket: createBucketBuilder(), // versioned, RETAIN, access logs by default
+  bucket: createBucketBuilder(), // private/OAC, versioned, RETAIN, access logs by default
   cdn: createDistributionBuilder()
     .domainNames([domain, www])
     .certificate(certificate)
-    .origin(bucket.map((b) => S3BucketOrigin.withOriginAccessControl(b))),
+    .origin(bucket.map((b) => S3BucketOrigin.withOriginAccessControl(b)))
+    .recommendedAlarms({ errorRate: { threshold: 2 } }),
   aliasRecords: zoneRecords([ALIAS("@", cloudfrontAliasTarget(distribution))]).zone(hostedZone),
-  // …budgets, SNS topics, health checks, alarms elided
+  // …budgets, SNS topics, health checks elided
 }).withStacks({ zone: dnsStack, cert: certStack, cdn: siteStack /* … */ });
 ```
 
-### [ukehoot.net](https://github.com/laazyj/ukehoot.net)
+**Try it:** the runnable [`ComposureCDK-StaticWebsiteStack`](../packages/examples/src/static-website/app.ts) example synthesises a complete, test-verified stack — OAC bucket, multi-behavior distribution with CloudFront functions, custom error pages, content deployment, and recommended CloudFront/S3/function alarms routed to an SNS topic.
 
-The website for UkeHoot is a static Eleventy site on S3 + CloudFront with Route 53 DNS, an `us-east-1` ACM certificate, CloudWatch alarms, and a monthly budget guard. The infrastructure follows the same multi-region, multi-stack shape as [jasonduffett.net](#jasonduffettnet). Its distinguishing difference is a CloudFront function that serves 301 redirects for the group's legacy Tumblr URLs (2012–2018) to their archived equivalents.
+**How it compares:** [ComposureCDK vs. idiomatic CDK — static-website comparison](comparison-report.md) is a deep dive against the canonical AWS sample, the AWS Solutions Constructs `CloudFrontToS3` pattern, and hand-rolled community monitoring stacks — with a feature matrix, equal-functionality code comparison, and honest caveats.
 
-### [uke-o-ono.com](https://github.com/laazyj/ukeoono.com)
+**Built with ComposureCDK:**
 
-The single-page flyer for Edinburgh ukulele band Uke O Ono is another static Eleventy site on S3 + CloudFront, sharing the same builder defaults and multi-stack shape as [jasonduffett.net](#jasonduffettnet) — including a CloudFront function for the www→apex 301 and pretty-URL rewrite, CloudWatch alarms, and a monthly budget guard. Its distinguishing difference is **DNS hosted at Cloudflare rather than Route 53**: there is no `@composurecdk/route53` hosted-zone or alias-record builder, so the apex and `www` records are CNAMEs pointed at the distribution by hand in Cloudflare. With no zone to DNS-validate against, the `us-east-1` ACM certificate is validated manually in Cloudflare and imported by ARN, rather than created and validated by the `@composurecdk/acm` builder.
-
-```ts
-// No Route 53 zone, so the cert is validated by hand in Cloudflare and
-// imported by ARN instead of created/DNS-validated by the builder.
-const certificate = Certificate.fromCertificateArn(siteStack, "SiteCert", certArn);
-
-return compose({
-  bucket: createBucketBuilder(), // versioned, RETAIN, access logs by default
-  cdn: createDistributionBuilder()
-    .domainNames([domain, www])
-    .certificate(certificate)
-    .origin(bucket.map((b) => S3BucketOrigin.withOriginAccessControl(b))),
-  // …CloudFront redirect function, budgets, SNS topics, alarms elided
-}).withStacks({ cdn: siteStack /* …alerts, alarms, OIDC stacks */ });
-```
+- **[jasonduffett.net](https://github.com/laazyj/jasonduffett.net)** — the reference build, exercising most of the surface area: `@composurecdk/cloudfront` + `s3` + `route53` + `acm` + `budgets` + `sns`, plus `@composurecdk/iam` for the GitHub-OIDC deploy role, across a multi-region, multi-stack shape.
+- **[ukehoot.net](https://github.com/laazyj/ukehoot.net)** — the same shape, distinguished by a CloudFront function serving 301 redirects for the group's legacy Tumblr URLs (2012–2018) to their archived equivalents.
+- **[uke-o-ono.com](https://github.com/laazyj/ukeoono.com)** — DNS hosted at **Cloudflare rather than Route 53**: apex/`www` are CNAMEs pointed at the distribution by hand, and the `us-east-1` ACM certificate is validated manually and imported by ARN rather than created and DNS-validated by the builder.
 
 ## Submitting your project
 
-Open a pull request adding an entry under **Case studies** above, or open an issue if you'd prefer the maintainer to write the entry up. Entries should link to a public repo or homepage so readers can verify the project exists.
+Open a pull request adding your project under the relevant category above (or proposing a new category), or open an issue if you'd prefer the maintainer to write the entry up. Entries should link to a public repo or homepage so readers can verify the project exists.
+
+<!--
+Skeleton for a new consumer entry:
+
+- **[Project Name](https://github.com/your-org/your-repo)** — one sentence naming the project's
+  distinguishing difference from the others in its category.
+
+Skeleton for a new category: copy the "Static sites on S3 + CloudFront" structure — an opening
+paragraph on the use case, a short canonical snippet, a link to the example app, a link to a
+comparison deep-dive (if one exists), and the list of real-world consumers.
+-->


### PR DESCRIPTION
Draft research report comparing the static-website showcase against the
canonical AWS sample (aws-cdk-examples/static-site), the AWS Solutions
Construct (CloudFrontToS3), and hand-rolled community monitoring stacks.
Includes a feature matrix, equal-functionality code comparison, honest
caveats, and recommendations for incorporating into public docs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YKdx9CsAJxXV2sFVTBPAgQ