### PR TITLE
test: expand IAM builder test coverage and increase thresholds

### DIFF
--- a/packages/iam/test/role-builder.test.ts
+++ b/packages/iam/test/role-builder.test.ts
@@ -172,6 +172,21 @@ describe("RoleBuilder", () => {
     });
   });
 
+  describe("permissions boundary", () => {
+    it("attaches a permissions boundary resolved from a concrete managed policy", () => {
+      const boundary = ManagedPolicy.fromAwsManagedPolicyName("PowerUserAccess");
+      const template = synth((b) => b.permissionsBoundary(boundary));
+
+      template.hasResourceProperties("AWS::IAM::Role", {
+        PermissionsBoundary: Match.objectLike({
+          "Fn::Join": Match.arrayWith([
+            Match.arrayWith([Match.stringLikeRegexp("PowerUserAccess")]),
+          ]),
+        }),
+      });
+    });
+  });
+
   describe("[COPY_STATE]", () => {
     it("preserves #inlinePolicies across .copy()", () => {
       assertCopyPreservesState({

--- a/packages/iam/test/statement-builder.test.ts
+++ b/packages/iam/test/statement-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Effect } from "aws-cdk-lib/aws-iam";
+import { ArnPrincipal, Effect, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { createStatementBuilder, WildcardResourceError } from "../src/statement-builder.js";
 
 describe("StatementBuilder", () => {
@@ -31,6 +31,16 @@ describe("StatementBuilder", () => {
         .build();
 
       expect(stmt.effect).toBe(Effect.ALLOW);
+    });
+
+    it("sets the effect explicitly via effect()", () => {
+      const stmt = createStatementBuilder()
+        .effect(Effect.DENY)
+        .actions(["s3:DeleteObject"])
+        .resources(["*"])
+        .build();
+
+      expect(stmt.effect).toBe(Effect.DENY);
     });
 
     it("supports Deny statements", () => {
@@ -70,6 +80,37 @@ describe("StatementBuilder", () => {
       expect(() =>
         createStatementBuilder().deny().actions(["s3:*"]).resources(["*"]).build(),
       ).not.toThrow();
+    });
+  });
+
+  describe("negated fields and principals", () => {
+    it("passes notActions, notResources and notPrincipals through", () => {
+      const stmt = createStatementBuilder()
+        .deny()
+        .notActions(["s3:DeleteObject", "s3:PutObject"])
+        .notResources(["arn:aws:s3:::locked/*"])
+        .notPrincipals([new ArnPrincipal("arn:aws:iam::111122223333:role/Admin")])
+        .build();
+
+      const rendered = stmt.toJSON() as {
+        NotAction: string[];
+        NotResource: string;
+        NotPrincipal: unknown;
+      };
+      expect(rendered.NotAction).toEqual(["s3:DeleteObject", "s3:PutObject"]);
+      expect(rendered.NotResource).toBe("arn:aws:s3:::locked/*");
+      expect(rendered.NotPrincipal).toBeDefined();
+    });
+
+    it("passes principals through", () => {
+      const principal = new ServicePrincipal("lambda.amazonaws.com");
+      const stmt = createStatementBuilder()
+        .allow()
+        .actions(["sts:AssumeRole"])
+        .principals([principal])
+        .build();
+
+      expect(stmt.principals).toContain(principal);
     });
   });
 

--- a/packages/iam/vitest.config.ts
+++ b/packages/iam/vitest.config.ts
@@ -1,8 +1,8 @@
 import { withCoverage } from "../../vitest.config.base.js";
 
 export default withCoverage({
-  statements: 75,
-  branches: 70,
-  functions: 68,
-  lines: 75,
+  statements: 90,
+  branches: 90,
+  functions: 100,
+  lines: 90,
 });


### PR DESCRIPTION
## What & why

This PR expands test coverage for the IAM statement and role builders:

- **StatementBuilder**: Added tests for the `effect()` method and negated fields (`notActions`, `notResources`, `notPrincipals`) and `principals()` support
- **RoleBuilder**: Added test for `permissionsBoundary()` method
- **Coverage thresholds**: Increased from 68-75% to 90-100% to reflect improved test coverage

These changes ensure the builders' public APIs are properly tested and documented through test cases.

## Checklist

- [x] Tests added for new/existing functionality
- [x] `npm run verify` passes locally (coverage thresholds updated to match new test coverage)

https://claude.ai/code/session_011nSUqE4aH6xphygGKyKB4N