### PR TITLE
feat(lambda): guard SQS visibility-timeout against function timeout

### DIFF
--- a/docs/adr/0011-cross-component-relationship-guards.md
+++ b/docs/adr/0011-cross-component-relationship-guards.md
@@ -1,0 +1,144 @@
+# ADR 0011: Cross-component relationship guards — builder-registered synth-time Aspects
+
+- **Status:** Proposed
+- **Date:** 2026-06-27
+
+## Context
+
+Some AWS best practices are not properties of one resource but _relationships
+between two_. The motivating case (laazyj/composureCDK#123): an SQS source
+queue's `visibilityTimeout` should be ≥ 6× the consumer Lambda's `timeout`, so
+Lambda can retry a throttled batch before the message becomes visible again. Its
+sibling #124 (`maxReceiveCount` floor) is the same shape; more will follow as
+builders gain cross-wiring.
+
+Three properties make these relationships hard to guard, and none is addressed
+by the single-value constraint catalogue of
+[ADR-0010](0010-aws-property-constraints.md):
+
+1. **The relationship spans two components built at different times.** Under
+   `compose()`, the queue is built before the function (the function depends on
+   it). No single builder's `build()` sees both sides in a way that lets it
+   compare — ADR-0010 validators are single-value and single-builder.
+2. **The value needed is withheld by the sibling's L2.** Following CDK's
+   [design guidelines][cdk-guidelines], an L2 treats its props as a write-only
+   struct: `Queue` does not re-expose `visibilityTimeout`; only `QueueProps`
+   carries it. A consumer holding the queue (concrete or via `ref()`) cannot
+   read it from the L2.
+3. **The consumer must not reach across the dependency graph to get it.**
+   Surfacing the value as a field on the producer's _result_ (the rejected
+   `resolvedProps` mechanism, #122/#198) widens every builder's public contract
+   and exposes construct handles a consumer can wire into undeclared
+   CloudFormation edges, eroding the guarantee that the `compose()` dependency
+   map is the system's true edge set.
+
+The unlock: the value is withheld only at the **L2**. The generated **L1
+re-exposes the resolved CloudFormation property as a public member** —
+`CfnQueue.visibilityTimeout` is a public getter. And the construct tree is fully
+assembled, with final property values, by synth — exactly when CDK `Aspects`
+run, the timing [ADR-0002](0002-policies.md) already uses for scope-wide
+policies.
+
+## Decision
+
+**A builder may install a _relationship guard_: a synth-time Aspect, registered
+during `build()`, that reads a sibling's resolved value off its L1 construct and
+emits a suppressible warning when the relationship between the two components is
+violated. The guard is dispatched on the wiring's discriminator, reads scalars
+only, and stays silent whenever the value is not knowable.**
+
+Concretely, for the first instance (`FunctionBuilder` + SQS event source):
+
+1. **Registered by the builder, scoped to a known pair.** The guard is installed
+   _inside_ `build()`, closing over the specific `(function, queue)` pair the
+   builder just wired — not a user-invoked ADR-0002 Policy. Using the builder is
+   the opt-in, which keeps the check **secure-by-default**.
+
+2. **Dispatched on the wiring discriminator, never `instanceof` of CDK
+   internals.** The guard is selected from a `Record<EventSourceKind, …>` keyed
+   by the same discriminator the contextual alarms already use; a kind with no
+   relationship to guard maps to `undefined`. The bound source's queue is
+   reached through `SqsEventSource.queue` (a public getter) keyed on the same
+   `"sqs"` discriminator that constructed it.
+
+3. **Reads the value from the L1 via `queue.node.defaultChild`**, identified
+   with the same jsii-safe `isCfnResource`/`cfnResourceType` idiom as
+   `policy-matcher` (robust where `instanceof` fails across bundled CDK realms).
+   This is a **scalar read** — it creates no construct reference and so no
+   CloudFormation edge, leaving the dependency graph unperturbed.
+
+4. **Runs at synth, via an Aspect, for order-independence.** Deferring the read
+   to synth sees the _final_ `visibilityTimeout` regardless of build order or
+   later mutation, reusing the Aspect timing ADR-0002 established.
+
+5. **Warns, suppressibly; does not throw.** The relationship is advisory best
+   practice, so it emits `Annotations.of(fn).addWarningV2(id, …)` under a stable,
+   **exported** id a caller can silence with `acknowledgeWarning(id)` —
+   deliberately distinct from ADR-0010 constraints, which throw because they gate
+   validity.
+
+6. **Silent whenever the value is not knowable, and only on actual violation.**
+   It emits nothing for unresolved `Token`s, imported queues (no L1 child), or
+   bare escape-hatch sources; with both sides concrete it warns only when the
+   queue value falls below the computed target — never on a compliant or
+   default-correct configuration.
+
+7. **Lives in the owning package, on `aws-cdk-lib` types only.** As with
+   single-domain Policies (ADR-0002 §5) and local constraint data (ADR-0010 §2),
+   the guard and its dispatch table live in `@composurecdk/lambda` under
+   `event-sources/`, using only `aws-cdk-lib` types (`IQueue`, `CfnQueue`). It
+   introduces **no dependency on `@composurecdk/sqs`**.
+
+## Consequences
+
+- Cross-component best-practice relationships become real, reliable checks: a
+  violation surfaces at `cdk synth`/`deploy` at the authoring site, suppressible
+  by id, with no false positive on correct or default configurations. This
+  resolves #123 and unblocks #124.
+- **To add a guard:** register an Aspect in the producing builder's `build()`
+  that reads the sibling's resolved scalar off its L1 and warns on violation,
+  dispatched on the wiring's discriminator. In this package that dispatch is the
+  `EventSourceKind` table; #124 (`maxReceiveCount`, via `CfnQueue.redrivePolicy`)
+  is the next entry.
+- The technique applies only when the sibling's value is recoverable at synth
+  (its L1, or similar). A value that never reaches a synth-readable surface needs
+  a different channel.
+- **L1-read-at-synth is a sanctioned technique** for recovering a value an L2
+  withholds, in preference to surfacing it on the producer's result type.
+- A third validation idiom now sits beside the existing two, with an explicit
+  boundary. **ADR-0002 Policies:** user-invoked, scope-wide, cross-cutting side
+  effects. **ADR-0010 constraints:** single-value legality, throw, at `build()`.
+  **This ADR — relationship guards:** builder-registered, component-pair-scoped,
+  advisory, warn, at synth.
+- A builder that installs a guard takes on one Aspect per wired pair; the synth
+  cost is negligible.
+- Following ADR-0002's precedent, `architecture.md` is not yet amended; this ADR
+  stands alone until the pattern is exercised by more than one instance.
+
+## Alternatives considered
+
+- **Surface the value on the producer's result (`resolvedProps`, #122/#198).**
+  Rejected — see the close comments on both. It widens every builder's public
+  contract and leaks construct handles that let a consumer create CloudFormation
+  edges outside the declared graph; a scalar-only variant is less idiomatic
+  still. The premise that justified it — "the value is unrecoverable from the
+  construct" — is false at the L1.
+- **A user-invoked, tree-walking Policy (ADR-0002), e.g.
+  `sqsLambdaRelationshipsPolicy(scope)`.** Rejected as the _primary_ mechanism:
+  it is opt-in, so it sacrifices secure-by-default, and it must re-derive the
+  function↔queue pairing by resolving `CfnEventSourceMapping` ARN tokens back to
+  constructs. It remains attractive as a _complementary_ opt-in tool that would
+  also catch raw-CDK wirings (the "holistic Aspect keyed by CFN resource type"
+  ADR-0010 anticipates); if built, it should share this guard's comparison logic.
+- **Read the L1 value at `build()` instead of at synth.** Workable because the
+  producer is built first, but it reads a possibly-non-final value and couples
+  correctness to build order; the Aspect costs little and removes both risks.
+- **Throw via `node.addValidation()` rather than warn.** Rejected: it blocks
+  synth, which is wrong for advisory best practice. A below-6× visibility timeout
+  is deployable and sometimes intentional; it warrants a suppressible warning,
+  not a hard failure.
+- **A decorator (ADR-0006).** Rejected for the reason ADR-0010 deferred it: a
+  decorator cannot see the bound source or the merged props, both internal to
+  `build()`, and pays the stacking cost for no benefit here.
+
+[cdk-guidelines]: https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0008: Per-package aws-cdk-lib version floors](0008-aws-cdk-lib-version-floors.md)
 - [ADR-0009: Defaults yield to a mutually-exclusive user-set sibling prop](0009-defaults-yield-to-mutually-exclusive-siblings.md)
 - [ADR-0010: AWS-property constraints — a catalogue with central mechanism and local data](0010-aws-property-constraints.md)
