### PR TITLE
chore(release): v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.9.1 (2026-07-11)
+
+### 🚀 Features
+
+- **custom-resources:** add AwsCustomResource builder ([#294](https://github.com/laazyj/composureCDK/pull/294), [#280](https://github.com/laazyj/composureCDK/issues/280))
+
+### 💀 Thank You
+
+- Jason Duffett
+
 ## 0.9.0 (2026-07-09)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -8910,7 +8910,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -8932,7 +8932,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -8955,7 +8955,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -8977,7 +8977,7 @@
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -8997,7 +8997,7 @@
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9020,7 +9020,7 @@
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9040,7 +9040,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -9059,7 +9059,7 @@
     },
     "packages/custom-resources": {
       "name": "@composurecdk/custom-resources",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9079,7 +9079,7 @@
     },
     "packages/dynamodb": {
       "name": "@composurecdk/dynamodb",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9101,7 +9101,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9124,7 +9124,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9139,7 +9139,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9160,7 +9160,7 @@
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9191,7 +9191,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9212,7 +9212,7 @@
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@composurecdk/iam": "^0.9.0",
@@ -9237,7 +9237,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9258,7 +9258,7 @@
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9295,7 +9295,7 @@
     },
     "packages/neptune": {
       "name": "@composurecdk/neptune",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9319,7 +9319,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9342,7 +9342,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9365,7 +9365,7 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9387,7 +9387,7 @@
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/custom-resources/package.json
+++ b/packages/custom-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/custom-resources",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Compose-native AwsCustomResource builder for AWS operations with no CloudFormation resource",
   "repository": {
     "type": "git",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/dynamodb",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable DynamoDB table builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/neptune",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable Amazon Neptune cluster builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.9.1**.

Generated by `release-prepare` workflow run [#29156059423](https://github.com/laazyj/composureCDK/actions/runs/29156059423).

## Merge checklist

- [ ] CI is green
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow will push tag `v0.9.1`, which triggers `release.yml` (deploy-test → npm publish).