### PR TITLE
chore: upgrade prettier to ^3.9.0 and reformat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.7",
         "nx": "23.0.1",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.0",
         "publint": "^0.3.21",
         "tshy": "^4.1.3",
         "typescript-eslint": "^8.61.0"
@@ -7532,9 +7532,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.7",
     "nx": "23.0.1",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.0",
     "publint": "^0.3.21",
     "tshy": "^4.1.3",
     "typescript-eslint": "^8.61.0"

--- a/packages/cloudformation/src/tags.ts
+++ b/packages/cloudformation/src/tags.ts
@@ -99,8 +99,7 @@ export function tags<T extends object = object>(defs: TagDefinitions<T>): AfterB
     validateTagRecord(defs.system);
   }
   const byComponent = defs.byComponent as
-    | Record<string, Record<string, string> | undefined>
-    | undefined;
+    Record<string, Record<string, string> | undefined> | undefined;
   if (byComponent) {
     for (const componentTags of Object.values(byComponent)) {
       if (componentTags === undefined) continue;

--- a/packages/cloudwatch/README.md
+++ b/packages/cloudwatch/README.md
@@ -190,12 +190,7 @@ All three action states are supported: `alarmActions`, `okActions`, and `insuffi
 Rules route by _alarm identity_ (id, path, predicate). When you instead need to route by _scope_ — e.g. one SNS topic for everything in `us-east-1` and another for the primary region — call `alarmActionsPolicy` multiple times, once per target scope. If the topics are themselves built by the composed system, this is the case where wrapping in [`afterBuild`](../core/README.md) is load-bearing: the closure captures the build `results` so each call can reference its topic.
 
 ```ts
-compose(
-  { usEast1Alerts: createTopicBuilder(), siteAlerts: createTopicBuilder() },
-  {
-    /* … */
-  },
-)
+compose({ usEast1Alerts: createTopicBuilder(), siteAlerts: createTopicBuilder() }, {/* … */})
   .withStacks({ usEast1Alerts: usEast1AlertsStack, siteAlerts: siteStack })
   .afterBuild((_scope, _id, results) => {
     alarmActionsPolicy(usEast1AlertsStack, {

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -47,9 +47,7 @@ The `recommended` preset also bans the TypeScript `private` modifier via `no-res
        messages: { someId: "..." },
      },
      create(ctx) {
-       return {
-         /* visitor */
-       };
+       return {/* visitor */};
      },
    };
    ```

--- a/packages/iam/README.md
+++ b/packages/iam/README.md
@@ -83,9 +83,7 @@ import { createServiceRoleBuilder } from "@composurecdk/iam";
 
 const lambdaRole = createServiceRoleBuilder("lambda.amazonaws.com")
   .description("Execution role for StopEC2 Lambda")
-  .addInlinePolicyStatements("StopEC2", [
-    /* statements */
-  ]);
+  .addInlinePolicyStatements("StopEC2", [/* statements */]);
 ```
 
 Thin sugar over `createRoleBuilder().assumedBy(new ServicePrincipal(...))`.

--- a/packages/iam/test/managed-policy-builder.test.ts
+++ b/packages/iam/test/managed-policy-builder.test.ts
@@ -93,8 +93,7 @@ describe("ManagedPolicyBuilder", () => {
           const stack = Stack.of(r.policy);
           const policies = Template.fromStack(stack).findResources("AWS::IAM::ManagedPolicy");
           const entry = Object.values(policies)[0] as
-            | { Properties: { PolicyDocument: { Statement: { Action: string }[] } } }
-            | undefined;
+            { Properties: { PolicyDocument: { Statement: { Action: string }[] } } } | undefined;
           return (entry?.Properties.PolicyDocument.Statement ?? []).map((s) => s.Action).sort();
         },
       });

--- a/packages/s3/test/bucket-builder.test.ts
+++ b/packages/s3/test/bucket-builder.test.ts
@@ -397,8 +397,7 @@ describe("BucketBuilder", () => {
 
       const logBucket = findLogBucket(template);
       const lifecycle = logBucket.Properties.LifecycleConfiguration as
-        | { Rules: Record<string, unknown>[] }
-        | undefined;
+        { Rules: Record<string, unknown>[] } | undefined;
       const rules = lifecycle?.Rules ?? [];
       expect(rules).toHaveLength(1);
       expect(rules[0]).toMatchObject({ Id: "ShortLogs", ExpirationInDays: 30 });

--- a/packages/s3/test/bucket-deployment-builder.test.ts
+++ b/packages/s3/test/bucket-deployment-builder.test.ts
@@ -357,8 +357,7 @@ describe("BucketDeploymentBuilder", () => {
             "Custom::CDKBucketDeployment",
           );
           const entry = Object.values(deployments)[0] as
-            | { Properties: { DestinationBucketName: unknown } }
-            | undefined;
+            { Properties: { DestinationBucketName: unknown } } | undefined;
           return JSON.stringify(entry?.Properties.DestinationBucketName);
         },
       });


### PR DESCRIPTION
## What & why

Upgrades `prettier` from `^3.8.4` to `^3.9.0`. Prettier 3.9 changed how it wraps two constructs, which required reformatting 7 files:

- Union-type `as` casts now collapse onto one line when they fit, instead of splitting each member onto its own line (`packages/cloudformation/src/tags.ts`, `packages/iam/test/managed-policy-builder.test.ts`, `packages/s3/test/bucket-builder.test.ts`, `packages/s3/test/bucket-deployment-builder.test.ts`).
- A call argument that's an object/array containing only a comment now collapses onto one line instead of expanding (`packages/cloudwatch/README.md`, `packages/eslint-plugin/README.md`, `packages/iam/README.md`).

No `.prettierrc` config changes — just updated output for the new formatter version.

## Checklist

- [x] Small, obvious dependency bump + reformat
- [x] `npm run verify` passes locally
- [x] No behavioral changes; no new tests needed


---
_Generated by [Claude Code](https://claude.ai/code/session_018LUqqUkR4ZRCg4YX5Zj46x)_