+- [ADR-0011: Cross-component relationship guards — builder-registered synth-time Aspects](0011-cross-component-relationship-guards.md)

--- a/packages/lambda/src/event-sources/event-source-relationship-guards.ts
+++ b/packages/lambda/src/event-sources/event-source-relationship-guards.ts
@@ -1,0 +1,143 @@
+import { Annotations, Aspects, CfnResource, type Duration, Token } from "aws-cdk-lib";
+import type { Function as LambdaFunction, IEventSource } from "aws-cdk-lib/aws-lambda";
+import type { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import { CfnQueue, type IQueue } from "aws-cdk-lib/aws-sqs";
+import type { IConstruct } from "constructs";
+import type { EventSourceKind } from "./composure-event-source.js";
+
+/**
+ * AWS guidance: an SQS source queue's `visibilityTimeout` should be at least
+ * this multiple of the consumer function's `timeout`, so Lambda has room to
+ * retry a throttled batch before a message becomes visible again.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+ */
+const SQS_VISIBILITY_TIMEOUT_MULTIPLIER = 6;
+
+/** Lambda's own default `timeout` when none is set (CDK leaves it unset). */
+const LAMBDA_DEFAULT_TIMEOUT_SECONDS = 3;
+
+/** SQS's own default `visibilityTimeout` when none is set (applied by CloudFormation). */
+const SQS_DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 30;
+
+/**
+ * Suppression id for the SQS visibility-timeout relationship guard. Stable and
+ * part of the public surface — silence the warning with
+ * `Annotations.of(scope).acknowledgeWarning(SQS_VISIBILITY_TIMEOUT_WARNING_ID)`,
+ * so it must not be renamed casually.
+ */
+export const SQS_VISIBILITY_TIMEOUT_WARNING_ID = "@composurecdk/lambda:sqs-visibility-timeout";
+
+/**
+ * Guards a cross-component relationship that spans an attached event source and
+ * its consumer function. `FunctionBuilder` dispatches on {@link EventSourceKind}
+ * so it never has to `instanceof` CDK internals — see ADR-0011.
+ *
+ * @internal
+ */
+export type EventSourceRelationshipGuard = (
+  fn: LambdaFunction,
+  id: string,
+  key: string,
+  bound: IEventSource,
+  timeout: Duration | undefined,
+) => void;
+
+/**
+ * Per-kind relationship guards, keyed by {@link EventSourceKind}. A kind maps to
+ * the (possibly empty) list of relationships to guard for a source of that kind
+ * — SQS gains a second entry for the `maxReceiveCount` floor (#124), and a bare
+ * escape-hatch source attached as `"unknown"` has none.
+ *
+ * @internal
+ */
+export const EVENT_SOURCE_RELATIONSHIP_GUARDS: Record<
+  EventSourceKind,
+  EventSourceRelationshipGuard[]
+> = {
+  sqs: [guardSqsVisibilityTimeout],
+  dynamodb: [],
+  unknown: [],
+};
+
+/**
+ * The source queue behind a bound SQS event source. Safe cast: only reached for
+ * the `"sqs"` kind, whose source `sqsEventSource()` constructs as an
+ * {@link SqsEventSource} in the same call. `SqsEventSource.queue` is a public
+ * getter.
+ */
+function sqsQueue(bound: IEventSource): IQueue {
+  return (bound as SqsEventSource).queue;
+}
+
+/**
+ * Warns when the source queue's `visibilityTimeout` is below 6× the consumer
+ * function's `timeout`. Registers a synth-time Aspect so it reads the queue's
+ * *final* value off its L1 `CfnQueue` — the value the L2 `Queue` does not
+ * re-expose — regardless of build order or later mutation (ADR-0011).
+ */
+function guardSqsVisibilityTimeout(
+  fn: LambdaFunction,
+  id: string,
+  key: string,
+  bound: IEventSource,
+  timeout: Duration | undefined,
+): void {
+  const queue = sqsQueue(bound);
+
+  Aspects.of(fn).add({
+    visit(node: IConstruct): void {
+      // The Aspect visits fn and its subtree; act once, against fn itself.
+      if (node !== fn) return;
+
+      const target = targetVisibilityTimeoutSeconds(timeout);
+      if (target === undefined) return; // token timeout — no concrete target to compare
+
+      const actual = readVisibilityTimeoutSeconds(queue);
+      if (actual === undefined || actual >= target) return; // unknowable or compliant — stay quiet
+
+      Annotations.of(fn).addWarningV2(
+        SQS_VISIBILITY_TIMEOUT_WARNING_ID,
+        `FunctionBuilder "${id}": SQS event source "${key}" — source queue visibilityTimeout is ` +
+          `${String(actual)}s but should be >= ${String(target)}s ` +
+          `(${String(SQS_VISIBILITY_TIMEOUT_MULTIPLIER)}x the function timeout) so Lambda can retry ` +
+          `a throttled batch. See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html`,
+      );
+    },
+  });
+}
+
+/**
+ * The 6× target in seconds, derived from the function timeout (or Lambda's 3s
+ * default). `undefined` when the timeout is a token, which has no concrete
+ * target at synth time. Guards `isUnresolved` *before* converting, so a token
+ * Duration never reaches `toSeconds()`.
+ */
+function targetVisibilityTimeoutSeconds(timeout: Duration | undefined): number | undefined {
+  if (timeout === undefined) {
+    return SQS_VISIBILITY_TIMEOUT_MULTIPLIER * LAMBDA_DEFAULT_TIMEOUT_SECONDS;
+  }
+  if (timeout.isUnresolved()) return undefined;
+  return SQS_VISIBILITY_TIMEOUT_MULTIPLIER * timeout.toSeconds();
+}
+
+/**
+ * The queue's resolved `visibilityTimeout` in seconds, read off its L1
+ * `CfnQueue` (the L2 `Queue` does not re-expose it). `undefined` when the queue
+ * is imported (no L1 child) or the value is an unresolved token; `30` (the SQS
+ * default) when the L1 carries no explicit value.
+ */
+function readVisibilityTimeoutSeconds(queue: IQueue): number | undefined {
+  const child = queue.node.defaultChild;
+  if (
+    child === undefined ||
+    !CfnResource.isCfnResource(child) ||
+    child.cfnResourceType !== CfnQueue.CFN_RESOURCE_TYPE_NAME
+  ) {
+    return undefined;
+  }
+
+  const value = (child as CfnQueue).visibilityTimeout;
+  if (value === undefined) return SQS_DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+  return Token.isUnresolved(value) ? undefined : value;
+}

--- a/packages/lambda/src/event-sources/sqs-event-source.ts
+++ b/packages/lambda/src/event-sources/sqs-event-source.ts
@@ -44,16 +44,19 @@ export const DEFAULT_SQS_EVENT_SOURCE_PROPS: Pick<
  *
  * Applies {@link DEFAULT_SQS_EVENT_SOURCE_PROPS}; pass `props` to override.
  *
- * ## Cross-component invariants (not enforced)
+ * ## Cross-component invariants
  *
  * AWS Well-Architected guidance spans the queue and the function:
  * - the source queue's visibility timeout should be ≥ 6× the function
  *   timeout, leaving room for Lambda to retry a throttled batch;
  * - the source queue's redrive `maxReceiveCount` should be ≥ 5 before the DLQ.
  *
- * These are not validated here — the queue often arrives as a `ref()` that is
- * not resolvable at configuration time. Tracked in laazyj/composureCDK#123
- * and #124.
+ * The visibility-timeout rule is enforced as a synth-time **relationship
+ * guard**: when this source is attached to a {@link IFunctionBuilder}, the
+ * builder reads the queue's resolved `visibilityTimeout` off its L1 `CfnQueue`
+ * (the `Queue` construct does not re-expose it) and warns, suppressibly, on an
+ * actual violation — see ADR-0011. The `maxReceiveCount` floor is tracked in
+ * laazyj/composureCDK#124.
  *
  * @param queue - The source queue, concrete or a `ref()` to a sibling.
  * @param props - Overrides for {@link DEFAULT_SQS_EVENT_SOURCE_PROPS} and any

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -25,6 +25,7 @@ import {
   EVENT_SOURCE_MAPPING_ID_READERS,
   isComposureEventSource,
 } from "./event-sources/composure-event-source.js";
+import { EVENT_SOURCE_RELATIONSHIP_GUARDS } from "./event-sources/event-source-relationship-guards.js";
 
 const LOGS_WRITER_POLICY_NAME = "LogsWriter";
 
@@ -357,6 +358,13 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
         kind,
         eventSourceMappingId: EVENT_SOURCE_MAPPING_ID_READERS[kind]?.(eventSource),
       });
