### PR TITLE
feat(sqs): add sibling FIFO and dead-letter queue builders (option A)

### DIFF
--- a/docs/adr/0013-queue-type-sibling-builders.md
+++ b/docs/adr/0013-queue-type-sibling-builders.md
@@ -1,0 +1,101 @@
+# ADR 0013: Queue-type sibling builders with exclusive prop surfaces
+
+- **Status:** Proposed
+- **Date:** 2026-07-02
+
+## Context
+
+Standard, FIFO, and dead-letter SQS queues have partly mutually exclusive
+configuration and inverted alarm recommendations (#34, #117):
+
+- FIFO-only props (`fifo`, `contentBasedDeduplication`, `deduplicationScope`,
+  `fifoThroughputLimit`) are rejected by AWS on standard queues, and FIFO adds
+  coupled invariants — the `.fifo` name suffix, the high-throughput
+  `fifoThroughputLimit`/`deduplicationScope` pairing.
+- A dead-letter queue must not carry its own `deadLetterQueue` redrive policy,
+  wants the maximum 14-day retention, and inverts the recommended-alarm set:
+  any visible message is itself the alert, while the primary-queue "consumer
+  falling behind" and "in-flight quota" signals don't apply.
+
+PR #253 prototyped a role switch (`.asDeadLetterQueue()`) on the single
+`createQueueBuilder()`. The behaviour was right, but the prop surface wasn't:
+every prop stayed reachable in every role — `deadLetterQueue` on a DLQ,
+`fifo` with primary-only alarm defaults — so invalid configurations were
+representable and only caught (if at all) at build time. A fluent method also
+cannot change the builder's type mid-chain: `IBuilder<Props, T>` regenerates
+the full prop surface from `Props` after every setter, so a role method
+cannot narrow what follows it.
+
+## Decision
+
+**One factory per queue type, each binding the shared builder machinery to a
+type-specific `Props` surface: `createQueueBuilder()` (standard),
+`createFifoQueueBuilder()`, and `createDlqQueueBuilder()`.**
+
+1. **Exclusive prop surfaces.** Because the fluent API is a mapped type over
+   `Props`, narrowing `Props` narrows the builder: the standard surface is
+   `Omit<QueueProps, FifoOnlyPropKey>`, the FIFO surface omits `fifo` (always
+   `true`) and retypes `queueName` as `` `${string}.fifo` `` (a template-literal
+   type, so a missing suffix is a compile error), and the DLQ surface omits
+   `deadLetterQueue`. Untyped callers hit equivalent build-time guards that
+   name the entry point they should be using.
+
+2. **Shared internals, not shared class hierarchies.** The builder classes
+   stay flat (the core `Builder` proxy discovers methods on the immediate
+   prototype only); duplication is limited to the ~15-line
+   props/`addAlarm`/`COPY_STATE` skeleton. Everything substantive is shared
+   via modules: `QUEUE_DEFAULTS`, `queue-validation.ts` (FIFO invariants,
+   redrive-target type match, `maxReceiveCount` floor), `build-queue.ts`
+   (construct + alarms + result), and a profile-driven alarm resolver.
+
+3. **Alarm behaviour is a data profile, not builder branching.** A
+   `QueueAlarmProfile` couples per-alarm enablement, merge defaults, and
+   descriptions; `resolveQueueAlarmDefinitions` is a single loop over the
+   alarm keys. Primary builders pass `PRIMARY_ALARM_PROFILE`; the DLQ builder
+   passes `dlqAlarmProfile(scope, retentionPeriod)`, whose age-alarm default
+   scales to 75% of the queue's resolved retention — so the "about to age
+   out" signal stays meaningful when retention is tuned, avoiding the
+   threshold-can-never-fire class of bug that #117 flagged. A token-valued
+   retention has no derivable basis, so the age alarm is skipped with the
+   standardized acknowledgeable warning (`resolveAlarmThresholdBasis` from
+   `@composurecdk/cloudwatch`, per #196). Profile defaults are partial: an
+   alarm with no generic baseline (`approximateNumberOfMessagesVisible` on a
+   primary queue) throws when enabled without an explicit threshold, rather
+   than inheriting a placeholder value that alarms on noise.
+
+4. **FIFO-ness on a DLQ is a prop, not a fourth factory.** AWS requires a
+   FIFO source's DLQ to be FIFO, so `createDlqQueueBuilder()` keeps the FIFO
+   props (validated identically to the FIFO builder). The alternative — a
+   `createFifoDlqQueueBuilder()` — is where the sibling-factory pattern stops
+   scaling: types × roles is a product, and factories multiply while a prop
+   composes. This is the accepted compromise of Option A; the DLQ surface is
+   consequently not fully exclusive (FIFO props appear on it without the
+   template-literal name type).
+
+5. **Discovery is carried by types and cross-links.** With three entry
+   points, the risk is a user configuring FIFO on the standard builder and
+   never finding the sibling. Mitigations: the compile error at the call
+   site, the build-time guard message naming the right factory, `@link`
+   cross-references in every factory's JSDoc, and a "Choosing a builder"
+   table at the top of the package README.
+
+## Consequences
+
+- Invalid queue configurations become unrepresentable in typed code:
+  `deadLetterQueue` on a DLQ and `fifo` on a standard queue are compile
+  errors, not runtime surprises. Each factory's defaults and alarm profile
+  are self-documenting at the call site.
+- Three entry points must stay in sync as `QueueProps` evolves; the prop
+  taxonomy (`FIFO_ONLY_PROP_KEYS`, `FifoQueueName`) in `queue-props.ts` is
+  the single place that carving is defined.
+- `QueueBuilderProps` no longer includes the FIFO props — a breaking change
+  for callers who used the passthrough from #115; they move to
+  `createFifoQueueBuilder()` unchanged otherwise.
+- The pattern generalises: a future queue variant with its own defaults and
+  alarm semantics adds a factory plus an alarm profile, but a variant that
+  _combines_ with existing ones (as FIFO × DLQ does) should be a prop on the
+  affected builders, not a factory per combination.
+- The rejected alternative — a single role-switched builder with per-role
+  narrowed types — requires moving role selection to the factory argument to
+  work at the type level; that competing design is explored in a parallel PR
+  for comparison.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0010: AWS-property constraints — a catalogue with central mechanism and local data](0010-aws-property-constraints.md)
 - [ADR-0011: Cross-component relationship guards — builder-registered synth-time Aspects](0011-cross-component-relationship-guards.md)
 - [ADR-0012: Explicit build id — decouple the construct id from the compose key](0012-explicit-build-id-decoupled-from-compose-key.md)
+- [ADR-0013: Queue-type sibling builders with exclusive prop surfaces](0013-queue-type-sibling-builders.md)

--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -1,10 +1,22 @@
 # @composurecdk/sqs
 
-SQS queue builder for [ComposureCDK](../../README.md).
+SQS queue builders for [ComposureCDK](../../README.md).
 
-This package provides a fluent builder for SQS queues with secure, AWS-recommended defaults and built-in CloudWatch alarms. It wraps the CDK [Queue](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.Queue.html) construct — refer to the CDK documentation for the full set of configurable properties.
+This package provides fluent builders for SQS queues with secure, AWS-recommended defaults and built-in CloudWatch alarms. They wrap the CDK [Queue](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.Queue.html) construct — refer to the CDK documentation for the full set of configurable properties.
 
-## Queue Builder
+## Choosing a builder
+
+Standard, FIFO, and dead-letter queues have distinct — and partly mutually exclusive — recommended configurations and alarms, so each has its own entry point with a prop surface restricted to what applies:
+
+| Builder                  | Queue type        | Distinct behaviour                                                                                                                      |
+| ------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `createQueueBuilder`     | Standard, primary | FIFO-only props are excluded from the type (and rejected at build).                                                                     |
+| `createFifoQueueBuilder` | FIFO, primary     | `fifo: true` always; `queueName` typed to require the `.fifo` suffix; high-throughput mode validated.                                   |
+| `createDlqQueueBuilder`  | Dead-letter       | 14-day retention; inverted alarm set (any message alerts); `deadLetterQueue` excluded — a DLQ is terminal. Supports `.fifo(true)` DLQs. |
+
+All three share the same [secure defaults](#secure-defaults), the same `Lifecycle`/`compose` integration, the same `addAlarm` escape hatch, and the same `QueueBuilderResult` shape.
+
+## Queue Builder (standard)
 
 ```ts
 import { Duration } from "aws-cdk-lib";
@@ -16,11 +28,86 @@ const orders = createQueueBuilder()
   .build(stack, "Orders");
 ```
 
-Every [QueueProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html) property is available as a fluent setter on the builder. FIFO queues are supported via the standard `fifo`, `contentBasedDeduplication`, and `fifoThroughputLimit` props — no FIFO-specific defaults are applied.
+Every [QueueProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.QueueProps.html) property except the FIFO-only ones (`fifo`, `contentBasedDeduplication`, `deduplicationScope`, `fifoThroughputLimit`) is available as a fluent setter. Setting a FIFO-only prop is a compile error — and a build-time error for untyped callers — pointing at `createFifoQueueBuilder` instead.
+
+## FIFO Queue Builder
+
+```ts
+import { DeduplicationScope, FifoThroughputLimit } from "aws-cdk-lib/aws-sqs";
+import { createFifoQueueBuilder } from "@composurecdk/sqs";
+
+const orderEvents = createFifoQueueBuilder()
+  .queueName("order-events.fifo") // type requires the `.fifo` suffix
+  .contentBasedDeduplication(true)
+  .build(stack, "OrderEvents");
+
+// High-throughput FIFO — the dedup scope pairing is validated at build.
+const highTps = createFifoQueueBuilder()
+  .queueName("order-events-ht.fifo")
+  .fifoThroughputLimit(FifoThroughputLimit.PER_MESSAGE_GROUP_ID)
+  .deduplicationScope(DeduplicationScope.MESSAGE_GROUP)
+  .build(stack, "OrderEventsHt");
+```
+
+FIFO-aware behaviour:
+
+- **`fifo: true` always.** The prop is not settable; the builder's identity is the switch.
+- **`queueName` is typed `` `${string}.fifo` ``** — AWS requires the suffix, so a bad name fails at compile time instead of synth. Omit the name to let CloudFormation generate a valid one.
+- **High-throughput coherence**: `fifoThroughputLimit: PER_MESSAGE_GROUP_ID` without `deduplicationScope: MESSAGE_GROUP` throws at build ([high-throughput FIFO](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/high-throughput-fifo.html)).
+- **Redrive type match**: a FIFO queue redriving to a standard DLQ (or vice versa on the standard builder) throws at build — AWS rejects the mismatch at deploy time otherwise.
+- **Alarms**: same set and thresholds as the standard builder. Since [November 2024](https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-sqs-increases-in-flight-limit-fifo-queues/) FIFO queues share the standard 120,000 in-flight quota, so the in-flight threshold applies unchanged. Note that FIFO throughput ceilings (300 TPS, or 3,000 with high-throughput mode) are account-level behaviour with no dedicated CloudWatch metric — if you need a "throughput wall" signal, add a custom alarm on `NumberOfMessagesSent` via `addAlarm`.
+
+## Dead-Letter Queue Builder
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createDlqQueueBuilder, createQueueBuilder } from "@composurecdk/sqs";
+
+const system = compose(
+  {
+    ordersDlq: createDlqQueueBuilder(),
+    orders: createQueueBuilder().deadLetterQueue(
+      ref("ordersDlq", (r) => ({ queue: r.queue, maxReceiveCount: 5 })),
+    ),
+  },
+  { ordersDlq: [], orders: ["ordersDlq"] },
+);
+```
+
+DLQ-specific behaviour:
+
+| Property          | Default             | Rationale                                                                                                                                                                    |
+| ----------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `retentionPeriod` | `Duration.days(14)` | The SQS maximum. A DLQ exists to give operators a window to investigate and redrive failed messages — maximizing that window is the point. Exported as `DLQ_QUEUE_DEFAULTS`. |
+
+- **`deadLetterQueue` is excluded** from the type (and rejected at build): a DLQ is the terminal destination for failed messages. A queue with its own redrive policy is a primary queue.
+- **FIFO DLQs**: AWS requires a FIFO source queue's DLQ to itself be FIFO, so the FIFO props remain available here — `createDlqQueueBuilder().fifo(true).queueName("orders-dlq.fifo")` — with the same suffix and high-throughput validation as the FIFO builder.
+- Consider restricting which queues may redrive into the DLQ via `.redriveAllowPolicy(...)`.
+
+### DLQ alarms
+
+The recommended-alarm set inverts relative to a primary queue — the defaults are exported as `DLQ_ALARM_DEFAULTS`:
+
+| Alarm                                   |   Default on a DLQ    | Rationale                                                                                                                                                                                                                                                                  |
+| --------------------------------------- | :-------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `approximateNumberOfMessagesVisible`    |       ✅ (> 0)        | Any message on a DLQ indicates a delivery failure that needs investigation.                                                                                                                                                                                                |
+| `approximateAgeOfOldestMessage`         | ✅ (75% of retention) | Nothing consumes a DLQ, so "consumer falling behind" is meaningless — instead this is the last call to investigate before SQS silently deletes the message at `retentionPeriod`. The threshold scales with the queue's actual retention (`DLQ_AGE_ALARM_RETENTION_RATIO`). |
+| `approximateNumberOfMessagesNotVisible` |          ❌           | Nothing is normally in flight on a DLQ. Opt back in via `recommendedAlarms` if you have a reason to watch it.                                                                                                                                                              |
+
+Every entry is individually overridable through the same `recommendedAlarms` API used for primary queues:
+
+```ts
+const ordersDlq = createDlqQueueBuilder()
+  .recommendedAlarms({
+    approximateNumberOfMessagesVisible: { threshold: 5 }, // alert only once a small backlog builds
+    approximateAgeOfOldestMessage: false, // rely on the visible-messages alarm alone
+  })
+  .build(stack, "OrdersDlq");
+```
 
 ## Secure Defaults
 
-`createQueueBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.
+All three builders apply the following defaults. Each can be overridden via the builder's fluent API.
 
 | Property                 | Default                       | Rationale                                                                                                                                                                                                                                                             |
 | ------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -28,12 +115,12 @@ Every [QueueProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s
 | `encryption`             | `QueueEncryption.SQS_MANAGED` | Encrypts at rest with the SQS-managed key (SSE-SQS). KMS encryption is opt-in via `.encryption(QueueEncryption.KMS)` + `.encryptionMasterKey(key)`. ([SQS data protection](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-data-protection.html))  |
 | `receiveMessageWaitTime` | `Duration.seconds(20)`        | Enables [long polling](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling) — fewer empty receives, lower cost, lower latency. 20s is the SQS maximum.                                                    |
 
-`visibilityTimeout` is intentionally not defaulted — it must match the longest consumer processing time, which is workload-specific. `retentionPeriod` is also left at CDK's default of 4 days; bump it to 14 days if you need a longer replay window.
+`visibilityTimeout` is intentionally not defaulted — it must match the longest consumer processing time, which is workload-specific. `retentionPeriod` is left at CDK's default of 4 days on the primary builders (the DLQ builder raises it to 14 days, see above).
 
-The defaults are exported as `QUEUE_DEFAULTS` for visibility and testing:
+The defaults are exported as `QUEUE_DEFAULTS` (shared) and `DLQ_QUEUE_DEFAULTS` (the DLQ layer) for visibility and testing:
 
 ```ts
-import { QUEUE_DEFAULTS } from "@composurecdk/sqs";
+import { DLQ_QUEUE_DEFAULTS, QUEUE_DEFAULTS } from "@composurecdk/sqs";
 ```
 
 ### Overriding defaults
@@ -48,21 +135,21 @@ const queue = createQueueBuilder()
 
 ## Recommended Alarms
 
-The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS) by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.
+The builders create [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS) by default. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.
+
+On the primary builders (`createQueueBuilder`, `createFifoQueueBuilder`):
 
 | Alarm                                   | Metric                                               | Default threshold | Rationale                                                                                                                                                                                                     |
 | --------------------------------------- | ---------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `approximateAgeOfOldestMessage`         | `ApproximateAgeOfOldestMessage` (Max, 1 min)         | > 300s (5 min)    | Primary "consumer falling behind" signal. Conservative starting point — tune to your SLA and `retentionPeriod`.                                                                                               |
 | `approximateNumberOfMessagesNotVisible` | `ApproximateNumberOfMessagesNotVisible` (Max, 1 min) | > 90,000          | 75% of the [120k in-flight messages](https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight) per-queue quota. Proactive guardrail before receives are rejected. |
 
-These defaults target primary queues; dead-letter queues need different thresholds (any message on a DLQ is itself an alert).
+The third AWS-recommended SQS alarm, `ApproximateNumberOfMessagesVisible`, is not enabled by default on a primary queue — its useful threshold depends entirely on the application's processing capacity, and any generic value would be either noise or silence. Enable it explicitly via `recommendedAlarms` with your own threshold. On a dead-letter queue it is on by default with threshold > 0 (see [DLQ alarms](#dlq-alarms)).
 
-The third AWS-recommended SQS alarm, `ApproximateNumberOfMessagesVisible`, is not enabled by default — its useful threshold depends entirely on the application's processing capacity, and any generic value would be either noise or silence. Use `addAlarm` (see [Custom alarms](#custom-alarms)) to add it for workloads where you know the right threshold.
-
-The defaults are exported as `QUEUE_ALARM_DEFAULTS` for visibility and testing:
+The defaults are exported as `QUEUE_ALARM_DEFAULTS` (primary) and `DLQ_ALARM_DEFAULTS` (dead-letter) for visibility and testing:
 
 ```ts
-import { QUEUE_ALARM_DEFAULTS } from "@composurecdk/sqs";
+import { DLQ_ALARM_DEFAULTS, QUEUE_ALARM_DEFAULTS } from "@composurecdk/sqs";
 ```
 
 ### Customizing thresholds
@@ -95,7 +182,7 @@ builder.recommendedAlarms({ approximateNumberOfMessagesNotVisible: false });
 
 ### Custom alarms
 
-Add custom alarms alongside the recommended ones via `addAlarm`. The callback receives an `AlarmDefinitionBuilder` typed to `IQueue`, so the metric factory has access to the queue's properties.
+Add custom alarms alongside the recommended ones via `addAlarm` (available on every builder). The callback receives an `AlarmDefinitionBuilder` typed to `IQueue`, so the metric factory has access to the queue's properties.
 
 ```ts
 import { Duration } from "aws-cdk-lib";

--- a/packages/sqs/src/build-queue.ts
+++ b/packages/sqs/src/build-queue.ts
@@ -1,0 +1,54 @@
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { type IQueue, Queue, type QueueProps } from "aws-cdk-lib/aws-sqs";
+import type { IConstruct } from "constructs";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { QueueAlarmProfile } from "./queue-alarm-profiles.js";
+import type { QueueBuilderExtensionProps } from "./queue-props.js";
+import { createQueueAlarms } from "./queue-alarms.js";
+
+/**
+ * The build output of every queue builder in this package
+ * ({@link createQueueBuilder}, {@link createFifoQueueBuilder},
+ * {@link createDlqQueueBuilder}). Contains the CDK constructs created
+ * during {@link Lifecycle.build}, keyed by role.
+ */
+export interface QueueBuilderResult {
+  /** The SQS queue construct created by the builder. */
+  queue: Queue;
+
+  /**
+   * CloudWatch alarms created for the queue, keyed by alarm name.
+   *
+   * Includes both AWS-recommended alarms and any custom alarms added
+   * via `addAlarm`. Access individual alarms by key (e.g.,
+   * `result.alarms.approximateAgeOfOldestMessage`).
+   *
+   * No alarm actions are configured — apply them via the result or an
+   * `afterBuild` hook.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * Shared build core for the queue builders: constructs the queue from
+ * the already-merged, already-validated props and attaches the
+ * recommended + custom alarms according to the builder's alarm profile.
+ *
+ * @internal
+ */
+export function buildQueueResult(
+  scope: IConstruct,
+  id: string,
+  mergedProps: QueueProps & QueueBuilderExtensionProps,
+  customAlarms: AlarmDefinitionBuilder<IQueue>[],
+  profile: QueueAlarmProfile,
+): QueueBuilderResult {
+  const { recommendedAlarms, ...queueProps } = mergedProps;
+
+  const queue = new Queue(scope, id, queueProps);
+  const alarms = createQueueAlarms(scope, id, queue, recommendedAlarms, customAlarms, profile);
+
+  return { queue, alarms };
+}

--- a/packages/sqs/src/dlq-alarm-defaults.ts
+++ b/packages/sqs/src/dlq-alarm-defaults.ts
@@ -1,0 +1,53 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { QueueAlarmDefaults } from "./queue-alarm-defaults.js";
+import { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";
+import { DLQ_QUEUE_DEFAULTS } from "./dlq-defaults.js";
+
+/**
+ * Fraction of a dead-letter queue's `retentionPeriod` at which the
+ * `approximateAgeOfOldestMessage` alarm fires by default. Messages older
+ * than this have sat unattended for most of their retention window and
+ * are approaching silent deletion by SQS — the alarm is the last call to
+ * investigate and redrive them.
+ */
+export const DLQ_AGE_ALARM_RETENTION_RATIO = 0.75;
+
+/**
+ * AWS-recommended default alarm configuration for dead-letter queues
+ * built with {@link createDlqQueueBuilder}.
+ *
+ * The enabled set inverts relative to a primary queue:
+ *
+ * - `approximateNumberOfMessagesVisible` (> 0) is **on** — any message
+ *   on a DLQ indicates a delivery failure that needs investigation.
+ * - `approximateAgeOfOldestMessage` is **on**, re-framed: nothing
+ *   consumes a DLQ, so instead of "consumers falling behind" it fires
+ *   when the oldest message has used {@link DLQ_AGE_ALARM_RETENTION_RATIO}
+ *   of the queue's `retentionPeriod` — the threshold below is derived
+ *   from the default 14-day retention, and the builder scales it to the
+ *   actual retention period at build time.
+ * - `approximateNumberOfMessagesNotVisible` is **off** — nothing is
+ *   normally in flight on a DLQ. The baseline (shared with
+ *   {@link QUEUE_ALARM_DEFAULTS} via spread) applies if explicitly
+ *   re-enabled.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+ */
+export const DLQ_ALARM_DEFAULTS = {
+  ...QUEUE_ALARM_DEFAULTS,
+
+  approximateAgeOfOldestMessage: {
+    threshold: DLQ_QUEUE_DEFAULTS.retentionPeriod.toSeconds() * DLQ_AGE_ALARM_RETENTION_RATIO,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+
+  /** 0 — any message on a dead-letter queue is itself the alert. */
+  approximateNumberOfMessagesVisible: {
+    threshold: 0,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  },
+} satisfies QueueAlarmDefaults;

--- a/packages/sqs/src/dlq-defaults.ts
+++ b/packages/sqs/src/dlq-defaults.ts
@@ -1,0 +1,19 @@
+import { Duration } from "aws-cdk-lib";
+import type { QueueProps } from "aws-cdk-lib/aws-sqs";
+
+/**
+ * AWS-recommended defaults layered on top of {@link QUEUE_DEFAULTS} for
+ * queues built with {@link createDlqQueueBuilder}.
+ */
+export const DLQ_QUEUE_DEFAULTS = {
+  /**
+   * 14 days — the SQS maximum. A dead-letter queue exists to give
+   * operators a window to investigate and redrive failed messages, so
+   * maximizing that window is the point; the 4-day CDK default would let
+   * messages expire before anyone notices them. The Well-Architected
+   * Reliability Pillar calls for retaining failed messages long enough
+   * to analyse and reprocess them.
+   * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
+   */
+  retentionPeriod: Duration.days(14),
+} satisfies Partial<QueueProps>;

--- a/packages/sqs/src/dlq-queue-builder.ts
+++ b/packages/sqs/src/dlq-queue-builder.ts
@@ -1,0 +1,125 @@
+import type { IQueue, QueueProps } from "aws-cdk-lib/aws-sqs";
+import { type IConstruct } from "constructs";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { QueueBuilderExtensionProps } from "./queue-props.js";
+import { QUEUE_DEFAULTS } from "./defaults.js";
+import { DLQ_QUEUE_DEFAULTS } from "./dlq-defaults.js";
+import { dlqAlarmProfile } from "./queue-alarm-profiles.js";
+import { buildQueueResult, type QueueBuilderResult } from "./build-queue.js";
+import { throwIfRedriveOnDlq, validateFifoQueueProps } from "./queue-validation.js";
+
+/**
+ * Configuration properties for the dead-letter queue builder.
+ *
+ * Extends the CDK {@link QueueProps} with builder-specific options,
+ * minus `deadLetterQueue` — a DLQ is the terminal destination for
+ * failed messages and must not carry its own redrive policy.
+ *
+ * The FIFO props remain available: AWS requires the dead-letter queue
+ * of a FIFO source queue to itself be FIFO, so set `.fifo(true)` (and a
+ * `.fifo`-suffixed `queueName`, validated at build) when the DLQ serves
+ * a FIFO queue.
+ *
+ * `recommendedAlarms` resolves against the dead-letter-queue defaults —
+ * see {@link DLQ_ALARM_DEFAULTS}. Any message on a DLQ is itself the
+ * alert, so `approximateNumberOfMessagesVisible` (> 0) and an age alarm
+ * scaled to the retention period are enabled by default, while the
+ * primary-queue in-flight alarm is not.
+ */
+export interface DlqQueueBuilderProps
+  extends Omit<QueueProps, "deadLetterQueue">, QueueBuilderExtensionProps {}
+
+/**
+ * A fluent builder for configuring and creating an AWS SQS dead-letter
+ * queue.
+ *
+ * Mirrors {@link createQueueBuilder | the standard queue builder} —
+ * same secure defaults, same `Lifecycle` composition — with
+ * DLQ-specific behaviour:
+ *
+ * - `retentionPeriod` defaults to 14 days, the SQS maximum
+ *   ({@link DLQ_QUEUE_DEFAULTS}) — the queue exists to give operators
+ *   an investigation and redrive window.
+ * - The recommended-alarm set inverts ({@link DLQ_ALARM_DEFAULTS}):
+ *   any visible message alarms (> 0), the age alarm fires at 75% of the
+ *   retention period (last call before SQS deletes the message), and
+ *   the in-flight alarm is off.
+ * - `deadLetterQueue` is not settable — a DLQ is a terminal
+ *   destination.
+ *
+ * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
+ *
+ * @example
+ * ```ts
+ * const ordersDlq = createDlqQueueBuilder().queueName("orders-dlq");
+ *
+ * const orders = createQueueBuilder()
+ *   .queueName("orders")
+ *   .deadLetterQueue(ref("ordersDlq", (r) => ({ queue: r.queue, maxReceiveCount: 5 })));
+ * ```
+ */
+export type IDlqQueueBuilder = ITaggedBuilder<DlqQueueBuilderProps, DlqQueueBuilder>;
+
+class DlqQueueBuilder implements Lifecycle<QueueBuilderResult> {
+  props: Partial<DlqQueueBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<IQueue>[] = [];
+
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<IQueue>) => AlarmDefinitionBuilder<IQueue>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IQueue>(key)));
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: DlqQueueBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
+  }
+
+  build(scope: IConstruct, id: string): QueueBuilderResult {
+    const mergedProps = { ...QUEUE_DEFAULTS, ...DLQ_QUEUE_DEFAULTS, ...this.props };
+
+    throwIfRedriveOnDlq(id, mergedProps);
+    validateFifoQueueProps("DlqQueueBuilder", id, mergedProps);
+
+    const profile = dlqAlarmProfile(scope, mergedProps.retentionPeriod);
+    return buildQueueResult(scope, id, mergedProps, this.#customAlarms, profile);
+  }
+}
+
+/**
+ * Creates a new {@link IDlqQueueBuilder} for configuring an AWS SQS
+ * dead-letter queue.
+ *
+ * The returned builder exposes every {@link DlqQueueBuilderProps}
+ * property as a fluent setter/getter and implements {@link Lifecycle}
+ * for use with {@link compose}. For the primary queues that redrive to
+ * it, use {@link createQueueBuilder} or {@link createFifoQueueBuilder}.
+ *
+ * @returns A fluent builder for an AWS SQS dead-letter queue.
+ *
+ * @example
+ * ```ts
+ * // Standard DLQ, wired to its primary via compose + ref:
+ * const system = compose(
+ *   {
+ *     ordersDlq: createDlqQueueBuilder(),
+ *     orders: createQueueBuilder().deadLetterQueue(
+ *       ref("ordersDlq", (r) => ({ queue: r.queue, maxReceiveCount: 5 })),
+ *     ),
+ *   },
+ *   { ordersDlq: [], orders: ["ordersDlq"] },
+ * );
+ *
+ * // FIFO DLQ for a FIFO source queue:
+ * const orderEventsDlq = createDlqQueueBuilder()
+ *   .queueName("order-events-dlq.fifo")
+ *   .fifo(true);
+ * ```
+ */
+export function createDlqQueueBuilder(): IDlqQueueBuilder {
+  return taggedBuilder<DlqQueueBuilderProps, DlqQueueBuilder>(DlqQueueBuilder);
+}

--- a/packages/sqs/src/fifo-queue-builder.ts
+++ b/packages/sqs/src/fifo-queue-builder.ts
@@ -1,0 +1,114 @@
+import type { IQueue, QueueProps } from "aws-cdk-lib/aws-sqs";
+import { type IConstruct } from "constructs";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { FifoQueueName, QueueBuilderExtensionProps } from "./queue-props.js";
+import { QUEUE_DEFAULTS } from "./defaults.js";
+import { PRIMARY_ALARM_PROFILE } from "./queue-alarm-profiles.js";
+import { buildQueueResult, type QueueBuilderResult } from "./build-queue.js";
+import {
+  throwIfRedriveTargetFifoMismatch,
+  validateFifoQueueProps,
+  warnIfLowMaxReceiveCount,
+} from "./queue-validation.js";
+
+/**
+ * Configuration properties for the FIFO SQS queue builder.
+ *
+ * Extends the CDK {@link QueueProps} with builder-specific options, with
+ * two FIFO-aware adjustments:
+ *
+ * - `fifo` is not settable — the builder always creates a FIFO queue.
+ * - `queueName` is typed as {@link FifoQueueName}, so a name missing the
+ *   AWS-required `.fifo` suffix is a compile error rather than a synth
+ *   failure.
+ */
+export interface FifoQueueBuilderProps
+  extends Omit<QueueProps, "fifo" | "queueName">, QueueBuilderExtensionProps {
+  /**
+   * Physical name of the FIFO queue. Must end in `.fifo` (AWS
+   * requirement, enforced by the type and validated at build for
+   * untyped callers). Omit to let CloudFormation generate a valid name.
+   */
+  queueName?: FifoQueueName;
+}
+
+/**
+ * A fluent builder for configuring and creating an AWS SQS FIFO queue.
+ *
+ * Mirrors {@link createQueueBuilder | the standard queue builder} —
+ * same secure defaults, same recommended alarms, same `Lifecycle`
+ * composition — with FIFO-specific behaviour:
+ *
+ * - `fifo: true` is always applied; it is not settable.
+ * - `queueName` must end in `.fifo` (compile-time via
+ *   {@link FifoQueueName}, build-time for untyped callers).
+ * - High-throughput mode (`fifoThroughputLimit: PER_MESSAGE_GROUP_ID`)
+ *   without `deduplicationScope: MESSAGE_GROUP` throws at build.
+ * - A non-FIFO `deadLetterQueue` target throws at build — AWS requires
+ *   a FIFO queue's DLQ to be FIFO (see {@link createDlqQueueBuilder}).
+ *
+ * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html
+ *
+ * @example
+ * ```ts
+ * const orderEvents = createFifoQueueBuilder()
+ *   .queueName("order-events.fifo")
+ *   .contentBasedDeduplication(true);
+ * ```
+ */
+export type IFifoQueueBuilder = ITaggedBuilder<FifoQueueBuilderProps, FifoQueueBuilder>;
+
+class FifoQueueBuilder implements Lifecycle<QueueBuilderResult> {
+  props: Partial<FifoQueueBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<IQueue>[] = [];
+
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<IQueue>) => AlarmDefinitionBuilder<IQueue>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<IQueue>(key)));
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: FifoQueueBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
+  }
+
+  build(scope: IConstruct, id: string): QueueBuilderResult {
+    const mergedProps = { ...QUEUE_DEFAULTS, ...this.props, fifo: true };
+
+    validateFifoQueueProps("FifoQueueBuilder", id, mergedProps);
+    throwIfRedriveTargetFifoMismatch("FifoQueueBuilder", id, true, mergedProps.deadLetterQueue);
+    warnIfLowMaxReceiveCount(scope, "FifoQueueBuilder", id, mergedProps);
+
+    return buildQueueResult(scope, id, mergedProps, this.#customAlarms, PRIMARY_ALARM_PROFILE);
+  }
+}
+
+/**
+ * Creates a new {@link IFifoQueueBuilder} for configuring an AWS SQS FIFO
+ * queue.
+ *
+ * The returned builder exposes every {@link FifoQueueBuilderProps}
+ * property as a fluent setter/getter and implements {@link Lifecycle}
+ * for use with {@link compose}. The queue is always FIFO — for a
+ * standard queue use {@link createQueueBuilder}; for a dead-letter
+ * queue (FIFO or standard) use {@link createDlqQueueBuilder}.
+ *
+ * @returns A fluent builder for an AWS SQS FIFO queue.
+ *
+ * @example
+ * ```ts
+ * // High-throughput FIFO — the dedup scope is required and validated.
+ * const orderEvents = createFifoQueueBuilder()
+ *   .queueName("order-events.fifo")
+ *   .fifoThroughputLimit(FifoThroughputLimit.PER_MESSAGE_GROUP_ID)
+ *   .deduplicationScope(DeduplicationScope.MESSAGE_GROUP);
+ * ```
+ */
+export function createFifoQueueBuilder(): IFifoQueueBuilder {
+  return taggedBuilder<FifoQueueBuilderProps, FifoQueueBuilder>(FifoQueueBuilder);
+}

--- a/packages/sqs/src/index.ts
+++ b/packages/sqs/src/index.ts
@@ -1,9 +1,18 @@
+export { createQueueBuilder, type IQueueBuilder, type QueueBuilderProps } from "./queue-builder.js";
 export {
-  createQueueBuilder,
-  type IQueueBuilder,
-  type QueueBuilderProps,
-  type QueueBuilderResult,
-} from "./queue-builder.js";
+  createFifoQueueBuilder,
+  type IFifoQueueBuilder,
+  type FifoQueueBuilderProps,
+} from "./fifo-queue-builder.js";
+export {
+  createDlqQueueBuilder,
+  type IDlqQueueBuilder,
+  type DlqQueueBuilderProps,
+} from "./dlq-queue-builder.js";
+export { type QueueBuilderResult } from "./build-queue.js";
+export { type FifoQueueName, type QueueBuilderExtensionProps } from "./queue-props.js";
 export { QUEUE_DEFAULTS } from "./defaults.js";
-export { type QueueAlarmConfig } from "./queue-alarm-config.js";
-export { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";
+export { DLQ_QUEUE_DEFAULTS } from "./dlq-defaults.js";
+export { type QueueAlarmConfig, type QueueAlarmKey } from "./queue-alarm-config.js";
+export { QUEUE_ALARM_DEFAULTS, type QueueAlarmDefaults } from "./queue-alarm-defaults.js";
+export { DLQ_ALARM_DEFAULTS, DLQ_AGE_ALARM_RETENTION_RATIO } from "./dlq-alarm-defaults.js";

--- a/packages/sqs/src/queue-alarm-config.ts
+++ b/packages/sqs/src/queue-alarm-config.ts
@@ -2,9 +2,13 @@ import type { AlarmConfig } from "@composurecdk/cloudwatch";
 
 /**
  * Controls which recommended alarms are created for an SQS queue.
- * All applicable alarms are enabled by default with AWS-recommended thresholds.
- * Set individual alarms to `false` to disable them, or provide an
- * {@link AlarmConfig} to tune thresholds.
+ * Which alarms are enabled by default — and their thresholds — depends
+ * on the builder: primary queues ({@link createQueueBuilder},
+ * {@link createFifoQueueBuilder}) and dead-letter queues
+ * ({@link createDlqQueueBuilder}) invert which signals matter. Set an
+ * individual alarm to `false` to disable it, or provide an
+ * {@link AlarmConfig} to enable it (if off by default) or tune its
+ * thresholds (if on by default).
  *
  * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
  */
@@ -18,15 +22,16 @@ export interface QueueAlarmConfig {
 
   /**
    * Alarm when the oldest unprocessed message in the queue has been
-   * waiting longer than the configured threshold. Primary signal that
-   * consumers are falling behind.
+   * waiting longer than the configured threshold.
+   *
+   * On a primary queue this is the primary signal that consumers are
+   * falling behind (default threshold: > 300 seconds). On a dead-letter
+   * queue it signals messages approaching the end of the queue's
+   * `retentionPeriod` unattended (default threshold: 75% of the
+   * retention period — see {@link DLQ_ALARM_DEFAULTS}).
    *
    * Metric: `AWS/SQS ApproximateAgeOfOldestMessage`, statistic Maximum,
    * period 1 minute.
-   * Default threshold: > 300 seconds (5 minutes).
-   *
-   * The default is conservative and should be tuned to the queue's
-   * SLA and `retentionPeriod`.
    *
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
    */
@@ -37,12 +42,46 @@ export interface QueueAlarmConfig {
    * messages approaches the SQS quota of 120,000 per queue. A breach
    * means new messages will start being rejected.
    *
+   * Enabled by default on primary queues (threshold: > 90,000 — 75% of
+   * the quota). Disabled by default on dead-letter queues, where nothing
+   * is normally in flight.
+   *
    * Metric: `AWS/SQS ApproximateNumberOfMessagesNotVisible`, statistic
    * Maximum, period 1 minute.
-   * Default threshold: > 90,000 (75% of the in-flight quota).
    *
-   * @see https://docs.aws.amazon.com/AmazonSQS/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight
+   * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html#quotas-in-flight
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
    */
   approximateNumberOfMessagesNotVisible?: AlarmConfig | false;
+
+  /**
+   * Alarm when the queue has visible (available-to-receive) messages
+   * above the threshold.
+   *
+   * Disabled by default on a primary queue — messages waiting to be
+   * consumed are the normal state, and no generic threshold suits every
+   * workload's processing capacity. Enable it explicitly with a
+   * threshold sized to your consumers; enabling it on a primary queue
+   * without a threshold throws at build.
+   *
+   * Enabled by default on a dead-letter queue, where any message present
+   * is itself the alert (default threshold: > 0). See
+   * {@link DLQ_ALARM_DEFAULTS}.
+   *
+   * Metric: `AWS/SQS ApproximateNumberOfMessagesVisible`, statistic
+   * Maximum, period 1 minute.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  approximateNumberOfMessagesVisible?: AlarmConfig | false;
 }
+
+/**
+ * Keys of the recommended SQS alarms a queue builder can create —
+ * every {@link QueueAlarmConfig} entry except the `enabled` master
+ * switch. Shared between the primary-queue defaults
+ * ({@link QUEUE_ALARM_DEFAULTS}) and the dead-letter-queue defaults
+ * ({@link DLQ_ALARM_DEFAULTS}) so every builder resolves the same
+ * config shape.
+ */
+export type QueueAlarmKey = Exclude<keyof QueueAlarmConfig, "enabled">;

--- a/packages/sqs/src/queue-alarm-defaults.ts
+++ b/packages/sqs/src/queue-alarm-defaults.ts
@@ -1,24 +1,33 @@
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
-
-interface QueueAlarmDefaults {
-  enabled: true;
-  approximateAgeOfOldestMessage: AlarmConfigDefaults;
-  approximateNumberOfMessagesNotVisible: AlarmConfigDefaults;
-}
+import type { QueueAlarmKey } from "./queue-alarm-config.js";
 
 /**
- * AWS-recommended default alarm configuration for SQS queues.
+ * Shape of a recommended-alarm default set: an {@link AlarmConfigDefaults}
+ * baseline per recommended SQS alarm. Partial — an alarm with no entry
+ * has no generic default and requires an explicit threshold when
+ * enabled. Implemented by {@link QUEUE_ALARM_DEFAULTS} (primary queues)
+ * and {@link DLQ_ALARM_DEFAULTS} (dead-letter queues).
+ */
+export type QueueAlarmDefaults = Partial<Record<QueueAlarmKey, AlarmConfigDefaults>>;
+
+/**
+ * AWS-recommended default alarm configuration for primary
+ * (consumer-fed) SQS queues, standard and FIFO alike — since November
+ * 2024 FIFO queues share the standard 120,000 in-flight quota, so the
+ * same thresholds apply.
  *
- * Tuned for primary (consumer-fed) queues. Dead-letter queues need
- * different thresholds — any message on a DLQ is itself an alert,
- * whereas a primary queue with messages is normal.
+ * These are threshold baselines only — which alarms are *enabled* by
+ * default differs per builder: dead-letter queues invert the set (see
+ * {@link DLQ_ALARM_DEFAULTS}) because any message on a DLQ is itself an
+ * alert, whereas a primary queue with messages is normal. There is no
+ * entry for `approximateNumberOfMessagesVisible`: no generic threshold
+ * suits a primary queue, so enabling it requires an explicit threshold.
  *
  * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+ * @see https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-sqs-increases-in-flight-limit-fifo-queues/
  */
-export const QUEUE_ALARM_DEFAULTS: QueueAlarmDefaults = {
-  enabled: true,
-
+export const QUEUE_ALARM_DEFAULTS = {
   /**
    * 5 minutes. Conservative starting point for a "consumer falling
    * behind" alarm. The right value depends on the workload's SLA and
@@ -43,4 +52,4 @@ export const QUEUE_ALARM_DEFAULTS: QueueAlarmDefaults = {
     datapointsToAlarm: 1,
     treatMissingData: TreatMissingData.NOT_BREACHING,
   },
-};
+} satisfies QueueAlarmDefaults;

--- a/packages/sqs/src/queue-alarm-profiles.ts
+++ b/packages/sqs/src/queue-alarm-profiles.ts
@@ -1,0 +1,126 @@
+import { Duration } from "aws-cdk-lib";
+import type { IQueue } from "aws-cdk-lib/aws-sqs";
+import type { IConstruct } from "constructs";
+import type { AlarmMetric } from "@composurecdk/cloudwatch";
+import { resolveAlarmThresholdBasis } from "@composurecdk/cloudwatch";
+import type { QueueAlarmKey } from "./queue-alarm-config.js";
+import type { QueueAlarmDefaults } from "./queue-alarm-defaults.js";
+import { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";
+import { DLQ_AGE_ALARM_RETENTION_RATIO, DLQ_ALARM_DEFAULTS } from "./dlq-alarm-defaults.js";
+
+const METRIC_PERIOD = Duration.minutes(1);
+const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+
+/** Metric factory for each recommended SQS alarm. */
+export const QUEUE_ALARM_METRICS: Record<QueueAlarmKey, (queue: IQueue) => AlarmMetric> = {
+  approximateAgeOfOldestMessage: (queue) =>
+    queue.metricApproximateAgeOfOldestMessage({ period: METRIC_PERIOD }),
+  approximateNumberOfMessagesNotVisible: (queue) =>
+    queue.metricApproximateNumberOfMessagesNotVisible({ period: METRIC_PERIOD }),
+  approximateNumberOfMessagesVisible: (queue) =>
+    queue.metricApproximateNumberOfMessagesVisible({ period: METRIC_PERIOD }),
+};
+
+/**
+ * How a queue builder interprets the recommended-alarm set: which alarms
+ * are created without explicit opt-in, the default thresholds each alarm
+ * merges against (an alarm with no baseline requires an explicit
+ * threshold when enabled), and the description each produces. Primary
+ * queues and dead-letter queues need different profiles because the
+ * alarm semantics invert — see {@link DLQ_ALARM_DEFAULTS}.
+ */
+export interface QueueAlarmProfile {
+  /** Whether each alarm is created when the user hasn't configured it. */
+  enablement: Record<QueueAlarmKey, boolean>;
+  /** Default config each alarm merges user overrides against. */
+  defaults: QueueAlarmDefaults;
+  /** Alarm description, given the resolved threshold. */
+  descriptions: Record<QueueAlarmKey, (threshold: number) => string>;
+}
+
+const describeInFlight = (threshold: number): string =>
+  `SQS queue's in-flight messages are approaching the 120,000 per-queue quota; ` +
+  `further receives will be rejected once the quota is hit. ` +
+  `Threshold: > ${String(threshold)} in-flight in ${METRIC_PERIOD_LABEL}.`;
+
+/** Recommended-alarm profile for primary (consumer-fed) queues, standard and FIFO. */
+export const PRIMARY_ALARM_PROFILE: QueueAlarmProfile = {
+  enablement: {
+    approximateAgeOfOldestMessage: true,
+    approximateNumberOfMessagesNotVisible: true,
+    approximateNumberOfMessagesVisible: false,
+  },
+  defaults: QUEUE_ALARM_DEFAULTS,
+  descriptions: {
+    approximateAgeOfOldestMessage: (threshold) =>
+      `SQS queue's oldest message has been waiting longer than the threshold, ` +
+      `indicating consumers are falling behind. Threshold: > ${String(threshold)} seconds in ${METRIC_PERIOD_LABEL}.`,
+    approximateNumberOfMessagesNotVisible: describeInFlight,
+    approximateNumberOfMessagesVisible: (threshold) =>
+      `Queue has more visible messages waiting than expected for this workload. ` +
+      `Threshold: > ${String(threshold)} in ${METRIC_PERIOD_LABEL}.`,
+  },
+};
+
+const DLQ_ALARM_ENABLEMENT: Record<QueueAlarmKey, boolean> = {
+  approximateAgeOfOldestMessage: true,
+  approximateNumberOfMessagesNotVisible: false,
+  approximateNumberOfMessagesVisible: true,
+};
+
+const DLQ_ALARM_DESCRIPTIONS: QueueAlarmProfile["descriptions"] = {
+  approximateAgeOfOldestMessage: (threshold) =>
+    `Dead-letter queue's oldest message is approaching the queue's retentionPeriod — ` +
+    `investigate and redrive it before SQS deletes it. ` +
+    `Threshold: > ${String(threshold)} seconds in ${METRIC_PERIOD_LABEL}.`,
+  approximateNumberOfMessagesNotVisible: describeInFlight,
+  approximateNumberOfMessagesVisible: (threshold) =>
+    `Dead-letter queue has messages present — any message here indicates a delivery ` +
+    `failure that needs investigation. Threshold: > ${String(threshold)} in ${METRIC_PERIOD_LABEL}.`,
+};
+
+/**
+ * Recommended-alarm profile for dead-letter queues. The age alarm's
+ * default threshold is {@link DLQ_AGE_ALARM_RETENTION_RATIO} of the
+ * queue's resolved `retentionPeriod`, so it keeps firing before messages
+ * age out even when retention is tuned. When the retention is an
+ * unresolved token there is no basis to derive from — the age alarm is
+ * skipped with an acknowledgeable warning (unless explicitly configured
+ * with a threshold), per the library-wide derived-threshold convention.
+ */
+export function dlqAlarmProfile(
+  scope: IConstruct,
+  retentionPeriod: Duration | undefined,
+): QueueAlarmProfile {
+  const retentionSeconds = resolveAlarmThresholdBasis({
+    scope,
+    value: retentionPeriod,
+    resolve: (duration) => duration.toSeconds(),
+    isUnresolved: (duration) => duration.isUnresolved(),
+    warningId: "@composurecdk/sqs:dlq-age-alarm-token-retention",
+    alarmLabel: "dead-letter queue message-age",
+    suppressHint: "recommendedAlarms({ approximateAgeOfOldestMessage: false })",
+  });
+
+  if (retentionSeconds === undefined) {
+    const { approximateNumberOfMessagesNotVisible, approximateNumberOfMessagesVisible } =
+      DLQ_ALARM_DEFAULTS;
+    return {
+      enablement: { ...DLQ_ALARM_ENABLEMENT, approximateAgeOfOldestMessage: false },
+      defaults: { approximateNumberOfMessagesNotVisible, approximateNumberOfMessagesVisible },
+      descriptions: DLQ_ALARM_DESCRIPTIONS,
+    };
+  }
+
+  return {
+    enablement: DLQ_ALARM_ENABLEMENT,
+    defaults: {
+      ...DLQ_ALARM_DEFAULTS,
+      approximateAgeOfOldestMessage: {
+        ...DLQ_ALARM_DEFAULTS.approximateAgeOfOldestMessage,
+        threshold: Math.round(retentionSeconds * DLQ_AGE_ALARM_RETENTION_RATIO),
+      },
+    },
+    descriptions: DLQ_ALARM_DESCRIPTIONS,
+  };
+}

--- a/packages/sqs/src/queue-alarms.ts
+++ b/packages/sqs/src/queue-alarms.ts
@@ -1,69 +1,71 @@
-import { Duration } from "aws-cdk-lib";
-import { type Alarm, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
+import { type Alarm, ComparisonOperator, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import type { IQueue } from "aws-cdk-lib/aws-sqs";
 import type { IConstruct } from "constructs";
 import type { AlarmDefinition } from "@composurecdk/cloudwatch";
 import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
-import type { QueueAlarmConfig } from "./queue-alarm-config.js";
-import { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";
+import type { QueueAlarmConfig, QueueAlarmKey } from "./queue-alarm-config.js";
+import type { QueueAlarmProfile } from "./queue-alarm-profiles.js";
+import { QUEUE_ALARM_METRICS } from "./queue-alarm-profiles.js";
 
-const METRIC_PERIOD = Duration.minutes(1);
-const METRIC_PERIOD_LABEL = `${String(METRIC_PERIOD.toMinutes())} minute`;
+const QUEUE_ALARM_KEYS = Object.keys(QUEUE_ALARM_METRICS) as QueueAlarmKey[];
+
+/**
+ * Non-threshold baseline for alarms enabled without a profile default —
+ * the threshold itself must come from the user's config.
+ */
+const OPT_IN_ALARM_BASELINE = {
+  evaluationPeriods: 1,
+  datapointsToAlarm: 1,
+  treatMissingData: TreatMissingData.NOT_BREACHING,
+};
 
 /**
  * Resolves the recommended alarm configuration into fully-resolved
  * {@link AlarmDefinition}s for an SQS queue.
+ *
+ * @param profile - The builder's alarm profile: which alarms are created
+ *   without explicit opt-in and the defaults they merge against.
  */
 export function resolveQueueAlarmDefinitions(
   queue: IQueue,
   config: QueueAlarmConfig | undefined,
+  profile: QueueAlarmProfile,
 ): AlarmDefinition[] {
   if (config?.enabled === false) return [];
 
-  const definitions: AlarmDefinition[] = [];
+  return QUEUE_ALARM_KEYS.flatMap((key): AlarmDefinition[] => {
+    const userConfig = config?.[key];
+    if (userConfig === false) return [];
+    if (userConfig === undefined && !profile.enablement[key]) return [];
 
-  if (config?.approximateAgeOfOldestMessage !== false) {
+    const baseline = profile.defaults[key];
+    if (baseline === undefined && userConfig?.threshold === undefined) {
+      throw new Error(
+        `Queue "${queue.node.id}": the "${key}" alarm has no generic default threshold for ` +
+          `this queue type — no value fits every workload. Supply one explicitly, e.g. ` +
+          `recommendedAlarms({ ${key}: { threshold: … } }).`,
+      );
+    }
+
     const cfg = resolveAlarmConfig(
-      config?.approximateAgeOfOldestMessage,
-      QUEUE_ALARM_DEFAULTS.approximateAgeOfOldestMessage,
+      userConfig,
+      // userConfig.threshold is present whenever baseline is not — the guard above ensures it.
+      baseline ?? { ...OPT_IN_ALARM_BASELINE, threshold: userConfig?.threshold ?? 0 },
     );
-    definitions.push({
-      key: "approximateAgeOfOldestMessage",
-      alarmName: cfg.alarmName,
-      metric: queue.metricApproximateAgeOfOldestMessage({ period: METRIC_PERIOD }),
-      threshold: cfg.threshold,
-      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: cfg.evaluationPeriods,
-      datapointsToAlarm: cfg.datapointsToAlarm,
-      treatMissingData: cfg.treatMissingData,
-      description:
-        `SQS queue's oldest message has been waiting longer than the threshold, ` +
-        `indicating consumers are falling behind. Threshold: > ${String(cfg.threshold)} seconds in ${METRIC_PERIOD_LABEL}.`,
-    });
-  }
-
-  if (config?.approximateNumberOfMessagesNotVisible !== false) {
-    const cfg = resolveAlarmConfig(
-      config?.approximateNumberOfMessagesNotVisible,
-      QUEUE_ALARM_DEFAULTS.approximateNumberOfMessagesNotVisible,
-    );
-    definitions.push({
-      key: "approximateNumberOfMessagesNotVisible",
-      alarmName: cfg.alarmName,
-      metric: queue.metricApproximateNumberOfMessagesNotVisible({ period: METRIC_PERIOD }),
-      threshold: cfg.threshold,
-      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: cfg.evaluationPeriods,
-      datapointsToAlarm: cfg.datapointsToAlarm,
-      treatMissingData: cfg.treatMissingData,
-      description:
-        `SQS queue's in-flight messages are approaching the 120,000 per-queue quota; ` +
-        `further receives will be rejected once the quota is hit. ` +
-        `Threshold: > ${String(cfg.threshold)} in-flight in ${METRIC_PERIOD_LABEL}.`,
-    });
-  }
-
-  return definitions;
+    return [
+      {
+        key,
+        alarmName: cfg.alarmName,
+        metric: QUEUE_ALARM_METRICS[key](queue),
+        threshold: cfg.threshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: cfg.evaluationPeriods,
+        datapointsToAlarm: cfg.datapointsToAlarm,
+        treatMissingData: cfg.treatMissingData,
+        description: profile.descriptions[key](cfg.threshold),
+      },
+    ];
+  });
 }
 
 /**
@@ -75,6 +77,8 @@ export function resolveQueueAlarmDefinitions(
  * @param queue - The SQS queue to create alarms for.
  * @param config - User-provided alarm configuration, or `false` to disable all.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @param profile - The builder's alarm profile; see
+ *   {@link resolveQueueAlarmDefinitions}.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
  * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
@@ -84,14 +88,13 @@ export function createQueueAlarms(
   id: string,
   queue: IQueue,
   config: QueueAlarmConfig | false | undefined,
-  customAlarms: AlarmDefinitionBuilder<IQueue>[] = [],
+  customAlarms: AlarmDefinitionBuilder<IQueue>[],
+  profile: QueueAlarmProfile,
 ): Record<string, Alarm> {
   if (config === false) return {};
+  if (!(config?.enabled ?? true)) return {};
 
-  const enabled = config?.enabled ?? QUEUE_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveQueueAlarmDefinitions(queue, config);
+  const recommended = resolveQueueAlarmDefinitions(queue, config, profile);
   const custom = customAlarms.map((b) => b.resolve(queue));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/sqs/src/queue-builder.ts
+++ b/packages/sqs/src/queue-builder.ts
@@ -1,74 +1,34 @@
-import { Annotations, Token } from "aws-cdk-lib";
-import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
-import { type IQueue, Queue, type QueueProps } from "aws-cdk-lib/aws-sqs";
+import type { IQueue, QueueProps } from "aws-cdk-lib/aws-sqs";
 import { type IConstruct } from "constructs";
 import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
-import type { QueueAlarmConfig } from "./queue-alarm-config.js";
-import { createQueueAlarms } from "./queue-alarms.js";
+import type { FifoOnlyPropKey, QueueBuilderExtensionProps } from "./queue-props.js";
 import { QUEUE_DEFAULTS } from "./defaults.js";
+import { PRIMARY_ALARM_PROFILE } from "./queue-alarm-profiles.js";
+import { buildQueueResult, type QueueBuilderResult } from "./build-queue.js";
+import {
+  throwIfFifoPropsOnStandardQueue,
+  throwIfRedriveTargetFifoMismatch,
+  warnIfLowMaxReceiveCount,
+} from "./queue-validation.js";
 
 /**
- * AWS-recommended minimum for `maxReceiveCount` on an SQS redrive
- * policy. A consumer needs a few retries before SQS gives up and
- * forwards the message to the dead-letter queue; anything below this
- * tends to surface as a flood of "poison" messages from transient
- * errors that would have succeeded on retry.
+ * Configuration properties for the standard SQS queue builder.
  *
- * @see https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+ * Extends the CDK {@link QueueProps} with additional builder-specific
+ * options, minus the FIFO-only properties (`fifo`,
+ * `contentBasedDeduplication`, `deduplicationScope`,
+ * `fifoThroughputLimit`) — FIFO queues have their own entry point,
+ * {@link createFifoQueueBuilder}, with FIFO-aware validation.
  */
-const RECOMMENDED_MIN_MAX_RECEIVE_COUNT = 5;
+export interface QueueBuilderProps
+  extends Omit<QueueProps, FifoOnlyPropKey>, QueueBuilderExtensionProps {}
 
 /**
- * Configuration properties for the SQS queue builder.
+ * A fluent builder for configuring and creating a standard AWS SQS queue.
  *
- * Extends the CDK {@link QueueProps} with additional builder-specific options.
- */
-export interface QueueBuilderProps extends QueueProps {
-  /**
-   * Configuration for AWS-recommended CloudWatch alarms.
-   *
-   * By default, the builder creates recommended alarms with sensible
-   * thresholds for every applicable metric. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
-   *
-   * No alarm actions are configured by default since notification
-   * methods are user-specific. Access alarms from the build result
-   * or use an `afterBuild` hook to apply actions.
-   *
-   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
-   */
-  recommendedAlarms?: QueueAlarmConfig | false;
-}
-
-/**
- * The build output of an {@link IQueueBuilder}. Contains the CDK constructs
- * created during {@link Lifecycle.build}, keyed by role.
- */
-export interface QueueBuilderResult {
-  /** The SQS queue construct created by the builder. */
-  queue: Queue;
-
-  /**
-   * CloudWatch alarms created for the queue, keyed by alarm name.
-   *
-   * Includes both AWS-recommended alarms and any custom alarms added
-   * via {@link IQueueBuilder.addAlarm}. Access individual alarms
-   * by key (e.g., `result.alarms.approximateAgeOfOldestMessage`).
-   *
-   * No alarm actions are configured — apply them via the result or an
-   * `afterBuild` hook.
-   *
-   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
-   */
-  alarms: Record<string, Alarm>;
-}
-
-/**
- * A fluent builder for configuring and creating an AWS SQS queue.
- *
- * Each configuration property from the CDK {@link QueueProps} is exposed
+ * Each configuration property from {@link QueueBuilderProps} is exposed
  * as an overloaded method: call with a value to set it (returns the builder
  * for chaining), or call with no arguments to read the current value.
  *
@@ -79,7 +39,11 @@ export interface QueueBuilderResult {
  *
  * The builder also creates AWS-recommended CloudWatch alarms by default.
  * Alarms can be customized or disabled via the `recommendedAlarms` property.
- * Custom alarms can be added via the {@link addAlarm} method.
+ * Custom alarms can be added via the `addAlarm` method.
+ *
+ * For the other queue types, use the sibling builders:
+ * - {@link createFifoQueueBuilder} — FIFO queues.
+ * - {@link createDlqQueueBuilder} — dead-letter queues.
  *
  * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_sqs.Queue.html
  *
@@ -110,31 +74,30 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
   }
 
   build(scope: IConstruct, id: string): QueueBuilderResult {
-    const { recommendedAlarms: alarmConfig, ...queueProps } = this.props;
+    const mergedProps = { ...QUEUE_DEFAULTS, ...this.props };
 
-    const mergedProps = {
-      ...QUEUE_DEFAULTS,
-      ...queueProps,
-    } as QueueBuilderProps;
+    throwIfFifoPropsOnStandardQueue(id, mergedProps);
+    throwIfRedriveTargetFifoMismatch("QueueBuilder", id, false, mergedProps.deadLetterQueue);
+    warnIfLowMaxReceiveCount(scope, "QueueBuilder", id, mergedProps);
 
-    warnIfLowMaxReceiveCount(scope, id, mergedProps);
-
-    const queue = new Queue(scope, id, mergedProps);
-
-    const alarms = createQueueAlarms(scope, id, queue, alarmConfig, this.#customAlarms);
-
-    return { queue, alarms };
+    return buildQueueResult(scope, id, mergedProps, this.#customAlarms, PRIMARY_ALARM_PROFILE);
   }
 }
 
 /**
- * Creates a new {@link IQueueBuilder} for configuring an AWS SQS queue.
+ * Creates a new {@link IQueueBuilder} for configuring a standard AWS SQS
+ * queue.
  *
- * This is the entry point for defining an SQS queue component. The returned
- * builder exposes every {@link QueueBuilderProps} property as a fluent setter/getter
- * and implements {@link Lifecycle} for use with {@link compose}.
+ * This is the entry point for defining a standard SQS queue component. The
+ * returned builder exposes every {@link QueueBuilderProps} property as a
+ * fluent setter/getter and implements {@link Lifecycle} for use with
+ * {@link compose}.
  *
- * @returns A fluent builder for an AWS SQS queue.
+ * FIFO queues and dead-letter queues have their own entry points with
+ * type-specific defaults, alarms, and validation:
+ * {@link createFifoQueueBuilder} and {@link createDlqQueueBuilder}.
+ *
+ * @returns A fluent builder for a standard AWS SQS queue.
  *
  * @example
  * ```ts
@@ -154,33 +117,4 @@ class QueueBuilder implements Lifecycle<QueueBuilderResult> {
  */
 export function createQueueBuilder(): IQueueBuilder {
   return taggedBuilder<QueueBuilderProps, QueueBuilder>(QueueBuilder);
-}
-
-/**
- * Annotates `scope` with a non-fatal warning when a redrive policy is
- * configured with `maxReceiveCount` below the AWS-recommended floor
- * of {@link RECOMMENDED_MIN_MAX_RECEIVE_COUNT}.
- *
- * The builder owns the redrive policy directly, so this is a true
- * check rather than a contextual reminder — the actual configured
- * value is compared. Short-circuits on unresolved tokens so stacks
- * that thread `maxReceiveCount` through CFN parameters aren't spammed.
- */
-function warnIfLowMaxReceiveCount(
-  scope: IConstruct,
-  id: string,
-  props: Partial<QueueBuilderProps>,
-): void {
-  const dlq = props.deadLetterQueue;
-  if (!dlq) return;
-  const maxReceiveCount = dlq.maxReceiveCount;
-  if (Token.isUnresolved(maxReceiveCount)) return;
-  if (maxReceiveCount >= RECOMMENDED_MIN_MAX_RECEIVE_COUNT) return;
-  Annotations.of(scope).addWarningV2(
-    "@composurecdk/sqs:redrive-low-max-receive-count",
-    `QueueBuilder "${id}": redrive policy maxReceiveCount is ${String(maxReceiveCount)}; ` +
-      `AWS recommends >= ${String(RECOMMENDED_MIN_MAX_RECEIVE_COUNT)} so the consumer ` +
-      `has room to retry before messages hit the dead-letter queue. ` +
-      `See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html`,
-  );
 }

--- a/packages/sqs/src/queue-props.ts
+++ b/packages/sqs/src/queue-props.ts
@@ -1,0 +1,53 @@
+import type { QueueProps } from "aws-cdk-lib/aws-sqs";
+import type { QueueAlarmConfig } from "./queue-alarm-config.js";
+
+/**
+ * A queue name for a FIFO queue. AWS requires the name of a FIFO queue to
+ * end in `.fifo`, so the constraint is expressed in the type — a
+ * non-conforming literal is a compile error at the call site rather than
+ * a synth failure. (Unresolved tokens are not supported as FIFO queue
+ * names by the CDK `Queue` construct itself.)
+ *
+ * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html
+ */
+export type FifoQueueName = `${string}.fifo`;
+
+/**
+ * The {@link QueueProps} keys that only have meaning on a FIFO queue.
+ * These are omitted from the standard queue builder's prop surface and
+ * guarded at build time, so a queue with FIFO behaviour is always an
+ * explicit choice of the FIFO-aware entry points.
+ */
+export const FIFO_ONLY_PROP_KEYS = [
+  "fifo",
+  "contentBasedDeduplication",
+  "deduplicationScope",
+  "fifoThroughputLimit",
+] as const satisfies readonly (keyof QueueProps)[];
+
+/** Union of the FIFO-only {@link QueueProps} keys. */
+export type FifoOnlyPropKey = (typeof FIFO_ONLY_PROP_KEYS)[number];
+
+/**
+ * Builder-only props every queue builder in this package layers on top
+ * of the CDK {@link QueueProps}. Defined once so the builders and the
+ * shared build core agree on what must be stripped before the props
+ * reach the `Queue` construct.
+ */
+export interface QueueBuilderExtensionProps {
+  /**
+   * Configuration for AWS-recommended CloudWatch alarms.
+   *
+   * By default, the builder creates recommended alarms with sensible
+   * thresholds for every applicable metric — which alarms apply depends
+   * on the builder (primary vs. dead-letter). Individual alarms can be
+   * customized or disabled. Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification
+   * methods are user-specific. Access alarms from the build result
+   * or use an `afterBuild` hook to apply actions.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#SQS
+   */
+  recommendedAlarms?: QueueAlarmConfig | false;
+}

--- a/packages/sqs/src/queue-validation.ts
+++ b/packages/sqs/src/queue-validation.ts
@@ -1,0 +1,149 @@
+import { Annotations, Token } from "aws-cdk-lib";
+import { DeduplicationScope, FifoThroughputLimit } from "aws-cdk-lib/aws-sqs";
+import type { DeadLetterQueue, QueueProps } from "aws-cdk-lib/aws-sqs";
+import type { IConstruct } from "constructs";
+import { FIFO_ONLY_PROP_KEYS } from "./queue-props.js";
+
+/**
+ * AWS-recommended minimum for `maxReceiveCount` on an SQS redrive
+ * policy. A consumer needs a few retries before SQS gives up and
+ * forwards the message to the dead-letter queue; anything below this
+ * tends to surface as a flood of "poison" messages from transient
+ * errors that would have succeeded on retry.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+ */
+const RECOMMENDED_MIN_MAX_RECEIVE_COUNT = 5;
+
+/**
+ * Annotates `scope` with a non-fatal warning when a redrive policy is
+ * configured with `maxReceiveCount` below the AWS-recommended floor
+ * of {@link RECOMMENDED_MIN_MAX_RECEIVE_COUNT}.
+ *
+ * The builder owns the redrive policy directly, so this is a true
+ * check rather than a contextual reminder — the actual configured
+ * value is compared. Short-circuits on unresolved tokens so stacks
+ * that thread `maxReceiveCount` through CFN parameters aren't spammed.
+ */
+export function warnIfLowMaxReceiveCount(
+  scope: IConstruct,
+  builderName: string,
+  id: string,
+  props: Partial<QueueProps>,
+): void {
+  const dlq = props.deadLetterQueue;
+  if (!dlq) return;
+  const maxReceiveCount = dlq.maxReceiveCount;
+  if (Token.isUnresolved(maxReceiveCount)) return;
+  if (maxReceiveCount >= RECOMMENDED_MIN_MAX_RECEIVE_COUNT) return;
+  Annotations.of(scope).addWarningV2(
+    "@composurecdk/sqs:redrive-low-max-receive-count",
+    `${builderName} "${id}": redrive policy maxReceiveCount is ${String(maxReceiveCount)}; ` +
+      `AWS recommends >= ${String(RECOMMENDED_MIN_MAX_RECEIVE_COUNT)} so the consumer ` +
+      `has room to retry before messages hit the dead-letter queue. ` +
+      `See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html`,
+  );
+}
+
+/**
+ * Throws when a FIFO-only prop reaches the standard queue builder — the
+ * standard builder's typed surface omits them, so this catches untyped
+ * (JavaScript) callers and points them at the FIFO-aware entry points
+ * instead of letting the queue synth with primary-queue alarm defaults
+ * that don't fit a FIFO queue.
+ */
+export function throwIfFifoPropsOnStandardQueue(id: string, props: Partial<QueueProps>): void {
+  for (const key of FIFO_ONLY_PROP_KEYS) {
+    if (props[key] === undefined) continue;
+    throw new Error(
+      `QueueBuilder "${id}": "${key}" is FIFO-specific and not supported by ` +
+        `createQueueBuilder(). Use createFifoQueueBuilder() for a FIFO queue, or ` +
+        `createDlqQueueBuilder().fifo(true) for a FIFO dead-letter queue.`,
+    );
+  }
+}
+
+/**
+ * Validates the FIFO-specific configuration invariants that would
+ * otherwise surface as a synth or deploy failure:
+ *
+ * - A non-token `queueName` must end in `.fifo` (AWS requirement).
+ * - High-throughput mode (`fifoThroughputLimit: PER_MESSAGE_GROUP_ID`)
+ *   requires `deduplicationScope: MESSAGE_GROUP`.
+ *
+ * No-op unless `props.fifo` is set, so builders whose FIFO-ness is a
+ * prop (the DLQ builder) can call it unconditionally — the validator
+ * owns both the invariants and their applicability.
+ *
+ * These are configuration errors, not advisory best practice, so they
+ * throw (unlike the `maxReceiveCount` warning).
+ *
+ * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/high-throughput-fifo.html
+ */
+export function validateFifoQueueProps(
+  builderName: string,
+  id: string,
+  props: Partial<QueueProps>,
+): void {
+  const { fifo, queueName, fifoThroughputLimit, deduplicationScope } = props;
+  if (!fifo) return;
+
+  if (queueName !== undefined && !Token.isUnresolved(queueName) && !queueName.endsWith(".fifo")) {
+    throw new Error(
+      `${builderName} "${id}": FIFO queues require a queueName ending in ".fifo"; ` +
+        `got "${queueName}". Omit queueName to let CloudFormation generate one.`,
+    );
+  }
+
+  if (
+    fifoThroughputLimit === FifoThroughputLimit.PER_MESSAGE_GROUP_ID &&
+    deduplicationScope !== DeduplicationScope.MESSAGE_GROUP
+  ) {
+    throw new Error(
+      `${builderName} "${id}": fifoThroughputLimit=PER_MESSAGE_GROUP_ID (high-throughput ` +
+        `FIFO) requires deduplicationScope=MESSAGE_GROUP. ` +
+        `See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/high-throughput-fifo.html`,
+    );
+  }
+}
+
+/**
+ * Throws when a queue's redrive target does not match its own FIFO-ness.
+ * AWS requires the dead-letter queue of a FIFO queue to be FIFO and the
+ * dead-letter queue of a standard queue to be standard; the mismatch
+ * otherwise fails at deploy time, after a successful synth.
+ *
+ * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
+ */
+export function throwIfRedriveTargetFifoMismatch(
+  builderName: string,
+  id: string,
+  fifo: boolean,
+  deadLetterQueue: DeadLetterQueue | undefined,
+): void {
+  if (!deadLetterQueue) return;
+  if (deadLetterQueue.queue.fifo === fifo) return;
+  const [queueKind, targetKind] = fifo ? ["FIFO", "standard"] : ["standard", "FIFO"];
+  throw new Error(
+    `${builderName} "${id}": a ${queueKind} queue cannot redrive to the ${targetKind} ` +
+      `dead-letter queue "${deadLetterQueue.queue.node.id}" — AWS requires the ` +
+      `dead-letter queue to match the source queue's type. ` +
+      `See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html`,
+  );
+}
+
+/**
+ * Throws when a dead-letter queue is given its own `deadLetterQueue`
+ * redrive policy — a DLQ is the terminal destination for failed
+ * messages; a queue that redrives elsewhere is a primary queue and
+ * belongs to `createQueueBuilder()` / `createFifoQueueBuilder()`.
+ */
+export function throwIfRedriveOnDlq(id: string, props: Partial<QueueProps>): void {
+  if (!props.deadLetterQueue) return;
+  throw new Error(
+    `DlqQueueBuilder "${id}": deadLetterQueue is not supported on a dead-letter queue — ` +
+      `a DLQ is the terminal destination for failed messages. If this queue needs its ` +
+      `own redrive policy it is a primary queue: use createQueueBuilder() or ` +
+      `createFifoQueueBuilder() instead.`,
+  );
+}

--- a/packages/sqs/test/_helpers.ts
+++ b/packages/sqs/test/_helpers.ts
@@ -1,0 +1,82 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import type { IQueue } from "aws-cdk-lib/aws-sqs";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import type { QueueBuilderResult } from "../src/build-queue.js";
+
+interface BuildableQueue {
+  build(scope: Stack, id: string): QueueBuilderResult;
+}
+
+/** Builds a queue builder into a fresh stack and returns the synth artefacts. */
+export function buildQueueStack<B extends BuildableQueue>(
+  factory: () => B,
+  id: string,
+  configureFn?: (builder: B) => void,
+): { stack: Stack; result: QueueBuilderResult; template: Template } {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const builder = factory();
+  configureFn?.(builder);
+  const result = builder.build(stack, id);
+  return { stack, result, template: Template.fromStack(stack) };
+}
+
+/**
+ * Asserts the secure defaults shared by every queue builder in this
+ * package: SSE-SQS encryption, long polling, and the enforceSSL
+ * deny-insecure-transport queue policy.
+ */
+export function expectSharedSecureDefaults(template: Template): void {
+  template.hasResourceProperties("AWS::SQS::Queue", {
+    SqsManagedSseEnabled: true,
+    ReceiveMessageWaitTimeSeconds: 20,
+  });
+  template.hasResourceProperties("AWS::SQS::QueuePolicy", {
+    PolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Effect: "Deny",
+          Condition: { Bool: { "aws:SecureTransport": "false" } },
+        }),
+      ]),
+    }),
+  });
+}
+
+interface CopyableQueueBuilder extends BuildableQueue {
+  copy(): CopyableQueueBuilder;
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<IQueue>) => AlarmDefinitionBuilder<IQueue>,
+  ): unknown;
+}
+
+/**
+ * Asserts that custom alarms added via `addAlarm` survive `.copy()` —
+ * the shared `[COPY_STATE]` contract every queue builder implements.
+ */
+export function expectCopyPreservesCustomAlarms(factory: () => CopyableQueueBuilder): void {
+  assertCopyPreservesState({
+    factory,
+    configure: (b) => {
+      b.addAlarm("firstCustom", (a) =>
+        a
+          .metric((queue) => queue.metricNumberOfEmptyReceives())
+          .threshold(1)
+          .greaterThan(),
+      );
+    },
+    mutate: (b) => {
+      b.addAlarm("secondCustom", (a) =>
+        a
+          .metric((queue) => queue.metricNumberOfEmptyReceives())
+          .threshold(5)
+          .greaterThan(),
+      );
+    },
+    build: (b) => b.build(new Stack(new App(), "S"), "Queue"),
+    inspect: (r) => Object.keys(r.alarms).sort(),
+  });
+}

