### PR TITLE
feat: consumer-side IAM grants across resource builders

### DIFF
--- a/docs/adr/0013-consumer-side-grants.md
+++ b/docs/adr/0013-consumer-side-grants.md
@@ -71,8 +71,9 @@ Concretely, the seam has three layers:
    `IGrantable`: `tableGrants` (`read`/`write`/`readWrite`/`fullAccess`),
    `queueGrants` (`consume`/`send`/`purge`), `bucketGrants`
    (`read`/`write`/`readWrite`/`put`/`delete`), `topicGrants`
-   (`publish`/`subscribe`). One `tableGrants` serves both DynamoDB builders
-   because `Table` and `TableV2` share `ITable`.
+   (`publish`/`subscribe`), `functionGrants` (`invoke`/`invokeUrl`). One
+   `tableGrants` serves both DynamoDB builders because `Table` and `TableV2`
+   share `ITable`.
 3. **Grantee builders** expose `grant(...)`, backed by a `GrantQueue<IGrantable>`
    applied in `build()`.
 
@@ -85,6 +86,13 @@ aws-cdk-lib's `IGrantable`. `RoleBuilder`'s `Role` implements it directly;
 `IGrantable` is thus the test for a grantee builder. A resource is never
 `IGrantable`, so the mutation always lands on the grantee's principal, never on
 the resource.