+
+      // Guard any cross-component relationship that spans this source and the
+      // function (e.g. the SQS visibilityTimeout >= 6x function-timeout rule),
+      // dispatched on kind so no CDK internals are inspected. See ADR-0011.
+      for (const guard of EVENT_SOURCE_RELATIONSHIP_GUARDS[kind]) {
+        guard(fn, id, entry.key, eventSource, mergedProps.timeout);
+      }
     }
 
     const alarms = createFunctionAlarms(

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -15,6 +15,7 @@ export {
   sqsEventSource,
   DEFAULT_SQS_EVENT_SOURCE_PROPS,
 } from "./event-sources/sqs-event-source.js";
+export { SQS_VISIBILITY_TIMEOUT_WARNING_ID } from "./event-sources/event-source-relationship-guards.js";
 export {
   dynamoEventSource,
   DEFAULT_DYNAMO_EVENT_SOURCE_PROPS,

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { App, Stack } from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
+import { App, CfnParameter, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { AttributeType, type ITable, StreamViewType, Table } from "aws-cdk-lib/aws-dynamodb";
 import { Code, type IEventSource, Runtime, StartingPosition } from "aws-cdk-lib/aws-lambda";
 import { DynamoEventSource, SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
@@ -441,5 +441,175 @@ describe("stream IteratorAge contextual alarm", () => {
       MetricName: "IteratorAge",
       Threshold: 120_000,
     });
+  });
+});
+
+describe("SQS visibility-timeout relationship guard", () => {
+  // The guard's stable ack id; every assertion scopes to it so an unrelated
+  // warning (e.g. the token-timeout duration alarm) can't mask a false pass.
+  const ACK = "sqs-visibility-timeout";
+
+  const expectSilent = (stack: Stack): void => {
+    expect(Annotations.fromStack(stack).findWarning("*", Match.stringLikeRegexp(ACK))).toEqual([]);
+  };
+  const expectWarns = (stack: Stack, message: string): void => {
+    Annotations.fromStack(stack).hasWarning("*", Match.stringLikeRegexp(message));
+  };
+
+  it("warns when the queue visibilityTimeout is below 6x the function timeout", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource(
+        "orders",
+        sqsEventSource(new Queue(stack, "Q", { visibilityTimeout: Duration.seconds(90) })),
+      )
+      .build(stack, "Fn");
+
+    expectWarns(
+      stack,
+      `SQS event source "orders".*visibilityTimeout is 90s but should be >= 180s.*\\[ack: @composurecdk/lambda:${ACK}\\]`,
+    );
+  });
+
+  it("stays silent when the queue visibilityTimeout meets the 6x target", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource(
+        "orders",
+        sqsEventSource(new Queue(stack, "Q", { visibilityTimeout: Duration.seconds(180) })),
+      )
+      .build(stack, "Fn");
+
+    expectSilent(stack);
+  });
+
+  it("computes the target from a minutes-based timeout", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.minutes(1))
+      .addEventSource(
+        "orders",
+        sqsEventSource(new Queue(stack, "Q", { visibilityTimeout: Duration.seconds(90) })),
+      )
+      .build(stack, "Fn");
+
+    expectWarns(stack, "visibilityTimeout is 90s but should be >= 360s");
+  });
+
+  it("stays silent for the default function timeout against the default queue", () => {
+    // No timeout -> 3s (target 18s); a plain queue -> SQS default 30s. 30 >= 18.
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource("orders", sqsEventSource(new Queue(stack, "Q")))
+      .build(stack, "Fn");
+
+    expectSilent(stack);
+  });
+
+  it("warns on the default 3s timeout when the queue is below the 18s target", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .addEventSource(
+        "orders",
+        sqsEventSource(new Queue(stack, "Q", { visibilityTimeout: Duration.seconds(10) })),
+      )
+      .build(stack, "Fn");
+
+    expectWarns(stack, "visibilityTimeout is 10s but should be >= 18s");
+  });
+
+  it("warns once per attached SQS source, naming each by key", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource(
+        "orders",
+        sqsEventSource(new Queue(stack, "Orders", { visibilityTimeout: Duration.seconds(90) })),
+      )
+      .addEventSource(
+        "refunds",
+        sqsEventSource(new Queue(stack, "Refunds", { visibilityTimeout: Duration.seconds(90) })),
+      )
+      .build(stack, "Fn");
+
+    expectWarns(stack, `SQS event source "orders"`);
+    expectWarns(stack, `SQS event source "refunds"`);
+  });
+
+  it("stays silent for an imported queue (no L1 to read)", () => {
+    const stack = new Stack(new App(), "S");
+    const imported = Queue.fromQueueArn(
+      stack,
+      "Imported",
+      "arn:aws:sqs:us-east-1:123456789012:orders",
+    );
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource("orders", sqsEventSource(imported))
+      .build(stack, "Fn");
+
+    expectSilent(stack);
+  });
+
+  it("stays silent for a bare escape-hatch source even when the queue violates", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource(
+        "orders",
+        new SqsEventSource(new Queue(stack, "Q", { visibilityTimeout: Duration.seconds(10) })),
+      )
+      .build(stack, "Fn");
+
+    expectSilent(stack);
+  });
+
+  it("stays silent for a token-valued function timeout", () => {
+    const stack = new Stack(new App(), "S");
+    const param = new CfnParameter(stack, "TimeoutSeconds", { type: "Number", default: 30 });
+    baseBuilder()
+      .timeout(Duration.seconds(param.valueAsNumber))
+      .addEventSource(
+        "orders",
+        sqsEventSource(new Queue(stack, "Q", { visibilityTimeout: Duration.seconds(10) })),
+      )
+      .build(stack, "Fn");
+
+    expectSilent(stack);
+  });
+
+  it("stays silent for a token-valued queue visibilityTimeout", () => {
+    const stack = new Stack(new App(), "S");
+    const param = new CfnParameter(stack, "VisibilitySeconds", { type: "Number", default: 10 });
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource(
+        "orders",
+        sqsEventSource(
+          new Queue(stack, "Q", { visibilityTimeout: Duration.seconds(param.valueAsNumber) }),
+        ),
+      )
+      .build(stack, "Fn");
+
+    expectSilent(stack);
+  });
+
+  it("stays silent for a DynamoDB stream source", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder()
+      .timeout(Duration.seconds(30))
+      .addEventSource("orders", dynamoEventSource(streamTable(stack)))
+      .build(stack, "Fn");
+
+    expectSilent(stack);
+  });
+
+  it("stays silent when no event source is attached", () => {
+    const stack = new Stack(new App(), "S");
+    baseBuilder().timeout(Duration.seconds(30)).build(stack, "Fn");
+
+    expectSilent(stack);
   });
 });


