### PR TITLE
test(core): reach 90/90 branch/statement coverage and raise the floor

### DIFF
--- a/packages/core/test/testing.test.ts
+++ b/packages/core/test/testing.test.ts
@@ -156,6 +156,49 @@ describe("assertCopyPreservesState", () => {
     }).toThrow(/no `\.copy\(\)` method/);
   });
 
+  it("falls back to String() when inspectable state cannot be JSON-serialised", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => Builder<Props, WithAccumulator>(WithAccumulator),
+        configure: (b) => {
+          b.add("first");
+        },
+        mutate: () => {
+          /* no-op — forces the "did not change" failure path */
+        },
+        build: buildResult,
+        inspect: () => circular,
+      });
+    }).toThrow(/\[object Object\]/);
+  });
+
+  it.each<{ name: string; baseline: unknown; mutated: unknown }>([
+    { name: "a primitive vs an object", baseline: {}, mutated: 1 },
+    { name: "null vs an object", baseline: null, mutated: {} },
+    { name: "an array vs a non-array", baseline: [], mutated: {} },
+    { name: "objects with differing key counts", baseline: { p: 1 }, mutated: { p: 1, q: 2 } },
+  ])("treats $name as unequal inspectable state", ({ baseline, mutated }) => {
+    const states = [baseline, mutated, baseline];
+    let call = 0;
+
+    expect(() => {
+      assertCopyPreservesState({
+        factory: () => Builder<Props, WithAccumulator>(WithAccumulator),
+        configure: (b) => {
+          b.add("first");
+        },
+        mutate: (b) => {
+          b.add("after-copy");
+        },
+        build: buildResult,
+        inspect: () => states[call++],
+      });
+    }).not.toThrow();
+  });
+
   it("compares non-trivially structured inspectable state via deep equality", () => {
     interface NestedResult {
       tree: { children: { name: string }[] };

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,8 +1,8 @@
 import { withCoverage } from "../../vitest.config.base.js";
 
 export default withCoverage({
-  statements: 87,
-  branches: 85,
+  statements: 90,
+  branches: 90,
   functions: 100,
   lines: 96,
 });


### PR DESCRIPTION
## What & why

Closes #258.

Raises `packages/core`'s per-file floor from branches:85 / statements:87 to 90/90 (`vitest.config.ts`).

`src/testing.ts` was the only file below the new floor (87.17% statements / 85.71% branches). Its two functions had genuine gaps:

- **`format()`** — the `JSON.stringify` failure fallback (`return String(value)`) had no test. Added one that feeds `assertCopyPreservesState` a circular inspectable-state object, which forces the error-message formatter through the `catch` arm.
- **`deepEqual()`** — four of its structural-mismatch arms had never been exercised (every existing test compared same-shaped values): primitive vs object, `null` vs object, array vs non-array, and objects with differing key counts. Added a parameterized test asserting `assertCopyPreservesState` correctly treats each of these as unequal — genuine correctness coverage of the "deep equality" contract the helper's docstring promises, not just a coverage-chasing exercise.

`core` now reports 100% statements/lines, 97.22% branches, with every file at or above the 90% floor (`compose.ts` 91.66%, `ref.ts` 90.9%, `testing.ts` 100%).

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMz3UmZvNhGpFf5KYq4XYX)_