### PR TITLE
feat(core): add at() to pin a component's construct id

### DIFF
--- a/docs/adr/0012-explicit-build-id-decoupled-from-compose-key.md
+++ b/docs/adr/0012-explicit-build-id-decoupled-from-compose-key.md
@@ -1,0 +1,142 @@
+# ADR 0012: Explicit build id — decouple the construct id from the compose key
+
+- **Status:** Accepted
+- **Date:** 2026-06-29
+
+## Context
+
+`compose()` derives each component's construct id from its key:
+
+```js
+results[key] = this.#components[key].build(componentScope, `${id}/${key}`, context);
+```
+
+The key therefore does double duty: it is both the **wiring name** (used in the
+dependency map and in `ref()`/context lookups) and the **construct id segment**
+(the `id` argument passed to `build`). For most systems that coupling is
+convenient. It becomes destructive the moment an already-deployed system is
+nested as a component inside a parent `compose()` (laazyj/composureCDK#245).
+
+A system built standalone as `apex.build(app, "jasonduffett.net")` puts a zone
+record at `jasonduffett.net/records/aExchange` → logical id
+`jasonduffettnetrecordsaExchange264619CE`. Nest that same system under key
+`jduffett` and the path becomes `jasonduffett.net/jduffett/records/aExchange` →
+a different logical id. CDK hashes the **full construct path string**, so the
+inserted `jduffett/` segment rotates _every_ logical id in the nested system —
+CloudFormation replaces every resource. There is no combination of parent id +
+key that reproduces the original single-segment path.
+
+The motivating case: a live apex site and a brand-new subsite should become two
+sub-lifecycles of one `compose()` so a delegation record can `ref()` both zones
+instead of using a raw escape hatch. The subsite's ids may change; the apex's
+must stay byte-for-byte identical or the refactor replaces the production zone,
+distribution, bucket and ~20 DNS records.
+
+A downstream workaround exists — a `Lifecycle` adapter that ignores the id
+`compose()` assigns and substitutes a fixed one:
+
+```ts
+const withFixedId = (inner, id) => ({ build: (s, _id, ctx) => inner.build(s, id, ctx) });
+```
+
+It works, but the `_id` is a tell: the framework computes an id and the
+component throws it away. The library should pass the intended id in the first
+place rather than force components to discard it.
+
+## Decision
+
+**A component may be tagged with an explicit construct id via `at(id, inner)`.
+`compose()` builds a tagged component under that id verbatim, instead of
+deriving `` `${parentId}/${key}` ``. The id rides on a `Symbol.for` brand that
+only `compose()` reads; the component's wiring key is unaffected.** This
+separates the key's two roles — wiring name vs. construct id — and lets a nested
+system preserve the logical ids it had standalone.
+
+1. **`at(id, inner)` returns an ordinary `Lifecycle`.** It carries the id on a
+   `BUILD_ID = Symbol.for("composurecdk.buildId")` brand and forwards `build`
+   straight to `inner`. The brand is realm-agnostic for the same reason as the
+   `Ref` brand ([ADR-0007](0007-dual-esm-cjs-publishing.md)): the ESM and
+   CommonJS copies of `@composurecdk/core` can both load in one process, so a
+   tag minted by either copy must be read by either. The tag is _not_ a
+   self-overriding wrapper — it does not discard the id argument.
+
+2. **`compose()` honours the brand through the `id` argument it already passes.**
+   `#buildWith` reads the pinned id (falling back to the `${parentId}/${key}`
+   derivation) and passes it as the `build` `id`. For a tagged component the
+   inner `build` receives and honours it end to end. Nothing is discarded — the
+   `id` argument means what it says, which is the property the downstream adapter
+   lacked.
+
+3. **The wiring key is untouched.** `at()` changes only the construct id, not the
+   key used in the dependency map, topological sort, or `ref()`/context lookups.
+   `BuildResult`'s `ReturnType<build>` inference is preserved because the tagged
+   value still structurally satisfies `Lifecycle<T>` — the brand is an extra
+   symbol property, invisible to the mapped type.
+
+4. **A pinned id is checked for collisions, per scope.** An explicit id re-roots
+   into the sibling namespace of the scope it builds into, so it can collide with
+   another component's id (its own `${id}/${key}` derivation, or another pin).
+   `#buildWith` tracks the ids built into each scope and throws a descriptive
+   error on a duplicate, rather than letting it surface as an opaque CDK
+   duplicate-construct error deeper in synth. Collisions are scoped: the same
+   pinned id in two different stacks (via `withStacks`) is legal.
+
+5. **`at` is the only public surface.** `BUILD_ID` and `buildIdOf` stay internal
+   to the package (mirroring the unexported `Ref` brand), so the public API gains
+   exactly one function.
+
+## Consequences
+
+- Nesting a deployed system into a parent graph no longer rotates its logical
+  ids: `compose({ jduffett: at("jasonduffett.net", apex), clara }, …)` builds
+  apex's components at `jasonduffett.net/<key>`, byte-identical to standalone.
+  This resolves #245 and unblocks the compose-of-sub-lifecycles refactor that
+  motivated it.
+- **`at()` subsumes the per-component-map and id-strategy alternatives.** One
+  component → `at()`. Several → several `at()` calls at the declaration site. No
+  separate `withIds()` method or `withIdStrategy()` hook is added; id control
+  lives where the component is declared, next to the `id` argument it sets.
+- **The compose key is no longer guaranteed to equal the construct id segment.**
+  Readers and tooling that assumed `${parentId}/${key}` must consult the
+  effective id. This is the deliberate decoupling; it is the one new invariant
+  the ADR introduces.
+- A pinned id shares its scope's sibling namespace, so callers own uniqueness.
+  The per-scope guard turns a misuse into an early, named error instead of a
+  late CDK one, but it does not absolve the caller of choosing non-colliding ids.
+- `architecture.md`'s "The result is a Lifecycle" / nesting section is amended
+  with a short note on `at()`, since id preservation under nesting is core
+  `compose()` behaviour rather than a niche concern.
+
+## Alternatives considered
+
+- **`fixedId(inner, id)` free-function wrapper that self-overrides** (the
+  downstream adapter, blessed). Rejected as the primary mechanism: it works by
+  _discarding_ the id `compose()` passes (`_id => inner.build(s, id, …)`), an
+  inversion of the `Lifecycle` contract. `at()` reaches the same outcome while
+  the framework passes the intended id, so the `id` argument is never thrown
+  away. The two differ only in honesty and in the collision guard, for the same
+  call-site cost.
+- **`withIds({ key: id })` — a parent-side map companion to `withStacks`.**
+  Workable and per-component, but it places id control in a separate chained
+  method parallel to stack routing, away from where the component is declared,
+  and threads extra state through `#buildWith` plus the
+  `ComposedSystem`/`ConfiguredSystem` interface split. `at()` is co-located with
+  the component and adds no interface surface.
+- **`withIdStrategy((parentId, key) => id)` — a pluggable hook analogous to
+  `StackStrategy`.** The most general option and the most surface, for a need
+  that is almost always "pin this one system." A function hook also has no
+  guardrails against colliding or invalid ids. Consistent with the project's
+  preference for targeted mechanisms over configurable derivation
+  ([ADR-0011](0011-cross-component-relationship-guards.md) alternatives), it was
+  rejected as speculative; it can supersede this ADR later if id derivation ever
+  needs to be pluggable across many call sites.
+- **Flatten instead of nest — spread the sub-system's components as siblings so
+  no extra key segment is ever created.** This makes the id problem _disappear_
+  rather than solving it, and arguably models the delegation use case more
+  directly (both zones become first-class `ref` targets). It was not adopted as
+  the answer to #245 because it requires authoring sub-systems as exportable
+  `{ components, dependencies, stacks }` fragments rather than sealed
+  `ComposedSystem`s — a larger, more opinionated change to how systems are
+  composed. It remains the better choice when the caller controls sub-system
+  authorship; `at()` is the answer when a sub-system must stay a sealed
+  `ComposedSystem` (third-party, or to keep the nested-unit encapsulation).

--- a/docs/adr/0012-explicit-build-id-decoupled-from-compose-key.md
+++ b/docs/adr/0012-explicit-build-id-decoupled-from-compose-key.md
@@ -5,138 +5,85 @@
 
 ## Context
 
-`compose()` derives each component's construct id from its key:
+`compose()` derives each component's construct id from its key, passing
+`` `${parentId}/${key}` `` as the `build` id. The key therefore does double
+duty: it is both the **wiring name** (used in the dependency map and in
+`ref()`/context lookups) and the **construct id segment**. For most systems that
+coupling is invisible and convenient.
 
-```js
-results[key] = this.#components[key].build(componentScope, `${id}/${key}`, context);
-```
-
-The key therefore does double duty: it is both the **wiring name** (used in the
-dependency map and in `ref()`/context lookups) and the **construct id segment**
-(the `id` argument passed to `build`). For most systems that coupling is
-convenient. It becomes destructive the moment an already-deployed system is
-nested as a component inside a parent `compose()` (laazyj/composureCDK#245).
-
-A system built standalone as `apex.build(app, "jasonduffett.net")` puts a zone
-record at `jasonduffett.net/records/aExchange` → logical id
-`jasonduffettnetrecordsaExchange264619CE`. Nest that same system under key
-`jduffett` and the path becomes `jasonduffett.net/jduffett/records/aExchange` →
-a different logical id. CDK hashes the **full construct path string**, so the
-inserted `jduffett/` segment rotates _every_ logical id in the nested system —
-CloudFormation replaces every resource. There is no combination of parent id +
-key that reproduces the original single-segment path.
+It becomes destructive the moment an already-deployed system is nested as a
+component inside a parent `compose()` (laazyj/composureCDK#245). CDK hashes the
+**full construct path string**, so the inserted key segment rotates _every_
+logical id in the nested system and CloudFormation replaces every resource. A
+zone record built standalone at `jasonduffett.net/records/aExchange` moves to
+`jasonduffett.net/jduffett/records/aExchange` once nested under key `jduffett` —
+a different hash, a different logical id. No combination of parent id + key
+reproduces the original single-segment path.
 
 The motivating case: a live apex site and a brand-new subsite should become two
-sub-lifecycles of one `compose()` so a delegation record can `ref()` both zones
-instead of using a raw escape hatch. The subsite's ids may change; the apex's
-must stay byte-for-byte identical or the refactor replaces the production zone,
-distribution, bucket and ~20 DNS records.
-
-A downstream workaround exists — a `Lifecycle` adapter that ignores the id
-`compose()` assigns and substitutes a fixed one:
-
-```ts
-const withFixedId = (inner, id) => ({ build: (s, _id, ctx) => inner.build(s, id, ctx) });
-```
-
-It works, but the `_id` is a tell: the framework computes an id and the
-component throws it away. The library should pass the intended id in the first
-place rather than force components to discard it.
+sub-lifecycles of one `compose()` so a delegation record can `ref()` both zones.
+The subsite's ids may change; the apex's must stay byte-for-byte identical or the
+refactor replaces a production zone, distribution, bucket and ~20 DNS records.
 
 ## Decision
 
 **A component may be tagged with an explicit construct id via `at(id, inner)`.
-`compose()` builds a tagged component under that id verbatim, instead of
-deriving `` `${parentId}/${key}` ``. The id rides on a `Symbol.for` brand that
-only `compose()` reads; the component's wiring key is unaffected.** This
-separates the key's two roles — wiring name vs. construct id — and lets a nested
-system preserve the logical ids it had standalone.
+`compose()` builds a tagged component under that id verbatim instead of deriving
+`` `${parentId}/${key}` ``, while the component's wiring key is unaffected.** This
+separates the key's two roles — wiring name vs. construct id — so a nested system
+can preserve the logical ids it had standalone.
 
-1. **`at(id, inner)` returns an ordinary `Lifecycle`.** It carries the id on a
-   `BUILD_ID = Symbol.for("composurecdk.buildId")` brand and forwards `build`
-   straight to `inner`. The brand is realm-agnostic for the same reason as the
-   `Ref` brand ([ADR-0007](0007-dual-esm-cjs-publishing.md)): the ESM and
-   CommonJS copies of `@composurecdk/core` can both load in one process, so a
-   tag minted by either copy must be read by either. The tag is _not_ a
-   self-overriding wrapper — it does not discard the id argument.
-
-2. **`compose()` honours the brand through the `id` argument it already passes.**
-   `#buildWith` reads the pinned id (falling back to the `${parentId}/${key}`
-   derivation) and passes it as the `build` `id`. For a tagged component the
-   inner `build` receives and honours it end to end. Nothing is discarded — the
-   `id` argument means what it says, which is the property the downstream adapter
-   lacked.
-
-3. **The wiring key is untouched.** `at()` changes only the construct id, not the
-   key used in the dependency map, topological sort, or `ref()`/context lookups.
-   `BuildResult`'s `ReturnType<build>` inference is preserved because the tagged
-   value still structurally satisfies `Lifecycle<T>` — the brand is an extra
-   symbol property, invisible to the mapped type.
-
-4. **A pinned id is checked for collisions, per scope.** An explicit id re-roots
-   into the sibling namespace of the scope it builds into, so it can collide with
-   another component's id (its own `${id}/${key}` derivation, or another pin).
-   `#buildWith` tracks the ids built into each scope and throws a descriptive
-   error on a duplicate, rather than letting it surface as an opaque CDK
-   duplicate-construct error deeper in synth. Collisions are scoped: the same
-   pinned id in two different stacks (via `withStacks`) is legal.
-
-5. **`at` is the only public surface.** `BUILD_ID` and `buildIdOf` stay internal
-   to the package (mirroring the unexported `Ref` brand), so the public API gains
-   exactly one function.
+- **The wiring key is untouched.** `at()` changes only the construct id; the
+  dependency map, topological sort, and `ref()`/context lookups still key off the
+  original key. Only the path segment passed to `build` changes.
+- **Collisions are guarded per scope.** A pinned id re-roots into the sibling
+  namespace of the scope it builds into, where it can collide with a derived id
+  or another pin. `compose()` tracks ids per scope and throws a typed
+  `DuplicateConstructIdError` at composition time, instead of letting it surface
+  as an opaque CDK duplicate-construct error deeper in synth. The same id in two
+  different stacks (via `withStacks`) remains legal.
+- **`at` is the only new public surface** — one function, no new interface or
+  chained method. (Implementation: the id rides a realm-agnostic `Symbol.for`
+  brand that only `compose()` reads, the same cross-realm convention as the `Ref`
+  brand — [ADR-0007](0007-dual-esm-cjs-publishing.md); the tagged value still
+  structurally satisfies `Lifecycle<T>`, so `BuildResult` inference is unchanged.)
 
 ## Consequences
 
-- Nesting a deployed system into a parent graph no longer rotates its logical
-  ids: `compose({ jduffett: at("jasonduffett.net", apex), clara }, …)` builds
-  apex's components at `jasonduffett.net/<key>`, byte-identical to standalone.
-  This resolves #245 and unblocks the compose-of-sub-lifecycles refactor that
-  motivated it.
-- **`at()` subsumes the per-component-map and id-strategy alternatives.** One
-  component → `at()`. Several → several `at()` calls at the declaration site. No
-  separate `withIds()` method or `withIdStrategy()` hook is added; id control
-  lives where the component is declared, next to the `id` argument it sets.
-- **The compose key is no longer guaranteed to equal the construct id segment.**
-  Readers and tooling that assumed `${parentId}/${key}` must consult the
-  effective id. This is the deliberate decoupling; it is the one new invariant
-  the ADR introduces.
-- A pinned id shares its scope's sibling namespace, so callers own uniqueness.
-  The per-scope guard turns a misuse into an early, named error instead of a
-  late CDK one, but it does not absolve the caller of choosing non-colliding ids.
-- `architecture.md`'s "The result is a Lifecycle" / nesting section is amended
-  with a short note on `at()`, since id preservation under nesting is core
-  `compose()` behaviour rather than a niche concern.
+- **Nesting a deployed system no longer rotates its logical ids.**
+  `compose({ jduffett: at("jasonduffett.net", apex), clara }, …)` builds apex's
+  components at `jasonduffett.net/<key>`, byte-identical to standalone. Resolves
+  #245 and unblocks the compose-of-sub-lifecycles refactor.
+- **New invariant: the compose key is no longer guaranteed to equal the construct
+  id segment.** This is the deliberate decoupling. Readers and tooling that
+  assumed `${parentId}/${key}` must consult the _effective_ id.
+- **Callers own id uniqueness.** The per-scope guard turns a misuse into an early,
+  named error, but does not choose non-colliding ids for the caller.
+- `architecture.md`'s nesting section gains a short note, since id preservation
+  under nesting is core `compose()` behaviour rather than a niche concern.
 
 ## Alternatives considered
 
-- **`fixedId(inner, id)` free-function wrapper that self-overrides** (the
-  downstream adapter, blessed). Rejected as the primary mechanism: it works by
-  _discarding_ the id `compose()` passes (`_id => inner.build(s, id, …)`), an
-  inversion of the `Lifecycle` contract. `at()` reaches the same outcome while
-  the framework passes the intended id, so the `id` argument is never thrown
-  away. The two differ only in honesty and in the collision guard, for the same
-  call-site cost.
-- **`withIds({ key: id })` — a parent-side map companion to `withStacks`.**
-  Workable and per-component, but it places id control in a separate chained
-  method parallel to stack routing, away from where the component is declared,
-  and threads extra state through `#buildWith` plus the
-  `ComposedSystem`/`ConfiguredSystem` interface split. `at()` is co-located with
-  the component and adds no interface surface.
-- **`withIdStrategy((parentId, key) => id)` — a pluggable hook analogous to
-  `StackStrategy`.** The most general option and the most surface, for a need
-  that is almost always "pin this one system." A function hook also has no
-  guardrails against colliding or invalid ids. Consistent with the project's
-  preference for targeted mechanisms over configurable derivation
-  ([ADR-0011](0011-cross-component-relationship-guards.md) alternatives), it was
-  rejected as speculative; it can supersede this ADR later if id derivation ever
-  needs to be pluggable across many call sites.
-- **Flatten instead of nest — spread the sub-system's components as siblings so
-  no extra key segment is ever created.** This makes the id problem _disappear_
-  rather than solving it, and arguably models the delegation use case more
-  directly (both zones become first-class `ref` targets). It was not adopted as
-  the answer to #245 because it requires authoring sub-systems as exportable
-  `{ components, dependencies, stacks }` fragments rather than sealed
-  `ComposedSystem`s — a larger, more opinionated change to how systems are
-  composed. It remains the better choice when the caller controls sub-system
-  authorship; `at()` is the answer when a sub-system must stay a sealed
-  `ComposedSystem` (third-party, or to keep the nested-unit encapsulation).
+- **`withIds({ key: id })` — a parent-side map, a companion to `withStacks`.**
+  Per-component and workable, but places id control in a separate chained method
+  away from where the component is declared, and threads extra state through the
+  system-interface split. `at()` is co-located with the component and adds no
+  interface surface.
+- **`withIdStrategy((parentId, key) => id)` — a pluggable derivation hook.** The
+  most general option and the most surface, for a need that is almost always "pin
+  this one system," and with no guardrail against colliding ids. Rejected as
+  speculative, consistent with the project's preference for targeted mechanisms
+  over configurable derivation ([ADR-0011](0011-cross-component-relationship-guards.md));
+  it can supersede this ADR later if id derivation ever needs to be pluggable.
+- **Flatten instead of nest — spread the sub-system's components as siblings** so
+  no extra key segment is created. This makes the id problem _disappear_ and
+  arguably models the delegation case more directly, but requires authoring
+  sub-systems as open `{ components, dependencies, stacks }` fragments rather than
+  sealed `ComposedSystem`s. It is the better choice when the caller controls
+  sub-system authorship; `at()` is the answer when a sub-system must stay a sealed
+  unit (third-party, or to keep encapsulation).
+- **A self-overriding `fixedId(inner, id)` wrapper that discards the id
+  `compose()` passes** (the existing downstream workaround). Reaches the same
+  outcome by inverting the `Lifecycle` contract — the component throws away the
+  framework-supplied id — and has no collision guard. `at()` keeps the `build` id
+  meaningful end to end for the same call-site cost.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0009: Defaults yield to a mutually-exclusive user-set sibling prop](0009-defaults-yield-to-mutually-exclusive-siblings.md)
 - [ADR-0010: AWS-property constraints — a catalogue with central mechanism and local data](0010-aws-property-constraints.md)
 - [ADR-0011: Cross-component relationship guards — builder-registered synth-time Aspects](0011-cross-component-relationship-guards.md)
+- [ADR-0012: Explicit build id — decouple the construct id from the compose key](0012-explicit-build-id-decoupled-from-compose-key.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,21 @@ Cycle detection happens at composition time, not build time. This means structur
 
 `compose` returns a `Lifecycle`. This means a composed system can itself be used as a component in a larger system. Composition is recursive — systems can be nested without special handling. When a composed system is nested, the parent context flows through: components inside the nested system can `ref("outerKey")` to reach siblings of the nested system, provided the outer `compose` declares the corresponding dependency. Inner dependency values shadow the parent context on key collision, matching lexical scoping ([ADR-0003](adr/0003-nested-compose-context-propagation.md)).
 
+### Pinning a component's construct id with `at`
+
+By default a component's construct id is derived from its key as `` `${parentId}/${key}` ``. Nesting an already-deployed system under a new key therefore lengthens every construct path and rotates every CloudFormation logical id — a destructive replacement. `at(id, component)` decouples the construct id from the wiring key: `compose` builds the tagged component under `id` verbatim, so a nested system preserves the logical ids it had standalone.
+
+```typescript
+compose(
+  { existing: at("MySystem", deployedSystem), addition },
+  { existing: [], addition: [] },
+).build(app, "MySystem");
+// deployedSystem's components build at `MySystem/<key>`, not
+// `MySystem/existing/<key>` — logical ids preserved.
+```
+
+The id rides on a `Symbol.for` brand that only `compose` reads; the wiring key (used in the dependency map and in `ref()`) is unaffected. A pinned id shares the sibling namespace of the scope it builds into, so `compose` throws if it collides with another component's id. See [ADR-0012](adr/0012-explicit-build-id-decoupled-from-compose-key.md).
+
 ### Dependency declarations are exhaustive
 
 Every component must appear as a key in the dependencies record, even if it has no dependencies (in which case the value is `[]`). This is enforced by the type system. The alternative — making the dependencies record partial and defaulting missing keys to no dependencies — was rejected because it makes it too easy to forget a component and mask a missing dependency declaration.

--- a/packages/core/src/build-id.ts
+++ b/packages/core/src/build-id.ts
@@ -1,0 +1,63 @@
+import { type Lifecycle } from "./lifecycle.js";
+
+/**
+ * @internal Brands a {@link Lifecycle} produced by {@link at} with the construct
+ * id it should build under, so {@link compose} can read it without `instanceof`.
+ *
+ * Registered in the global symbol registry for the same dual-package reason as
+ * the `Ref` brand (ADR-0007): the ESM and CommonJS copies of `@composurecdk/core`
+ * can both load in one process, and a brand minted by either copy must be
+ * recognised by either.
+ */
+export const BUILD_ID = Symbol.for("composurecdk.buildId");
+
+/**
+ * Tags a {@link Lifecycle} with an explicit construct id, decoupling the id it
+ * builds under from the key it is registered under in {@link compose}.
+ *
+ * By default `compose` derives each component's build id from its key as
+ * `` `${parentId}/${key}` ``. Nesting an already-deployed system under a new key
+ * therefore lengthens every construct path and rotates every CloudFormation
+ * logical id — a destructive replacement. `at` pins the id so the component
+ * builds at the same path it did standalone, preserving logical ids.
+ *
+ * The returned value is an ordinary {@link Lifecycle}; the id rides on a
+ * {@link BUILD_ID} brand that only `compose` reads. Build behaviour is otherwise
+ * unchanged — the tag forwards the id `compose` passes straight to the inner
+ * component, so the `id` argument is honoured end to end rather than discarded.
+ *
+ * The pinned id shares the sibling namespace of the scope it is built into, so
+ * it must not collide with another component's id; `compose` throws if it does.
+ *
+ * @param id - The construct id the component should build under.
+ * @param inner - The component to tag.
+ * @returns A {@link Lifecycle} that `compose` builds under `id`.
+ *
+ * @example
+ * ```ts
+ * compose(
+ *   { jduffett: at("jasonduffett.net", apexSystem), clara },
+ *   { jduffett: [], clara: [] },
+ * ).build(app, "jasonduffett.net");
+ * // apex components build at `jasonduffett.net/<key>`, not
+ * // `jasonduffett.net/jduffett/<key>` — logical ids preserved.
+ * ```
+ */
+export function at<T extends object>(id: string, inner: Lifecycle<T>): Lifecycle<T> {
+  const tagged: Lifecycle<T> & { readonly [BUILD_ID]: string } = {
+    [BUILD_ID]: id,
+    build: (scope, buildId, context) => inner.build(scope, buildId, context),
+  };
+  return tagged;
+}
+
+/**
+ * Reads the {@link BUILD_ID} brand off a component, returning the id it was
+ * tagged with by {@link at}, or `undefined` if it was not tagged.
+ *
+ * @internal Consumed by {@link compose} to override the default id derivation.
+ */
+export function buildIdOf(component: Lifecycle): string | undefined {
+  const value = (component as { [BUILD_ID]?: unknown })[BUILD_ID];
+  return typeof value === "string" ? value : undefined;
+}

--- a/packages/core/src/compose.ts
+++ b/packages/core/src/compose.ts
@@ -1,6 +1,8 @@
 import { Graph, alg, json } from "@dagrejs/graphlib";
 import { type IConstruct } from "constructs";
+import { buildIdOf } from "./build-id.js";
 import { CyclicDependencyError } from "./cyclic-dependency-error.js";
+import { DuplicateConstructIdError } from "./duplicate-construct-id-error.js";
 import { type Lifecycle } from "./lifecycle.js";
 import { type StackStrategy } from "./stack-strategy.js";
 
@@ -253,6 +255,10 @@ class ComposedLifecycle<
   ): BuildOutcome<Components> {
     const results: Record<string, object> = {};
     const componentScopes: Record<string, IConstruct> = {};
+    // Tracks the construct ids built into each scope so an explicit id from
+    // at() that collides with a sibling fails loudly here, rather than as an
+    // opaque CDK duplicate-construct error deeper in synth.
+    const idsByScope = new Map<IConstruct, Set<string>>();
 
     for (const key of alg.topsort(this.#graph)) {
       const componentScope = stacks?.[key] ?? scope;
@@ -261,7 +267,18 @@ class ComposedLifecycle<
       // Inner deps shadow parent context on key collision.
       const innerContext = Object.fromEntries(deps.map((dep) => [dep, results[dep]]));
       const context = { ...parentContext, ...innerContext };
-      results[key] = this.#components[key].build(componentScope, `${id}/${key}`, context);
+      const component = this.#components[key];
+      // An at()-tagged component pins its own id; otherwise derive it from the key.
+      const componentId = buildIdOf(component) ?? `${id}/${key}`;
+
+      let usedIds = idsByScope.get(componentScope);
+      if (!usedIds) idsByScope.set(componentScope, (usedIds = new Set<string>()));
+      if (usedIds.has(componentId)) {
+        throw new DuplicateConstructIdError(componentId, key);
+      }
+      usedIds.add(componentId);
+
+      results[key] = component.build(componentScope, componentId, context);
     }
 
     return {

--- a/packages/core/src/duplicate-construct-id-error.ts
+++ b/packages/core/src/duplicate-construct-id-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Thrown when {@link compose} would build two components under the same construct
+ * id in the same scope — typically because an explicit id from `at()` collides
+ * with a sibling's id. Carries the offending id and component key so callers can
+ * inspect or report the collision programmatically, and surfaces the failure at
+ * composition time rather than as an opaque CDK duplicate-construct error deeper
+ * in synth.
+ */
+export class DuplicateConstructIdError extends Error {
+  /**
+   * @param id - The construct id that two components share.
+   * @param componentKey - The key of the component that triggered the collision.
+   */
+  constructor(
+    public readonly id: string,
+    public readonly componentKey: string,
+  ) {
+    super(
+      `Duplicate construct id "${id}" for component "${componentKey}" in the same scope. ` +
+        `An explicit id from at() must not collide with another component's id.`,
+    );
+    this.name = "DuplicateConstructIdError";
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { at } from "./build-id.js";
 export { Builder, COPY_STATE, type IBuilder } from "./builder.js";
 export { constructId, sanitizeConstructId } from "./construct-id.js";
 export {
@@ -7,6 +8,7 @@ export {
   type AfterBuildHook,
 } from "./compose.js";
 export { CyclicDependencyError } from "./cyclic-dependency-error.js";
+export { DuplicateConstructIdError } from "./duplicate-construct-id-error.js";
 export { type Lifecycle } from "./lifecycle.js";
 export { Ref, ref, resolve, isRef, type Resolvable } from "./ref.js";
 export {

--- a/packages/core/test/compose.test.ts
+++ b/packages/core/test/compose.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { Construct } from "constructs";
 import { compose, type AfterBuildHook } from "../src/compose.js";
+import { at } from "../src/build-id.js";
 import { groupedStacks } from "../src/stack-strategy.js";
 import { CyclicDependencyError } from "../src/cyclic-dependency-error.js";
+import { DuplicateConstructIdError } from "../src/duplicate-construct-id-error.js";
 import { type Lifecycle } from "../src/lifecycle.js";
 import { ref, resolve, type Resolvable } from "../src/ref.js";
 
@@ -230,6 +232,68 @@ describe("compose", () => {
 
       expect(aBuild.mock.calls[0][1]).toBe("myapp/a");
       expect(bBuild.mock.calls[0][1]).toBe("myapp/b");
+    });
+  });
+
+  describe("at (explicit build id)", () => {
+    it("builds an at()-tagged component under its pinned id, leaving untagged siblings on the default derivation", () => {
+      const { lifecycle: a, build: aBuild } = spyComponent({ x: 1 });
+      const { lifecycle: b, build: bBuild } = spyComponent({ y: 2 });
+
+      const system = compose(
+        { jduffett: at("jasonduffett.net", a), clara: b },
+        { jduffett: [], clara: [] },
+      );
+      system.build(createScope(), "parent");
+
+      expect(aBuild.mock.calls[0][1]).toBe("jasonduffett.net");
+      expect(bBuild.mock.calls[0][1]).toBe("parent/clara");
+    });
+
+    it("preserves a nested system's internal ids regardless of the outer key", () => {
+      const { lifecycle: zone, build: zoneBuild } = spyComponent({ z: 1 });
+      const apex = compose({ zone }, { zone: [] });
+
+      // Nested under key "jduffett" but pinned to the standalone build id.
+      compose({ jduffett: at("jasonduffett.net", apex) }, { jduffett: [] }).build(
+        createScope(),
+        "parent",
+      );
+
+      // Without at() this would be "parent/jduffett/zone"; pinning re-roots it.
+      expect(zoneBuild.mock.calls[0][1]).toBe("jasonduffett.net/zone");
+    });
+
+    it("still forwards the resolved dependency context to a tagged component", () => {
+      const { lifecycle: a } = spyComponent({ from: "a" });
+      const { lifecycle: b, build: bBuild } = spyComponent({ from: "b" });
+
+      compose({ a, b: at("fixed", b) }, { a: [], b: ["a"] }).build(createScope(), "parent");
+
+      expect(bBuild.mock.calls[0][2]).toEqual({ a: { from: "a" } });
+    });
+
+    it("throws when an explicit id collides with a sibling's id in the same scope", () => {
+      const { lifecycle: a } = spyComponent({ x: 1 });
+      const { lifecycle: b } = spyComponent({ y: 2 });
+
+      const system = compose({ a, b: at("parent/a", b) }, { a: [], b: [] });
+
+      expect(() => system.build(createScope(), "parent")).toThrow(DuplicateConstructIdError);
+    });
+
+    it("allows the same explicit id in different scopes", () => {
+      const { lifecycle: a, build: aBuild } = spyComponent({ x: 1 });
+      const { lifecycle: b, build: bBuild } = spyComponent({ y: 2 });
+      const scopeA = new Construct(undefined as never, "scopeA");
+      const scopeB = new Construct(undefined as never, "scopeB");
+
+      compose({ a: at("shared", a), b: at("shared", b) }, { a: [], b: [] })
+        .withStacks({ a: scopeA, b: scopeB })
+        .build(createScope(), "parent");
+
+      expect(aBuild.mock.calls[0][1]).toBe("shared");
+      expect(bBuild.mock.calls[0][1]).toBe("shared");
     });
   });
 


### PR DESCRIPTION
## Summary

Nesting an already-deployed `compose()` system as a component inside a parent `compose()` rotates **every** CloudFormation logical id, because `compose()` derives each component's construct id from its key as `` `${parentId}/${key}` ``. The inserted key segment lengthens every construct path, and CDK hashes the full path — so adopting the compose-of-sub-lifecycles pattern on a live stack was a destructive change with no first-class escape (#245).

This adds **`at(id, component)`**: tag a `Lifecycle` with an explicit construct id, and `compose()` builds it under that id verbatim instead of deriving one from the key. A nested system can then preserve the exact logical ids it had standalone.

```ts
compose(
  { existing: at("MySystem", deployedSystem), addition },
  { existing: [], addition: [] },
).build(app, "MySystem");
// deployedSystem's components build at `MySystem/<key>`, not
// `MySystem/existing/<key>` — logical ids preserved.
```

## How it works

- `at(id, inner)` returns an ordinary `Lifecycle`, carrying the id on a `Symbol.for("composurecdk.buildId")` brand — the same realm-agnostic brand convention as `Ref`/`COPY_STATE` (ADR-0007), so it survives the dual ESM/CJS boundary.
- `compose()` reads the brand and passes the pinned id through the **`id` argument it already passes** to `build`. Nothing is discarded — the inner build receives and honours the id end to end. This is the key distinction from the downstream `withFixedId` adapter, which worked by throwing the framework-supplied id away.
- The **wiring key is untouched**: dependency declarations, topological sort, and `ref()`/context lookups all still key off the original component key. `BuildResult` type inference is preserved (the brand is an invisible extra symbol property).
- A pinned id shares the sibling namespace of the scope it builds into, so `compose()` now tracks ids **per scope** and throws a typed `DuplicateConstructIdError` on collision — surfaced at composition time instead of as an opaque CDK duplicate-construct error deeper in synth. Same id in two different stacks (via `withStacks`) remains legal.

## Design

`at()` was chosen over a parent-side `withIds({...})` map and a pluggable `withIdStrategy(...)` hook: id control lives at the component declaration site, next to the `id` argument it sets, and adds exactly one public function with no new interface surface. Full rationale and the alternatives (including the "flatten instead of nest" approach) are in **ADR-0012**; `architecture.md`'s nesting section gains a short note.

## Tests

New `describe("at (explicit build id)")` block in `compose.test.ts` covers: pinning the id while leaving untagged siblings on the default derivation, preserving a nested system's internal ids regardless of the outer key, forwarding resolved dependency context to a tagged component, the per-scope collision error, and the same id allowed across different scopes.

Closes #245