### PR TITLE
chore: group aws-cdk dependabot updates separately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
     schedule:
       interval: weekly
     groups:
+      aws-cdk:
+        patterns:
+          - "aws-cdk"
+          - "aws-cdk*"
+          - "@aws-cdk/*"
       npm-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "aws-cdk"
+          - "aws-cdk*"
+          - "@aws-cdk/*"


### PR DESCRIPTION
## What

Split `aws-cdk-lib` and `aws-cdk` (and related `aws-cdk*` / `@aws-cdk/*` packages) into their own Dependabot group, and exclude them from the general `npm-dependencies` group.

## Why

These dependencies are significant and often introduce breaking changes relative to the rest of the npm updates. Keeping them in a dedicated group means CDK bumps land in their own PR, separate from routine dependency updates — making them easier to review and test in isolation.

## Details

- New `aws-cdk` group matches `aws-cdk`, `aws-cdk*`, and `@aws-cdk/*`.
- `npm-dependencies` gains matching `exclude-patterns` so those packages don't get pulled into the catch-all PR.
- Dependabot config validated with yaml-lint.