### PR TITLE
feat(route53): support absolute and token record names in the zone DSL

### DIFF
--- a/packages/route53/src/zone/zone-dsl.ts
+++ b/packages/route53/src/zone/zone-dsl.ts
@@ -25,6 +25,29 @@ export interface RecordOptions {
   readonly ttl?: Duration;
   /** Optional comment passed through to the CDK construct. */
   readonly comment?: string;
+  /**
+   * Stable construct id and result-map key for this record, decoupled from its
+   * DNS `name`. Defaults to the name, which is right for almost every record.
+   *
+   * Supply it when the name is an unresolved CDK token (e.g. an SES DKIM CNAME
+   * name): a token stringifies to an unstable encoding and cannot serve as a
+   * construct id, so the zone DSL rejects a token name unless an explicit `id`
+   * is set. Orthogonal to {@link absoluteName} — this fixes the construct id,
+   * that fixes the emitted DNS name.
+   */
+  readonly id?: string;
+  /**
+   * Treat `name` as already fully-qualified and emit it verbatim, instead of
+   * letting CDK append the zone apex.
+   *
+   * Needed for names that already carry the full domain — notably token names
+   * (SES Easy DKIM), where CDK's static `endsWith` check runs against the token
+   * encoding, fails to match the zone suffix, and double-appends the apex. A
+   * concrete name is normalised to a single trailing dot; a token is emitted
+   * as-is (CFN treats a record-set name as absolute, so no dot is appended and
+   * the `..` hazard is avoided). Orthogonal to {@link id}.
+   */
+  readonly absoluteName?: boolean;
 }
 
 export interface ARecordSpec extends RecordOptions {

--- a/packages/route53/src/zone/zone-records.ts
+++ b/packages/route53/src/zone/zone-records.ts
@@ -1,4 +1,10 @@
-import { type IHostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { Token } from "aws-cdk-lib";
+import {
+  type CfnRecordSet,
+  type IHostedZone,
+  type RecordSet,
+  RecordTarget,
+} from "aws-cdk-lib/aws-route53";
 import { Construct, type IConstruct } from "constructs";
 import { constructId, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type AaaaRecordBuilderResult, createAaaaRecordBuilder } from "../aaaa-record-builder.js";
@@ -150,87 +156,85 @@ class ZoneRecordsBuilder implements IZoneRecordsBuilder {
     };
     for (const group of groupRecords(this.#specs)) {
       const head = group[0];
+      // Identity (construct id + result-map key) is decoupled from the DNS
+      // name: `id` overrides `name` when supplied. This is what lets a
+      // token-named record (SES DKIM) keep a stable, readable id.
+      const key = head.id ?? head.name;
+      if (Token.isUnresolved(key)) {
+        throw new Error(
+          `zoneRecords: the ${head.type} record has an unresolved token as its name ` +
+            `and no explicit id. A token cannot be a stable construct id — pass ` +
+            `{ id: "..." } in the record options.`,
+        );
+      }
       // Use the APEX sentinel ("@") as the result-map key, but a readable
       // "Apex" as the construct id so the synthesised logical ID keeps a
       // human-visible marker. ("@" sanitises to empty and produces opaque
       // logical IDs like `DNSrecordsa85669662`.) CDK's duplicate-id check
       // catches the rare case of a user-supplied label also spelled "Apex".
-      const key = head.name;
       const childId = key === APEX ? "Apex" : constructId(key);
+      // `absoluteName` emits the DNS name verbatim. CDK's L2 always qualifies
+      // `recordName`, so the only faithful path is to override the built
+      // record set's `Name` after the fact — see overrideAbsoluteName.
+      const absolute = pickOption(group, "absoluteName");
+      const abs = <T extends { record: RecordSet }>(built: T): T => {
+        if (absolute) overrideAbsoluteName(built.record, head.name);
+        return built;
+      };
       switch (head.type) {
         case "A":
-          result.a[key] = buildA(subScope("a"), childId, group as ARecordSpec[], zone, context);
+          result.a[key] = abs(
+            buildA(subScope("a"), childId, group as ARecordSpec[], zone, context),
+          );
           break;
         case "AAAA":
-          result.aaaa[key] = buildAaaa(
-            subScope("aaaa"),
-            childId,
-            group as AaaaRecordSpec[],
-            zone,
-            context,
+          result.aaaa[key] = abs(
+            buildAaaa(subScope("aaaa"), childId, group as AaaaRecordSpec[], zone, context),
           );
           break;
         case "CNAME":
-          result.cname[key] = buildCname(
-            subScope("cname"),
-            childId,
-            group as CnameRecordSpec[],
-            zone,
-            context,
+          result.cname[key] = abs(
+            buildCname(subScope("cname"), childId, group as CnameRecordSpec[], zone, context),
           );
           break;
         case "TXT":
-          result.txt[key] = buildTxt(
-            subScope("txt"),
-            childId,
-            group as TxtRecordSpec[],
-            zone,
-            context,
+          result.txt[key] = abs(
+            buildTxt(subScope("txt"), childId, group as TxtRecordSpec[], zone, context),
           );
           break;
         case "MX":
-          result.mx[key] = buildMx(subScope("mx"), childId, group as MxRecordSpec[], zone, context);
+          result.mx[key] = abs(
+            buildMx(subScope("mx"), childId, group as MxRecordSpec[], zone, context),
+          );
           break;
         case "SRV":
-          result.srv[key] = buildSrv(
-            subScope("srv"),
-            childId,
-            group as SrvRecordSpec[],
-            zone,
-            context,
+          result.srv[key] = abs(
+            buildSrv(subScope("srv"), childId, group as SrvRecordSpec[], zone, context),
           );
           break;
         case "CAA":
-          result.caa[key] = buildCaa(
-            subScope("caa"),
-            childId,
-            group as CaaRecordSpec[],
-            zone,
-            context,
+          result.caa[key] = abs(
+            buildCaa(subScope("caa"), childId, group as CaaRecordSpec[], zone, context),
           );
           break;
         case "NS":
-          result.ns[key] = buildNs(subScope("ns"), childId, group as NsRecordSpec[], zone, context);
+          result.ns[key] = abs(
+            buildNs(subScope("ns"), childId, group as NsRecordSpec[], zone, context),
+          );
           break;
         case "DS":
-          result.ds[key] = buildDs(subScope("ds"), childId, group as DsRecordSpec[], zone, context);
+          result.ds[key] = abs(
+            buildDs(subScope("ds"), childId, group as DsRecordSpec[], zone, context),
+          );
           break;
         case "HTTPS":
-          result.https[key] = buildHttps(
-            subScope("https"),
-            childId,
-            group as HttpsRecordSpec[],
-            zone,
-            context,
+          result.https[key] = abs(
+            buildHttps(subScope("https"), childId, group as HttpsRecordSpec[], zone, context),
           );
           break;
         case "SVCB":
-          result.svcb[key] = buildSvcb(
-            subScope("svcb"),
-            childId,
-            group as SvcbRecordSpec[],
-            zone,
-            context,
+          result.svcb[key] = abs(
+            buildSvcb(subScope("svcb"), childId, group as SvcbRecordSpec[], zone, context),
           );
           break;
         case "ALIAS": {
@@ -244,9 +248,9 @@ class ZoneRecordsBuilder implements IZoneRecordsBuilder {
           }
           const spec = aliasGroup[0];
           if (spec.ipv6) {
-            result.aaaa[key] = buildAliasAaaa(subScope("aaaa"), childId, spec, zone, context);
+            result.aaaa[key] = abs(buildAliasAaaa(subScope("aaaa"), childId, spec, zone, context));
           } else {
-            result.a[key] = buildAliasA(subScope("a"), childId, spec, zone, context);
+            result.a[key] = abs(buildAliasA(subScope("a"), childId, spec, zone, context));
           }
           break;
         }
@@ -264,6 +268,29 @@ type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
 /** CDK-style record-name convention: apex is `undefined`. */
 const sub = (name: string) => (name === APEX ? undefined : name);
+
+/**
+ * The verbatim, absolute form of a record name. A concrete name is normalised
+ * to exactly one trailing dot (idempotent, so an already-dotted name is safe).
+ * A token is returned as-is: CFN treats a record-set `Name` as an absolute
+ * FQDN and never appends the hosted zone, so a token already carrying the full
+ * domain (SES DKIM) resolves correctly — and no dot is appended to a token,
+ * side-stepping the `..` hazard of a naive `` `${token}.` ``.
+ */
+function absoluteNameValue(name: string): string {
+  return Token.isUnresolved(name) ? name : `${name.replace(/\.+$/, "")}.`;
+}
+
+/**
+ * Replace a built record set's `Name` with its absolute form. CDK's L2 always
+ * runs `recordName` through its fully-qualify step, which double-appends the
+ * zone to an already-qualified token; overriding the property on the
+ * underlying {@link CfnRecordSet} is the only way to keep the name intact.
+ */
+function overrideAbsoluteName(record: RecordSet, name: string): void {
+  const cfn = record.node.defaultChild as CfnRecordSet;
+  cfn.addPropertyOverride("Name", absoluteNameValue(name));
+}
 
 /** Preserve insertion order while dropping duplicates. */
 const dedupe = <T>(xs: readonly T[]): T[] => [...new Set(xs)];

--- a/packages/route53/test/zone-dsl.test.ts
+++ b/packages/route53/test/zone-dsl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { App, Duration, Stack } from "aws-cdk-lib";
+import { App, Duration, Lazy, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Distribution } from "aws-cdk-lib/aws-cloudfront";
 import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
@@ -469,5 +469,117 @@ describe("zoneRecords", () => {
         .zone(zone)
         .build(stack, "DNS"),
     ).toThrow(/only one alias record/);
+  });
+});
+
+describe("zoneRecords — absolute and token names", () => {
+  it("emits a concrete absolute name verbatim instead of appending the zone", () => {
+    const { stack, zone } = setup();
+    zoneRecords([
+      CNAME("sel._domainkey.other.net", "t.dkim.amazonses.com.", { absoluteName: true }),
+    ])
+      .zone(zone)
+      .build(stack, "DNS");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "CNAME",
+      Name: "sel._domainkey.other.net.",
+    });
+  });
+
+  it("appends the zone to the same name when absoluteName is not set (baseline)", () => {
+    const { stack, zone } = setup();
+    zoneRecords([CNAME("sel._domainkey.other.net", "t.example.com.")])
+      .zone(zone)
+      .build(stack, "DNS");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Route53::RecordSet", {
+      Name: "sel._domainkey.other.net.example.com.",
+    });
+  });
+
+  it("normalises an already-dotted absolute name to a single trailing dot", () => {
+    const { stack, zone } = setup();
+    zoneRecords([CNAME("x.other.net.", "t.example.com.", { absoluteName: true })])
+      .zone(zone)
+      .build(stack, "DNS");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Route53::RecordSet", {
+      Name: "x.other.net.",
+    });
+  });
+
+  it("supports absoluteName for non-CNAME record types too", () => {
+    const { stack, zone } = setup();
+    zoneRecords([TXT("_verify.other.net", "token", { absoluteName: true })])
+      .zone(zone)
+      .build(stack, "DNS");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "TXT",
+      Name: "_verify.other.net.",
+    });
+  });
+
+  it("rejects a token record name with no explicit id", () => {
+    const { stack, zone } = setup();
+    const tokenName = Lazy.string({ produce: () => "sel._domainkey.ask.example.com" });
+
+    expect(() =>
+      zoneRecords([CNAME(tokenName, "t.dkim.amazonses.com.", { absoluteName: true })])
+        .zone(zone)
+        .build(stack, "DNS"),
+    ).toThrow(/unresolved token[\s\S]*explicit id/);
+  });
+
+  it("accepts a token name with an explicit id, keying the result and Name correctly", () => {
+    const { stack, zone } = setup();
+    const tokenName = Lazy.string({ produce: () => "sel._domainkey.ask.example.com" });
+
+    const built = zoneRecords([
+      CNAME(tokenName, "t.dkim.amazonses.com.", { id: "dkim1", absoluteName: true }),
+    ])
+      .zone(zone)
+      .build(stack, "DNS");
+
+    // Result-map key is the stable id, not the token.
+    expect(Object.keys(built.cname)).toEqual(["dkim1"]);
+    // Name is the token verbatim — no zone appended, no trailing dot added.
+    Template.fromStack(stack).hasResourceProperties("AWS::Route53::RecordSet", {
+      Type: "CNAME",
+      Name: "sel._domainkey.ask.example.com",
+    });
+  });
+
+  it("keeps id and absoluteName orthogonal: a token with id but no absoluteName is still qualified", () => {
+    const { stack, zone } = setup();
+    const label = Lazy.string({ produce: () => "generated" });
+
+    zoneRecords([CNAME(label, "t.example.com.", { id: "gen" })])
+      .zone(zone)
+      .build(stack, "DNS");
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Route53::RecordSet", {
+      Name: "generated.example.com.",
+    });
+  });
+
+  it("gives token-named records stable construct ids from their explicit id", () => {
+    const { stack, zone } = setup();
+    const t1 = Lazy.string({ produce: () => "a._domainkey.ask.example.com" });
+    const t2 = Lazy.string({ produce: () => "b._domainkey.ask.example.com" });
+
+    const built = zoneRecords([
+      CNAME(t1, "a.dkim.amazonses.com.", { id: "dkim1", absoluteName: true }),
+      CNAME(t2, "b.dkim.amazonses.com.", { id: "dkim2", absoluteName: true }),
+    ])
+      .zone(zone)
+      .build(stack, "DNS");
+
+    expect(Object.keys(built.cname).sort()).toEqual(["dkim1", "dkim2"]);
+    Template.fromStack(stack).resourceCountIs("AWS::Route53::RecordSet", 2);
+    const ids = stack.node.findAll().map((c) => c.node.id);
+    expect(ids).toContain("dkim1");
+    expect(ids).toContain("dkim2");
   });
 });


