### PR TITLE
feat(eslint): enforce package boundaries via nx project graph

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
 import eslintComments from "@eslint-community/eslint-plugin-eslint-comments";
+import nx from "@nx/eslint-plugin";
 import composurecdk from "@composurecdk/eslint-plugin";
 
 export default defineConfig(
@@ -108,6 +109,52 @@ export default defineConfig(
               group: ["@composurecdk/*", "@composurecdk/**"],
               message:
                 "@composurecdk/core is the root of the dependency graph and must not import from any other @composurecdk package.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Graph-wide package boundaries via the Nx project graph. Tags live in
+    // each package's package.json (`nx.tags`). This catches what a
+    // specifier-level rule cannot: cross-package cycles, deep imports past a
+    // package's public entry points, and reliance on undeclared (transitive)
+    // dependencies — i.e. phantom deps. Siblings may depend on siblings by
+    // design (e.g. cloudfront -> s3), so `scope:lib` may depend on itself.
+    files: ["packages/*/src/**/*.ts"],
+    plugins: { "@nx": nx },
+    rules: {
+      "@nx/enforce-module-boundaries": [
+        "error",
+        {
+          // Also bans imports that don't resolve to a package's public entry
+          // point — i.e. deep imports into another package's internals and
+          // reliance on undeclared (transitive) dependencies.
+          banTransitiveDependencies: true,
+          // `estree` is a types-only module supplied by `@types/estree`, which
+          // the eslint-plugin package declares as a devDependency. Nx keys the
+          // transitive check on the import specifier, and `estree` has no
+          // matching package name (the package is `@types/estree`), so the rule
+          // cannot resolve it. The import is compile-time-only; allow it.
+          allow: ["estree"],
+          depConstraints: [
+            {
+              sourceTag: "scope:core",
+              onlyDependOnLibsWithTags: [],
+              bannedExternalImports: ["aws-cdk-lib", "@aws-cdk/*"],
+            },
+            {
+              sourceTag: "scope:lib",
+              onlyDependOnLibsWithTags: ["scope:core", "scope:lib"],
+            },
+            {
+              sourceTag: "scope:aggregate",
+              onlyDependOnLibsWithTags: ["scope:core", "scope:lib", "scope:aggregate"],
+            },
+            {
+              sourceTag: "scope:tooling",
+              onlyDependOnLibsWithTags: [],
             },
           ],
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@composurecdk/eslint-plugin": "*",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "^10.0.1",
+        "@nx/eslint-plugin": "23.0.1",
         "@nx/js": "23.0.1",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.4.1",
@@ -2350,6 +2351,38 @@
         "nx": ">= 22 <= 24 || ^23.0.0-0"
       }
     },
+    "node_modules/@nx/eslint-plugin": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-23.0.1.tgz",
+      "integrity": "sha512-fZ4fU4fYxvmHYUtiPuh9vg6KItjqaz4c8SHeqOCRvDsbm7NwQidWsGiruk853No5KnmCHfj/En87v/qGOguoGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "23.0.1",
+        "@nx/js": "23.0.1",
+        "@phenomnomnominal/tsquery": "~6.2.0",
+        "@typescript-eslint/type-utils": "^8.0.0",
+        "@typescript-eslint/utils": "^8.0.0",
+        "chalk": "^4.1.0",
+        "confusing-browser-globals": "^1.0.9",
+        "globals": "^17.0.0",
+        "jsonc-eslint-parser": "^2.1.0",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint-config-prettier": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/parser": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nx/js": {
       "version": "23.0.1",
       "resolved": "https://registry.npmjs.org/@nx/js/-/js-23.0.1.tgz",
@@ -2573,6 +2606,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@phenomnomnominal/tsquery": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-6.2.0.tgz",
+      "integrity": "sha512-Vo9nkhfZxDB/sBiqIY3pjDC4mOSyure+AFlEW5hcy/tRE82MqCXjRN4InnVNMldinRt0dLYqg4HAU2XPq5e1LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/esquery": "^1.5.4",
+        "esquery": "^1.7.0"
+      },
+      "peerDependencies": {
+        "typescript": ">3.0.0"
       }
     },
     "node_modules/@publint/pack": {
@@ -2929,6 +2976,16 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/esquery": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/esquery/-/esquery-1.5.4.tgz",
+      "integrity": "sha512-yYO4Q8H+KJHKW1rEeSzHxcZi90durqYgWVfnh5K6ZADVBjBv2e1NEveYX5yT2bffgN7RqzH3k9930m+i2yBoMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -4674,6 +4731,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/constructs": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
@@ -5538,6 +5602,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5920,6 +5997,56 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+      "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/jsonc-parser": {
@@ -9127,6 +9254,7 @@
       "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/estree": "^1.0.6",
         "@types/node": "^25.9.3",
         "@typescript-eslint/parser": "^8.58.0",
         "eslint": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "composurecdk",
   "description": "Composable, lifecycle-managed AWS infrastructure built on AWS CDK — monorepo for the @composurecdk/* packages.",
   "scripts": {
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix .",
+    "lint": "nx show projects > /dev/null 2>&1 && eslint .",
+    "lint:fix": "nx show projects > /dev/null 2>&1 && eslint --fix .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "npx nx run-many -t typecheck",
@@ -54,6 +54,7 @@
     "@composurecdk/eslint-plugin": "*",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint/js": "^10.0.1",
+    "@nx/eslint-plugin": "23.0.1",
     "@nx/js": "23.0.1",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.4.1",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -77,5 +77,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -76,5 +76,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -75,5 +75,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -72,5 +72,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -76,5 +76,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -75,5 +75,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,5 +91,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:core"
+    ]
+  }
 }

--- a/packages/custom-resources/package.json
+++ b/packages/custom-resources/package.json
@@ -72,5 +72,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -76,5 +76,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -77,5 +77,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,10 +35,16 @@
     "eslint": "^10.0.0"
   },
   "devDependencies": {
+    "@types/estree": "^1.0.6",
     "@types/node": "^25.9.3",
     "@typescript-eslint/parser": "^8.58.0",
     "eslint": "^10.4.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
+  },
+  "nx": {
+    "tags": [
+      "scope:tooling"
+    ]
   }
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -74,5 +74,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -42,5 +42,10 @@
     "aws-cdk": "^2.1126.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