--- a/packages/sqs/test/dlq-queue-builder.test.ts
+++ b/packages/sqs/test/dlq-queue-builder.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { App, CfnParameter, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match } from "aws-cdk-lib/assertions";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { createDlqQueueBuilder } from "../src/dlq-queue-builder.js";
+import { DLQ_QUEUE_DEFAULTS } from "../src/dlq-defaults.js";
+import { DLQ_AGE_ALARM_RETENTION_RATIO } from "../src/dlq-alarm-defaults.js";
+import {
+  buildQueueStack,
+  expectCopyPreservesCustomAlarms,
+  expectSharedSecureDefaults,
+} from "./_helpers.js";
+
+function buildResult(configureFn?: (builder: ReturnType<typeof createDlqQueueBuilder>) => void) {
+  return buildQueueStack(createDlqQueueBuilder, "OrdersDlq", configureFn);
+}
+
+describe("DLQ defaults", () => {
+  it("DLQ_QUEUE_DEFAULTS sets retentionPeriod to the SQS maximum of 14 days", () => {
+    expect(DLQ_QUEUE_DEFAULTS.retentionPeriod.toDays()).toBe(14);
+  });
+});
+
+describe("DlqQueueBuilder", () => {
+  describe("queue defaults", () => {
+    it("applies a 14-day retention period", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: 14 * 24 * 60 * 60,
+      });
+    });
+
+    it("still applies the shared secure defaults", () => {
+      const { template } = buildResult();
+
+      expectSharedSecureDefaults(template);
+    });
+
+    it("allows retentionPeriod to be overridden via the fluent API", () => {
+      const { template } = buildResult((b) => b.retentionPeriod(Duration.days(4)));
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        MessageRetentionPeriod: 4 * 24 * 60 * 60,
+      });
+    });
+  });
+
+  describe("validation", () => {
+    it("throws when a redrive policy is smuggled past the typed surface", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const sink = new Queue(stack, "Sink");
+
+      expect(() => {
+        const builder = createDlqQueueBuilder();
+        // deadLetterQueue is excluded from the typed surface; cast to mimic an untyped caller
+        (builder as unknown as { deadLetterQueue(value: object): unknown }).deadLetterQueue({
+          queue: sink,
+          maxReceiveCount: 5,
+        });
+        builder.build(stack, "OrdersDlq");
+      }).toThrow(/deadLetterQueue is not supported on a dead-letter queue/);
+    });
+
+    it("validates the .fifo suffix when building a FIFO DLQ", () => {
+      expect(() => buildResult((b) => b.fifo(true).queueName("orders-dlq"))).toThrow(
+        /DlqQueueBuilder "OrdersDlq": FIFO queues require a queueName ending in ".fifo"/,
+      );
+    });
+
+    it("builds a FIFO DLQ for a FIFO source queue", () => {
+      const { template } = buildResult((b) => b.fifo(true).queueName("orders-dlq.fifo"));
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        FifoQueue: true,
+        QueueName: "orders-dlq.fifo",
+        MessageRetentionPeriod: 14 * 24 * 60 * 60,
+      });
+    });
+  });
+
+  describe("recommended alarms", () => {
+    it("creates the inverted DLQ alarm set by default", () => {
+      const { result, template } = buildResult();
+
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeDefined();
+      expect(result.alarms.approximateAgeOfOldestMessage).toBeDefined();
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+
+    it("alarms on any visible message (> 0)", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesVisible",
+        Namespace: "AWS/SQS",
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        Statistic: "Maximum",
+        Period: 60,
+      });
+    });
+
+    it("alarms when the oldest message reaches 75% of the default retention", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        Threshold: Duration.days(14).toSeconds() * DLQ_AGE_ALARM_RETENTION_RATIO,
+      });
+    });
+
+    it("scales the age threshold to an overridden retention period", () => {
+      const { template } = buildResult((b) => b.retentionPeriod(Duration.days(4)));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        Threshold: 4 * 24 * 60 * 60 * DLQ_AGE_ALARM_RETENTION_RATIO,
+      });
+    });
+
+    it("an explicit age threshold wins over the retention-derived default", () => {
+      const { template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateAgeOfOldestMessage: { threshold: 3600 } }),
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        Threshold: 3600,
+      });
+    });
+
+    it("skips the age alarm with a warning when retention is an unresolved token", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const retentionParam = new CfnParameter(stack, "Retention", {
+        type: "Number",
+        default: 1209600,
+      });
+
+      const result = createDlqQueueBuilder()
+        .retentionPeriod(Duration.seconds(retentionParam.valueAsNumber))
+        .build(stack, "OrdersDlq");
+
+      expect(result.alarms.approximateAgeOfOldestMessage).toBeUndefined();
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeDefined();
+      Annotations.fromStack(stack).hasWarning(
+        "/TestStack",
+        Match.stringLikeRegexp(
+          "Skipping the recommended dead-letter queue message-age alarm.*" +
+            "\\[ack: @composurecdk/sqs:dlq-age-alarm-token-retention\\]",
+        ),
+      );
+    });
+
+    it("allows overriding the visible-messages threshold", () => {
+      const { template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateNumberOfMessagesVisible: { threshold: 5 } }),
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesVisible",
+        Threshold: 5,
+      });
+    });
+
+    it("allows disabling individual DLQ alarms", () => {
+      const { result, template } = buildResult((b) =>
+        b.recommendedAlarms({
+          approximateNumberOfMessagesVisible: false,
+          approximateAgeOfOldestMessage: false,
+        }),
+      );
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+
+    it("allows opting back into the in-flight alarm, inheriting the shared baseline", () => {
+      const { template, result } = buildResult((b) =>
+        b.recommendedAlarms({ approximateNumberOfMessagesNotVisible: {} }),
+      );
+
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeDefined();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesNotVisible",
+        Threshold: 90_000,
+      });
+    });
+
+    it("disables all recommended alarms when recommendedAlarms is false", () => {
+      const { result, template } = buildResult((b) => b.recommendedAlarms(false));
+
+      expect(Object.keys(result.alarms)).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+    });
+  });
+
+  describe("copy", () => {
+    it("preserves custom alarms across .copy()", () => {
+      expectCopyPreservesCustomAlarms(createDlqQueueBuilder);
+    });
+  });
+});