### PR DESCRIPTION
Closes #123.

## What

Adds a synth-time **relationship guard** to `FunctionBuilder`: when an SQS event source is attached, it warns (suppressibly) if the source queue's `visibilityTimeout` is below **6× the consumer function's `timeout`** — the AWS Well-Architected floor that leaves Lambda room to retry a throttled batch before a message becomes visible again.

> FunctionBuilder "Fn": SQS event source "orders" — source queue visibilityTimeout is 90s but should be >= 180s (6x the function timeout) so Lambda can retry a throttled batch. See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

It's a **real comparison**, not a reminder. Both sides are concrete (function `timeout` defaults to 3s, queue `visibilityTimeout` to 30s), so it fires **only on an actual violation** — never on a correct or default-correct configuration. It stays silent for token values, imported queues, bare escape-hatch sources, and non-SQS kinds. Suppressible by its stable, exported id `SQS_VISIBILITY_TIMEOUT_WARNING_ID` (`@composurecdk/lambda:sqs-visibility-timeout`).

## How — ADR-0011

The value the rule needs (`visibilityTimeout`) is withheld by the **L2** `Queue` but re-exposed by the **L1** `CfnQueue` as a public getter. So the guard reads it off `queue.node.defaultChild` at synth, via a CDK `Aspect` registered during `build()`, dispatched on `EventSourceKind` so the builder never inspects CDK internals. A scalar read creates no construct reference and so no CloudFormation edge — the `compose()` dependency graph is untouched.

