### PR TITLE
docs: accept ADR-0011, promote Policies to architecture.md

### DIFF
--- a/docs/adr/0011-cross-component-relationship-guards.md
+++ b/docs/adr/0011-cross-component-relationship-guards.md
@@ -1,6 +1,6 @@
 # ADR 0011: Cross-component relationship guards — builder-registered synth-time Aspects
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-27
 
 ## Context
@@ -8,9 +8,8 @@
 Some AWS best practices are not properties of one resource but _relationships
 between two_. The motivating case (laazyj/composureCDK#123): an SQS source
 queue's `visibilityTimeout` should be ≥ 6× the consumer Lambda's `timeout`, so
-Lambda can retry a throttled batch before the message becomes visible again. Its
-sibling #124 (`maxReceiveCount` floor) is the same shape; more will follow as
-builders gain cross-wiring.
+Lambda can retry a throttled batch before the message becomes visible again.
+More relationships of this shape will surface as builders gain cross-wiring.
 
 Three properties make these relationships hard to guard, and none is addressed
 by the single-value constraint catalogue of
@@ -94,12 +93,15 @@ Concretely, for the first instance (`FunctionBuilder` + SQS event source):
 - Cross-component best-practice relationships become real, reliable checks: a
   violation surfaces at `cdk synth`/`deploy` at the authoring site, suppressible
   by id, with no false positive on correct or default configurations. This
-  resolves #123 and unblocks #124.
+  resolves #123.
 - **To add a guard:** register an Aspect in the producing builder's `build()`
   that reads the sibling's resolved scalar off its L1 and warns on violation,
-  dispatched on the wiring's discriminator. In this package that dispatch is the
-  `EventSourceKind` table; #124 (`maxReceiveCount`, via `CfnQueue.redrivePolicy`)
-  is the next entry.
+  dispatched on the wiring's discriminator (in this package, the
+  `EventSourceKind` table). A guard is the right tool _only_ when the check
+  needs a value from the other component. A threshold the owning builder can
+  check on its own — an SQS queue's `maxReceiveCount` floor of 5, which needs
+  nothing from the consumer — stays a local check in that builder
+  (`@composurecdk/sqs`'s `QueueBuilder`), not a guard here.
 - The technique applies only when the sibling's value is recoverable at synth
   (its L1, or similar). A value that never reaches a synth-readable surface needs
   a different channel.
@@ -112,8 +114,9 @@ Concretely, for the first instance (`FunctionBuilder` + SQS event source):
   advisory, warn, at synth.
 - A builder that installs a guard takes on one Aspect per wired pair; the synth
   cost is negligible.
-- Following ADR-0002's precedent, `architecture.md` is not yet amended; this ADR
-  stands alone until the pattern is exercised by more than one instance.
+- `architecture.md` is not yet amended for relationship guards. Following the
+  "> 2 consumers" bar ADR-0002 set for its own promotion, this ADR stands alone
+  until a second cross-component instance exercises the pattern.
 
 ## Alternatives considered
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -353,6 +353,36 @@ class MyBuilder implements Lifecycle<MyResult> {
 
 This is the only change required. The builder does not need to know whether it received a concrete value or a `Ref` — `resolve` handles both uniformly.
 
+## Policies
+
+Some concerns are not builder-local: they apply to whatever matching constructs happen to exist under a scope, not to any one component. Examples: attaching CloudWatch alarm actions to every `Alarm` in a stack, overriding `removalPolicy` on every stateful resource for a throwaway environment, or enforcing a tagging convention across services.
+
+A **Policy** is a free function `(scope: IConstruct, config?) => void` that applies a cross-cutting rule to every matching construct in the subtree under `scope`. It returns nothing and is installed once at setup — distinct from a builder (which produces one component) and a `Ref` (which wires two).
+
+### How it works
+
+Policies are backed by CDK `Aspects` or `PropertyInjectors`, never manual `node.findAll()` walks (which miss late-added constructs) or `afterBuild` hooks (which would couple them to `compose`):
+
+- **`Aspects`** for post-construction mutation — e.g. `alarmActionsPolicy` calls `addAlarmAction` on already-built alarms. Aspects fire during synth, after the tree is final, so the policy sees constructs added after it was installed and call ordering does not matter.
+- **`PropertyInjectors`** for props that cannot be changed after construction — e.g. `removalPolicy`, rewritten as the construct is instantiated.
+
+Matching constructs are detected with version-portable jsii guards (`CfnResource.isCfnResource(x) && x.cfnResourceType === Cfn*.CFN_RESOURCE_TYPE_NAME`), not `instanceof` — which fails across the bundled ESM/CJS copies of CDK. A Policy takes no `compose` dependency, so it works in any CDK app; a composed system can still install one from an `afterBuild` hook.
+
+```typescript
+// Install once on any scope — an App, a Stack, or the scope passed to build().
+alarmActionsPolicy(app, {
+  defaults: { alarmActions: [new SnsAction(standardTopic)] },
+  rules: [{ match: "HighSev", alarmActions: [new SnsAction(pagerTopic)] }],
+});
+```
+
+### Design rationale
+
+- **Single-domain policies live in their package** under `src/policies/`, co-located with the detection logic and types they rely on (e.g. `alarmActionsPolicy` in `@composurecdk/cloudwatch`). Pan-domain policies that span services stay in `packages/examples/` until ≥ 2 of them justify a dedicated `@composurecdk/policies` package.
+- **Named with a `<noun>Policy` suffix** to signal a scope-wide side effect applied at setup, distinct from builders and factories.
+
+See [ADR-0002](adr/0002-policies.md).
+
 ## How the pieces fit together
 
 ```


### PR DESCRIPTION
Documentation follow-up to #240 (the SQS visibility-timeout relationship guard).

## What

- **ADR-0011 → Accepted.** The first relationship guard has merged (#240), so the decision moves from Proposed to Accepted.
- **Correct ADR-0011's `#124` reference.** The ADR cited `maxReceiveCount` (#124) as "the next relationship guard." That's wrong: `maxReceiveCount` is a **queue-local** invariant — a fixed floor of 5 that needs nothing from the consumer function — and it's already implemented in `@composurecdk/sqs`'s `QueueBuilder` (`warnIfLowMaxReceiveCount`, #124 closed COMPLETED). It is not cross-component, so it is not a relationship guard. The ADR now uses it as the **boundary example** instead: *a guard is the right tool only when the check needs a value from the other component; a threshold the owning builder can check on its own stays a local check there.*
- **Promote ADR-0002 (Policies) to `architecture.md`.** ADR-0002 deferred its own `architecture.md` integration "until battle-tested across more than two consumers." With three (`alarmActionsPolicy`, `alarmNamePolicy`, `cleanDeskPolicy`) it now clears that bar, so Policies becomes a first-class documented concept.

## Deliberately deferred

Relationship guards (ADR-0011) are **not** added to `architecture.md` yet. They have one genuine instance (the visibility-timeout guard); following the ">2 consumers" bar ADR-0002 set, promotion waits for a real second cross-component instance. The ADR's closing consequence records this.

## Why no code PR

The originally-planned `maxReceiveCount` code change was dropped: #124 is already done and correctly placed in `QueueBuilder`, and forcing it into a lambda relationship guard would duplicate the existing warning and misapply the pattern (the threshold is consumer-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