--- a/packages/sqs/test/fifo-queue-builder.test.ts
+++ b/packages/sqs/test/fifo-queue-builder.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Match } from "aws-cdk-lib/assertions";
+import { DeduplicationScope, FifoThroughputLimit, Queue } from "aws-cdk-lib/aws-sqs";
+import { createFifoQueueBuilder } from "../src/fifo-queue-builder.js";
+import {
+  buildQueueStack,
+  expectCopyPreservesCustomAlarms,
+  expectSharedSecureDefaults,
+} from "./_helpers.js";
+
+function buildResult(configureFn?: (builder: ReturnType<typeof createFifoQueueBuilder>) => void) {
+  return buildQueueStack(createFifoQueueBuilder, "OrderEvents", configureFn);
+}
+
+describe("FifoQueueBuilder", () => {
+  describe("build", () => {
+    it("always creates a FIFO queue", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::SQS::Queue", { FifoQueue: true });
+    });
+
+    it("builds without a queueName — CloudFormation generates a valid one", () => {
+      const { template } = buildResult();
+
+      template.hasResourceProperties("AWS::SQS::Queue", { QueueName: Match.absent() });
+    });
+
+    it("creates a queue with the specified .fifo queue name", () => {
+      const { template } = buildResult((b) => b.queueName("order-events.fifo"));
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        FifoQueue: true,
+        QueueName: "order-events.fifo",
+      });
+    });
+
+    it("forwards FIFO-specific props to the underlying CDK construct", () => {
+      const { template } = buildResult((b) =>
+        b
+          .contentBasedDeduplication(true)
+          .deduplicationScope(DeduplicationScope.MESSAGE_GROUP)
+          .fifoThroughputLimit(FifoThroughputLimit.PER_MESSAGE_GROUP_ID),
+      );
+
+      template.hasResourceProperties("AWS::SQS::Queue", {
+        ContentBasedDeduplication: true,
+        DeduplicationScope: "messageGroup",
+        FifoThroughputLimit: "perMessageGroupId",
+      });
+    });
+
+    it("forwards shared QueueProps to the underlying CDK construct", () => {
+      const { template } = buildResult((b) => b.visibilityTimeout(Duration.seconds(120)));
+
+      template.hasResourceProperties("AWS::SQS::Queue", { VisibilityTimeout: 120 });
+    });
+
+    it("applies the shared secure defaults", () => {
+      const { template } = buildResult();
+
+      expectSharedSecureDefaults(template);
+    });
+  });
+
+  describe("validation", () => {
+    it("throws when queueName does not end in .fifo", () => {
+      expect(() =>
+        buildResult((b) => {
+          // A non-.fifo literal is a compile error; cast to exercise the runtime guard
+          (b as unknown as { queueName(value: string): unknown }).queueName("order-events");
+        }),
+      ).toThrow(
+        /FifoQueueBuilder "OrderEvents": FIFO queues require a queueName ending in ".fifo"/,
+      );
+    });
+
+    it("throws when high-throughput mode is missing the message-group dedup scope", () => {
+      expect(() =>
+        buildResult((b) => b.fifoThroughputLimit(FifoThroughputLimit.PER_MESSAGE_GROUP_ID)),
+      ).toThrow(/requires deduplicationScope=MESSAGE_GROUP/);
+    });
+
+    it("accepts high-throughput mode with deduplicationScope MESSAGE_GROUP", () => {
+      expect(() =>
+        buildResult((b) =>
+          b
+            .fifoThroughputLimit(FifoThroughputLimit.PER_MESSAGE_GROUP_ID)
+            .deduplicationScope(DeduplicationScope.MESSAGE_GROUP),
+        ),
+      ).not.toThrow();
+    });
+
+    it("throws when the redrive target is a standard queue", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const standardDlq = new Queue(stack, "Dlq");
+
+      expect(() =>
+        createFifoQueueBuilder()
+          .deadLetterQueue({ queue: standardDlq, maxReceiveCount: 5 })
+          .build(stack, "OrderEvents"),
+      ).toThrow(/FIFO queue cannot redrive to the standard dead-letter queue "Dlq"/);
+    });
+
+    it("accepts a FIFO redrive target and keeps the maxReceiveCount warning", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const fifoDlq = new Queue(stack, "Dlq", { fifo: true });
+
+      createFifoQueueBuilder()
+        .deadLetterQueue({ queue: fifoDlq, maxReceiveCount: 2 })
+        .build(stack, "OrderEvents");
+
+      Annotations.fromStack(stack).hasWarning(
+        "/TestStack",
+        Match.stringLikeRegexp(
+          'FifoQueueBuilder "OrderEvents": redrive policy maxReceiveCount is 2.*' +
+            "\\[ack: @composurecdk/sqs:redrive-low-max-receive-count\\]",
+        ),
+      );
+    });
+  });
+
+  describe("recommended alarms", () => {
+    it("creates the primary-queue alarm set with the shared thresholds", () => {
+      const { result, template } = buildResult();
+
+      expect(result.alarms.approximateAgeOfOldestMessage).toBeDefined();
+      expect(result.alarms.approximateNumberOfMessagesNotVisible).toBeDefined();
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesNotVisible",
+        Threshold: 90_000,
+      });
+    });
+
+    it("allows tuning an individual alarm", () => {
+      const { template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateAgeOfOldestMessage: { threshold: 60 } }),
+      );
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateAgeOfOldestMessage",
+        Threshold: 60,
+      });
+    });
+  });
+
+  describe("copy", () => {
+    it("preserves custom alarms across .copy()", () => {
+      expectCopyPreservesCustomAlarms(createFifoQueueBuilder);
+    });
+  });
+});

