### PR TITLE
ci: move coverage comment out of the reusable ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,21 @@ jobs:
 
   # Self-contained coverage reporting (no external service): run the suite once
   # on a single Node version, merge every package's json-summary output into one
-  # markdown table (scripts/coverage-summary.mjs), publish it to the Actions run
-  # summary, and mirror it into a sticky PR comment. The per-file thresholds in
-  # each vitest.config.ts already gate coverage during `npm run test`; this job
-  # only surfaces the numbers to reviewers. See docs/ci.md#coverage-reporting.
+  # markdown table (scripts/coverage-summary.mjs) and publish it to the Actions
+  # run summary. The per-file thresholds in each vitest.config.ts already gate
+  # coverage during `npm run test`; this job only surfaces the numbers to
+  # reviewers. See docs/ci.md#coverage-reporting.
+  #
+  # The sticky PR comment is posted by coverage-comment.yml, not here: this
+  # workflow is workflow_call-able from release.yml, and a job requesting
+  # `pull-requests: write` fails validation under that caller's narrower
+  # permission ceiling — even when the posting step could never run.
   coverage:
     name: Coverage report
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: write
     env:
       NX_DAEMON: false
     steps:
@@ -116,16 +120,26 @@ jobs:
         if: always()
         run: npm run coverage:summary
 
-      - name: Post coverage comment
-        # Skipped for fork PRs (read-only GITHUB_TOKEN); the job summary still
-        # carries the numbers. continue-on-error keeps a comment failure from
-        # masking the real test result.
+      # The workflow_run listener has no access to this run's PR context, so the
+      # number travels with the artifact.
+      - name: Record PR number
         if: always() && github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p coverage
+          printf '%s' "$PR_NUMBER" > coverage/pr-number.txt
+
+      - name: Upload coverage summary
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          header: coverage
-          path: coverage/coverage-summary.md
+          name: coverage-summary
+          path: |
+            coverage/coverage-summary.md
+            coverage/pr-number.txt
+          if-no-files-found: error
+          retention-days: 1
 
   # Derive the distinct floors from cdk-floors.json so the enforce matrix
   # stays in sync without duplicating values in YAML.

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,66 @@
+name: Coverage Comment
+
+# Posts the coverage table from ci.yml's `coverage` job as a sticky PR comment.
+#
+# This lives outside ci.yml because ci.yml is workflow_call-able from
+# release.yml, and permissions only narrow down a reusable-workflow chain: a
+# `pull-requests: write` job inside ci.yml fails validation for every caller
+# that does not itself hold that scope. Splitting the write here keeps ci.yml
+# at `contents: read` and safe to call from anywhere.
+#
+# workflow_run also runs in the base-repo context with a writable token, so the
+# comment now works for fork PRs, which the in-line step could never do.
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-comment-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Post coverage comment
+    # Reusable-workflow calls do not raise their own workflow_run event, so a
+    # release-triggered ci.yml never lands here; the guard covers push runs.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      # The summary artifact is only uploaded when the coverage job got far
+      # enough to build a table. A cancelled or infra-failed run has none, and
+      # download-artifact fails closed rather than posting a stale comment.
+      - name: Download coverage summary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-summary
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          number=$(cat pr-number.txt)
+          case "$number" in
+            "" | *[!0-9]*)
+              echo "Refusing to comment: '$number' is not a PR number." >&2
+              exit 1
+              ;;
+          esac
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      # header: coverage keys the comment so pushes update it in place rather
+      # than appending one comment per push.
+      - name: Post coverage comment
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: coverage
+          number: ${{ steps.pr.outputs.number }}
+          path: coverage-summary.md

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,21 +4,22 @@ CI/CD pipeline for ComposureCDK: how the workflows chain, how to bootstrap AWS a
 
 ## Pipeline overview
 
