### PR TITLE
feat(core): add combine() multi-ref combinator (#270)

### DIFF
--- a/docs/adr/0013-consumer-side-grants.md
+++ b/docs/adr/0013-consumer-side-grants.md
@@ -124,7 +124,10 @@ compose(
   package and a grantee, as it already does.
 - **Out of scope.** API Gateway AWS-service integrations, whose `credentialsRole`
   has no owner in the current builder surface and so cannot yet be a grantee
-  (tracked in laazyj/composureCDK#270); and Neptune's `allowAccessFrom`, which
+  (tracked in laazyj/composureCDK#270; resolved by keeping the role an explicit
+  sibling and merging it with the integration target via `combine`, see
+  [ADR-0015](0015-combine-multi-ref-combinator.md)); and Neptune's
+  `allowAccessFrom`, which
   couples an IAM grant with a security-group rule and will migrate its IAM half to
   a consumer-side `clusterGrants.connect(...)` in a separate breaking change.
 

--- a/docs/adr/0015-combine-multi-ref-combinator.md
+++ b/docs/adr/0015-combine-multi-ref-combinator.md
@@ -1,0 +1,129 @@
+# ADR 0015: Combining multiple refs into one — the `combine()` Ref combinator
+
+- **Status:** Accepted
+- **Date:** 2026-07-05
+
+## Context
+
+`ref()` captures a lazy reference to **one** component's build output and resolves
+it against the build context during `build()`. A `Resolvable<T>` — the union
+`T | Ref<T>` — is the currency every builder seam speaks: `addMethod`,
+`addIntegration`, and the like all accept one, and internally call
+`resolve(value, context)`. This one-reference-per-value shape covers almost all
+wiring, because a consumer usually adapts a single dependency into the form it
+needs.
+
+Some constructs, though, are assembled from **more than one** sibling at once. A
+direct API Gateway → AWS-service `AwsIntegration` (API Gateway calling DynamoDB,
+SQS, S3, … without a Lambda hop) needs two siblings simultaneously: the target's
+identifier — a table's `tableName`, interpolated into the VTL request template —
+**and** the `credentialsRole` API Gateway assumes to make the call. A single
+`ref` reaches only one of them.
+
+Absent a combinator, the workaround was to introduce a component whose only job
+is to merge two sibling refs into one object — a fake `Lifecycle` that builds
+nothing:
+
+```ts
+// ANTI-PATTERN: a component that exists only to merge two sibling refs
+const tableAndRole = {
+  build: (_s, _i, ctx) => ({
+    tableName: (ctx.table as TableV2BuilderResult).table.tableName,
+    role: (ctx.apiRole as RoleBuilderResult).role,
+  }),
+};
+```
+
+This is a smell. It manufactures a node in the `compose` graph that models no
+resource, forces untyped `ctx[...] as ...` casts, and exists purely to work
+around `ref`'s single-component reach.
+
+## Decision
+
+Add `combine(refs, transform?)` to `@composurecdk/core` — a **Ref combinator**.
+It takes a record of `Resolvable` values, resolves each against the build
+context, assembles the results into a record keyed the same way, and returns a
+**single `Ref`** to that record. An optional `transform` maps the merged record
+to the value the consumer needs (shorthand for `combine(refs).map(transform)`).
+
+```ts
+export type Resolved<R> = R extends Ref<infer T> ? T : R;
+
+export function combine<R extends Record<string, unknown>>(
+  refs: R,
+): Ref<{ [K in keyof R]: Resolved<R[K]> }>;
+export function combine<R extends Record<string, unknown>, U>(
+  refs: R,
+  transform: (values: { [K in keyof R]: Resolved<R[K]> }) => U,
+): Ref<U>;
+```
+
+Three properties make it fit the existing model rather than extend it:
+
+1. **It returns a `Ref`.** The result is an ordinary `Ref`, so it drops into any
+   `Resolvable<T>` seam that already exists — no builder learns a new type, and
+   the combined value composes further with `.get()`/`.map()`.
+2. **It owns nothing.** `combine` resolves references and merges values; it
+   creates no construct and holds no state. Every sibling it references remains a
+   first-class node in the `compose` graph, declared and wired by the system
+   author.
+3. **Its types are inferred.** `Resolved<R>` mirrors what `resolve` does at
+   runtime — a `Ref<T>` yields `T`, a concrete value passes through — so the
+   merged record's keys and types follow from the input with no annotation, and
+   entries may freely mix refs and concrete values.
+
+The AWS-service integration is then just one application: the credentials role is
+a plain `createServiceRoleBuilder("apigateway.amazonaws.com")` sibling that the
+system grants against with consumer-side grants ([ADR-0013](0013-consumer-side-grants.md)),
+and `combine` merges that role with the target into the `AwsIntegration` handed
+to `addMethod`. No dedicated builder, no auto-created role, no new apigateway
+surface.
+
+### When to use it
+
+Reach for `combine` only when a single `ref` genuinely cannot express the
+dependency — i.e. **one construct is assembled from two or more distinct
+siblings**. The canonical case is a construct that interpolates one sibling's
+identifier while referencing another sibling's identity.
+
+### When not to use it
+
+- **One sibling, reshaped.** Use `ref(component, transform)` or `.get()`/`.map()`.
+  A `combine` with a single entry is a needless wrapper.
+- **Wiring a permission.** Use a consumer-side grant on the grantee
+  ([ADR-0013](0013-consumer-side-grants.md)), not a `combine` that hand-assembles
+  a role into a construct. `combine` is for _reading_ sibling values, not for
+  routing IAM.
+- **As an ownership escape hatch.** `combine` does not make a consumer own a
+  resource. If a resource needs an owner in the builder surface, that is a builder
+  design question, not something to paper over by merging refs.
+
+## Consequences
+
+- The fake-`Lifecycle` merge is gone: a consumer needing several siblings names
+  them in one `combine`, keeping every node in the `compose` graph a real
+  resource and every reference typed.
+- `core` gains one small, general, `aws-cdk-lib`-free export. It composes with
+  the existing `Ref` machinery — no seam changes, no new `Resolvable` variant,
+  and it is available to every builder package at once.
+- Direct API Gateway → AWS-service integrations are expressible today with
+  explicit, visible roles and consumer-side grants — closing
+  [#270](https://github.com/laazyj/composureCDK/issues/270) without the
+  auto-role builder that [#276](https://github.com/laazyj/composureCDK/pull/276)
+  proposed.
+- The single-reference `ref` remains the default and the common case; `combine`
+  is the deliberate exception for multi-sibling assembly, documented as such so
+  it is not reached for when a plain `ref` would do.
+
+## Alternatives considered
+
+- **A fake `Lifecycle` that merges two refs.** Rejected: it invents a graph node
+  that models no resource and relies on untyped context casts — the anti-pattern
+  this ADR removes.
+- **A dedicated AWS-service integration builder that owns its role
+  ([#276](https://github.com/laazyj/composureCDK/pull/276)).** Rejected: it adds
+  role auto-creation `aws-cdk-lib` does not provide, obscuring design CDK keeps
+  explicit, and solves only the apigateway instance of a general problem.
+- **Extending `ref` to accept multiple component keys.** Rejected: it overloads
+  the single-reference primitive and muddies its type. A separate combinator
+  keeps `ref` simple and names the multi-sibling case explicitly.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0012: Explicit build id — decouple the construct id from the compose key](0012-explicit-build-id-decoupled-from-compose-key.md)
 - [ADR-0013: Consumer-side IAM grants — declare a grant where the dependency already points](0013-consumer-side-grants.md)
 - [ADR-0014: Role-parameterized builders for mutually-exclusive L2 surfaces](0014-role-parameterized-queue-builder.md)
+- [ADR-0015: Combining multiple refs into one — the `combine()` Ref combinator](0015-combine-multi-ref-combinator.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,6 +340,50 @@ Internally, the builder stores the `Resolvable<T>` as-is. At build time, it call
 
 `resolve` distinguishes a `Ref` from a concrete value via the `isRef` guard. `isRef` recognises a `Ref` by a `Symbol.for("composurecdk.ref")` brand rather than `instanceof` — because packages are published dual ESM/CJS ([ADR-0007](adr/0007-dual-esm-cjs-publishing.md)), the ESM and CommonJS copies of `@composurecdk/core` can both load in one process, and `instanceof` is realm-bound. The `Symbol.for(...)` brand is shared across realms, so a `Ref` minted by either copy is still recognised.
 
+### Combining refs — one consumer, many dependencies
+
+A `ref` reaches exactly one component. Most wiring needs only that: a consumer adapts one dependency's output into the shape it needs. But some constructs are assembled from **more than one** sibling at once. A direct API Gateway → AWS-service `AwsIntegration`, for example, needs both the target's identifier (a table's `tableName`, for the VTL request template) **and** a credentials role — two separate siblings, and a single `ref` cannot carry both.
+
+`combine` closes that gap. It takes a record of `Resolvable` values, resolves each against the build context, and returns a **single `Ref`** to the merged record — optionally transformed:
+
+```typescript
+compose(
+  {
+    table: createTableBuilder(),
+    apiRole: createServiceRoleBuilder("apigateway.amazonaws.com").grant(
+      tableGrants.read(ref("table", (r) => r.table)),
+    ),
+    api: createRestApiBuilder().addResource("gadgets", (g) =>
+      g.addMethod(
+        "GET",
+        combine(
+          { table: ref<TableV2BuilderResult>("table"), role: ref<RoleBuilderResult>("apiRole") },
+          ({ table, role }) =>
+            new AwsIntegration({
+              service: "dynamodb",
+              action: "Scan",
+              options: {
+                credentialsRole: role.role,
+                requestTemplates: { "application/json": scanTemplate(table.table.tableName) },
+              },
+            }),
+        ),
+      ),
+    ),
+  },
+  { table: [], apiRole: ["table"], api: ["table", "apiRole"] },
+);
+```
+
+Because `combine` returns a `Ref`, it drops into any place a `Resolvable<T>` is already accepted — here `addMethod` — with **no change to the consuming builder**. The merged record's keys and types are inferred from the input, so `({ table, role })` is fully typed. Entries may mix concrete values and refs, and the result composes with `.get()`/`.map()` like any other `Ref`.
+
+`combine` is for **assembling one construct from several siblings** — nothing more. It is deliberately not an ownership mechanism: the credentials role above is an ordinary sibling the system declares and grants against with [consumer-side grants](adr/0013-consumer-side-grants.md), visible in the `compose` graph, exactly as CDK would have you write it. Reach for it only when a single `ref` genuinely cannot express the dependency:
+
+- **One sibling, reshaped?** Use `ref(component, transform)` or `.get()`/`.map()`. `combine` of a single entry adds a needless wrapper.
+- **Wiring a permission?** Use a consumer-side grant on the grantee, not a `combine` that hand-rolls a role into a construct.
+
+See [ADR-0015](adr/0015-combine-multi-ref-combinator.md) for the full rationale, including the fake-`Lifecycle` merge anti-pattern it replaces.
+
 ### Implementing Ref support in a builder
 
 A builder that accepts cross-component references follows this pattern:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ export { CyclicDependencyError } from "./cyclic-dependency-error.js";
 export { DuplicateConstructIdError } from "./duplicate-construct-id-error.js";
 export { type Grant, grantVia, GrantQueue } from "./grant.js";
 export { type Lifecycle } from "./lifecycle.js";
-export { Ref, ref, resolve, isRef, type Resolvable } from "./ref.js";
+export { Ref, ref, combine, resolve, isRef, type Resolvable, type Resolved } from "./ref.js";
 export {
   type StackStrategy,
   type ScopeFactory,

--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -64,6 +64,30 @@ export class Ref<T> {
   }
 
   /**
+   * Creates a `Ref` that resolves a record of {@link Resolvable} values into a
+   * record of their resolved results.
+   *
+   * Backs the {@link combine} factory. Each entry is resolved against the build
+   * context independently, so a single consumer can gather values from several
+   * siblings at once — the gap {@link Ref.to} leaves, since it reaches only one
+   * component.
+   *
+   * @param refs - A record whose values are concrete values or `Ref`s.
+   * @returns A `Ref` to the record of resolved values.
+   */
+  static combine<R extends Record<string, unknown>>(
+    refs: R,
+  ): Ref<{ [K in keyof R]: Resolved<R[K]> }> {
+    return new Ref((context) => {
+      const resolved = {} as { [K in keyof R]: Resolved<R[K]> };
+      for (const key of Object.keys(refs) as (keyof R)[]) {
+        resolved[key] = resolve(refs[key] as Resolvable<Resolved<R[typeof key]>>, context);
+      }
+      return resolved;
+    });
+  }
+
+  /**
    * Narrows this reference to a specific property of the resolved value.
    *
    * @param key - The property key to select.
@@ -134,6 +158,61 @@ export function ref<T extends object, U>(
   transform?: (value: T) => U,
 ): Ref<T> | Ref<U> {
   const base = Ref.to<T>(component);
+  return transform ? base.map(transform) : base;
+}
+
+/**
+ * The concrete type a {@link Resolvable} resolves to: the inner type of a
+ * {@link Ref}, or the value itself when it is already concrete. Mirrors what
+ * {@link resolve} returns at runtime.
+ */
+export type Resolved<R> = R extends Ref<infer T> ? T : R;
+
+/**
+ * Combines several {@link Resolvable} values into a single {@link Ref} of their
+ * resolved results, keyed the same way as the input record.
+ *
+ * `ref()` reaches exactly one component, so a consumer that must assemble a
+ * construct from **more than one** sibling has no single reference to hand to a
+ * `Resolvable<T>` seam. `combine` closes that gap: it resolves each entry
+ * against the build context and returns one `Ref`, which drops into any place a
+ * `Ref`/`Resolvable` is already accepted — no change to the consuming builder.
+ *
+ * Entries may mix concrete values and refs. Pass a `transform` to adapt the
+ * merged record into the shape the consumer needs (a shorthand for
+ * `combine(refs).map(transform)`).
+ *
+ * @param refs - A record whose values are concrete values or `Ref`s.
+ * @param transform - Optional function mapping the merged record to a new value.
+ * @returns A `Ref` to the merged record, optionally transformed.
+ *
+ * @example
+ * ```ts
+ * // One integration assembled from two siblings — a table and a credentials role
+ * addMethod("GET", combine(
+ *   { table: ref<TableV2BuilderResult>("table"), role: ref<RoleBuilderResult>("apiRole") },
+ *   ({ table, role }) => new AwsIntegration({
+ *     service: "dynamodb", action: "Scan",
+ *     options: {
+ *       credentialsRole: role.role,
+ *       requestTemplates: { "application/json": scanTemplate(table.table.tableName) },
+ *     },
+ *   }),
+ * ))
+ * ```
+ */
+export function combine<R extends Record<string, unknown>>(
+  refs: R,
+): Ref<{ [K in keyof R]: Resolved<R[K]> }>;
+export function combine<R extends Record<string, unknown>, U>(
+  refs: R,
+  transform: (values: { [K in keyof R]: Resolved<R[K]> }) => U,
+): Ref<U>;
+export function combine<R extends Record<string, unknown>, U>(
+  refs: R,
+  transform?: (values: { [K in keyof R]: Resolved<R[K]> }) => U,
+): Ref<{ [K in keyof R]: Resolved<R[K]> }> | Ref<U> {
+  const base = Ref.combine(refs);
   return transform ? base.map(transform) : base;
 }
 

--- a/packages/core/test/ref.test.ts
+++ b/packages/core/test/ref.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ref, resolve, isRef, REF_BRAND, type Resolvable } from "../src/ref.js";
+import { ref, combine, resolve, isRef, REF_BRAND, type Resolvable } from "../src/ref.js";
 
 interface FakeResult {
   value: string;
@@ -88,6 +88,81 @@ describe("Ref", () => {
 
       expect(r.resolve(fakeContext)).toEqual({ label: "hello-42" });
     });
+  });
+});
+
+describe("combine", () => {
+  it("merges several refs into a record keyed the same as the input", () => {
+    const c = combine({
+      first: ref<FakeResult>("component"),
+      second: ref<{ name: string }>("other"),
+    });
+
+    expect(c.resolve(fakeContext)).toEqual({
+      first: { value: "hello", nested: { id: 42 } },
+      second: { name: "world" },
+    });
+  });
+
+  it("resolves each entry independently against the context", () => {
+    const c = combine({
+      value: ref<FakeResult>("component").get("value"),
+      name: ref<{ name: string }>("other").get("name"),
+    });
+
+    expect(c.resolve(fakeContext)).toEqual({ value: "hello", name: "world" });
+  });
+
+  it("applies a transform over the merged record", () => {
+    const c = combine(
+      {
+        value: ref<FakeResult>("component").get("value"),
+        name: ref<{ name: string }>("other").get("name"),
+      },
+      ({ value, name }) => `${value} ${name}`,
+    );
+
+    expect(c.resolve(fakeContext)).toBe("hello world");
+  });
+
+  it("mixes concrete values and refs", () => {
+    const c = combine({
+      table: ref<FakeResult>("component"),
+      literal: "concrete",
+    });
+
+    expect(c.resolve(fakeContext)).toEqual({
+      table: { value: "hello", nested: { id: 42 } },
+      literal: "concrete",
+    });
+  });
+
+  it("propagates the component-not-found error from a missing ref", () => {
+    const c = combine({
+      present: ref<FakeResult>("component"),
+      absent: ref<FakeResult>("missing"),
+    });
+
+    expect(() => c.resolve(fakeContext)).toThrow('Ref to "missing" cannot be resolved');
+  });
+
+  it("returns a real Ref that composes with map and get", () => {
+    const c = combine({
+      value: ref<FakeResult>("component").get("value"),
+      name: ref<{ name: string }>("other").get("name"),
+    });
+
+    expect(isRef(c)).toBe(true);
+    expect(c.get("value").resolve(fakeContext)).toBe("hello");
+    expect(c.map((r) => r.name.toUpperCase()).resolve(fakeContext)).toBe("WORLD");
+  });
+
+  it("is interchangeable with a concrete value at a Resolvable seam", () => {
+    const c: Resolvable<{ value: string }> = combine({
+      value: ref<FakeResult>("component").get("value"),
+    });
+
+    expect(resolve(c, fakeContext)).toEqual({ value: "hello" });
   });
 });
 


### PR DESCRIPTION
Closes #270. Chosen over the option B builder in #276.

## What

Adds `combine(refs, transform?)` to `@composurecdk/core` — a **Ref combinator**. It resolves a record of `Resolvable` values against the build context and returns a **single `Ref`** to the merged record, optionally transformed:

```ts
addMethod("GET", combine(
  { table: ref<TableV2BuilderResult>("table"), role: ref<RoleBuilderResult>("apiRole") },
  ({ table, role }) => new AwsIntegration({
    service: "dynamodb", action: "Scan",
    options: {
      credentialsRole: role.role,
      requestTemplates: { "application/json": scanTemplate(table.table.tableName) },
    },
  }),
));
```

## Why

`ref()` reaches exactly one component, so a consumer that assembles a construct from **more than one** sibling — e.g. a direct API Gateway → AWS-service `AwsIntegration` needing both a target's identifier (for its VTL template) **and** a credentials role — had no single reference to hand to a `Resolvable<T>` seam. The workaround was a fake `Lifecycle` whose only job was to merge two sibling refs — a `compose` graph node modelling no resource, wired with untyped context casts.

`combine` closes that gap without new machinery:

- **Returns a `Ref`** — drops into every existing `Resolvable<T>` seam (`addMethod`, …) with no change to any consuming builder, and composes further with `.get()`/`.map()`.
- **Owns nothing** — creates no construct, holds no state; every sibling it references stays a first-class node in the `compose` graph.
- **Infers its types** — `Resolved<R>` mirrors `resolve()` at runtime (a `Ref<T>` yields `T`, a concrete value passes through), so the merged record's keys/types follow from the input and entries may mix refs and concrete values.

## Why not option B (#276)

The [#276](https://github.com/laazyj/composureCDK/pull/276) builder's real payload was auto-creating an IAM credentials role per integration — net-new machinery `aws-cdk-lib` does not provide, obscuring a part of the design CDK keeps explicit. `combine` addresses the actual, general gap instead; the credentials role stays an **explicit sibling** granted against with consumer-side grants ([ADR-0013](../blob/main/docs/adr/0013-consumer-side-grants.md)). AwsIntegration is just the motivating example — `combine` applies wherever one construct is assembled from several siblings.

## Docs & ADR

- `docs/architecture.md` — new "Combining refs — one consumer, many dependencies" subsection under **Ref**, with the example and explicit *when-not-to-use* guidance.
- **ADR-0015** — generalised decision: intent, when to use, when not to (single sibling → plain `ref`; permission wiring → consumer-side grants; not an ownership escape hatch). Indexed and cross-referenced from ADR-0013's out-of-scope note.

## Scope

Core + docs only, one cohesive change. No apigateway surface change, no auto-created roles. Option B's branch/PR #276 is left untouched to close separately.

## Testing

7 new unit tests (merge, independent resolution, transform, mixed concrete/ref entries, error propagation, `.map()`/`.get()` composition, `Resolvable`-seam interchangeability). 100% function/line coverage on `ref.ts`; `npm run verify` green across all 21 projects.