### PR DESCRIPTION
## What

Adds two **orthogonal** per-record options to the zone DSL (`RecordOptions`), plus a guard:

- **`absoluteName`** — emit the DNS name verbatim instead of letting CDK's L2 append the zone apex. Concrete names are normalised to a single trailing dot; tokens are emitted as-is.
- **`id`** — decouple a record's construct id / result-map key from its DNS `name` (defaults to the name).
- **Token guard** — reject a token record name that has no explicit `id`, so construct-id instability fails loudly at build time.

## Why

CDK's `RecordSet` always runs `recordName` through `determineFullyQualifiedDomainName`, which appends the zone unless the name ends in `.` or already ends with `.<zone>`. For a **token** name that check runs against the opaque `${Token[…]}` encoding, never matches, and double-appends the apex — silently breaking e.g. SES Easy DKIM CNAMEs. The faithful fix is to override the built record set's `Name` on the underlying `CfnRecordSet` (chosen over the `${token}.` dot-trick, which risks a `..` double-dot, and over a per-builder flag, which would spread the same override across 11 builders — see the issue thread). This keeps the uniform `CnameRecord` result type.

Separately, a token name can't serve as a stable construct id (its encoding embeds an order-dependent counter), so `id` supplies a stable label and the guard enforces it.

## Orthogonality