+
+Grantee and resource are roles a construct plays, not fixed identities: the same
+construct can be both. A Lambda `Function` is a grantee via
+`createFunctionBuilder().grant(...)` (it reaches out to a table or bucket) and,
+in the opposite direction, an invokable resource via `functionGrants.invoke(...)`
+(some other grantee is allowed to call it). The two are distinct edges pointing
+opposite ways, so each is declared on its own consumer.
 
 ```ts
 compose(

--- a/docs/adr/0013-consumer-side-grants.md
+++ b/docs/adr/0013-consumer-side-grants.md
@@ -1,0 +1,134 @@
+# ADR 0013: Consumer-side IAM grants — declare a grant where the dependency already points
+
+- **Status:** Proposed
+- **Date:** 2026-07-04
+
+## Context
+
+Granting IAM permissions is a cross-cutting concern. Many resource types expose
+`grant*` methods — a DynamoDB table's `grantReadWriteData`, a bucket's
+`grantWrite`, a queue's `grantConsumeMessages`, a topic's `grantPublish`, a log
+group's `grantWrite` — and any compute or identity that uses one of those
+resources needs such a grant. "How does one component ask for access to another"
+is therefore not a property of any single builder; it spans every resource
+package and every grantee. Left unaddressed, each new resource or wiring answers
+it differently and the library accretes a divergent granting idiom per package.
+A single pattern is warranted.
+
+aws-cdk-lib answers it by putting `grant*` on the **resource**, while the policy
+it generates attaches to the **grantee**: the call mutates the grantee's identity
+policy and only reads the resource's ARN. The real dependency is
+one-directional — grantee → resource.
+
+Adopting that shape inside `compose()` inverts the dependency graph. A grant
+applied during a resource's `build()` needs the grantee in that resource's
+context, forcing the resource to depend on its own consumer:
+
+```ts
+// grant on the resource → resource.build() needs the grantee → the edge points backwards
+table.grantReadWriteData(ref("role", (r) => r.role));
+compose({ table, role }, { table: ["role"], role: [] });
+//                          ^^^^^^^^^^^^^^ the role uses the table, yet the table "depends on" the role
+```
+
+The consumer already depends on the resource for its real work, so this reverse
+edge is at best misleading and — whenever the grantee is the same component that
+consumes the resource — an outright cycle. The `compose()` dependency map is
+meant to be the system's true edge set (the guarantee
+[ADR-0011](0011-cross-component-relationship-guards.md) also protects); a grant
+that inverts an edge breaks it.
+
+Two constraints bound any fix: `@composurecdk/core` has no `aws-cdk-lib`
+dependency and should keep only `constructs`; and a grant spans a grantee package
+and a resource package, so the solution must not make either depend on the other,
+nor every resource package on `@composurecdk/iam`.
+
+## Decision
+
+Declare a grant on the **consumer** — the grantee builder — rather than the
+resource. The grant is captured as data at configuration time and applied during
+the grantee's own `build()`, so the grant edge runs in the same direction as the
+data-flow dependency it secures.
+
+Three principles shape the design. First, **direction follows dependency**: the
+grantee already depends on the resource, so the grant belongs on the grantee's
+side of that existing edge, never on a new reverse edge. Second, **defer to the
+construct's own authority**: the grant invokes the resource construct's native
+`grant*` method rather than assembling IAM actions itself, so the library holds
+no policy of its own to keep correct. Third, **the shared contract couples
+nothing**: it is generic over the grantee type and lives in `core`, so no
+resource package depends on a grantee package (or on `@composurecdk/iam`), and
+each resource's capability vocabulary is owned by that resource's package.
+
+Concretely, the seam has three layers:
+
+1. **`core`** defines a generic, `aws-cdk-lib`-free contract: `Grant<G>` (a
+   deferred grant applied to a grantee of type `G`), `grantVia(resource, apply)`
+   (builds a `Grant` that resolves a resource `Ref` and calls `apply`), and
+   `GrantQueue<G>` (the grantee-side accumulator).
+2. **Each resource package** exports one capability namespace built from
+   `grantVia`, typed against the construct interface plus a type-only
+   `IGrantable`: `tableGrants` (`read`/`write`/`readWrite`/`fullAccess`),
+   `queueGrants` (`consume`/`send`/`purge`), `bucketGrants`
+   (`read`/`write`/`readWrite`/`put`/`delete`), `topicGrants`
+   (`publish`/`subscribe`). One `tableGrants` serves both DynamoDB builders
+   because `Table` and `TableV2` share `ITable`.
+3. **Grantee builders** expose `grant(...)`, backed by a `GrantQueue<IGrantable>`
+   applied in `build()`.
+
+A grantee is a construct an IAM statement can attach to — one that implements
+aws-cdk-lib's `IGrantable`. `RoleBuilder`'s `Role` implements it directly;
+`FunctionBuilder`'s `Function` implements it by exposing its execution role as
+`grantPrincipal`, so granting to the function routes the policy onto that role
+(whichever role it ends up with — its default least-privilege role, a
+`.configureRole` extension, an external `.role(ref)`, or the CDK auto-role).
+`IGrantable` is thus the test for a grantee builder. A resource is never
+`IGrantable`, so the mutation always lands on the grantee's principal, never on
+the resource.
+
+```ts
+compose(
+  {
+    bucket: createBucketBuilder(),
+    handler: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_22_X)
+      .handler("index.handler")
+      .code(Code.fromAsset("handler"))
+      .grant(bucketGrants.write(ref("bucket", (r) => r.bucket))),
+  },
+  { bucket: [], handler: ["bucket"] }, // handler → bucket; no reverse edge, no cycle
+);
+```
+
+## Consequences
+
+- The `compose()` dependency map stays truthful: a grant edge points from
+  consumer to resource, matching the data flow, and never manufactures a reverse
+  edge or the cycle it can cause.
+- **To grant:** `<granteeBuilder>.grant(<resourceGrants>.<capability>(ref(...)))`.
+  **To make a resource grantable:** add a `grants.ts` of `grantVia` helpers — no
+  core change, no wiring. **To make a builder a grantee:** add a `GrantQueue`
+  (`#grants`, `grant()`, `copyInto` in the `.copy()` hook, `applyTo` in `build()`).
+- Capability names are owned by, and discoverable from, the resource package; the
+  grantee side is uniform across every resource.
+- No new cross-package dependencies: the contract is in `core`, which everything
+  already depends on; only the consuming application imports both a resource
+  package and a grantee, as it already does.
+- **Out of scope.** API Gateway AWS-service integrations, whose `credentialsRole`
+  has no owner in the current builder surface and so cannot yet be a grantee
+  (tracked in laazyj/composureCDK#270); and Neptune's `allowAccessFrom`, which
+  couples an IAM grant with a security-group rule and will migrate its IAM half to
+  a consumer-side `clusterGrants.connect(...)` in a separate breaking change.
+
+## Alternatives considered
+
+- **Resource-side grants (aws-cdk-lib's shape), e.g. `table.grantReadWriteData(ref)`.**
+  Rejected: it inverts the grant edge and is cycle-prone whenever the grantee also
+  consumes the resource — the common case.
+- **A thunk-based grantee method, e.g. `role.grant(ref("table", (t) => (g) => t.grantReadWriteData(g)))`.**
+  Rejected: the capability is written inline at every call site with no
+  discoverable catalogue, and each resource's action knowledge leaks into consumer
+  code.
+- **Put the shared contract in `@composurecdk/iam`.** Rejected: every grantable
+  resource package would then depend on `@composurecdk/iam` (today only `lambda`
+  does). A generic `Grant<G>` in `core` needs no such edges.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0010: AWS-property constraints — a catalogue with central mechanism and local data](0010-aws-property-constraints.md)
 - [ADR-0011: Cross-component relationship guards — builder-registered synth-time Aspects](0011-cross-component-relationship-guards.md)
 - [ADR-0012: Explicit build id — decouple the construct id from the compose key](0012-explicit-build-id-decoupled-from-compose-key.md)
+- [ADR-0013: Consumer-side IAM grants — declare a grant where the dependency already points](0013-consumer-side-grants.md)

--- a/packages/core/src/grant.ts
+++ b/packages/core/src/grant.ts
@@ -1,0 +1,110 @@
+import { resolve, type Resolvable } from "./ref.js";
+
+/**
+ * A deferred, cross-component permission grant, declared on the **consumer**.
+ *
+ * ComposureCDK expresses IAM grants where the dependency already points — from
+ * the grantee (a role, a function) to the resource it uses — rather than on the
+ * resource, which would invert the {@link compose} dependency edge. A `Grant`
+ * captures that intent as data at configuration time and applies it during the
+ * grantee builder's own `build()`, once the resource {@link Ref} it references
+ * has resolved against the build context.
+ *
+ * `Grant` is generic over the grantee type `G` so this contract stays free of
+ * any `aws-cdk-lib` dependency. Grantee packages instantiate it as
+ * `Grant<IGrantable>`; resource packages produce one via {@link grantVia}.
+ *
+ * @typeParam G - The grantee type the grant is applied to (e.g. `IGrantable`).
+ */
+export interface Grant<G> {
+  /**
+   * Applies the grant to `grantee`, resolving any {@link Ref} to the target
+   * resource against `context`.
+   *
+   * @param grantee - The principal receiving the permission.
+   * @param context - The resolved dependency outputs, keyed by component name.
+   */
+  applyTo(grantee: G, context: Record<string, object>): void;
+}
+
+/**
+ * Builds a {@link Grant} from a resource and a function that applies a
+ * permission to a grantee.
+ *
+ * Resource packages use this to expose capability helpers (e.g.
+ * `tableGrants.readWrite`, `bucketGrants.write`). When the returned grant is
+ * applied, `resource` is resolved against the build context and passed to
+ * `apply` together with the grantee.
+ *
+ * @typeParam R - The resolved resource type (e.g. `ITable`, `IBucket`).
+ * @typeParam G - The grantee type (e.g. `IGrantable`).
+ * @param resource - The resource to grant on, concrete or a {@link Ref}.
+ * @param apply - Applies the permission for `grantee` to the resolved `resource`.
+ * @returns A {@link Grant} to pass to a grantee builder's `grant(...)`.
+ *
+ * @example
+ * ```ts
+ * // In a resource package:
+ * export const bucketGrants = {
+ *   write: (b: Resolvable<IBucket>): Grant<IGrantable> =>
+ *     grantVia(b, (bucket, grantee: IGrantable) => bucket.grantWrite(grantee)),
+ * };
+ * ```
+ */
+export function grantVia<R, G>(
+  resource: Resolvable<R>,
+  apply: (resource: R, grantee: G) => void,
+): Grant<G> {
+  return {
+    applyTo(grantee, context) {
+      apply(resolve(resource, context), grantee);
+    },
+  };
+}
+
+/**
+ * A queue of pending {@link Grant}s held by a grantee builder.
+ *
+ * A grantee builder accumulates grants declared at configuration time via
+ * {@link GrantQueue.add | add}, then applies them all with
+ * {@link GrantQueue.applyTo | applyTo} during its `build()` — once the grantee
+ * construct exists and the build context is available.
+ * {@link GrantQueue.copyInto | copyInto} supports the builder's `.copy()` hook.
+ *
+ * @typeParam G - The grantee type applied to (e.g. `IGrantable`).
+ *
+ * @example
+ * ```ts
+ * // In a grantee builder:
+ * readonly #grants = new GrantQueue<IGrantable>();
+ * grant(...grants: Grant<IGrantable>[]): this {
+ *   this.#grants.add(...grants);
+ *   return this;
+ * }
+ * // in [COPY_STATE]: this.#grants.copyInto(target.#grants);
+ * // in build():     this.#grants.applyTo(grantee, context);
+ * ```
+ */
+export class GrantQueue<G> {
+  readonly #grants: Grant<G>[] = [];
+
+  /** Enqueues grants to apply at build time. */
+  add(...grants: Grant<G>[]): void {
+    this.#grants.push(...grants);
+  }
+
+  /** Copies the queued grants onto `target`. @internal — see ADR-0005. */
+  copyInto(target: GrantQueue<G>): void {
+    target.#grants.push(...this.#grants);
+  }
+
+  /**
+   * Applies every queued grant to `grantee`, resolving each target resource
+   * against `context`.
+   */
+  applyTo(grantee: G, context: Record<string, object>): void {
+    for (const grant of this.#grants) {
+      grant.applyTo(grantee, context);
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./compose.js";
 export { CyclicDependencyError } from "./cyclic-dependency-error.js";
 export { DuplicateConstructIdError } from "./duplicate-construct-id-error.js";
+export { type Grant, grantVia, GrantQueue } from "./grant.js";
 export { type Lifecycle } from "./lifecycle.js";
 export { Ref, ref, resolve, isRef, type Resolvable } from "./ref.js";
 export {

--- a/packages/core/test/grant.test.ts
+++ b/packages/core/test/grant.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { grantVia, GrantQueue, type Grant } from "../src/grant.js";
+import { ref, type Resolvable } from "../src/ref.js";
+
+// A stand-in resource whose "native grant method" records who it was called
+// for, so we can assert the delegation and the resolved-resource identity.
+class FakeResource {
+  readonly granted: string[] = [];
+  grantWrite(grantee: { id: string }): void {
+    this.granted.push(grantee.id);
+  }
+}
+
+const grantee = { id: "role-a" };
+
+const makeGrant = (resource: Resolvable<FakeResource>): Grant<typeof grantee> =>
+  grantVia(resource, (r: FakeResource, g: typeof grantee) => {
+    r.grantWrite(g);
+  });
+
+describe("grantVia", () => {
+  it("resolves a concrete resource and delegates to its native grant method", () => {
+    const resource = new FakeResource();
+
+    makeGrant(resource).applyTo(grantee, {});
+
+    expect(resource.granted).toEqual(["role-a"]);
+  });
+
+  it("resolves a Ref against the build context before delegating", () => {
+    const resource = new FakeResource();
+    const context = { store: { resource } };
+
+    makeGrant(ref<{ resource: FakeResource }, FakeResource>("store", (o) => o.resource)).applyTo(
+      grantee,
+      context,
+    );
+
+    expect(resource.granted).toEqual(["role-a"]);
+  });
+
+  it("passes the grantee through unchanged", () => {
+    const resource = new FakeResource();
+    const other = { id: "role-b" };
+
+    makeGrant(resource).applyTo(other, {});
+
+    expect(resource.granted).toEqual(["role-b"]);
+  });
+});
+
+describe("GrantQueue", () => {
+  it("applies every queued grant to the grantee", () => {
+    const a = new FakeResource();
+    const b = new FakeResource();
+    const queue = new GrantQueue<typeof grantee>();
+
+    queue.add(makeGrant(a), makeGrant(b));
+    queue.applyTo(grantee, {});
+
+    expect(a.granted).toEqual(["role-a"]);
+    expect(b.granted).toEqual(["role-a"]);
+  });
+
+  it("applies nothing when empty", () => {
+    expect(() => {
+      new GrantQueue<typeof grantee>().applyTo(grantee, {});
+    }).not.toThrow();
+  });
+
+  it("copyInto copies queued grants onto the target", () => {
+    const resource = new FakeResource();
+    const source = new GrantQueue<typeof grantee>();
+    source.add(makeGrant(resource));
+
+    const target = new GrantQueue<typeof grantee>();
+    source.copyInto(target);
+    target.applyTo(grantee, {});
+
+    expect(resource.granted).toEqual(["role-a"]);
+  });
+
+  it("copyInto leaves the source and target independent after the copy", () => {
+    const shared = new FakeResource();
+    const sourceOnly = new FakeResource();
+    const targetOnly = new FakeResource();
+    const source = new GrantQueue<typeof grantee>();
+    source.add(makeGrant(shared));
+
+    const target = new GrantQueue<typeof grantee>();
+    source.copyInto(target);
+    // Mutate each after the copy — additions must not leak across.
+    source.add(makeGrant(sourceOnly));
+    target.add(makeGrant(targetOnly));
+
+    target.applyTo(grantee, {});
+
+    expect(shared.granted).toEqual(["role-a"]);
+    expect(targetOnly.granted).toEqual(["role-a"]);
+    expect(sourceOnly.granted).toEqual([]);
+  });
+});

--- a/packages/dynamodb/src/grants.ts
+++ b/packages/dynamodb/src/grants.ts
@@ -1,0 +1,37 @@
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import type { IGrantable } from "aws-cdk-lib/aws-iam";
+import { type Grant, grantVia, type Resolvable } from "@composurecdk/core";
+
+/** Wraps one of {@link ITable}'s native grant methods as a capability helper. */
+const capability =
+  (apply: (table: ITable, grantee: IGrantable) => void) =>
+  (table: Resolvable<ITable>): Grant<IGrantable> =>
+    grantVia(table, apply);
+
+/**
+ * Consumer-side grant helpers for a DynamoDB table. Pass one to a grantee
+ * builder's `grant(...)` — e.g.
+ * `role.grant(tableGrants.readWrite(ref("table", (r) => r.table)))`.
+ *
+ * `ITable` is implemented by both `Table` and `TableV2`, so these helpers serve
+ * either builder's result. Each delegates to the table's native `grant*Data`
+ * method. See ADR-0013.
+ */
+export const tableGrants = {
+  /** Read access (`dynamodb:GetItem`, `Query`, `Scan`, …). */
+  read: capability((table, grantee) => {
+    table.grantReadData(grantee);
+  }),
+  /** Write access (`dynamodb:PutItem`, `UpdateItem`, `DeleteItem`, …). */
+  write: capability((table, grantee) => {
+    table.grantWriteData(grantee);
+  }),
+  /** Combined read and write access. */
+  readWrite: capability((table, grantee) => {
+    table.grantReadWriteData(grantee);
+  }),
+  /** Full access to the table and its indexes (`dynamodb:*`). */
+  fullAccess: capability((table, grantee) => {
+    table.grantFullAccess(grantee);
+  }),
+};

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -10,6 +10,7 @@ export {
   type TableV2BuilderProps,
   type TableV2BuilderResult,
 } from "./table-v2-builder.js";
+export { tableGrants } from "./grants.js";
 export { TABLE_DEFAULTS, TABLE_V2_DEFAULTS } from "./defaults.js";
 export { type TableAlarmConfig } from "./table-alarm-config.js";
 export { TABLE_ALARM_DEFAULTS } from "./table-alarm-defaults.js";

--- a/packages/dynamodb/test/grants.test.ts
+++ b/packages/dynamodb/test/grants.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { ref } from "@composurecdk/core";
+import { tableGrants } from "../src/grants.js";
+
+function setup() {
+  const app = new App();
+  const stack = new Stack(app, "S");
+  const table = new Table(stack, "Table", {
+    partitionKey: { name: "id", type: AttributeType.STRING },
+  });
+  const role = new Role(stack, "Role", { assumedBy: new ServicePrincipal("lambda.amazonaws.com") });
+  return { stack, table, role };
+}
+
+// The granted actions land on the role's policy; asserting on the rendered
+// template keeps us decoupled from whether CDK emits a single action or an array.
+const policyJson = (stack: Stack) => JSON.stringify(Template.fromStack(stack).toJSON());
+
+describe("tableGrants", () => {
+  it.each([
+    ["read", ["dynamodb:GetItem"]],
+    ["write", ["dynamodb:PutItem"]],
+    ["readWrite", ["dynamodb:GetItem", "dynamodb:PutItem"]],
+    ["fullAccess", ["dynamodb:*"]],
+  ] as const)("%s delegates to the matching native grant method", (capability, actions) => {
+    const { stack, table, role } = setup();
+
+    tableGrants[capability](table).applyTo(role, {});
+
+    const json = policyJson(stack);
+    for (const action of actions) expect(json).toContain(action);
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
+  });
+
+  it("resolves a Resolvable table from the build context before granting", () => {
+    const { stack, table, role } = setup();
+
+    tableGrants
+      .readWrite(ref<{ table: Table }, Table>("store", (r) => r.table))
+      .applyTo(role, { store: { table } });
+
+    expect(policyJson(stack)).toContain("dynamodb:PutItem");
+  });
+});

--- a/packages/iam/src/role-builder.ts
+++ b/packages/iam/src/role-builder.ts
@@ -1,4 +1,5 @@
 import {
+  type IGrantable,
   type IManagedPolicy,
   PolicyDocument,
   PolicyStatement,
@@ -6,7 +7,14 @@ import {
   type RoleProps,
 } from "aws-cdk-lib/aws-iam";
 import type { IConstruct } from "constructs";
-import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import {
+  COPY_STATE,
+  type Grant,
+  GrantQueue,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { ROLE_DEFAULTS } from "./role-defaults.js";
 import { StatementBuilder } from "./statement-builder.js";
@@ -96,6 +104,7 @@ interface InlinePolicyEntry {
 class RoleBuilder implements Lifecycle<RoleBuilderResult> {
   props: Partial<RoleBuilderProps> = {};
   readonly #inlinePolicies: InlinePolicyEntry[] = [];
+  readonly #grants = new GrantQueue<IGrantable>();
 
   /**
    * Append an inline policy to the role, embedded in the underlying
@@ -116,9 +125,32 @@ class RoleBuilder implements Lifecycle<RoleBuilderResult> {
     return this;
   }
 
+  /**
+   * Grant this role access to a resource built by a sibling component.
+   *
+   * Grants are declared on the consumer — the role that needs the access —
+   * so the dependency edge points from the role to the resource, matching the
+   * data flow. Each {@link Grant} comes from a resource package's capability
+   * helper (e.g. `tableGrants.readWrite(ref("table", (r) => r.table))`) and is
+   * applied during this builder's {@link build}, once the resource resolves.
+   *
+   * @see ADR-0013
+   *
+   * @example
+   * ```ts
+   * createServiceRoleBuilder("apigateway.amazonaws.com")
+   *   .grant(tableGrants.readWrite(ref("table", (r) => r.table)));
+   * ```
+   */
+  grant(...grants: Grant<IGrantable>[]): this {
+    this.#grants.add(...grants);
+    return this;
+  }
+
   /** @internal — see ADR-0005. */
   [COPY_STATE](target: RoleBuilder): void {
     target.#inlinePolicies.push(...this.#inlinePolicies);
+    this.#grants.copyInto(target.#grants);
   }
 
   build(scope: IConstruct, id: string, context: Record<string, object> = {}): RoleBuilderResult {
@@ -164,6 +196,7 @@ class RoleBuilder implements Lifecycle<RoleBuilderResult> {
     };
 
     const role = new Role(scope, id, mergedProps);
+    this.#grants.applyTo(role, context);
 
     return { role, inlinePolicies: addedInlinePolicies };
   }

--- a/packages/iam/test/role-grants.test.ts
+++ b/packages/iam/test/role-grants.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { type IGrantable, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { compose, grantVia, type Lifecycle, ref, type Resolvable } from "@composurecdk/core";
+import { createRoleBuilder } from "../src/role-builder.js";
+
+// A read grant on a real Bucket. `grant()` is resource-agnostic, so exercising
+// it against an actual construct's native `grantRead` is the faithful check —
+// this is exactly what a resource package's capability helper produces.
+const readBucket = (bucket: Resolvable<Bucket>) =>
+  grantVia(bucket, (b: Bucket, grantee: IGrantable) => {
+    b.grantRead(grantee);
+  });
+
+const lambdaRole = () =>
+  createRoleBuilder().assumedBy(new ServicePrincipal("lambda.amazonaws.com"));
+
+// The role's default policy renders as an AWS::IAM::Policy carrying the granted
+// s3 read actions — its presence proves the grant reached the role.
+const expectRoleHasS3ReadPolicy = (template: Template): void => {
+  template.resourceCountIs("AWS::IAM::Policy", 1);
+  template.hasResourceProperties("AWS::IAM::Policy", {
+    PolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({ Action: Match.arrayWith([Match.stringLikeRegexp("s3:GetObject")]) }),
+      ]),
+    }),
+  });
+};
+
+describe("RoleBuilder.grant", () => {
+  it("applies a queued grant to the built role", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const bucket = new Bucket(stack, "Bucket");
+
+    lambdaRole().grant(readBucket(bucket)).build(stack, "TestRole");
+
+    expectRoleHasS3ReadPolicy(Template.fromStack(stack));
+  });
+
+  it("resolves a ref grant through compose context, edge pointing role -> resource", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+
+    const store: Lifecycle<{ bucket: Bucket }> = {
+      build: (scope, id) => ({ bucket: new Bucket(scope, id) }),
+    };
+    const role = lambdaRole().grant(
+      readBucket(ref<{ bucket: Bucket }, Bucket>("store", (r) => r.bucket)),
+    );
+
+    // role depends on store (role: ["store"]) — the grant follows the data-flow
+    // edge and composes without a cycle.
+    expect(() =>
+      compose({ store, role }, { store: [], role: ["store"] }).build(stack, "Sys"),
+    ).not.toThrow();
+
+    expectRoleHasS3ReadPolicy(Template.fromStack(stack));
+  });
+
+  it("preserves queued grants across .copy()", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const bucket = new Bucket(stack, "Bucket");
+
+    const original = lambdaRole().grant(readBucket(bucket));
+    original.copy().build(stack, "CopiedRole");
+
+    // The copied role received the s3 policy → the grant survived the copy.
+    expectRoleHasS3ReadPolicy(Template.fromStack(stack));
+  });
+});

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -1,5 +1,5 @@
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
-import { type IRole, ManagedPolicy } from "aws-cdk-lib/aws-iam";
+import { type IGrantable, type IRole, ManagedPolicy } from "aws-cdk-lib/aws-iam";
 import {
   Function as LambdaFunction,
   type FunctionProps,
@@ -7,7 +7,14 @@ import {
 } from "aws-cdk-lib/aws-lambda";
 import type { ILogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
-import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
+import {
+  COPY_STATE,
+  type Grant,
+  GrantQueue,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import {
@@ -202,6 +209,7 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
   props: Partial<FunctionBuilderProps> = {};
   readonly #customAlarms: AlarmDefinitionBuilder<LambdaFunction>[] = [];
   readonly #eventSources: EventSourceEntry[] = [];
+  readonly #grants = new GrantQueue<IGrantable>();
   #configureRole?: (rb: IRoleBuilder) => unknown;
   #useCdkAutoRole = false;
 
@@ -279,10 +287,35 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
     return this;
   }
 
+  /**
+   * Grant this function's execution role access to a resource built by a
+   * sibling component.
+   *
+   * A Lambda `Function` is an `IGrantable`, so the grant routes onto whichever
+   * execution role the function ends up with (the default least-privilege role,
+   * a {@link configureRole} extension, an external {@link role}, or the CDK
+   * auto-role). Declaring it here keeps the dependency edge pointing from the
+   * function to the resource. Each {@link Grant} comes from a resource
+   * package's capability helper and is applied during {@link build}.
+   *
+   * @see ADR-0013
+   *
+   * @example
+   * ```ts
+   * createFunctionBuilder()
+   *   .grant(bucketGrants.write(ref("bucket", (r) => r.bucket)));
+   * ```
+   */
+  grant(...grants: Grant<IGrantable>[]): this {
+    this.#grants.add(...grants);
+    return this;
+  }
+
   /** @internal — see ADR-0005. */
   [COPY_STATE](target: FunctionBuilder): void {
     target.#customAlarms.push(...this.#customAlarms);
     target.#eventSources.push(...this.#eventSources);
+    this.#grants.copyInto(target.#grants);
     target.#configureRole = this.#configureRole;
     target.#useCdkAutoRole = this.#useCdkAutoRole;
   }
@@ -332,6 +365,7 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
     } as FunctionProps;
 
     const fn = new LambdaFunction(scope, id, mergedProps);
+    this.#grants.applyTo(fn, context);
 
     const eventSources: Record<string, IEventSource> = {};
     const attachedEventSources: AttachedEventSource[] = [];

--- a/packages/lambda/src/grants.ts
+++ b/packages/lambda/src/grants.ts
@@ -1,0 +1,31 @@
+import type { IGrantable } from "aws-cdk-lib/aws-iam";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
+import { type Grant, grantVia, type Resolvable } from "@composurecdk/core";
+
+/** Wraps one of {@link IFunction}'s native grant methods as a capability helper. */
+const capability =
+  (apply: (fn: IFunction, grantee: IGrantable) => void) =>
+  (fn: Resolvable<IFunction>): Grant<IGrantable> =>
+    grantVia(fn, apply);
+
+/**
+ * Consumer-side grant helpers for *invoking* a Lambda function. Pass one to a
+ * grantee builder's `grant(...)` so that grantee may call the function — e.g.
+ * `role.grant(functionGrants.invoke(ref("handler", (r) => r.function)))`.
+ *
+ * Note the direction: here the function is the **resource** being invoked and
+ * the grantee is the caller. This is the mirror of
+ * `createFunctionBuilder().grant(...)`, where the function is the **grantee**
+ * receiving access to some other resource — a Lambda `Function` is both. Each
+ * delegates to the function's native `grant*` method. See ADR-0013.
+ */
+export const functionGrants = {
+  /** Invoke the function (`lambda:InvokeFunction`). */
+  invoke: capability((fn, grantee) => {
+    fn.grantInvoke(grantee);
+  }),
+  /** Invoke the function through its function URL (`lambda:InvokeFunctionUrl`). */
+  invokeUrl: capability((fn, grantee) => {
+    fn.grantInvokeUrl(grantee);
+  }),
+};

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -4,6 +4,7 @@ export {
   type FunctionBuilderResult,
   type IFunctionBuilder,
 } from "./function-builder.js";
+export { functionGrants } from "./grants.js";
 export { FUNCTION_DEFAULTS } from "./defaults.js";
 export { type FunctionAlarmConfig, type PercentageAlarmConfig } from "./alarm-config.js";
 export { FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";

--- a/packages/lambda/test/function-grants.test.ts
+++ b/packages/lambda/test/function-grants.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { type IGrantable } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import { compose, grantVia, type Lifecycle, ref, type Resolvable } from "@composurecdk/core";
+import { createFunctionBuilder } from "../src/function-builder.js";
+
+// A write grant on a real Bucket, built the same way a resource package's
+// capability helper (bucketGrants.write) does — grant() is resource-agnostic,
+// so exercising a real construct's native grantWrite is the faithful check.
+const writeBucket = (bucket: Resolvable<Bucket>) =>
+  grantVia(bucket, (b: Bucket, grantee: IGrantable) => {
+    b.grantWrite(grantee);
+  });
+
+const handler = () =>
+  createFunctionBuilder()
+    .runtime(Runtime.NODEJS_22_X)
+    .handler("index.handler")
+    .code(Code.fromInline("exports.handler = async () => {};"));
+
+// The grant lands on the function's execution role, rendered as an
+// AWS::IAM::Policy carrying the s3 write actions.
+const expectExecRoleHasS3WritePolicy = (template: Template): void => {
+  template.hasResourceProperties("AWS::IAM::Policy", {
+    PolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({ Action: Match.arrayWith([Match.stringLikeRegexp("s3:PutObject")]) }),
+      ]),
+    }),
+  });
+};
+
+describe("FunctionBuilder.grant", () => {
+  it("applies a grant to the function's execution role", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const bucket = new Bucket(stack, "Bucket");
+
+    handler().grant(writeBucket(bucket)).build(stack, "Handler");
+
+    expectExecRoleHasS3WritePolicy(Template.fromStack(stack));
+  });
+
+  it("resolves a ref grant through compose context, edge pointing handler -> resource", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+
+    const store: Lifecycle<{ bucket: Bucket }> = {
+      build: (scope, id) => ({ bucket: new Bucket(scope, id) }),
+    };
+    const fn = handler().grant(
+      writeBucket(ref<{ bucket: Bucket }, Bucket>("store", (r) => r.bucket)),
+    );
+
+    // handler depends on store (handler: ["store"]) — the grant follows the
+    // data-flow edge and composes without a cycle.
+    expect(() =>
+      compose({ store, handler: fn }, { store: [], handler: ["store"] }).build(stack, "Sys"),
+    ).not.toThrow();
+
+    expectExecRoleHasS3WritePolicy(Template.fromStack(stack));
+  });
+
+  it("preserves queued grants across .copy()", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const bucket = new Bucket(stack, "Bucket");
+
+    handler().grant(writeBucket(bucket)).copy().build(stack, "CopiedHandler");
+
+    expectExecRoleHasS3WritePolicy(Template.fromStack(stack));
+  });
+});

