### PR TITLE
feat(route53): make NsRecordBuilder values Resolvable

### DIFF
--- a/packages/route53/src/ns-record-builder.ts
+++ b/packages/route53/src/ns-record-builder.ts
@@ -12,12 +12,17 @@ import { NS_RECORD_DEFAULTS } from "./defaults.js";
 /**
  * Configuration properties for the Route53 NS record builder.
  *
- * Extends the CDK {@link NsRecordProps} but replaces `zone` with a
- * {@link Resolvable} so it can be wired from composed components.
+ * Extends the CDK {@link NsRecordProps} but replaces `zone` and `values` with
+ * {@link Resolvable}s so they can be wired from composed components. Making
+ * `values` resolvable lets a delegation record draw its name servers from a
+ * child hosted zone's `hostedZoneNameServers`, which is only known at build
+ * time.
  */
-export interface NsRecordBuilderProps extends Omit<NsRecordProps, "zone"> {
+export interface NsRecordBuilderProps extends Omit<NsRecordProps, "zone" | "values"> {
   /** The hosted zone in which to create the record. */
   zone?: Resolvable<IHostedZone>;
+  /** The fully-qualified name-server host names for the delegated subdomain. */
+  values?: Resolvable<string[]>;
 }
 
 /**
@@ -52,7 +57,14 @@ class NsRecordBuilder implements Lifecycle<NsRecordBuilderResult> {
           `Call .recordName() with the delegated subdomain — the apex NS set is managed by Route53.`,
       );
     }
-    if (!values || values.length === 0) {
+    if (!values) {
+      throw new Error(
+        `NsRecordBuilder "${id}" requires non-empty values. ` +
+          `Call .values() with one or more fully-qualified name-server host names.`,
+      );
+    }
+    const resolvedValues = resolve(values, context);
+    if (resolvedValues.length === 0) {
       throw new Error(
         `NsRecordBuilder "${id}" requires non-empty values. ` +
           `Call .values() with one or more fully-qualified name-server host names.`,
@@ -63,7 +75,7 @@ class NsRecordBuilder implements Lifecycle<NsRecordBuilderResult> {
       ...NS_RECORD_DEFAULTS,
       ...rest,
       recordName,
-      values,
+      values: resolvedValues,
       zone: resolve(zone, context),
     } as NsRecordProps;
 

--- a/packages/route53/test/record-variants.test.ts
+++ b/packages/route53/test/record-variants.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { compose, ref } from "@composurecdk/core";
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Distribution } from "aws-cdk-lib/aws-cloudfront";
@@ -18,6 +19,10 @@ import { createMxRecordBuilder } from "../src/mx-record-builder.js";
 import { createSrvRecordBuilder } from "../src/srv-record-builder.js";
 import { createCaaRecordBuilder } from "../src/caa-record-builder.js";
 import { createNsRecordBuilder } from "../src/ns-record-builder.js";
+import {
+  createHostedZoneBuilder,
+  type HostedZoneBuilderResult,
+} from "../src/hosted-zone-builder.js";
 import { createDsRecordBuilder } from "../src/ds-record-builder.js";
 import { createHttpsRecordBuilder } from "../src/https-record-builder.js";
 import { createSvcbRecordBuilder } from "../src/svcb-record-builder.js";
@@ -204,6 +209,32 @@ describe("NsRecordBuilder", () => {
     template.hasResourceProperties("AWS::Route53::RecordSet", {
       Type: "NS",
       Name: "sub.example.com.",
+    });
+  });
+
+  it("resolves Ref-based values from a child zone's name servers", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+
+    compose(
+      {
+        parent: createHostedZoneBuilder().zoneName("example.com"),
+        child: createHostedZoneBuilder().zoneName("sub.example.com"),
+        delegation: createNsRecordBuilder()
+          .zone(ref("parent", (r: HostedZoneBuilderResult) => r.hostedZone))
+          .recordName("sub")
+          .values(
+            ref("child", (r: HostedZoneBuilderResult) => r.hostedZone.hostedZoneNameServers ?? []),
+          ),
+      },
+      { parent: [], child: [], delegation: ["parent", "child"] },
+    ).build(stack, "Delegation");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "NS",
+      Name: "sub.example.com.",
+      ResourceRecords: Match.objectLike({ "Fn::GetAtt": Match.arrayWith(["NameServers"]) }),
     });
   });
 });


### PR DESCRIPTION
## What

Re-declare the `NsRecordBuilder` `values` prop as `Resolvable<string[]>`, mirroring how `zone` is already handled. A `Ref` can now supply the name servers at build time. The `build()` method resolves `values` before the non-empty check (presence and empty-array checks are split so the empty-array validation runs against the *resolved* value).

## Why

This unlocks the canonical subdomain-delegation pattern: a parent zone's NS record can draw its values directly from a child hosted zone's `hostedZoneNameServers` created in the same composition, instead of requiring the name servers to be known up front.

```ts
compose(
  {
    parent: createHostedZoneBuilder().zoneName("example.com"),
    child:  createHostedZoneBuilder().zoneName("sub.example.com"),
    delegation: createNsRecordBuilder()
      .zone(ref("parent", r => r.hostedZone))
      .recordName("sub")
      .values(ref("child", r => r.hostedZone.hostedZoneNameServers ?? [])),
  },
  { parent: [], child: [], delegation: ["parent", "child"] },
)
```

## Notes

- Scoped to NS only, matching the existing `zone` pattern (whole-value `Resolvable<T>`) — a `Ref` resolves the entire array. Per-element resolution (`Resolvable<string>[]`) is not supported; mixing concrete and ref'd name servers in one `.values([...])` call isn't a goal here.
- Sibling record builders (`txt`, `mx`, `srv`, `caa`, `ds`) still take concrete `values` and are unchanged.

## Testing

- Added a test wiring a child zone's `hostedZoneNameServers` into the NS record via `ref(...)` inside `compose(...)`, asserting the synthesised `ResourceRecords` is an `Fn::GetAtt … NameServers` reference.
- Existing NS tests (concrete values, empty-array rejection) pass unchanged.
- `npx nx test route53` (113 passed), `npm run lint`, `npm run format:check` all green.