### PR TITLE
ci: report test coverage on PRs without an external service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,58 @@ jobs:
       - name: Test
         run: npm run test
 
+  # Self-contained coverage reporting (no external service): run the suite once
+  # on a single Node version, merge every package's json-summary output into one
+  # markdown table (scripts/coverage-summary.mjs), publish it to the Actions run
+  # summary, and mirror it into a sticky PR comment. The per-file thresholds in
+  # each vitest.config.ts already gate coverage during `npm run test`; this job
+  # only surfaces the numbers to reviewers. See docs/ci.md#coverage-reporting.
+  coverage:
+    name: Coverage report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      NX_DAEMON: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # nx test depends on ^build + typecheck, so the graph builds what it needs.
+      # Coverage (v8, json-summary reporter) is always on via vitest.config.base.
+      - name: Test with coverage
+        run: npm run test
+
+      # if: always() — a threshold miss fails the step above but reviewers still
+      # want the table showing which package dipped.
+      - name: Build coverage summary
+        if: always()
+        run: npm run coverage:summary
+
+      - name: Post coverage comment
+        # Skipped for fork PRs (read-only GITHUB_TOKEN); the job summary still
+        # carries the numbers. continue-on-error keeps a comment failure from
+        # masking the real test result.
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: coverage
+          path: coverage/coverage-summary.md
+
   # Derive the distinct floors from cdk-floors.json so the enforce matrix
   # stays in sync without duplicating values in YAML.
   cdk-floors-list:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -18,11 +18,26 @@ ci.yml ──► deploy-test.yml ──► release.yml ◄── tag push (PAT o
                                           release-prepare.yml (workflow_dispatch → opens PR)
 ```
 
-- **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20 + 24 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)).
+- **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20/22/24/26 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)). A sibling `coverage` job reports test coverage on PRs (see [Coverage reporting](#coverage-reporting)).
 - **`deploy-test.yml`** — manual `workflow_dispatch`. Calls CI, then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation.
 - **`release-prepare.yml`** — manual `workflow_dispatch`. Runs `nx release version` + `nx release changelog`, pushes branch `release/vX.Y.Z`, opens a PR titled `chore(release): vX.Y.Z`. The PR is the integration point that lets release coexist with branch protection on `main`.
 - **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it tags the commit and creates a GitHub Release from the matching `CHANGELOG.md` section. The tag is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
 - **`release.yml`** — triggered by `v*.*.*` tag pushes (from release-tag.yml or a manual `git push origin vX.Y.Z`). Runs deploy-test, then `npx nx release publish` to npm with provenance, authenticated via [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC) in the `npm` environment. Trust is configured against this workflow file (`release.yml`), so both the automated chain and the manual escape hatch resolve to the same OIDC `job_workflow_ref` claim.
+
+## Coverage reporting
+
+Coverage is reported on PRs without any external service (no Codecov/Coveralls account, no secrets, no data leaving GitHub). It is a reporting layer only — the actual gate is each package's `perFile` thresholds in `vitest.config.ts`, enforced by `npm run test`.
+
+How it fits together:
+
+- **`vitest.config.base.ts`** emits the `json-summary` reporter alongside `text`, so every `npm run test` writes `packages/<pkg>/coverage/coverage-summary.json`. `nx.json` lists `{projectRoot}/coverage` in the `test` target's `outputs`, so a cached test run still restores the summary files.
+- **[`scripts/coverage-summary.mjs`](../scripts/coverage-summary.mjs)** (`npm run coverage:summary`) merges every package's summary into one markdown table — per-package and an overall total computed as summed-covered / summed-total, not an average of percentages. It writes `coverage/coverage-summary.md`, prints to stdout, and appends to `$GITHUB_STEP_SUMMARY` when set.
+- **The `coverage` job in `ci.yml`** runs the suite once on Node 24, builds the summary (so it lands on the Actions run page), and posts it as a sticky PR comment via `marocchino/sticky-pull-request-comment` (keyed `header: coverage`, so it updates in place instead of adding a comment per push).
+
+Notes:
+
+- The comment step is `continue-on-error` and gated to `pull_request` events. **Fork PRs** get a read-only `GITHUB_TOKEN`, so the comment is skipped there — the numbers still appear on the job summary page. Promoting fork-PR comments would need the `pull_request_target` / `workflow_run` two-workflow pattern, deliberately avoided here for simplicity.
+- The summary and comment run with `if: always()`, so when a package dips below its threshold and fails `npm run test`, reviewers still see the table (with the offending package flagged) instead of an empty comment. The job status still reflects the failure — the gate is unchanged.
 
 ## Versioning
 

--- a/nx.json
+++ b/nx.json
@@ -12,6 +12,7 @@
     },
     "test": {
       "dependsOn": ["^build", "typecheck"],
+      "outputs": ["{projectRoot}/coverage"],
       "cache": true
     },
     "check:exports": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format:check": "prettier --check .",
     "typecheck": "npx nx run-many -t typecheck",
     "test": "npx nx run-many -t test",
+    "coverage:summary": "node scripts/coverage-summary.mjs",
     "cdk-floors:apply": "node scripts/cdk-floors.mjs apply",
     "cdk-floors:check": "node scripts/cdk-floors.mjs check",
     "cdk-floors:enforce": "node scripts/cdk-floors.mjs enforce",

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+/**
+ * `coverage-summary` — merge every package's `coverage/coverage-summary.json`
+ * (emitted by the vitest `json-summary` reporter, wired in
+ * `vitest.config.base.ts`) into a single markdown table.
+ *
+ * Self-contained coverage reporting for PRs — no external service. Run after
+ * `npm run test` in CI; the output is:
+ *
+ *   1. printed to stdout,
+ *   2. written to `coverage/coverage-summary.md` (the CI job feeds this file to
+ *      the sticky PR-comment action), and
+ *   3. appended to `$GITHUB_STEP_SUMMARY` when present, so coverage also shows
+ *      on the Actions run page.
+ *
+ * Per-package pass/fail is already enforced by each `vitest.config.ts`'s
+ * `perFile` thresholds during `npm run test`; this script only *reports*, it
+ * does not gate.
+ *
+ * Usage:
+ *   node scripts/coverage-summary.mjs                # default output path
+ *   node scripts/coverage-summary.mjs --out=path.md  # custom markdown path
+ */
+
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packagesDir = join(repoRoot, "packages");
+
+const outArg = process.argv.find((a) => a.startsWith("--out="));
+const outPath = outArg
+  ? resolve(outArg.slice("--out=".length))
+  : join(repoRoot, "coverage", "coverage-summary.md");
+
+const METRICS = ["statements", "branches", "functions", "lines"];
+
+// Absolute-percentage buckets for the at-a-glance marker. Per-package
+// thresholds live in each vitest.config.ts and are enforced by the test run
+// itself — these are just a visual cue, not a gate.
+function marker(pct) {
+  if (pct >= 90) return "🟢";
+  if (pct >= 75) return "🟡";
+  return "🔴";
+}
+
+function pctCell(entry) {
+  const pct = typeof entry?.pct === "number" ? entry.pct : 0;
+  return `${marker(pct)} ${pct.toFixed(2)}%`;
+}
+
+// Discover packages that actually produced a coverage summary. Packages with
+// no vitest run (or excluded from coverage) are simply absent — reported as a
+// skipped count so silent gaps are visible.
+const rows = [];
+const skipped = [];
+for (const name of readdirSync(packagesDir).sort()) {
+  const summaryPath = join(packagesDir, name, "coverage", "coverage-summary.json");
+  let raw;
+  try {
+    raw = readFileSync(summaryPath, "utf8");
+  } catch {
+    skipped.push(name);
+    continue;
+  }
+  const total = JSON.parse(raw).total;
+  rows.push({ name, total });
+}
+
+// Overall coverage = sum of covered / sum of total across packages, per metric
+// (a plain average of percentages would over-weight tiny packages).
+const overall = Object.fromEntries(METRICS.map((m) => [m, { covered: 0, total: 0 }]));
+for (const { total } of rows) {
+  for (const m of METRICS) {
+    overall[m].covered += total[m].covered;
+    overall[m].total += total[m].total;
+  }
+}
+const overallPct = Object.fromEntries(
+  METRICS.map((m) => {
+    const { covered, total } = overall[m];
+    return [m, { pct: total === 0 ? 100 : (covered / total) * 100 }];
+  }),
+);
+
+const lines = [];
+lines.push("## Coverage");
+lines.push("");
+if (rows.length === 0) {
+  lines.push(
+    "No `coverage/coverage-summary.json` files found — did the test run produce coverage?",
+  );
+} else {
+  lines.push(
+    `Overall line coverage: **${overallPct.lines.pct.toFixed(2)}%** across ${rows.length} package(s).`,
+  );
+  lines.push("");
+  lines.push("| Package | Statements | Branches | Functions | Lines |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const { name, total } of rows) {
+    lines.push(`| ${name} | ${METRICS.map((m) => pctCell(total[m])).join(" | ")} |`);
+  }
+  lines.push(`| **Total** | ${METRICS.map((m) => pctCell(overallPct[m])).join(" | ")} |`);
+  if (skipped.length > 0) {
+    lines.push("");
+    lines.push(`_No coverage reported for: ${skipped.join(", ")}._`);
+  }
+}
+lines.push("");
+const markdown = lines.join("\n");
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, markdown);
+process.stdout.write(markdown);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown);
+}

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -20,7 +20,10 @@ export function withCoverage(
         coverage: {
           provider: "v8",
           enabled: true,
-          reporter: ["text"],
+          // text: local console. json-summary: machine-readable per-package
+          // totals at coverage/coverage-summary.json, merged by
+          // scripts/coverage-summary.mjs into the CI PR comment + job summary.
+          reporter: ["text", "json-summary"],
           thresholds: {
             ...thresholds,
             perFile: true,


### PR DESCRIPTION
Add self-contained coverage reporting so build coverage is visible to
reviewers on pull requests, with no Codecov/Coveralls account, secrets,
or data leaving GitHub.

- vitest.config.base: emit the json-summary reporter alongside text, so
  every `npm run test` writes packages/<pkg>/coverage/coverage-summary.json.
- nx.json: declare {projectRoot}/coverage as a test output so cached runs
  restore the summary files.
- scripts/coverage-summary.mjs (npm run coverage:summary): merge every
  package summary into one markdown table (overall total computed as
  summed-covered / summed-total), write coverage/coverage-summary.md,
  print to stdout, and append to $GITHUB_STEP_SUMMARY.
- ci.yml: new `coverage` job runs the suite once on Node 24, publishes the
  table to the Actions run summary, and posts it as a sticky PR comment.
  Per-file thresholds in each vitest.config.ts remain the gate; this only
  surfaces the numbers.
- docs/ci.md: document the flow and the fork-PR caveat.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J3A89CwguTRJdjjf9eu94Y