--- a/packages/lambda/test/grants.test.ts
+++ b/packages/lambda/test/grants.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ref } from "@composurecdk/core";
+import { functionGrants } from "../src/grants.js";
+
+function setup() {
+  const app = new App();
+  const stack = new Stack(app, "S");
+  const fn = new LambdaFunction(stack, "Fn", {
+    runtime: Runtime.NODEJS_22_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => {};"),
+  });
+  const role = new Role(stack, "Role", {
+    assumedBy: new ServicePrincipal("apigateway.amazonaws.com"),
+  });
+  return { stack, fn, role };
+}
+
+const policyJson = (stack: Stack) => JSON.stringify(Template.fromStack(stack).toJSON());
+
+describe("functionGrants", () => {
+  it.each([
+    ["invoke", "lambda:InvokeFunction"],
+    ["invokeUrl", "lambda:InvokeFunctionUrl"],
+  ] as const)("%s delegates to the matching native grant method", (capability, action) => {
+    const { stack, fn, role } = setup();
+
+    functionGrants[capability](fn).applyTo(role, {});
+
+    expect(policyJson(stack)).toContain(action);
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
+  });
+
+  it("resolves a Resolvable function from the build context before granting", () => {
+    const { stack, fn, role } = setup();
+
+    functionGrants
+      .invoke(ref<{ function: LambdaFunction }, LambdaFunction>("handler", (r) => r.function))
+      .applyTo(role, { handler: { function: fn } });
+
+    expect(policyJson(stack)).toContain("lambda:InvokeFunction");
+  });
+});