The two options fix different problems and compose independently:

|  | relative | already-FQDN |
|---|---|---|
| **concrete** | nothing needed | `absoluteName` |
| **token** | `id` | both (DKIM) |

A token name needs `id` whether or not it's already qualified; a concrete already-FQDN name needs `absoluteName` but no `id`. Auto-inferring `absoluteName` from token-ness would be unsafe — a token can equally be a relative label that *should* be qualified.

## Behavior change (not marked breaking)

A token record name with no `id` previously synthesised a broken, double-appended record; it now errors at build time with an actionable message. Since the prior output was the bug being fixed, this is classified as a `feat`, not a `BREAKING CHANGE` — flagging here for visibility rather than the release footer. Purely additive for all existing concrete-name callers.

## Context

Groundwork for the `DKIM()` helper (#281) and SES `.publishDkim()` (#279). Independent of the core-guard PR (#283); the DSL guard throws before `constructId` is reached, and the two layer cleanly once both land.

## Tests

New `zoneRecords — absolute and token names` suite covers the full 2×2 matrix + guard: concrete-verbatim, baseline zone-append, dot normalisation, non-CNAME types, token-rejection, token-with-id (result keyed by id, Name verbatim), the id⊥absoluteName orthogonality case, and stable construct ids for multiple token records. 140 route53 tests pass; new code fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)