-Five GitHub Actions workflows chain together:
+Five GitHub Actions workflows chain together, with `coverage-comment.yml` hanging off CI as a listener rather than a link in the chain:
 
 ```
 ci.yml ──► deploy-test.yml ──► release.yml ◄── tag push (PAT or manual)
    ▲              ▲                              ▲
    │              │                              │
  PRs/push    workflow_dispatch              release-tag.yml ◄── push to main
-                                            (filters chore(release): commits,
-                                             pushes tag with RELEASE_PR_TOKEN)
-                                                  ▲
-                                                  │
+   │                                        (filters chore(release): commits,
+   │ workflow_run                            pushes tag with RELEASE_PR_TOKEN)
+   ▼                                              ▲
+coverage-comment.yml                              │
                                           release-prepare.yml (workflow_dispatch → opens PR)
 ```
 
-- **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20/22/24/26 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)). A sibling `coverage` job reports test coverage on PRs (see [Coverage reporting](#coverage-reporting)).
+- **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20/22/24/26 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)). A sibling `coverage` job reports test coverage on PRs (see [Coverage reporting](#coverage-reporting)). It holds no write scopes, so it stays callable from `release.yml`.
+- **`coverage-comment.yml`** — `workflow_run` listener on CI. Posts the coverage table as a sticky PR comment (see [Coverage reporting](#coverage-reporting)).
 - **`deploy-test.yml`** — manual `workflow_dispatch`. Calls CI, then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation.
 - **`release-prepare.yml`** — manual `workflow_dispatch`. Runs `nx release version` + `nx release changelog`, pushes branch `release/vX.Y.Z`, opens a PR titled `chore(release): vX.Y.Z`. The PR is the integration point that lets release coexist with branch protection on `main`.
 - **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it tags the commit and creates a GitHub Release from the matching `CHANGELOG.md` section. The tag is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
@@ -32,12 +33,15 @@ How it fits together:
 
 - **`vitest.config.base.ts`** emits the `json-summary` reporter alongside `text`, so every `npm run test` writes `packages/<pkg>/coverage/coverage-summary.json`. `nx.json` lists `{projectRoot}/coverage` in the `test` target's `outputs`, so a cached test run still restores the summary files.
 - **[`scripts/coverage-summary.mjs`](../scripts/coverage-summary.mjs)** (`npm run coverage:summary`) merges every package's summary into one markdown table — per-package and an overall total computed as summed-covered / summed-total, not an average of percentages. It writes `coverage/coverage-summary.md`, prints to stdout, and appends to `$GITHUB_STEP_SUMMARY` when set.
-- **The `coverage` job in `ci.yml`** runs the suite once on Node 24, builds the summary (so it lands on the Actions run page), and posts it as a sticky PR comment via `marocchino/sticky-pull-request-comment` (keyed `header: coverage`, so it updates in place instead of adding a comment per push).
+- **The `coverage` job in `ci.yml`** runs the suite once on Node 24, builds the summary (so it lands on the Actions run page), and — on `pull_request` events — uploads `coverage-summary.md` plus the PR number as a `coverage-summary` artifact.
+- **[`coverage-comment.yml`](../.github/workflows/coverage-comment.yml)** listens for CI's `workflow_run` completion, downloads that artifact, and posts it as a sticky PR comment via `marocchino/sticky-pull-request-comment` (keyed `header: coverage`, so it updates in place instead of adding a comment per push).
 
 Notes:
 
-- The comment step is `continue-on-error` and gated to `pull_request` events. **Fork PRs** get a read-only `GITHUB_TOKEN`, so the comment is skipped there — the numbers still appear on the job summary page. Promoting fork-PR comments would need the `pull_request_target` / `workflow_run` two-workflow pattern, deliberately avoided here for simplicity.
-- The summary and comment run with `if: always()`, so when a package dips below its threshold and fails `npm run test`, reviewers still see the table (with the offending package flagged) instead of an empty comment. The job status still reflects the failure — the gate is unchanged.
+- **Why two workflows.** `ci.yml` is `workflow_call`-able from `release.yml`, and GitHub only ever _narrows_ permissions down a reusable-workflow chain. A job inside `ci.yml` declaring `pull-requests: write` therefore fails validation for any caller that lacks that scope — statically, at parse time, regardless of whether the posting step's `if:` would ever let it run. Keeping `ci.yml` at `contents: read` makes it callable from anywhere; the write scope lives only in `coverage-comment.yml`.
+- **Fork PRs** now get a comment too. `workflow_run` executes in the base-repo context with a writable `GITHUB_TOKEN`, which the old in-line comment step could not obtain. The listener never checks out or executes PR code — it only reads the uploaded markdown and the PR number, which it validates is numeric before use.
+- `coverage-comment.yml` must exist on the **default branch** to fire; `workflow_run` always dispatches the default-branch copy. Changes to it are not exercised by the PR that introduces them.
+- The summary and upload steps run with `if: always()`, so when a package dips below its threshold and fails `npm run test`, reviewers still see the table (with the offending package flagged). The job status still reflects the failure — the gate is unchanged.
 
 ## Versioning
 


### PR DESCRIPTION
## Problem

The v0.9.0 release run ([29030687121](https://github.com/laazyj/composureCDK/actions/runs/29030687121)) failed workflow validation before a single job started:

> Error calling workflow `ci.yml`. The nested job `coverage` is requesting `pull-requests: write`, but is only allowed `pull-requests: none`.

## Root cause

Permissions only ever **narrow** down a reusable-workflow chain — `release.yml` → `deploy-test.yml` → `ci.yml`. Walk it and watch the scope collapse:

1. `release.yml` declares a top-level `permissions:` block listing only `contents: write` and `id-token: write`. Writing an explicit block sets every *unlisted* scope to `none` — not to its default. So `pull-requests: none` from the top.
2. Its `deploy-test` job narrows further to `contents: read`, `id-token: write`.
3. `deploy-test.yml`'s `ci` job has no `permissions:` block, so it inherits that ceiling verbatim.
4. `ci.yml`'s `coverage` job asks for `pull-requests: write` → exceeds the ceiling → the file is rejected.

The trap: job-level `permissions:` is **static**, read at parse time. The posting step was already gated on `if: github.event_name == 'pull_request'` and could never have run on a tag push — but the *declaration alone* fails validation. It's a parse-time error, not a runtime one, so the entire release run dies before anything executes.

## Fix

Split the write scope out of the reusable workflow rather than propagating it down the chain. Granting `pull-requests: write` to a release run that provably never posts a comment would have worked, but it's the wrong direction for least privilege.

- **`ci.yml`** — `coverage` job drops `pull-requests: write` and the sticky-comment step. On `pull_request` events it uploads `coverage-summary.md` + the PR number as a `coverage-summary` artifact. The `$GITHUB_STEP_SUMMARY` output is unchanged, so the table still lands on the Actions run page. The workflow now holds `contents: read` only, and is safe to call from anywhere.
- **`coverage-comment.yml`** (new) — a `workflow_run` listener on CI that downloads the artifact and posts the sticky comment (still keyed `header: coverage`, so it updates in place). Sole holder of `pull-requests: write`, and never in the release call graph.
- **`docs/ci.md`** — pipeline diagram + Coverage reporting section updated, recording *why* the split exists so the comment step doesn't get folded back into `ci.yml` and re-break release.

## Side effect: fork PRs now get a coverage comment

`docs/ci.md` previously called this out as an accepted limitation — fork PRs get a read-only `GITHUB_TOKEN`, so the in-line step was skipped. `workflow_run` runs in the base-repo context with a writable token, so it works there now.

The usual `workflow_run` privilege-escalation path stays closed: the listener never checks out or executes PR code. It reads the uploaded markdown and the PR number, and validates the number is numeric before passing it to the comment action.

## Verification

- All four workflow files parse; `ci.yml` contains no `write` scope outside a comment.
- `npm run lint` and `npm run format:check` clean.
- Rebased onto current `main` (picks up `3521cb2 ci: pin npm 11`, which also touched `ci.yml`).

Not verifiable from here: the release chain's validity can only be confirmed by GitHub on the next tag push. Note also that `workflow_run` always dispatches the **default-branch** copy of a listener — `coverage-comment.yml` will not fire until this merges, so this PR will not post a coverage comment of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)