### PR TITLE
feat(sqs): add dead-letter-queue role switch to QueueBuilder

### DIFF
--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -55,9 +55,9 @@ The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.
 | `approximateAgeOfOldestMessage`         | `ApproximateAgeOfOldestMessage` (Max, 1 min)         | > 300s (5 min)    | Primary "consumer falling behind" signal. Conservative starting point — tune to your SLA and `retentionPeriod`.                                                                                               |
 | `approximateNumberOfMessagesNotVisible` | `ApproximateNumberOfMessagesNotVisible` (Max, 1 min) | > 90,000          | 75% of the [120k in-flight messages](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight) per-queue quota. Proactive guardrail before receives are rejected. |
 
-These defaults target primary queues; dead-letter queues need different thresholds (any message on a DLQ is itself an alert).
+These defaults target primary queues; dead-letter queues need different thresholds (any message on a DLQ is itself an alert) — see [Dead-letter queue role](#dead-letter-queue-role).
 
-The third AWS-recommended SQS alarm, `ApproximateNumberOfMessagesVisible`, is not enabled by default — its useful threshold depends entirely on the application's processing capacity, and any generic value would be either noise or silence. Use `addAlarm` (see [Custom alarms](#custom-alarms)) to add it for workloads where you know the right threshold.
+The third AWS-recommended SQS alarm, `ApproximateNumberOfMessagesVisible`, is not enabled by default on a primary queue — its useful threshold depends entirely on the application's processing capacity, and any generic value would be either noise or silence. Enable it explicitly via `recommendedAlarms` with your own threshold, or use `addAlarm` (see [Custom alarms](#custom-alarms)) for full control over the metric.
 
 The defaults are exported as `QUEUE_ALARM_DEFAULTS` for visibility and testing:
 
@@ -125,6 +125,60 @@ for (const alarm of Object.values(result.alarms)) {
 ```
 
 For composing the alarm-actions wiring across multiple builders in a single `compose` system, see [`alarmActionsPolicy`](../cloudwatch/README.md) in `@composurecdk/cloudwatch`.
+
+## Dead-Letter Queue Role
+
+Call `.asDeadLetterQueue()` to switch the builder into the dead-letter-queue role. It's the same `QueueBuilder` — just a mode flag — so a DLQ still gets every secure default from [Secure Defaults](#secure-defaults), plus a set of adjustments tuned for a queue that exists to be investigated rather than actively consumed:
+
+```ts
+import { createQueueBuilder } from "@composurecdk/sqs";
+
+const ordersDlq = createQueueBuilder()
+  .queueName("orders-dlq")
+  .asDeadLetterQueue()
+  .build(stack, "OrdersDlq");
+
+const orders = createQueueBuilder()
+  .queueName("orders")
+  .deadLetterQueue({ queue: ordersDlq.queue, maxReceiveCount: 5 })
+  .build(stack, "Orders");
+```
+
+### Defaults
+
+| Property          | Default             | Rationale                                                                                                                                                                                               |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `retentionPeriod` | `Duration.days(14)` | The SQS maximum. A DLQ exists to give operators a window to investigate and redrive failed messages — maximizing that window is the point. Exported as `DLQ_QUEUE_DEFAULTS` for visibility and testing. |
+
+`QueueBuilder` warns (via `Annotations`) if a queue built with `.asDeadLetterQueue()` also configures its own `deadLetterQueue` redrive policy — a DLQ is meant to be a terminal destination, and redriving from it to another queue is almost always unintended.
+
+### Alarms
+
+The recommended-alarm set inverts: any message present on a DLQ is itself the alert, whereas the primary-queue signals ("consumer falling behind", "in-flight quota") don't apply to a queue nothing actively consumes from.
+
+| Alarm                                   | Default on a DLQ | Rationale                                                                                                                           |
+| --------------------------------------- | :--------------: | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `approximateNumberOfMessagesVisible`    |     ✅ (> 0)     | Any message on a DLQ indicates a delivery failure that needs investigation.                                                         |
+| `approximateAgeOfOldestMessage`         |        ❌        | Meaningless on a queue nothing consumes from. Opt back in via `recommendedAlarms` to alert on messages sitting unattended too long. |
+| `approximateNumberOfMessagesNotVisible` |        ❌        | Nothing is ever in flight on a DLQ. Opt back in via `recommendedAlarms` if you have a reason to watch it.                           |
+
+Every entry is individually overridable through the same `recommendedAlarms` API used for primary queues:
+
+```ts
+const ordersDlq = createQueueBuilder()
+  .asDeadLetterQueue()
+  .recommendedAlarms({
+    approximateNumberOfMessagesVisible: { threshold: 5 }, // alert only once a small backlog builds up
+    approximateAgeOfOldestMessage: { threshold: 3600 }, // opt back in: alert after an hour unattended
+  })
+  .build(stack, "OrdersDlq");
+```
+
+The default enablement is exported as `DLQ_ALARM_DEFAULTS` for visibility and testing:
+
+```ts
+import { DLQ_ALARM_DEFAULTS } from "@composurecdk/sqs";
+```
 
 ## Examples
 

--- a/packages/sqs/src/dlq-alarm-defaults.ts
+++ b/packages/sqs/src/dlq-alarm-defaults.ts
@@ -1,0 +1,24 @@
+import type { QueueAlarmKey } from "./queue-alarm-config.js";
+
+/**
+ * Default enablement for each recommended SQS alarm when a queue is built
+ * in the dead-letter-queue role via `createQueueBuilder().asDeadLetterQueue()`,
+ * as opposed to the primary-queue enablement baked into
+ * `resolveQueueAlarmDefinitions`. Numeric thresholds are shared with
+ * {@link QUEUE_ALARM_DEFAULTS} — only which alarms are created
+ * automatically differs, and every entry remains individually
+ * overridable via `recommendedAlarms`.
+ *
+ * Inverted from a primary queue: any message present on a DLQ is itself
+ * an alert, so `approximateNumberOfMessagesVisible` flips on. "Consumer
+ * falling behind" (`approximateAgeOfOldestMessage`) and "in-flight quota"
+ * (`approximateNumberOfMessagesNotVisible`) are meaningless on a queue
+ * nothing actively consumes from, so they flip off.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+ */
+export const DLQ_ALARM_DEFAULTS: Record<QueueAlarmKey, boolean> = {
+  approximateAgeOfOldestMessage: false,
+  approximateNumberOfMessagesNotVisible: false,
+  approximateNumberOfMessagesVisible: true,
+};

--- a/packages/sqs/src/dlq-defaults.ts
+++ b/packages/sqs/src/dlq-defaults.ts
@@ -1,0 +1,18 @@
+import { Duration } from "aws-cdk-lib";
+import type { QueueProps } from "aws-cdk-lib/aws-sqs";
+
+/**
+ * AWS-recommended defaults layered on top of {@link QUEUE_DEFAULTS} when a
+ * queue is built in the dead-letter-queue role via
+ * `createQueueBuilder().asDeadLetterQueue()`.
+ */
+export const DLQ_QUEUE_DEFAULTS: Partial<QueueProps> = {
+  /**
+   * 14 days — the SQS maximum. A dead-letter queue exists to give
+   * operators a window to investigate and redrive failed messages, so
+   * maximizing that window is the point; a primary queue's 4-day CDK
+   * default would let messages expire before anyone notices them.
+   * @see https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-basic-architecture.html
+   */
+  retentionPeriod: Duration.days(14),
+};

--- a/packages/sqs/src/index.ts
+++ b/packages/sqs/src/index.ts
@@ -5,5 +5,8 @@ export {
   type QueueBuilderResult,
 } from "./queue-builder.js";
 export { QUEUE_DEFAULTS } from "./defaults.js";
-export { type QueueAlarmConfig } from "./queue-alarm-config.js";
+export { DLQ_QUEUE_DEFAULTS } from "./dlq-defaults.js";
+export { type QueueAlarmConfig, type QueueAlarmKey } from "./queue-alarm-config.js";
 export { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";
+export { DLQ_ALARM_DEFAULTS } from "./dlq-alarm-defaults.js";
+export { type QueueRole } from "./queue-role.js";

--- a/packages/sqs/src/queue-alarm-config.ts
+++ b/packages/sqs/src/queue-alarm-config.ts
@@ -1,10 +1,24 @@
 import type { AlarmConfig } from "@composurecdk/cloudwatch";
 
 /**
+ * Keys of the recommended SQS alarms a {@link createQueueBuilder | QueueBuilder}
+ * can create. Shared between the primary-queue defaults
+ * ({@link QUEUE_ALARM_DEFAULTS}) and the dead-letter-queue defaults
+ * ({@link DLQ_ALARM_DEFAULTS}) so both roles resolve the same config shape.
+ */
+export type QueueAlarmKey =
+  | "approximateAgeOfOldestMessage"
+  | "approximateNumberOfMessagesNotVisible"
+  | "approximateNumberOfMessagesVisible";
+
+/**
  * Controls which recommended alarms are created for an SQS queue.
- * All applicable alarms are enabled by default with AWS-recommended thresholds.
- * Set individual alarms to `false` to disable them, or provide an
- * {@link AlarmConfig} to tune thresholds.
+ * Which alarms are enabled by default — and their thresholds — depends on
+ * the queue's role (primary vs. dead-letter, see
+ * {@link createQueueBuilder}'s `.asDeadLetterQueue()`). Set an individual
+ * alarm to `false` to disable it regardless of role, or provide an
+ * {@link AlarmConfig} to enable it (if off by default) or tune its
+ * thresholds (if on by default).
  *
  * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
  */
@@ -45,4 +59,24 @@ export interface QueueAlarmConfig {
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
    */
   approximateNumberOfMessagesNotVisible?: AlarmConfig | false;
+
+  /**
+   * Alarm when the queue has visible (available-to-receive) messages
+   * above the threshold.
+   *
+   * Disabled by default on a primary queue — messages waiting to be
+   * consumed are the normal state, and no generic threshold suits every
+   * workload's processing capacity; enable it explicitly with a
+   * threshold sized to your consumers.
+   *
+   * Enabled by default on a dead-letter queue built via
+   * `.asDeadLetterQueue()`, where any message present is itself the
+   * alert (default threshold: > 0). See {@link DLQ_ALARM_DEFAULTS}.
+   *
+   * Metric: `AWS/SQS ApproximateNumberOfMessagesVisible`, statistic
+   * Maximum, period 1 minute.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  approximateNumberOfMessagesVisible?: AlarmConfig | false;
 }

--- a/packages/sqs/src/queue-alarm-defaults.ts
+++ b/packages/sqs/src/queue-alarm-defaults.ts
@@ -5,14 +5,19 @@ interface QueueAlarmDefaults {
   enabled: true;
   approximateAgeOfOldestMessage: AlarmConfigDefaults;
   approximateNumberOfMessagesNotVisible: AlarmConfigDefaults;
+  approximateNumberOfMessagesVisible: AlarmConfigDefaults;
 }
 
 /**
  * AWS-recommended default alarm configuration for SQS queues.
  *
- * Tuned for primary (consumer-fed) queues. Dead-letter queues need
- * different thresholds — any message on a DLQ is itself an alert,
- * whereas a primary queue with messages is normal.
+ * These are threshold baselines only — which alarms are *enabled* by
+ * default (as opposed to requiring an explicit opt-in) depends on the
+ * queue's role and is decided in `resolveQueueAlarmDefinitions`. Tuned
+ * for primary (consumer-fed) queues; dead-letter queues invert which
+ * alarms apply automatically (see {@link DLQ_ALARM_DEFAULTS}) — any
+ * message on a DLQ is itself an alert, whereas a primary queue with
+ * messages is normal.
  *
  * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
  */
@@ -39,6 +44,20 @@ export const QUEUE_ALARM_DEFAULTS: QueueAlarmDefaults = {
    */
   approximateNumberOfMessagesNotVisible: {
     threshold: 90_000,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /**
+   * 0 — matches the dead-letter-queue semantic of "any message present
+   * is notable" (see {@link DLQ_ALARM_DEFAULTS}, where this alarm is
+   * enabled by default). Only used as a merge baseline when this alarm
+   * is explicitly enabled; on a primary queue, override the threshold
+   * to a value sized to your workload's processing capacity.
+   */
+  approximateNumberOfMessagesVisible: {
+    threshold: 0,
     evaluationPeriods: 1,
     datapointsToAlarm: 1,
     treatMissingData: TreatMissingData.NOT_BREACHING,

--- a/packages/sqs/src/queue-alarms.ts
+++ b/packages/sqs/src/queue-alarms.ts
@@ -2,68 +2,104 @@ import { Duration } from "aws-cdk-lib";
 import { type Alarm, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
 import type { IQueue } from "aws-cdk-lib/aws-sqs";
 import type { IConstruct } from "constructs";
-import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import type { AlarmDefinition, AlarmMetric } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
-import type { QueueAlarmConfig } from "./queue-alarm-config.js";
+import type { QueueAlarmConfig, QueueAlarmKey } from "./queue-alarm-config.js";
 import { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";
+import { DLQ_ALARM_DEFAULTS } from "./dlq-alarm-defaults.js";
+import type { QueueRole } from "./queue-role.js";
 
 const METRIC_PERIOD = Duration.minutes(1);
 const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
 
 /**
+ * Default enablement for each recommended alarm, per queue role. Adding a
+ * future role (e.g. FIFO) is purely additive here — one more row, no
+ * changes to {@link resolveQueueAlarmDefinitions}.
+ */
+const ALARM_DEFAULT_ENABLEMENT: Record<QueueRole, Record<QueueAlarmKey, boolean>> = {
+  primary: {
+    approximateAgeOfOldestMessage: true,
+    approximateNumberOfMessagesNotVisible: true,
+    approximateNumberOfMessagesVisible: false,
+  },
+  dlq: DLQ_ALARM_DEFAULTS,
+};
+
+/** A recommended alarm's metric factory and role-aware description text. */
+interface AlarmSpec {
+  key: QueueAlarmKey;
+  metric: (queue: IQueue) => AlarmMetric;
+  describe: (role: QueueRole, threshold: number) => string;
+}
+
+const ALARM_SPECS: AlarmSpec[] = [
+  {
+    key: "approximateAgeOfOldestMessage",
+    metric: (queue) => queue.metricApproximateAgeOfOldestMessage({ period: METRIC_PERIOD }),
+    describe: (role, threshold) =>
+      role === "dlq"
+        ? `Messages have been sitting unattended on this dead-letter queue longer than the ` +
+          `threshold — investigate before they age out via the queue's retentionPeriod. ` +
+          `Threshold: > ${String(threshold)} seconds in ${METRIC_PERIOD_LABEL}.`
+        : `SQS queue's oldest message has been waiting longer than the threshold, ` +
+          `indicating consumers are falling behind. Threshold: > ${String(threshold)} seconds in ${METRIC_PERIOD_LABEL}.`,
+  },
+  {
+    key: "approximateNumberOfMessagesNotVisible",
+    metric: (queue) => queue.metricApproximateNumberOfMessagesNotVisible({ period: METRIC_PERIOD }),
+    describe: (_role, threshold) =>
+      `SQS queue's in-flight messages are approaching the 120,000 per-queue quota; ` +
+      `further receives will be rejected once the quota is hit. ` +
+      `Threshold: > ${String(threshold)} in-flight in ${METRIC_PERIOD_LABEL}.`,
+  },
+  {
+    key: "approximateNumberOfMessagesVisible",
+    metric: (queue) => queue.metricApproximateNumberOfMessagesVisible({ period: METRIC_PERIOD }),
+    describe: (role, threshold) =>
+      role === "dlq"
+        ? `Dead-letter queue has messages present — any message here indicates a delivery ` +
+          `failure that needs investigation. Threshold: > ${String(threshold)} in ${METRIC_PERIOD_LABEL}.`
+        : `Queue has more visible messages waiting than expected for this workload. ` +
+          `Threshold: > ${String(threshold)} in ${METRIC_PERIOD_LABEL}.`,
+  },
+];
+
+/**
  * Resolves the recommended alarm configuration into fully-resolved
  * {@link AlarmDefinition}s for an SQS queue.
+ *
+ * @param role - Which default enablement/thresholds apply. `"dlq"`
+ *   inverts which alarms are on by default (see {@link DLQ_ALARM_DEFAULTS});
+ *   set via `createQueueBuilder().asDeadLetterQueue()`.
  */
 export function resolveQueueAlarmDefinitions(
   queue: IQueue,
   config: QueueAlarmConfig | undefined,
+  role: QueueRole = "primary",
 ): AlarmDefinition[] {
   if (config?.enabled === false) return [];
 
-  const definitions: AlarmDefinition[] = [];
+  return ALARM_SPECS.flatMap((spec): AlarmDefinition[] => {
+    const userConfig = config?.[spec.key];
+    if (userConfig === false) return [];
+    if (userConfig === undefined && !ALARM_DEFAULT_ENABLEMENT[role][spec.key]) return [];
 
-  if (config?.approximateAgeOfOldestMessage !== false) {
-    const cfg = resolveAlarmConfig(
-      config?.approximateAgeOfOldestMessage,
-      QUEUE_ALARM_DEFAULTS.approximateAgeOfOldestMessage,
-    );
-    definitions.push({
-      key: "approximateAgeOfOldestMessage",
-      alarmName: cfg.alarmName,
-      metric: queue.metricApproximateAgeOfOldestMessage({ period: METRIC_PERIOD }),
-      threshold: cfg.threshold,
-      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: cfg.evaluationPeriods,
-      datapointsToAlarm: cfg.datapointsToAlarm,
-      treatMissingData: cfg.treatMissingData,
-      description:
-        `SQS queue's oldest message has been waiting longer than the threshold, ` +
-        `indicating consumers are falling behind. Threshold: > ${String(cfg.threshold)} seconds in ${METRIC_PERIOD_LABEL}.`,
-    });
-  }
-
-  if (config?.approximateNumberOfMessagesNotVisible !== false) {
-    const cfg = resolveAlarmConfig(
-      config?.approximateNumberOfMessagesNotVisible,
-      QUEUE_ALARM_DEFAULTS.approximateNumberOfMessagesNotVisible,
-    );
-    definitions.push({
-      key: "approximateNumberOfMessagesNotVisible",
-      alarmName: cfg.alarmName,
-      metric: queue.metricApproximateNumberOfMessagesNotVisible({ period: METRIC_PERIOD }),
-      threshold: cfg.threshold,
-      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: cfg.evaluationPeriods,
-      datapointsToAlarm: cfg.datapointsToAlarm,
-      treatMissingData: cfg.treatMissingData,
-      description:
-        `SQS queue's in-flight messages are approaching the 120,000 per-queue quota; ` +
-        `further receives will be rejected once the quota is hit. ` +
-        `Threshold: > ${String(cfg.threshold)} in-flight in ${METRIC_PERIOD_LABEL}.`,
-    });
-  }
-
-  return definitions;
+    const cfg = resolveAlarmConfig(userConfig, QUEUE_ALARM_DEFAULTS[spec.key]);
+    return [
+      {
+        key: spec.key,
+        alarmName: cfg.alarmName,
+        metric: spec.metric(queue),
+        threshold: cfg.threshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: cfg.evaluationPeriods,
+        datapointsToAlarm: cfg.datapointsToAlarm,
+        treatMissingData: cfg.treatMissingData,
+        description: spec.describe(role, cfg.threshold),
+      },
+    ];
+  });
 }
 
 /**
@@ -75,6 +111,8 @@ export function resolveQueueAlarmDefinitions(
  * @param queue - The SQS queue to create alarms for.
  * @param config - User-provided alarm configuration, or `false` to disable all.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @param role - Which default enablement/thresholds apply; see
+ *   {@link resolveQueueAlarmDefinitions}.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
  * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
@@ -85,13 +123,14 @@ export function createQueueAlarms(
   queue: IQueue,
   config: QueueAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<IQueue>[] = [],
+  role: QueueRole = "primary",
 ): Record<string, Alarm> {
   if (config === false) return {};
 
   const enabled = config?.enabled ?? QUEUE_ALARM_DEFAULTS.enabled;
   if (!enabled) return {};
 
-  const recommended = resolveQueueAlarmDefinitions(queue, config);
+  const recommended = resolveQueueAlarmDefinitions(queue, config, role);
   const custom = customAlarms.map((b) => b.resolve(queue));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/sqs/src/queue-builder.ts
+++ b/packages/sqs/src/queue-builder.ts
@@ -8,6 +8,8 @@ import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { QueueAlarmConfig } from "./queue-alarm-config.js";
 import { createQueueAlarms } from "./queue-alarms.js";
 import { QUEUE_DEFAULTS } from "./defaults.js";
+import { DLQ_QUEUE_DEFAULTS } from "./dlq-defaults.js";
+import type { QueueRole } from "./queue-role.js";
 
 /**
  * AWS-recommended minimum for `maxReceiveCount` on an SQS redrive
@@ -81,6 +83,13 @@ export interface QueueBuilderResult {
  * Alarms can be customized or disabled via the `recommendedAlarms` property.
  * Custom alarms can be added via the {@link addAlarm} method.
  *
+ * Calling `.asDeadLetterQueue()` switches the builder into the
+ * dead-letter-queue role: it applies {@link DLQ_QUEUE_DEFAULTS} (14-day
+ * retention) and inverts which recommended alarms are enabled by default
+ * — any message present becomes the alert, rather than a "consumer
+ * falling behind" or "in-flight quota" signal that doesn't apply to a
+ * queue nothing actively consumes from.
+ *
  * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.Queue.html
  *
  * @example
@@ -88,6 +97,10 @@ export interface QueueBuilderResult {
  * const orders = createQueueBuilder()
  *   .queueName("orders")
  *   .visibilityTimeout(Duration.seconds(60));
+ *
+ * const ordersDlq = createQueueBuilder()
+ *   .queueName("orders-dlq")
+ *   .asDeadLetterQueue();
  * ```
  */
 export type IQueueBuilder = ITaggedBuilder<QueueBuilderProps, QueueBuilder>;
