### PR TITLE
feat(eslint): forbid aws-cdk-lib and sibling imports in core

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,6 +80,41 @@ export default defineConfig(
     rules: composurecdk.configs.recommended.rules,
   },
   {
+    // @composurecdk/core is the root of the dependency graph. It stays
+    // CDK-version-agnostic — depending only on `constructs` (peer) and
+    // `@dagrejs/graphlib` — and must never import a sibling @composurecdk
+    // package or a CDK construct library. See docs/architecture.md. This
+    // encodes as lint what was previously an unwritten convention; the
+    // graph-wide version (phantom deps, cycles, deep imports) is a planned
+    // follow-up via @nx/enforce-module-boundaries.
+    files: ["packages/core/src/**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "aws-cdk-lib",
+                "aws-cdk-lib/*",
+                "aws-cdk-lib/**",
+                "@aws-cdk/*",
+                "@aws-cdk/**",
+              ],
+              message:
+                "@composurecdk/core must not depend on aws-cdk-lib or any @aws-cdk/* construct library — it stays CDK-version-agnostic and depends only on `constructs`. See docs/architecture.md.",
+            },
+            {
+              group: ["@composurecdk/*", "@composurecdk/**"],
+              message:
+                "@composurecdk/core is the root of the dependency graph and must not import from any other @composurecdk package.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // The tagged-builder wrapper IS the implementation of the tagged-builder
     // surface — by definition it must reach for `Builder` / `IBuilder` from
     // `@composurecdk/core`. Disable the rule at the file level rather than


### PR DESCRIPTION
## What

Encodes a previously-unwritten convention as lint: **`@composurecdk/core` is the root of the dependency graph and stays CDK-version-agnostic.** A `files`-scoped block in `eslint.config.mjs` (`packages/core/src/**/*.ts`) uses the built-in `no-restricted-imports` rule to ban:

- `aws-cdk-lib` and its subpaths (`aws-cdk-lib/*`, `aws-cdk-lib/**`)
- `@aws-cdk/*` alpha construct libraries
- any `@composurecdk/*` sibling package

core continues to depend only on `constructs` (peer) and `@dagrejs/graphlib`.

## Why

The convention held by discipline alone. As the package footprint and contributor base grow, drift should be caught in lint rather than review. This is the smallest possible step: zero new dependencies, no toolchain compatibility risk, and it fits the existing file-scoped override style already in `eslint.config.mjs`.

## Verification

- Rule fires on bare imports, subpath imports, `import type`, and sibling imports (verified with a throwaway probe file).
- Clean tree passes `npm run lint` and `npm run format:check`.
- The graph is already clean — no existing violations — so this starts green and acts as a ratchet.

## Follow-up (not in this PR)

Graph-wide protection — phantom deps, deep imports into internals, and circular dependencies across all 22 packages — is planned via `@nx/enforce-module-boundaries`. Siblings-may-depend-on-siblings is an accepted design point (e.g. `cloudfront → s3`), so that follow-up's tag constraints will permit service→service edges. That PR should be gated on an ESLint 10 peer-compatibility check for `@nx/eslint-plugin`.