### PR TITLE
test(apigateway): reach 90% branch coverage and raise the floor

### DIFF
--- a/packages/apigateway/src/defaults.ts
+++ b/packages/apigateway/src/defaults.ts
@@ -33,7 +33,7 @@ export const DEPLOY_OPTIONS_DEFAULTS: StageOptions = {
  * {@link createRestApiBuilder}. Each property can be individually overridden
  * via the builder's fluent API.
  */
-export const REST_API_DEFAULTS: Partial<RestApiBuilderProps> = {
+export const REST_API_DEFAULTS = {
   /**
    * Automatically create an access log group with structured JSON output.
    * Access logging provides an audit trail of all API calls for security
@@ -43,14 +43,14 @@ export const REST_API_DEFAULTS: Partial<RestApiBuilderProps> = {
   accessLogging: true,
 
   deployOptions: DEPLOY_OPTIONS_DEFAULTS,
-};
+} satisfies Partial<RestApiBuilderProps>;
 
 /**
  * Secure, AWS-recommended defaults applied to every spec-driven REST API
  * built with {@link createSpecRestApiBuilder}. Each property can be
  * individually overridden via the builder's fluent API.
  */
-export const SPEC_REST_API_DEFAULTS: Partial<SpecRestApiBuilderProps> = {
+export const SPEC_REST_API_DEFAULTS = {
   /**
    * Automatically create an access log group with structured JSON output.
    * @see https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/opex-logging.html
@@ -58,4 +58,4 @@ export const SPEC_REST_API_DEFAULTS: Partial<SpecRestApiBuilderProps> = {
   accessLogging: true,
 
   deployOptions: DEPLOY_OPTIONS_DEFAULTS,
-};
+} satisfies Partial<SpecRestApiBuilderProps>;

--- a/packages/apigateway/src/rest-api-builder.ts
+++ b/packages/apigateway/src/rest-api-builder.ts
@@ -119,7 +119,7 @@ class RestApiBuilder implements Lifecycle<RestApiBuilderResult> {
       scope,
       id,
       accessLogging,
-      REST_API_DEFAULTS.deployOptions ?? {},
+      REST_API_DEFAULTS.deployOptions,
       restApiProps.deployOptions ?? {},
     );
 

--- a/packages/apigateway/src/spec-rest-api-builder.ts
+++ b/packages/apigateway/src/spec-rest-api-builder.ts
@@ -68,7 +68,7 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
       scope,
       id,
       accessLogging,
-      SPEC_REST_API_DEFAULTS.deployOptions ?? {},
+      SPEC_REST_API_DEFAULTS.deployOptions,
       specRestApiProps.deployOptions ?? {},
     );
 

--- a/packages/apigateway/test/rest-api-alarms.test.ts
+++ b/packages/apigateway/test/rest-api-alarms.test.ts
@@ -27,6 +27,8 @@ function mockIntegration() {
 
 const methodResponse200 = { methodResponses: [{ statusCode: "200" }] };
 
+const ALARM_KEYS = ["clientError", "serverError", "latency"] as const;
+
 function buildResult(configureFn: (builder: ReturnType<typeof createRestApiBuilder>) => void) {
   const app = new App();
   const stack = new Stack(app, "TestStack");
@@ -197,10 +199,9 @@ describe("recommended alarms", () => {
       template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
     });
 
-    it.each([
-      { key: "clientError", others: ["serverError", "latency"] },
-      { key: "latency", others: ["clientError", "serverError"] },
-    ])("disables only the $key alarm when set to false", ({ key, others }) => {
+    it.each(
+      ALARM_KEYS.map((key) => ({ key, others: ALARM_KEYS.filter((other) => other !== key) })),
+    )("disables only the $key alarm when set to false", ({ key, others }) => {
       const { result, template } = buildResult((b) => {
         withStubMethod(b);
         b.recommendedAlarms({ [key]: false });

--- a/packages/apigateway/test/rest-api-alarms.test.ts
+++ b/packages/apigateway/test/rest-api-alarms.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { ApiDefinition, MockIntegration, PassthroughBehavior } from "aws-cdk-lib/aws-apigateway";
+import {
+  ApiDefinition,
+  MockIntegration,
+  PassthroughBehavior,
+  RestApi,
+} from "aws-cdk-lib/aws-apigateway";
 import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { createRestApiBuilder } from "../src/rest-api-builder.js";
 import { createSpecRestApiBuilder } from "../src/spec-rest-api-builder.js";
+import { resolveRestApiAlarmDefinitions } from "../src/rest-api-alarms.js";
 
 function mockIntegration() {
   return new MockIntegration({
@@ -203,6 +209,18 @@ describe("recommended alarms", () => {
       template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
     });
 
+    it("disables only the latency alarm when set to false", () => {
+      const { result, template } = buildResult((b) => {
+        withStubMethod(b);
+        b.recommendedAlarms({ latency: false });
+      });
+
+      expect(result.alarms.clientError).toBeDefined();
+      expect(result.alarms.serverError).toBeDefined();
+      expect(result.alarms.latency).toBeUndefined();
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    });
+
     it("disables multiple individual alarms", () => {
       const { result, template } = buildResult((b) => {
         withStubMethod(b);
@@ -225,6 +243,15 @@ describe("recommended alarms", () => {
         AlarmActions: Match.absent(),
       });
     });
+  });
+});
+
+describe("resolveRestApiAlarmDefinitions", () => {
+  it("returns no definitions when explicitly disabled", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const api = new RestApi(stack, "TestApi");
+
+    expect(resolveRestApiAlarmDefinitions(api, { enabled: false })).toEqual([]);
   });
 });
 

--- a/packages/apigateway/test/rest-api-alarms.test.ts
+++ b/packages/apigateway/test/rest-api-alarms.test.ts
@@ -197,27 +197,19 @@ describe("recommended alarms", () => {
       template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
     });
 
-    it("disables individual alarms when set to false", () => {
+    it.each([
+      { key: "clientError", others: ["serverError", "latency"] },
+      { key: "latency", others: ["clientError", "serverError"] },
+    ])("disables only the $key alarm when set to false", ({ key, others }) => {
       const { result, template } = buildResult((b) => {
         withStubMethod(b);
-        b.recommendedAlarms({ clientError: false });
+        b.recommendedAlarms({ [key]: false });
       });
 
-      expect(result.alarms.clientError).toBeUndefined();
-      expect(result.alarms.serverError).toBeDefined();
-      expect(result.alarms.latency).toBeDefined();
-      template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
-    });
-
-    it("disables only the latency alarm when set to false", () => {
-      const { result, template } = buildResult((b) => {
-        withStubMethod(b);
-        b.recommendedAlarms({ latency: false });
-      });
-
-      expect(result.alarms.clientError).toBeDefined();
-      expect(result.alarms.serverError).toBeDefined();
-      expect(result.alarms.latency).toBeUndefined();
+      expect(result.alarms[key]).toBeUndefined();
+      for (const other of others) {
+        expect(result.alarms[other]).toBeDefined();
+      }
       template.resourceCountIs("AWS::CloudWatch::Alarm", 2);
     });
 

--- a/packages/apigateway/test/rest-api-builder.test.ts
+++ b/packages/apigateway/test/rest-api-builder.test.ts
@@ -149,6 +149,14 @@ describe("RestApiBuilder", () => {
       });
     });
 
+    it("creates a method with no explicit integration", () => {
+      const template = synthTemplate((b) => b.restApiName("My Service").addMethod("GET"));
+
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "GET",
+      });
+    });
+
     it("creates nested resources", () => {
       const template = synthTemplate((b) =>
         withStubMethod(b.restApiName("My Service")).addResource("users", (users) =>

--- a/packages/apigateway/vitest.config.ts
+++ b/packages/apigateway/vitest.config.ts
@@ -2,7 +2,7 @@ import { withCoverage } from "../../vitest.config.base.js";
 
 export default withCoverage({
   statements: 96,
-  branches: 75,
+  branches: 90,
   functions: 100,
   lines: 100,
 });


### PR DESCRIPTION
## What & why

Closes #257.

Raises `packages/apigateway`'s per-file branch-coverage floor from 75% to 90% (`vitest.config.ts`), backing it with tests for the four branches the #256 baseline left uncovered.

Two of the four were genuinely reachable and are closed with real tests:
- **`ResourceBuilder.applyTo`** — a method declared with no explicit integration (the `integration === undefined` arm) was never exercised; added a synth test for `addMethod("GET")` with no integration.
- **`resolveRestApiAlarmDefinitions`** — the "disable only one alarm" arm had no coverage for `latency`; extended the existing "disables individual alarms" test into a parameterized `it.each` covering `clientError` and `latency`, plus a direct unit test of the `enabled: false` guard, which `createRestApiAlarms` short-circuits before ever calling the helper.

The other two were unreachable defensive branches rather than test gaps, so they're removed rather than tested-around:
- `REST_API_DEFAULTS.deployOptions ?? {}` / `SPEC_REST_API_DEFAULTS.deployOptions ?? {}` could never take the `{}` arm — both constants always set `deployOptions`. Narrowing the constants with `satisfies Partial<…Props>` (instead of a `: Partial<…Props>` annotation that widened `deployOptions` back to optional) types `deployOptions` as always-present, so the fallback drops out. No behavioural change; the constant values are identical.

apigateway now reports 100% statements/branches/functions/lines.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change