@@ -95,6 +108,7 @@ export type IQueueBuilder = ITaggedBuilder<QueueBuilderProps, QueueBuilder>;
 class QueueBuilder implements Lifecycle<QueueBuilderResult> {
   props: Partial<QueueBuilderProps> = {};
   readonly #customAlarms: AlarmDefinitionBuilder<IQueue>[] = [];
+  #role: QueueRole = "primary";
 
   addAlarm(
     key: string,
@@ -104,9 +118,23 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
     return this;
   }
 
+  /**
+   * Switches the builder into the dead-letter-queue role: applies
+   * {@link DLQ_QUEUE_DEFAULTS} (14-day retention) and enables the
+   * dead-letter-queue recommended-alarm defaults (see
+   * {@link DLQ_ALARM_DEFAULTS}) in place of the primary-queue ones.
+   * Every default remains individually overridable through the
+   * builder's usual fluent API.
+   */
+  asDeadLetterQueue(): this {
+    this.#role = "dlq";
+    return this;
+  }
+
   /** @internal — see ADR-0005. */
   [COPY_STATE](target: QueueBuilder): void {
     target.#customAlarms.push(...this.#customAlarms);
+    target.#role = this.#role;
   }
 
   build(scope: IConstruct, id: string): QueueBuilderResult {
@@ -114,14 +142,16 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
 
     const mergedProps = {
       ...QUEUE_DEFAULTS,
+      ...(this.#role === "dlq" ? DLQ_QUEUE_DEFAULTS : {}),
       ...queueProps,
     } as QueueBuilderProps;
 
     warnIfLowMaxReceiveCount(scope, id, mergedProps);
+    warnIfDlqHasRedrivePolicy(scope, id, this.#role, mergedProps);
 
     const queue = new Queue(scope, id, mergedProps);
 
-    const alarms = createQueueAlarms(scope, id, queue, alarmConfig, this.#customAlarms);
+    const alarms = createQueueAlarms(scope, id, queue, alarmConfig, this.#customAlarms, this.#role);
 
     return { queue, alarms };
   }
@@ -182,5 +212,29 @@ function warnIfLowMaxReceiveCount(
       `AWS recommends >= ${String(RECOMMENDED_MIN_MAX_RECEIVE_COUNT)} so the consumer ` +
       `has room to retry before messages hit the dead-letter queue. ` +
       `See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html`,
+  );
+}
+
+/**
+ * Annotates `scope` with a non-fatal warning when a queue built via
+ * `.asDeadLetterQueue()` also configures its own redrive policy
+ * (`deadLetterQueue`). A dead-letter queue is meant to be a terminal
+ * destination for failed messages — redriving from it to yet another
+ * queue is almost always unintended.
+ */
+function warnIfDlqHasRedrivePolicy(
+  scope: IConstruct,
+  id: string,
+  role: QueueRole,
+  props: Partial<QueueBuilderProps>,
+): void {
+  if (role !== "dlq") return;
+  if (!props.deadLetterQueue) return;
+  Annotations.of(scope).addWarningV2(
+    "@composurecdk/sqs:dlq-with-redrive-policy",
+    `QueueBuilder "${id}": built via asDeadLetterQueue() but also configures its own ` +
+      `deadLetterQueue redrive policy. A dead-letter queue is meant to be a terminal ` +
+      `destination for failed messages — redriving from it to another queue is unusual ` +
+      `and likely unintended.`,
   );
 }

--- a/packages/sqs/src/queue-role.ts
+++ b/packages/sqs/src/queue-role.ts
@@ -1,0 +1,10 @@
+/**
+ * The recommended-defaults role a {@link createQueueBuilder | QueueBuilder}
+ * applies. `"primary"` is the default (a consumer-fed queue). `"dlq"`
+ * applies dead-letter-queue defaults and inverted alarm semantics via
+ * `.asDeadLetterQueue()`.
+ *
+ * Modeled as a union rather than a boolean so it extends to future roles
+ * (e.g. FIFO-tuned defaults) without another builder entry point.
+ */
+export type QueueRole = "primary" | "dlq";

--- a/packages/sqs/test/dlq-role.test.ts
+++ b/packages/sqs/test/dlq-role.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import { createQueueBuilder } from "../src/queue-builder.js";
+import { DLQ_QUEUE_DEFAULTS } from "../src/dlq-defaults.js";
+import { DLQ_ALARM_DEFAULTS } from "../src/dlq-alarm-defaults.js";
+
+function buildResult(configureFn?: (builder: ReturnType<typeof createQueueBuilder>) => void) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = createQueueBuilder().asDeadLetterQueue();
+  configureFn?.(builder);
+  const result = builder.build(stack, "OrdersDlq");
+  return { stack, result, template: Template.fromStack(stack) };
+}
+
+describe("DLQ_QUEUE_DEFAULTS", () => {
+  it("sets retentionPeriod to the SQS maximum of 14 days", () => {
+    expect(DLQ_QUEUE_DEFAULTS.retentionPeriod?.toDays()).toBe(14);
+  });
+});
+
+describe("DLQ_ALARM_DEFAULTS", () => {
+  it("inverts enablement relative to a primary queue", () => {
+    expect(DLQ_ALARM_DEFAULTS).toEqual({
+      approximateAgeOfOldestMessage: false,
+      approximateNumberOfMessagesNotVisible: false,
+      approximateNumberOfMessagesVisible: true,
+    });
+  });
+});
+
+describe("QueueBuilder.asDeadLetterQueue()", () => {
+  describe("queue defaults", () => {
+    it("applies a 14-day retention period", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: 14 * 24 * 60 * 60,
+      });
+    });
+
+    it("still applies the shared secure defaults (enforceSSL, encryption, long polling)", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        SqsManagedSseEnabled: true,
+        ReceiveMessageWaitTimeSeconds: 20,
+      });
+      template.hasResourceProperties("AWS::SQS::QueuePolicy", {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Deny",
+              Condition: { Bool: { "aws:SecureTransport": "false" } },
+            }),
+          ]),
+        }),
+      });
+    });
+
+    it("allows retentionPeriod to be overridden via the fluent API", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+
+      createQueueBuilder()
+        .asDeadLetterQueue()
+        .retentionPeriod(Duration.days(4))
+        .build(stack, "OrdersDlq");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: 4 * 24 * 60 * 60,
+      });
+    });
+
+    it("warns when the DLQ also configures its own redrive policy", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const sink = new Queue(stack, "Sink");
+
+      createQueueBuilder()
+        .asDeadLetterQueue()
+        .deadLetterQueue({ queue: sink, maxReceiveCount: 5 })
+        .build(stack, "OrdersDlq");
+
+      Annotations.fromStack(stack).hasWarning(
+        "/TestStack",
+        Match.stringLikeRegexp(
+          "built via asDeadLetterQueue\\(\\) but also configures its own.*\\[ack: @composurecdk/sqs:dlq-with-redrive-policy\\]",
+        ),
+      );
+    });
+
+    it("does not warn about a redrive policy on a primary queue", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const sink = new Queue(stack, "Sink");
+
+      createQueueBuilder()
+        .deadLetterQueue({ queue: sink, maxReceiveCount: 5 })
+        .build(stack, "Orders");
+
+      expect(
+        Annotations.fromStack(stack).findWarning(
+          "*",
+          Match.stringLikeRegexp("dlq-with-redrive-policy"),
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe("recommended alarms", () => {
+    it("creates only the approximateNumberOfMessagesVisible alarm by default", () => {
+      const { result, template } = buildResult();
+
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeDefined();
+      expect(result.alarms.approximateAgeOfOldestMessage).toBeUndefined();
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("creates the approximateNumberOfMessagesVisible alarm with threshold > 0", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesVisible",
+        Namespace: "AWS/SQS",
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        Statistic: "Maximum",
+        Period: 60,
+      });
+    });
+
+    it("allows opting back into approximateAgeOfOldestMessage on a DLQ", () => {
+      const { result, template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateAgeOfOldestMessage: { threshold: 600 } }),
+      );
+
+      expect(result.alarms.approximateAgeOfOldestMessage).toBeDefined();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        Threshold: 600,
+      });
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+
+    it("allows opting back into approximateNumberOfMessagesNotVisible on a DLQ", () => {
+      const { result } = buildResult((b) =>
+        b.recommendedAlarms({ approximateNumberOfMessagesNotVisible: { threshold: 1000 } }),
+      );
+
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeDefined();
+    });
+
+    it("allows disabling the default-on approximateNumberOfMessagesVisible alarm", () => {
+      const { result, template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateNumberOfMessagesVisible: false }),
+      );
+
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("allows overriding the approximateNumberOfMessagesVisible threshold", () => {
+      const { template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateNumberOfMessagesVisible: { threshold: 5 } }),
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesVisible",
+        Threshold: 5,
+      });
+    });
+
+    it("disables all recommended alarms when recommendedAlarms is false", () => {
+      const { result, template } = buildResult((b) => b.recommendedAlarms(false));
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("primary queue (unaffected)", () => {
+    it("still creates the primary-queue alarm set by default and not approximateNumberOfMessagesVisible", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createQueueBuilder().build(stack, "Orders");
+
+      expect(result.alarms.approximateAgeOfOldestMessage).toBeDefined();
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeDefined();
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeUndefined();
+    });
+
+    it("allows opting into approximateNumberOfMessagesVisible on a primary queue", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const result = createQueueBuilder()
+        .recommendedAlarms({ approximateNumberOfMessagesVisible: { threshold: 1000 } })
+        .build(stack, "Orders");
+
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeDefined();
+    });
+
+    it("leaves retentionPeriod at the CDK default (not 14 days)", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      createQueueBuilder().build(stack, "Orders");
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: Match.absent(),
+      });
+    });
+  });
+
+  describe("copy", () => {
+    it("preserves the dlq role across .copy()", () => {
+      // If the role were not copied, the clone would fall back to the
+      // primary-queue alarm defaults instead of the DLQ ones, and this
+      // assertion would catch the mismatch.
+      assertCopyPreservesState({
+        factory: () => createQueueBuilder(),
+        configure: (b) => {
+          b.asDeadLetterQueue();
+        },
+        mutate: (b) => {
+          b.addAlarm("customOne", (a) =>
+            a
+              .metric((queue) => queue.metricNumberOfEmptyReceives())
+              .threshold(1)
+              .greaterThan(),
+          );
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Queue"),
+        inspect: (r) => Object.keys(r.alarms).sort(),
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Implements the DLQ-variant scope item from #34 using **Option B** from the [design discussion](https://github.com/laazyj/composureCDK/issues/34#issuecomment-4448537437) — a role flag on the existing `QueueBuilder` rather than a separate `createDlqQueueBuilder()`. One builder, one entry point, and it extends naturally to future roles (e.g. FIFO) without a new entry point.

`createQueueBuilder().asDeadLetterQueue()` switches the builder into the dead-letter-queue role:

- **Well-Architected queue defaults**: layers `DLQ_QUEUE_DEFAULTS` (14-day retention — the SQS maximum, maximizing the investigation/redrive window) on top of the existing secure defaults (`enforceSSL`, SSE-SQS, long polling).
- **Inverted recommended alarms**: any message present on a DLQ is itself the alert, so `approximateNumberOfMessagesVisible` (threshold > 0) is enabled by default, while the primary-queue "consumer falling behind" (`approximateAgeOfOldestMessage`) and "in-flight quota" (`approximateNumberOfMessagesNotVisible`) alarms — meaningless on a queue nothing actively consumes from — are off by default. Every alarm remains individually overridable via the existing `recommendedAlarms` API, in either direction.
- **Redrive-policy warning**: `Annotations`-based warning if a DLQ-role queue also configures its own `deadLetterQueue` redrive, since a DLQ is meant to be a terminal destination.

The role→enablement mapping is a single `Record<QueueRole, Record<QueueAlarmKey, boolean>>` table (`ALARM_DEFAULT_ENABLEMENT` in `queue-alarms.ts`), and alarm resolution is a single data-driven loop over `ALARM_SPECS` — adding a future role is additive (one more table row), not new branching.

This closes the DLQ-variant portion of #34. The remaining scope item — `SubscriptionBuilder` auto-creating a DLQ when none is provided — is left for a follow-up, since it would introduce a new `@composurecdk/sns` → `@composurecdk/sqs` package dependency (a first for this monorepo) and deserves its own discussion.

## New public API

- `createQueueBuilder().asDeadLetterQueue()`
- `DLQ_QUEUE_DEFAULTS`, `DLQ_ALARM_DEFAULTS` (exported for visibility/testing, per the existing `QUEUE_DEFAULTS`/`QUEUE_ALARM_DEFAULTS` convention)
- `QueueAlarmConfig` grows an `approximateNumberOfMessagesVisible` field (usable on primary queues too, as an opt-in with an explicit threshold)
- `QueueRole`, `QueueAlarmKey` types

## Checklist

- [x] Linked to an issue (#34)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change (`packages/sqs/test/dlq-role.test.ts`, 51/51 sqs tests passing)


---
_Generated by [Claude Code](https://claude.ai/code/session_017Pudtcrpb5n5GQYzoM8gGg)_