--- a/packages/sqs/test/queue-alarms.test.ts
+++ b/packages/sqs/test/queue-alarms.test.ts
@@ -108,6 +108,26 @@ describe("recommended alarms", () => {
       expect(Object.keys(result.alarms)).toHaveLength(0);
       template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
     });
+
+    it("creates approximateNumberOfMessagesVisible when opted in with an explicit threshold", () => {
+      const { result, template } = buildResult((b) =>
+        b.recommendedAlarms({ approximateNumberOfMessagesVisible: { threshold: 1000 } }),
+      );
+
+      expect(result.alarms.approximateNumberOfMessagesVisible).toBeDefined();
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "ApproximateNumberOfMessagesVisible",
+        Threshold: 1000,
+      });
+    });
+
+    it("throws when approximateNumberOfMessagesVisible is opted in without a threshold", () => {
+      // No generic visible-messages threshold fits a primary queue, so the
+      // opt-in must bring its own instead of silently inheriting a noisy 0.
+      expect(() =>
+        buildResult((b) => b.recommendedAlarms({ approximateNumberOfMessagesVisible: {} })),
+      ).toThrow(/"approximateNumberOfMessagesVisible" alarm has no generic default threshold/);
+    });
   });
 
   describe("no default actions", () => {

--- a/packages/sqs/test/queue-builder.test.ts
+++ b/packages/sqs/test/queue-builder.test.ts
@@ -118,13 +118,29 @@ describe("QueueBuilder", () => {
       });
     });
 
