### PR TITLE
ci: pin npm 11 across the Node test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
+      # Pin npm across the whole matrix. Node 20/22 ship npm 10 while 24/26 ship
+      # npm 11, and the two disagree on how optional peer deps are pinned in the
+      # lockfile (npm 11 prunes entries like vitest's optional `yaml` peer that
+      # npm 10 still expects). Our lockfile is generated under npm 11 (release
+      # tooling runs on Node 24), so `npm ci` on the npm 10 legs would otherwise
+      # fail with "Missing: yaml@2.9.0 from lock file". Install under one npm.
+      - name: Pin npm
+        run: npm install -g npm@11
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Problem

`npm ci` fails on the **Node 20** and **Node 22** CI legs while **24/26** pass — see [run 29009481789](https://github.com/laazyj/composureCDK/actions/runs/29009481789?pr=289):

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: yaml@2.9.0 from lock file
```

The split is exactly the bundled npm version, not anything in the source:

| Node | npm | Result |
|------|-----|--------|
| 20 | 10.8.2 | ❌ |
| 22 | 10.9.x | ❌ |
| 24 | 11.x | ✅ |
| 26 | 11.x | ✅ |

npm 10 and npm 11 disagree on how **optional peer dependencies** are pinned in the lockfile. npm 11 prunes entries like vitest's optional `yaml` peer that npm 10 still expects. Our lockfile is generated under npm 11 (release tooling runs on Node 24), so `npm ci` on the npm 10 legs reports the tree out of sync.

## Fix

Install `npm@11` on every matrix leg before `npm ci`, so the lockfile is consumed by the same resolver that produced it. Scoped to `ci.yml` — it's the only workflow with a multi-Node matrix; every other workflow already runs on Node 24 (npm 11).

## Release note

This unblocks the v0.9.0 release PR (#289). Recommended sequence: merge this to `main`, then re-dispatch `release-prepare` (specifier `0.9.0`, `bump-peer-deps=true`) — it force-pushes `release/v0.9.0` in place, which then inherits the npm pin and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)