### PR TITLE
fix(core): reject leaked tokens in construct IDs

### DIFF
--- a/packages/core/src/construct-id.ts
+++ b/packages/core/src/construct-id.ts
@@ -15,6 +15,18 @@
 const UNSAFE = /[/\x00-\x1f\x7f]/g;
 
 /**
+ * Characters that are never legitimate in a construct ID. Braces and brackets
+ * signal a leaked CDK token — a string token always encodes as
+ * `${Token[TOKEN.n]}`, which contains all four — but no valid DNS name, ARN, or
+ * path contains them either, so rejecting them is safe for real inputs.
+ *
+ * `$` is deliberately excluded: on its own it is borderline (it can appear in
+ * odd-but-legal names), and the brace/bracket set already catches the token
+ * encoding.
+ */
+const REJECTED = /[{}[\]]/;
+
+/**
  * Return a construct-ID-safe copy of `raw` by replacing unsafe characters
  * (`/` and control characters) with a single `-`.
  *
@@ -22,13 +34,30 @@ const UNSAFE = /[/\x00-\x1f\x7f]/g;
  * permissive, and collapsing further (e.g., to PascalCase) would destroy
  * information a reader expects to see in the synthesised tree.
  *
+ * Throws on `{`, `}`, `[`, or `]`. These never appear in a well-formed ID; in
+ * practice they mean an unresolved CDK token (`${Token[TOKEN.n]}`) has leaked
+ * into an ID, which yields an unstable logical ID whose hash churns with the
+ * token counter. Failing here surfaces the mistake at its source rather than
+ * silently stripping it to a stable-looking but still-broken ID. Core stays
+ * `aws-cdk-lib`-free, so this is a character check, not a `Token.isUnresolved`
+ * check — callers that need token-aware handling must guard before calling.
+ *
  * @example
  * ```ts
  * sanitizeConstructId("a/b")       // "a-b"
  * sanitizeConstructId("_sip._tcp") // "_sip._tcp" (unchanged)
+ * sanitizeConstructId("${Token[TOKEN.7]}") // throws
  * ```
  */
 export function sanitizeConstructId(raw: string): string {
+  if (REJECTED.test(raw)) {
+    throw new Error(
+      `Invalid construct ID ${JSON.stringify(raw)}: ` +
+        `the characters { } [ ] are not allowed. ` +
+        `This usually means an unresolved CDK token has leaked into a construct ID — ` +
+        `supply a stable, static ID instead.`,
+    );
+  }
   return raw.replace(UNSAFE, "-");
 }
 
@@ -39,7 +68,9 @@ export function sanitizeConstructId(raw: string): string {
  *
  * Intended for composing IDs from a mix of static prefixes and user-supplied
  * fragments — the sanitization step means callers don't have to reason about
- * what characters their inputs might contain.
+ * most characters their inputs might contain. Throws if any part contains
+ * `{ } [ ]` (see {@link sanitizeConstructId}), which signals a leaked CDK
+ * token.
  *
  * @example
  * ```ts

--- a/packages/core/test/construct-id.test.ts
+++ b/packages/core/test/construct-id.test.ts
@@ -22,6 +22,20 @@ describe("sanitizeConstructId", () => {
   it("handles the empty string", () => {
     expect(sanitizeConstructId("")).toBe("");
   });
+
+  it("throws on braces and brackets", () => {
+    for (const raw of ["a{b", "a}b", "a[b", "a]b", "${Token[TOKEN.7]}"]) {
+      expect(() => sanitizeConstructId(raw)).toThrow(/not allowed/);
+    }
+  });
+
+  it("names the leaked token in the error", () => {
+    expect(() => sanitizeConstructId("${Token[TOKEN.7]}")).toThrow(/unresolved CDK token/);
+  });
+
+  it("does not reject a lone dollar sign", () => {
+    expect(sanitizeConstructId("cost$center")).toBe("cost$center");
+  });
 });
 
 describe("constructId", () => {
@@ -42,5 +56,9 @@ describe("constructId", () => {
 
   it("returns an empty string when every part is falsy", () => {
     expect(constructId(undefined, null, false, "")).toBe("");
+  });
+
+  it("throws when any part contains a leaked token", () => {
+    expect(() => constructId("records", "${Token[TOKEN.7]}")).toThrow(/not allowed/);
   });
 });


### PR DESCRIPTION
## What

`sanitizeConstructId` (and `constructId`, which calls it per part) now **throw** when a part contains `{`, `}`, `[`, or `]`, instead of silently passing them through.

## Why

These characters never appear in a well-formed construct ID. In practice they mean an unresolved CDK token — which always encodes as `${Token[TOKEN.n]}` — has leaked into an ID. That produces an unstable CloudFormation logical ID whose hash churns with the token counter (and a meaningless human-readable segment, since CDK strips non-alphanumerics anyway).

**Throw rather than strip:** silently stripping the token yields a stable-*looking* but still-broken ID and hides the bug at the point it matters. Failing surfaces the mistake at its source — consistent with the project's eager-validation posture.

`@composurecdk/core` stays `aws-cdk-lib`-free, so this is a **character check**, not a `Token.isUnresolved` check. It reliably catches leaked *string* tokens (their encoding contains all four characters) without coupling core to CDK. Callers that need true token-aware handling (e.g. substituting a stable ID) must guard before calling — the route53 zone DSL will do exactly that in a follow-up.

`$` is deliberately excluded — on its own it's borderline (can appear in odd-but-legal names), and the brace/bracket set already catches the token encoding.

## Context

Backstop for the route53 DKIM / absolute-name work in #281. This is one of three independent PRs; it stands alone.

## Breaking change

`sanitizeConstructId` and `constructId` now throw on inputs containing `{ } [ ]` instead of passing them through. Callers that relied on those characters surviving into a construct ID must supply a stable, static ID instead. Flagged with a `BREAKING CHANGE:` footer for the release notes.

## Tests

Full coverage on `construct-id.ts`: each brace/bracket char, the full token encoding, the error-message content, lone-`$` allowed, and part-level propagation through `constructId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)