-    it("creates a FIFO queue when configured", () => {
-      const template = synthTemplate((b) => b.fifo(true).queueName("orders.fifo"));
+    it("throws when a FIFO-only prop is smuggled past the typed surface", () => {
+      // The standard surface omits the FIFO props at the type level; the
+      // runtime guard catches untyped (JavaScript) callers and points
+      // them at the FIFO-aware entry points.
+      expect(() =>
+        synthTemplate((b) => {
+          // fifo is excluded from the typed surface; cast to mimic an untyped caller
+          (b as unknown as { fifo(value: boolean): unknown }).fifo(true);
+          b.queueName("orders.fifo");
+        }),
+      ).toThrow(/"fifo" is FIFO-specific.*createFifoQueueBuilder\(\)/s);
+    });
 
-      template.hasResourceProperties("AWS::SQS::Queue", {
-        FifoQueue: true,
-        QueueName: "orders.fifo",
-      });
+    it("throws when the redrive target is a FIFO queue", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const fifoDlq = new Queue(stack, "Dlq", { fifo: true });
+
+      expect(() =>
+        createQueueBuilder()
+          .deadLetterQueue({ queue: fifoDlq, maxReceiveCount: 5 })
+          .build(stack, "Orders"),
+      ).toThrow(/standard queue cannot redrive to the FIFO dead-letter queue "Dlq"/);
     });
 
     it("forwards the visibility timeout to the underlying CDK construct", () => {


### PR DESCRIPTION
## What & why

Implements ergonomic FIFO (#117) and dead-letter (#34) queue support as **Option A** from the design discussions: one factory per queue type, each binding the shared builder machinery to a type-specific prop surface. This is one of **two competing PRs** — the sibling PR implements Option B (a role-parameterized single builder) so the two API shapes can be compared with identical behaviour underneath. It supersedes the approach in #253, whose role switch left every prop reachable in every role (the `deadLetterQueue`-on-a-DLQ awkwardness).

### The three entry points

| Builder | Surface changes | Behaviour |
| --- | --- | --- |
| `createQueueBuilder()` | FIFO-only props (`fifo`, `contentBasedDeduplication`, `deduplicationScope`, `fifoThroughputLimit`) removed from the type and rejected at build with a pointer to the FIFO entry points | unchanged otherwise |
| `createFifoQueueBuilder()` | `fifo` not settable (always `true`); `queueName` typed `` `${string}.fifo` `` so a missing suffix is a compile error | high-throughput mode without `deduplicationScope: MESSAGE_GROUP` throws; FIFO↔standard redrive-target mismatch throws (deploy-time failure surfaced at build); same secure defaults and primary alarm set — FIFO shares the standard 120k in-flight quota since Nov 2024, so no threshold fork is needed (the "latent threshold bug" in #117 is moot; documented instead) |
| `createDlqQueueBuilder()` | `deadLetterQueue` removed — a DLQ is terminal (build guard for untyped callers) | 14-day retention (`DLQ_QUEUE_DEFAULTS`); inverted alarms (below); FIFO props remain available because a FIFO source requires a FIFO DLQ — the deliberate Option A compromise, since factories multiply per combination while a prop composes (see ADR-0013 §4) |

### DLQ alarm semantics (`DLQ_ALARM_DEFAULTS`)

- `approximateNumberOfMessagesVisible` **on**, threshold > 0 — any message on a DLQ is the alert.
- `approximateAgeOfOldestMessage` **on**, re-framed as "about to age out": default threshold is 75% of the queue's *resolved* `retentionPeriod` (`DLQ_AGE_ALARM_RETENTION_RATIO`), so tuning retention can't strand the alarm. Token-valued retention skips the alarm with the standardized acknowledgeable warning (`resolveAlarmThresholdBasis`, per #196).
- `approximateNumberOfMessagesNotVisible` **off** — nothing is in flight on a DLQ; opt back in via `recommendedAlarms`.

### Shared functionality (what keeps three factories honest)

- `queue-props.ts` — single home for the prop taxonomy (`FIFO_ONLY_PROP_KEYS`, `FifoQueueName`, `QueueBuilderExtensionProps`).
- `queue-validation.ts` — FIFO invariants (owning their own applicability), redrive-target type match, `maxReceiveCount` floor.
- `build-queue.ts` — construct + alarms + `QueueBuilderResult`.
- `queue-alarms.ts` + `queue-alarm-profiles.ts` — one data-driven resolution loop over per-type profiles (enablement / partial defaults / descriptions). An alarm with no generic baseline (visible-messages on a primary queue) now **throws when enabled without an explicit threshold** instead of inheriting a noisy placeholder.

Discovery mitigations for the three-entry-point risk: compile errors at the call site, build guards that name the right factory, JSDoc cross-links, and a "Choosing a builder" table atop the README. Full rationale in [ADR-0013](docs/adr/0013-queue-type-sibling-builders.md) (status: Proposed; the Option B PR carries a competing ADR under the same number — only the merged one keeps it).

### Breaking change

`QueueBuilderProps` no longer includes the FIFO passthrough props from #115; FIFO callers move to `createFifoQueueBuilder()` unchanged otherwise.

Out of scope (unchanged from #253): `SubscriptionBuilder` auto-DLQ + SNS resource-policy wiring (#34 items 3–4) — needs the first sns→sqs package dependency and its own discussion.

## Checklist

- [x] Linked to an issue (#34, #117)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change (68 sqs tests, incl. validation throws, retention-scaled thresholds, token-retention skip, copy semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGnjGQrqGPaTL9mnfB5NKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGnjGQrqGPaTL9mnfB5NKw)_