This is documented as a new, general idiom in [**ADR-0011**](docs/adr/0011-cross-component-relationship-guards.md), sitting beside ADR-0002 (Policies) and ADR-0010 (constraints). Key properties:

- **Builder-registered, secure-by-default** — using the builder is the opt-in; no user-invoked policy to forget.
- **No cross-package dependency** — uses only `aws-cdk-lib` types (`CfnQueue`, `IQueue`); **lambda does not depend on `@composurecdk/sqs`**.
- **List-per-kind dispatch** (`EVENT_SOURCE_RELATIONSHIP_GUARDS: Record<EventSourceKind, Guard[]>`) so the `maxReceiveCount` floor (#124) drops in as a second `sqs` entry without restructuring.

## Why this, not the alternatives

This supersedes two rejected directions, both now closed:

- **`resolvedProps` on builder results (#122/#198)** — too large an architectural change, and it leaked construct handles a consumer could wire into edges outside the declared `compose()` graph. The premise that justified it ("the value is unrecoverable from the construct") is false at the L1.
- **The unconditional-warning attempt (#195)** — fired on every synth regardless of the queue's actual value. This PR supersedes it with a real comparison; **#195 can be closed.**

ADR-0011 §Alternatives records the full set (tree-walking Policy, build-time read, `addValidation` throw, decorator).

## Testing

`packages/lambda/test/event-sources.test.ts` adds an "SQS visibility-timeout relationship guard" block: warn-on-violation (with the 6× math and ack id), minutes-based timeout, the default-3s path (silent vs. warn), one-warning-per-source, and the quiet cases — compliant queue, imported queue, escape-hatch source, token timeout, token visibilityTimeout, DynamoDB source, and no source.

- `nx test lambda` — 120 passed (build + typecheck + test)
- `npm run lint` / `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