+  },
+  "nx": {
+    "tags": [
+      "scope:aggregate"
+    ]
   }
 }

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -76,5 +76,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -78,5 +78,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -75,5 +75,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -49,5 +49,10 @@
     "constructs": "^10.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
+  },
+  "nx": {
+    "tags": [
+      "scope:aggregate"
+    ]
   }
 }

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -78,5 +78,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -87,5 +87,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -77,5 +77,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -77,5 +77,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -76,5 +76,10 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "nx": {
+    "tags": [
+      "scope:lib"
+    ]
+  }
 }


### PR DESCRIPTION
## What

Adds `@nx/enforce-module-boundaries` to guard the package dependency graph as the footprint and contributor base grow. Package roles are declared as tags in each `package.json` under the `nx.tags` key (package-based convention — **no `project.json` files introduced**):

| Tag | Packages | May depend on |
|---|---|---|
| `scope:core` | core | *nothing* — also bans `aws-cdk-lib` / `@aws-cdk/*` |
| `scope:lib` | the 18 builder/service packages | `scope:core`, `scope:lib` |
| `scope:aggregate` | module-compat, examples | core, lib, aggregate |
| `scope:tooling` | eslint-plugin | *nothing* |

Siblings may depend on siblings by design (e.g. `cloudfront -> s3`), so `scope:lib` may depend on itself.

## What it protects (all three verified with probes)

- **Cycles** — cross-package circular dependencies are rejected by default.
- **Deep imports** — `banTransitiveDependencies` rejects any import that doesn't resolve to a package's public entry point; the `exports` maps make internal paths unresolvable, so deep imports into another package's internals are caught.
- **Phantom deps** — the same option rejects importing a package not declared in that package's `package.json`, so undeclared (transitively-hoisted) dependencies are caught.

## Notes for reviewers

- **Graph priming.** The rule reads a *cached* Nx project graph and silently skips (warning only) when none exists — so a cold `npm run lint` would false-green. The `lint`/`lint:fix` scripts now prime the graph first (`nx show projects > /dev/null 2>&1 && eslint .`). Verified: cold-cache `npm run lint` enforces and is green.
- **`estree` allow-list.** Every `eslint-plugin` rule file imports `estree` types, supplied transitively by `@types/estree`. This PR declares `@types/estree` as an `eslint-plugin` devDependency (correct hygiene) and allow-lists the `estree` specifier — Nx keys the transitive check on the import specifier, which has no matching package name (`@types/estree`), so it cannot resolve it. Every other package passed with no changes, confirming declared deps are already clean.
- **Nx version lockstep.** `@nx/eslint-plugin` is pinned to `23.0.1` to match `nx` / `@nx/js`.
- **ESLint 10 compatibility** confirmed: the plugin has no hard `eslint` peer and runs under flat config + typescript-eslint 8.
- **Relationship to the core `no-restricted-imports` guard** (separate PR): the two are complementary and intended to coexist. `no-restricted-imports` blocks core's banned specifiers without needing the Nx graph; this rule adds graph-wide cycle/deep-import/phantom-dep coverage. Both touch `eslint.config.mjs`, so expect a trivial merge.

## Verification

- Cold `npm run lint` → exit 0, rule enforcing (no skip).
- `npm run format:check` clean.
- Full `npm run verify` (build + `check:exports` + lint + all 22 projects' tests) passed via the pre-push hook.