### PR TITLE
test(route53): raise branch-coverage floor to 90%

### DIFF
--- a/packages/route53/test/health-check-alarms.test.ts
+++ b/packages/route53/test/health-check-alarms.test.ts
@@ -4,6 +4,7 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { HealthCheckType, type IHealthCheck } from "aws-cdk-lib/aws-route53";
 import { createHealthCheckBuilder } from "../src/health-check-builder.js";
+import { resolveHealthCheckAlarmDefinitions } from "../src/health-check-alarms.js";
 
 const ENV_US_EAST_1 = { account: "123456789012", region: "us-east-1" };
 
@@ -164,6 +165,20 @@ describe("recommended alarms", () => {
           );
         }),
       ).toThrow(/Duplicate alarm key/);
+    });
+  });
+
+  describe("resolveHealthCheckAlarmDefinitions", () => {
+    const fakeHealthCheck = { healthCheckId: "hc-123" } as IHealthCheck;
+
+    it("returns no definitions when config is disabled", () => {
+      expect(resolveHealthCheckAlarmDefinitions(fakeHealthCheck, { enabled: false })).toEqual([]);
+    });
+
+    it("returns the healthCheckStatus definition when config is undefined", () => {
+      const definitions = resolveHealthCheckAlarmDefinitions(fakeHealthCheck, undefined);
+      expect(definitions).toHaveLength(1);
+      expect(definitions[0]?.key).toBe("healthCheckStatus");
     });
   });
 

--- a/packages/route53/test/record-variants.test.ts
+++ b/packages/route53/test/record-variants.test.ts
@@ -34,6 +34,25 @@ function setup(): { stack: Stack; zone: PublicHostedZone } {
   return { stack, zone };
 }
 
+describe("zone requirement", () => {
+  const builders: [string, () => { build: (s: Stack, id: string) => unknown }][] = [
+    ["Aaaa", createAaaaRecordBuilder],
+    ["Cname", createCnameRecordBuilder],
+    ["Txt", createTxtRecordBuilder],
+    ["Mx", createMxRecordBuilder],
+    ["Srv", createSrvRecordBuilder],
+    ["Caa", createCaaRecordBuilder],
+    ["Ns", createNsRecordBuilder],
+    ["Ds", createDsRecordBuilder],
+    ["Svcb", createSvcbRecordBuilder],
+  ];
+
+  it.each(builders)("%s requires a zone", (id, create) => {
+    const { stack } = setup();
+    expect(() => create().build(stack, id)).toThrow(/requires a zone/);
+  });
+});
+
 describe("AaaaRecordBuilder", () => {
   it("synthesises an AAAA record", () => {
     const { stack, zone } = setup();
@@ -47,6 +66,34 @@ describe("AaaaRecordBuilder", () => {
     template.hasResourceProperties("AWS::Route53::RecordSet", {
       Type: "AAAA",
       Name: "v6.example.com.",
+    });
+  });
+
+  it("requires a target", () => {
+    const { stack, zone } = setup();
+    expect(() => createAaaaRecordBuilder().zone(zone).build(stack, "Aaaa")).toThrow(
+      /requires a target/,
+    );
+  });
+
+  it("synthesises an AAAA alias record without a default TTL", () => {
+    const { stack, zone } = setup();
+    const distribution = new Distribution(stack, "Dist", {
+      defaultBehavior: { origin: new HttpOrigin("origin.example.net") },
+    });
+
+    createAaaaRecordBuilder()
+      .zone(zone)
+      .target(cloudfrontAliasTarget(distribution))
+      .build(stack, "AaaaAlias");
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "AAAA",
+      AliasTarget: Match.objectLike({
+        DNSName: Match.objectLike({ "Fn::GetAtt": ["DistB3B78991", "DomainName"] }),
+      }),
+      TTL: Match.absent(),
     });
   });
 });
@@ -188,6 +235,13 @@ describe("NsRecordBuilder", () => {
     expect(() =>
       createNsRecordBuilder().zone(zone).values(["ns-1.awsdns-01.com"]).build(stack, "Ns"),
     ).toThrow(/requires a recordName/);
+  });
+
+  it("requires values to be set", () => {
+    const { stack, zone } = setup();
+    expect(() => createNsRecordBuilder().zone(zone).recordName("sub").build(stack, "Ns")).toThrow(
+      /requires .*values/,
+    );
   });
 
   it("requires non-empty values", () => {

--- a/packages/route53/vitest.config.ts
+++ b/packages/route53/vitest.config.ts
@@ -2,7 +2,7 @@ import { withCoverage } from "../../vitest.config.base.js";
 
 export default withCoverage({
   statements: 83,
-  branches: 66,
+  branches: 90,
   functions: 100,
   lines: 83,
 });


### PR DESCRIPTION
## What & why

Raises the `packages/route53` branch-coverage floor from 66% to 90% (`perFile: true`), as requested in #261 (follow-up from the #256 baseline).

The 66% floor was a placeholder baseline. This PR adds tests for the branches that were previously uncovered, then tightens the threshold in `packages/route53/vitest.config.ts`. Per-file branch coverage is now ≥90% for every source file (package total 95.9%).

New tests cover:
- **Record builders** — the `requires a zone` guard clause across all record builders (`Aaaa`, `Cname`, `Txt`, `Mx`, `Srv`, `Caa`, `Ns`, `Ds`, `Svcb`), collapsed into one `it.each` table.
- **AAAA builder** — the `requires a target` guard and the CloudFront alias path (which omits the default TTL).
- **NS builder** — the unset-`values` guard (distinct from the empty-array guard).
- **`resolveHealthCheckAlarmDefinitions`** — a direct unit test for the `enabled: false` early-return and the `config === undefined` path, which the builder short-circuits before reaching.

No source behaviour changes — tests and the threshold value only.

Closes #261

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXerbr6eqDHkKvz5r5Eqeh)_