### PR TITLE
Add 'blocked' label merge gate workflow

### DIFF
--- a/.github/workflows/blocked-label.yml
+++ b/.github/workflows/blocked-label.yml
@@ -1,0 +1,21 @@
+name: Blocked label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  blocked:
+    name: Not blocked
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if 'blocked' label is present
+        if: contains(github.event.pull_request.labels.*.name, 'blocked')
+        run: |
+          echo "::error::This PR carries the 'blocked' label and cannot be merged. Remove the label to unblock."
+          exit 1


### PR DESCRIPTION
Adds a required-check workflow that fails whenever a PR targeting main
carries the 'blocked' label. The labeled/unlabeled triggers re-run the
check immediately so the merge button flips state without a new commit.

To take effect, the 'Not blocked' check must be marked required in the
main branch protection rule / ruleset.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hdKt2ietbrzcJ2k3suiNz