--- a/packages/s3/src/grants.ts
+++ b/packages/s3/src/grants.ts
@@ -1,0 +1,41 @@
+import type { IGrantable } from "aws-cdk-lib/aws-iam";
+import type { IBucket } from "aws-cdk-lib/aws-s3";
+import { type Grant, grantVia, type Resolvable } from "@composurecdk/core";
+
+/** Wraps one of {@link IBucket}'s native grant methods as a capability helper. */
+const capability =
+  (apply: (bucket: IBucket, grantee: IGrantable) => void) =>
+  (bucket: Resolvable<IBucket>): Grant<IGrantable> =>
+    grantVia(bucket, apply);
+
+/**
+ * Consumer-side grant helpers for an S3 bucket. Pass one to a grantee builder's
+ * `grant(...)` — e.g.
+ * `handler.grant(bucketGrants.write(ref("bucket", (r) => r.bucket)))`.
+ *
+ * Each delegates to the bucket's native `grant*` method, scoped to the whole
+ * bucket (grant on a key prefix directly on the construct when needed). See
+ * ADR-0013.
+ */
+export const bucketGrants = {
+  /** Read objects (`s3:GetObject`, `ListBucket`, …). */
+  read: capability((bucket, grantee) => {
+    bucket.grantRead(grantee);
+  }),
+  /** Write and overwrite objects (`s3:PutObject`, `Abort*`, …). */
+  write: capability((bucket, grantee) => {
+    bucket.grantWrite(grantee);
+  }),
+  /** Combined read and write access. */
+  readWrite: capability((bucket, grantee) => {
+    bucket.grantReadWrite(grantee);
+  }),
+  /** Put objects without read (`s3:PutObject`). */
+  put: capability((bucket, grantee) => {
+    bucket.grantPut(grantee);
+  }),
+  /** Delete objects (`s3:DeleteObject`). */
+  delete: capability((bucket, grantee) => {
+    bucket.grantDelete(grantee);
+  }),
+};

