### PR TITLE
chore(release): rebrand changelog authors heading to skull

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig(
           allowDefaultProject: [
             "eslint.config.mjs",
             "scripts/*.mjs",
+            "scripts/*.cjs",
             "scripts/cdk-floor/*.mjs",
             "packages/examples/test/smoke/*.mjs",
             "vitest.config.base.ts",
@@ -50,6 +51,23 @@ export default defineConfig(
         process: "readonly",
         fetch: "readonly",
       },
+    },
+  },
+  {
+    files: ["scripts/*.cjs"],
+    extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      sourceType: "commonjs",
+      globals: {
+        require: "readonly",
+        module: "writable",
+        console: "readonly",
+      },
+    },
+    // CommonJS is required here: nx loads non-".ts" changelog renderers with
+    // require(), which cannot import an ESM module in this "type": "module" repo.
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
     },
   },
   {

--- a/nx.json
+++ b/nx.json
@@ -44,7 +44,9 @@
     "changelog": {
       "automaticFromRef": true,
       "projectChangelogs": false,
-      "workspaceChangelog": true,
+      "workspaceChangelog": {
+        "renderer": "{workspaceRoot}/scripts/changelog-renderer.cjs"
+      },
       "git": {
         "commit": false,
         "tag": false,

--- a/scripts/changelog-renderer.cjs
+++ b/scripts/changelog-renderer.cjs
@@ -1,0 +1,18 @@
+// Custom nx release changelog renderer.
+//
+// Rebrands the default "❤️ Thank You" authors heading to the skull mark from
+// jasonduffett.net. Only that heading is touched — everything else inherits
+// nx's DefaultChangelogRenderer, so upstream changelog changes flow through on
+// upgrade. Wired in via release.changelog.workspaceChangelog.renderer in
+// nx.json. Preview with `npm run release:dryrun`.
+//
+// CommonJS (.cjs): nx resolves non-".ts" renderer paths with require(), which
+// cannot load an ESM module even though this workspace is "type": "module".
+const DefaultChangelogRenderer = require("nx/release/changelog-renderer").default;
+
+module.exports = class ComposureChangelogRenderer extends DefaultChangelogRenderer {
+  async renderAuthors() {
+    const lines = await super.renderAuthors();
+    return lines.map((line) => line.replace("❤️ Thank You", "💀 Thank You"));
+  }
+};


### PR DESCRIPTION
## What

nx's built-in `DefaultChangelogRenderer` hardcodes the authors section heading as **`### ❤️ Thank You`** — there's no config option to change just the emoji. This points `release.changelog.workspaceChangelog.renderer` at a thin subclass that overrides `renderAuthors()` to swap the heart for the 💀 mark from [jasonduffett.net](https://jasonduffett.net), inheriting everything else so upstream changelog changes still flow through on nx upgrades.

```
### 💀 Thank You

- Jason Duffett
```

## Changes

- **`scripts/changelog-renderer.cjs`** — subclass of nx's `DefaultChangelogRenderer`; only the authors heading is rewritten.
- **`nx.json`** — `workspaceChangelog` expands from `true` to `{ renderer: … }`. All other changelog defaults (output file, etc.) are unchanged.
- **`eslint.config.mjs`** — scope a block to `scripts/*.cjs` so `require()`/`module.exports` lint cleanly there. The CommonJS ban stays on everywhere else.

## Why `.cjs`

nx loads non-`.ts` renderer paths with `require()`, which can't import an ESM module — and this workspace is `"type": "module"`, so a `.js`/`.mjs` renderer would be ESM. `.cjs` is the format nx's loader can consume here. (A `.ts` renderer would avoid the eslint scoping but would be the only TypeScript file under `scripts/`, which is otherwise all plain `.mjs`.)

## Verification

Previewed against current git history via `npm run release:dryrun` (the changelog path only) — output renders `### 💀 Thank You`. Cosmetic only: applies to future `nx release changelog` runs; existing `CHANGELOG.md` entries are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)