--- a/packages/s3/src/index.ts
+++ b/packages/s3/src/index.ts
@@ -5,6 +5,7 @@ export {
   type IBucketBuilder,
   type ServerAccessLogsConfig,
 } from "./bucket-builder.js";
+export { bucketGrants } from "./grants.js";
 export {
   BUCKET_DEFAULTS,
   DEFAULT_ACCESS_LOG_BUCKET_LIFECYCLE_RULES,

--- a/packages/s3/test/grants.test.ts
+++ b/packages/s3/test/grants.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { ref } from "@composurecdk/core";
+import { bucketGrants } from "../src/grants.js";
+
+function setup() {
+  const app = new App();
+  const stack = new Stack(app, "S");
+  const bucket = new Bucket(stack, "Bucket");
+  const role = new Role(stack, "Role", { assumedBy: new ServicePrincipal("lambda.amazonaws.com") });
+  return { stack, bucket, role };
+}
+
+const policyJson = (stack: Stack) => JSON.stringify(Template.fromStack(stack).toJSON());
+
+describe("bucketGrants", () => {
+  it.each([
+    ["read", ["s3:GetObject"]],
+    ["write", ["s3:PutObject"]],
+    ["readWrite", ["s3:GetObject", "s3:PutObject"]],
+    ["put", ["s3:PutObject"]],
+    ["delete", ["s3:DeleteObject"]],
+  ] as const)("%s delegates to the matching native grant method", (capability, actions) => {
+    const { stack, bucket, role } = setup();
+
+    bucketGrants[capability](bucket).applyTo(role, {});
+
+    const json = policyJson(stack);
+    for (const action of actions) expect(json).toContain(action);
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
+  });
+
+  it("resolves a Resolvable bucket from the build context before granting", () => {
+    const { stack, bucket, role } = setup();
+
+    bucketGrants
+      .write(ref<{ bucket: Bucket }, Bucket>("store", (r) => r.bucket))
+      .applyTo(role, { store: { bucket } });
+
+    expect(policyJson(stack)).toContain("s3:PutObject");
+  });
+});

--- a/packages/sns/src/grants.ts
+++ b/packages/sns/src/grants.ts
@@ -1,0 +1,27 @@
+import type { IGrantable } from "aws-cdk-lib/aws-iam";
+import type { ITopic } from "aws-cdk-lib/aws-sns";
+import { type Grant, grantVia, type Resolvable } from "@composurecdk/core";
+
+/** Wraps one of {@link ITopic}'s native grant methods as a capability helper. */
+const capability =
+  (apply: (topic: ITopic, grantee: IGrantable) => void) =>
+  (topic: Resolvable<ITopic>): Grant<IGrantable> =>
+    grantVia(topic, apply);
+
+/**
+ * Consumer-side grant helpers for an SNS topic. Pass one to a grantee builder's
+ * `grant(...)` — e.g.
+ * `handler.grant(topicGrants.publish(ref("topic", (r) => r.topic)))`.
+ *
+ * Each delegates to the topic's native `grant*` method. See ADR-0013.
+ */
+export const topicGrants = {
+  /** Publish messages (`sns:Publish`). */
+  publish: capability((topic, grantee) => {
+    topic.grantPublish(grantee);
+  }),
+  /** Subscribe endpoints (`sns:Subscribe`). */
+  subscribe: capability((topic, grantee) => {
+    topic.grantSubscribe(grantee);
+  }),
+};

--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -4,6 +4,7 @@ export {
   type TopicBuilderResult,
   type ITopicBuilder,
 } from "./topic-builder.js";
+export { topicGrants } from "./grants.js";
 export { TOPIC_DEFAULTS } from "./defaults.js";
 export { type TopicAlarmConfig } from "./topic-alarm-config.js";
 export { TOPIC_ALARM_DEFAULTS } from "./topic-alarm-defaults.js";

--- a/packages/sns/test/grants.test.ts
+++ b/packages/sns/test/grants.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { ref } from "@composurecdk/core";
+import { topicGrants } from "../src/grants.js";
+
+function setup() {
+  const app = new App();
+  const stack = new Stack(app, "S");
+  const topic = new Topic(stack, "Topic");
+  const role = new Role(stack, "Role", { assumedBy: new ServicePrincipal("lambda.amazonaws.com") });
+  return { stack, topic, role };
+}
+
+const policyJson = (stack: Stack) => JSON.stringify(Template.fromStack(stack).toJSON());
+
+describe("topicGrants", () => {
+  it.each([
+    ["publish", "sns:Publish"],
+    ["subscribe", "sns:Subscribe"],
+  ] as const)("%s delegates to the matching native grant method", (capability, action) => {
+    const { stack, topic, role } = setup();
+
+    topicGrants[capability](topic).applyTo(role, {});
+
+    expect(policyJson(stack)).toContain(action);
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
+  });
+
+  it("resolves a Resolvable topic from the build context before granting", () => {
+    const { stack, topic, role } = setup();
+
+    topicGrants
+      .publish(ref<{ topic: Topic }, Topic>("store", (r) => r.topic))
+      .applyTo(role, { store: { topic } });
+
+    expect(policyJson(stack)).toContain("sns:Publish");
+  });
+});

--- a/packages/sqs/src/grants.ts
+++ b/packages/sqs/src/grants.ts
@@ -1,0 +1,31 @@
+import type { IGrantable } from "aws-cdk-lib/aws-iam";
+import type { IQueue } from "aws-cdk-lib/aws-sqs";
+import { type Grant, grantVia, type Resolvable } from "@composurecdk/core";
+
+/** Wraps one of {@link IQueue}'s native grant methods as a capability helper. */
+const capability =
+  (apply: (queue: IQueue, grantee: IGrantable) => void) =>
+  (queue: Resolvable<IQueue>): Grant<IGrantable> =>
+    grantVia(queue, apply);
+
+/**
+ * Consumer-side grant helpers for an SQS queue. Pass one to a grantee builder's
+ * `grant(...)` — e.g.
+ * `role.grant(queueGrants.consume(ref("queue", (r) => r.queue)))`.
+ *
+ * Each delegates to the queue's native `grant*` method. See ADR-0013.
+ */
+export const queueGrants = {
+  /** Receive and delete messages (`sqs:ReceiveMessage`, `DeleteMessage`, …). */
+  consume: capability((queue, grantee) => {
+    queue.grantConsumeMessages(grantee);
+  }),
+  /** Send messages (`sqs:SendMessage`, `GetQueueAttributes`, …). */
+  send: capability((queue, grantee) => {
+    queue.grantSendMessages(grantee);
+  }),
+  /** Purge the queue (`sqs:PurgeQueue`). */
+  purge: capability((queue, grantee) => {
+    queue.grantPurge(grantee);
+  }),
+};

--- a/packages/sqs/src/index.ts
+++ b/packages/sqs/src/index.ts
@@ -4,6 +4,7 @@ export {
   type QueueBuilderProps,
   type QueueBuilderResult,
 } from "./queue-builder.js";
+export { queueGrants } from "./grants.js";
 export { QUEUE_DEFAULTS } from "./defaults.js";
 export { type QueueAlarmConfig } from "./queue-alarm-config.js";
 export { QUEUE_ALARM_DEFAULTS } from "./queue-alarm-defaults.js";

--- a/packages/sqs/test/grants.test.ts
+++ b/packages/sqs/test/grants.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { ref } from "@composurecdk/core";
+import { queueGrants } from "../src/grants.js";
+
+function setup() {
+  const app = new App();
+  const stack = new Stack(app, "S");
+  const queue = new Queue(stack, "Queue");
+  const role = new Role(stack, "Role", { assumedBy: new ServicePrincipal("lambda.amazonaws.com") });
+  return { stack, queue, role };
+}
+
+const policyJson = (stack: Stack) => JSON.stringify(Template.fromStack(stack).toJSON());
+
+describe("queueGrants", () => {
+  it.each([
+    ["consume", ["sqs:ReceiveMessage", "sqs:DeleteMessage"]],
+    ["send", ["sqs:SendMessage"]],
+    ["purge", ["sqs:PurgeQueue"]],
+  ] as const)("%s delegates to the matching native grant method", (capability, actions) => {
+    const { stack, queue, role } = setup();
+
+    queueGrants[capability](queue).applyTo(role, {});
+
+    const json = policyJson(stack);
+    for (const action of actions) expect(json).toContain(action);
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
+  });
+
+  it("resolves a Resolvable queue from the build context before granting", () => {
+    const { stack, queue, role } = setup();
+
+    queueGrants
+      .send(ref<{ queue: Queue }, Queue>("store", (r) => r.queue))
+      .applyTo(role, { store: { queue } });
+
+    expect(policyJson(stack)).toContain("sqs:SendMessage");
+  });
+});


### PR DESCRIPTION
## What & why

Implements consumer-side IAM grants (#269) for DynamoDB, SQS, S3, SNS, and Lambda.

aws-cdk-lib models a grant as a method on the **resource** (`table.grantReadWriteData(role)`), but the generated policy attaches to the **grantee** — so applying a grant during a resource's `build()` inside `compose()` inverts the dependency edge (`table → consumer`) and is cycle-prone. This PR flips it: grants are declared on the **consumer**, so the grant edge follows the existing data-flow dependency (`role → table`, `handler → bucket`).

See [ADR-0013](docs/adr/0013-consumer-side-grants.md) for the full rationale.

## Design

A three-layer seam with **zero new cross-package dependencies** and **no reimplementation of aws-cdk-lib IAM internals** (helpers delegate to the construct's native `grant*` methods):

- **`@composurecdk/core`** — a generic, `aws-cdk-lib`-free contract: `Grant<G>`, `grantVia(resource, apply)`, and `GrantQueue<G>` (the grantee-side accumulator).
- **Resource packages** — one capability namespace each, delegating to native methods:
  - `tableGrants` — `read` / `write` / `readWrite` / `fullAccess` (one set serves both `Table` and `TableV2` via `ITable`)
  - `queueGrants` — `consume` / `send` / `purge`
  - `bucketGrants` — `read` / `write` / `readWrite` / `put` / `delete`
  - `topicGrants` — `publish` / `subscribe`
  - `functionGrants` — `invoke` / `invokeUrl` (the resource-side mirror — a `Function` is both a grantee and an invokable resource)
- **Grantee builders** — `.grant(...)` on `RoleBuilder` and `FunctionBuilder` (both produce an `IGrantable`; the Lambda grant routes onto whichever of the four execution-role seams the function uses).

```ts
compose(
  {
    bucket: createBucketBuilder(),
    handler: createFunctionBuilder()
      .runtime(Runtime.NODEJS_22_X).handler("index.handler").code(Code.fromAsset("handler"))
      .grant(bucketGrants.write(ref("bucket", (r) => r.bucket))),
  },
  { bucket: [], handler: ["bucket"] }, // handler → bucket; no reverse edge, no cycle
);
```

The contract lives in `core` (which everything already depends on), so no grantee package imports a resource package and no resource package imports a grantee — only the consuming app imports both, as it already does.

## Out of scope / follow-ups

- **API Gateway AWS-service integrations** cannot yet adopt `.grant()` — their `credentialsRole` has no owner in the current apigateway builder surface, forcing a sibling-role + merge anti-pattern. Tracked in #270; the AWS integration will implement `.grant()` per this pattern once that lands.
- **Neptune** — `allowAccessFrom` bundles an IAM grant with a security-group rule; its IAM half will migrate to a consumer-side `clusterGrants.connect(...)` in a separate breaking change.
- **Examples sweep** — refactoring existing `packages/examples/` usages the new API simplifies (separate PR).

## Checklist

- [x] Linked to an issue — implements #269 (minus apigateway, #270)
- [x] `npm run verify` passes locally
- [x] Tests added per package (`core`, `iam`, `dynamodb`, `sqs`, `s3`, `sns`, `lambda`)
- [x] Ships ADR-0013 for the new pattern


🤖 Generated with [Claude Code](https://claude.com/claude-code)
