### PR TITLE
feat(ses): sending-side builders — configuration set, event destinations, send grants, reputation alarms

### DIFF
--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -2,7 +2,7 @@
 
 Compose-native builders for [AWS SES](https://docs.aws.amazon.com/ses/latest/dg/Welcome.html), part of [ComposureCDK](../../README.md).
 
-SES is Amazon's email service for **sending** and **receiving** mail. This package currently covers the **receiving** path — email identities, receipt rule sets, receipt filters, and rule actions. Sending-side builders (configuration sets, dedicated IP pools, VDM, reputation alarms) will follow.
+SES is Amazon's email service for **sending** and **receiving** mail. This package covers both: the **sending** path — configuration sets, event routing, send grants, and account reputation alarms — and the **receiving** path — email identities, receipt rule sets, receipt filters, and rule actions. (Dedicated IP pools, account-level VDM, and SES templates will follow.)
 
 ## Install
 
@@ -10,7 +10,7 @@ SES is Amazon's email service for **sending** and **receiving** mail. This packa
 npm install @composurecdk/ses
 ```
 
-Peer dependencies: `@composurecdk/core`, `@composurecdk/route53` (for `.publishDkim()`), `aws-cdk-lib`, `constructs`.
+Peer dependencies: `@composurecdk/core`, `@composurecdk/cloudformation`, `@composurecdk/cloudwatch` (for reputation alarms), `@composurecdk/route53` (for `.publishDkim()`), `aws-cdk-lib`, `constructs`.
 
 ## Email identity
 
@@ -31,6 +31,113 @@ const { emailIdentity, dkim } = createEmailIdentityBuilder()
 - **`.publishDkim(zone)`** — for the `.domain()` case (e.g. a subdomain whose apex lives elsewhere), publishes the DKIM DNS records into `zone`: three CNAMEs for Easy DKIM, one TXT for BYODKIM. Mutually exclusive with `.publicHostedZone()` (which already publishes); not valid for an email identity.
 - **`.mailFromDomain(...)`** — a [custom MAIL FROM domain](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html); defaults to `REJECT_MESSAGE` on MX failure (no insecure fallback to `amazonses.com`, preserving SPF/DMARC alignment).
 - The result exposes `dkim` — the identity's DKIM DNS records as `{ name, value }[]` (CDK's `dkimRecords`), for manual publication when a zone isn't available — and `dkimRecords` (the Route 53 records) when `.publishDkim()` was used.
+
+## Sending
+
+The sending path centres on a **configuration set** (the unit that tracks and
+controls a stream of outbound mail), a **send grant** to whatever role sends, and
+an account-level **reputation safety net**.
+
+```ts
+import {
+  createConfigurationSetBuilder,
+  createEmailIdentityBuilder,
+  createReputationAlarmBuilder,
+  identityGrants,
+  snsDestination,
+} from "@composurecdk/ses";
+import { EmailSendingEvent } from "aws-cdk-lib/aws-ses";
+import { compose, ref } from "@composurecdk/core";
+
+compose(
+  {
+    feedback: createTopicBuilder(),
+
+    // TLS required + reputation metrics on by default; route bounces/complaints out.
+    mailConfig: createConfigurationSetBuilder().addEventDestination("feedback", {
+      destination: snsDestination(ref<TopicBuilderResult>("feedback").get("topic")),
+      events: [EmailSendingEvent.BOUNCE, EmailSendingEvent.COMPLAINT, EmailSendingEvent.REJECT],
+    }),
+
+    // Associate the identity with the config set so every send is tracked.
+    identity: createEmailIdentityBuilder()
+      .domain("mail.example.com")
+      .configurationSet(ref<ConfigurationSetBuilderResult>("mailConfig").get("configurationSet")),
+
+    // Least-privilege ses:SendEmail on the identity, scoped to one From address.
+    sender: createFunctionBuilder().grant(
+      identityGrants.sendFrom(ref<EmailIdentityBuilderResult>("identity").get("emailIdentity"), [
+        "alerts@mail.example.com",
+      ]),
+    ),
+
+    // Account-level bounce/complaint alarms (create once per account/Region).
+    reputation: createReputationAlarmBuilder(),
+  },
+  {
+    feedback: [],
+    mailConfig: ["feedback"],
+    identity: ["mailConfig"],
+    sender: ["identity"],
+    reputation: [],
+  },
+);
+```
+
+### Configuration set
+
+A [configuration set](https://docs.aws.amazon.com/ses/latest/dg/using-configuration-sets.html)
+applies to every message sent with it — enforcing TLS, publishing reputation
+metrics, and routing send events.
+
+- **`.addEventDestination(key, { destination, events?, enabled? })`** — routes send
+  events to a destination. The `snsDestination` / `eventBusDestination` /
+  `cloudWatchDestination` helpers accept `Resolvable`s so a destination can `ref()`
+  a sibling topic or bus. Routing `BOUNCE`/`COMPLAINT` to a suppression workflow is
+  how a production sender protects its reputation — AWS **requires** you to track
+  them. (EventBridge destinations can only target the account's **default** bus.)
+- Every other [`ConfigurationSetProps`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.ConfigurationSetProps.html)
+  field passes through — `dedicatedIpPool`, `suppressionReasons`, `vdmOptions`,
+  `sendingEnabled`, etc.
+
+#### Secure defaults
+
+| Default             | Value     | Why                                                                                                           |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
+| `tlsPolicy`         | `REQUIRE` | Encrypt in transit. Override with `.tlsPolicy(ConfigurationSetTlsPolicy.OPTIONAL)` for receivers without TLS. |
+| `reputationMetrics` | `true`    | Publish per-config-set bounce/complaint metrics (CloudFormation defaults this off).                           |
+
+> **Migrating from raw `aws-cdk-lib`?** `tlsPolicy` defaults to `REQUIRE` here vs.
+> CloudFormation's `OPTIONAL` — a more secure posture, but a behaviour change on
+> migration.
+
+### Send grants
+
+Sending is authorised on the **identity** resource (a configuration set has no ARN),
+so grants live on `identityGrants` and are declared on the **consumer** (the role or
+function that sends), per [ADR-0013](../../docs/adr/0013-consumer-side-grants.md).
+
+- **`identityGrants.send(identity)`** — `ses:SendEmail` + `ses:SendRawEmail` on the
+  identity ARN (delegates to CDK's native `grantSendEmail`).
+- **`identityGrants.sendFrom(identity, fromAddresses)`** — the same, scoped with a
+  `ses:FromAddress` condition (StringLike, so `alerts+*@example.com` works) — the
+  least-privilege posture so a leaked credential can't send as arbitrary addresses.
+
+### Reputation alarms
+
+`createReputationAlarmBuilder()` creates the AWS-recommended account-level alarms:
+
+| Alarm           | Metric (`AWS/SES`)         | Default threshold | SES action at threshold            |
+| --------------- | -------------------------- | ----------------- | ---------------------------------- |
+| `bounceRate`    | `Reputation.BounceRate`    | `>= 0.05` (5%)    | Account under review (pause ≥10%)  |
+| `complaintRate` | `Reputation.ComplaintRate` | `>= 0.001` (0.1%) | Account under review (pause ≥0.5%) |
+
+Both use `Average` over a 1-hour period with `treatMissingData: IGNORE`, per the
+[SES reputation-alarm guidance](https://docs.aws.amazon.com/ses/latest/dg/reputationdashboard-cloudwatch-alarm.html).
+These metrics are **account/Region-scoped and dimensionless**, so build this once per
+account/Region — not per configuration set. Tune or disable via `recommendedAlarms`,
+add custom alarms with `.addAlarm()`, and apply alarm actions from the result (no
+actions are configured by default). Set `.recommendedAlarms(false)` to disable.
 
 ## Receipt rule set
 

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -137,7 +137,9 @@ Both use `Average` over a 1-hour period with `treatMissingData: IGNORE`, per the
 These metrics are **account/Region-scoped and dimensionless**, so build this once per
 account/Region — not per configuration set. Tune or disable via `recommendedAlarms`,
 add custom alarms with `.addAlarm()`, and apply alarm actions from the result (no
-actions are configured by default). Set `.recommendedAlarms(false)` to disable.
+actions are configured by default). `.recommendedAlarms(false)` disables the
+**recommended** alarms only — custom alarms added via `.addAlarm()` are an explicit
+opt-in and are always created.
 
 ## Receipt rule set
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -47,6 +47,8 @@
     }
   },
   "peerDependencies": {
+    "@composurecdk/cloudformation": "^0.9.0",
+    "@composurecdk/cloudwatch": "^0.9.0",
     "@composurecdk/core": "^0.9.0",
     "@composurecdk/route53": "^0.9.0",
     "aws-cdk-lib": "^2.216.0",

--- a/packages/ses/src/configuration-set-builder.ts
+++ b/packages/ses/src/configuration-set-builder.ts
@@ -1,0 +1,142 @@
+import {
+  ConfigurationSet,
+  type ConfigurationSetEventDestination,
+  type ConfigurationSetProps,
+  type EmailSendingEvent,
+  type EventDestination,
+} from "aws-cdk-lib/aws-ses";
+import { type IConstruct } from "constructs";
+import {
+  Builder,
+  COPY_STATE,
+  constructId,
+  type IBuilder,
+  type Lifecycle,
+  resolve,
+  type Resolvable,
+} from "@composurecdk/core";
+import { CONFIGURATION_SET_DEFAULTS } from "./configuration-set-defaults.js";
+
+/**
+ * Configuration for the SES configuration-set builder. Every
+ * {@link ConfigurationSetProps} field passes through unchanged; event
+ * destinations are owned by {@link IConfigurationSetBuilder.addEventDestination}.
+ */
+export type ConfigurationSetBuilderProps = ConfigurationSetProps;
+
+/** Options for a single configuration-set event destination. */
+export interface EventDestinationOptions {
+  /**
+   * Where to publish the events — an SNS topic, EventBridge bus, or CloudWatch
+   * dimensions. Use the {@link snsDestination} / {@link eventBusDestination} /
+   * {@link cloudWatchDestination} helpers, which accept `Resolvable`s so a
+   * destination can `ref()` a sibling component.
+   */
+  readonly destination: Resolvable<EventDestination>;
+  /**
+   * The send events to publish. Defaults to SES's behaviour of publishing all
+   * event types when omitted.
+   */
+  readonly events?: EmailSendingEvent[];
+  /**
+   * Whether SES publishes events to this destination.
+   * @default true
+   */
+  readonly enabled?: boolean;
+}
+
+/** The build output of an {@link IConfigurationSetBuilder}. */
+export interface ConfigurationSetBuilderResult {
+  /** The SES configuration set construct. */
+  configurationSet: ConfigurationSet;
+  /**
+   * Event destinations added via
+   * {@link IConfigurationSetBuilder.addEventDestination}, keyed by the name
+   * supplied to that call. Always present — `{}` when none were added.
+   */
+  eventDestinations: Record<string, ConfigurationSetEventDestination>;
+}
+
+/**
+ * A fluent builder for an SES configuration set — the unit that tracks and
+ * controls a stream of outbound mail (TLS enforcement, reputation metrics,
+ * suppression, and event routing). TLS is required and reputation metrics are on
+ * by default; both are individually overridable.
+ *
+ * @example
+ * ```ts
+ * const { configurationSet } = createConfigurationSetBuilder()
+ *   .addEventDestination("feedback", {
+ *     destination: snsDestination(ref<TopicBuilderResult>("events").get("topic")),
+ *     events: [EmailSendingEvent.BOUNCE, EmailSendingEvent.COMPLAINT],
+ *   })
+ *   .build(stack, "MailConfig");
+ * ```
+ */
+// eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::SES::ConfigurationSet has no Tags property
+export type IConfigurationSetBuilder = IBuilder<
+  ConfigurationSetBuilderProps,
+  ConfigurationSetBuilder
+>;
+
+interface EventDestinationEntry {
+  key: string;
+  options: EventDestinationOptions;
+}
+
+class ConfigurationSetBuilder implements Lifecycle<ConfigurationSetBuilderResult> {
+  props: Partial<ConfigurationSetBuilderProps> = {};
+  readonly #eventDestinations: EventDestinationEntry[] = [];
+
+  /**
+   * Register an event destination for this configuration set. Accepts a
+   * {@link snsDestination} / {@link eventBusDestination} / {@link cloudWatchDestination}
+   * helper (each `Resolvable`, so it can `ref()` a sibling topic or bus) and the
+   * {@link EmailSendingEvent}s to publish. Routing bounce/complaint events is how
+   * a sender drives suppression — AWS requires you to track them.
+   */
+  addEventDestination(key: string, options: EventDestinationOptions): this {
+    if (this.#eventDestinations.some((e) => e.key === key)) {
+      throw new Error(
+        `ConfigurationSetBuilder.addEventDestination: duplicate key "${key}". ` +
+          `Each event destination must use a unique key.`,
+      );
+    }
+    this.#eventDestinations.push({ key, options });
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: ConfigurationSetBuilder): void {
+    target.#eventDestinations.push(...this.#eventDestinations);
+  }
+
+  build(
+    scope: IConstruct,
+    id: string,
+    context: Record<string, object> = {},
+  ): ConfigurationSetBuilderResult {
+    const mergedProps = { ...CONFIGURATION_SET_DEFAULTS, ...this.props };
+    const configurationSet = new ConfigurationSet(scope, id, mergedProps);
+
+    const eventDestinations: Record<string, ConfigurationSetEventDestination> = {};
+    for (const entry of this.#eventDestinations) {
+      const { destination, events, enabled } = entry.options;
+      eventDestinations[entry.key] = configurationSet.addEventDestination(constructId(entry.key), {
+        destination: resolve(destination, context),
+        ...(events !== undefined && { events }),
+        ...(enabled !== undefined && { enabled }),
+      });
+    }
+
+    return { configurationSet, eventDestinations };
+  }
+}
+
+/**
+ * Creates a fluent builder for an SES configuration set.
+ */
+export function createConfigurationSetBuilder(): IConfigurationSetBuilder {
+  // eslint-disable-next-line composurecdk/builder-must-be-tagged -- AWS::SES::ConfigurationSet has no Tags property
+  return Builder<ConfigurationSetBuilderProps, ConfigurationSetBuilder>(ConfigurationSetBuilder);
+}

--- a/packages/ses/src/configuration-set-defaults.ts
+++ b/packages/ses/src/configuration-set-defaults.ts
@@ -1,0 +1,31 @@
+import { ConfigurationSetTlsPolicy, type ConfigurationSetProps } from "aws-cdk-lib/aws-ses";
+
+/**
+ * Secure, AWS-recommended defaults applied to every configuration set built with
+ * {@link createConfigurationSetBuilder} unless the caller overrides them. Each
+ * property is individually overridable through the builder's fluent API, so
+ * deviations are intentional and visible.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/using-configuration-sets.html
+ */
+export const CONFIGURATION_SET_DEFAULTS: Partial<ConfigurationSetProps> = {
+  /**
+   * Require TLS for every message sent with this configuration set (encrypt in
+   * transit — Well-Architected Security Pillar). CloudFormation defaults this to
+   * `OPTIONAL`; the AWS-recommended posture for outbound mail is to fail rather
+   * than fall back to plaintext. Override with `.tlsPolicy(ConfigurationSetTlsPolicy.OPTIONAL)`
+   * only if you must reach receivers that don't offer STARTTLS.
+   *
+   * @see https://docs.aws.amazon.com/ses/latest/dg/configuration-sets-tls.html
+   */
+  tlsPolicy: ConfigurationSetTlsPolicy.REQUIRE,
+  /**
+   * Publish reputation metrics (bounce and complaint rate) for this
+   * configuration set to CloudWatch, so sending health is observable per stream
+   * rather than only at the account level (Well-Architected Operational
+   * Excellence). CloudFormation defaults this off.
+   *
+   * @see https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-using-event-publishing.html
+   */
+  reputationMetrics: true,
+};

--- a/packages/ses/src/email-identity-builder.ts
+++ b/packages/ses/src/email-identity-builder.ts
@@ -6,6 +6,7 @@ import {
   type EasyDkimSigningKeyLength,
   EmailIdentity,
   type EmailIdentityProps,
+  type IConfigurationSet,
   Identity,
 } from "aws-cdk-lib/aws-ses";
 import { type IConstruct } from "constructs";
@@ -22,12 +23,16 @@ import { DEFAULT_MAIL_FROM_BEHAVIOR_ON_MX_FAILURE } from "./defaults.js";
 import { type PublishDkimSpec, publishDkimRecords } from "./publish-dkim.js";
 
 /**
- * Configuration for the SES email-identity builder. The `identity` and
- * `dkimIdentity` props are owned by the builder's fluent methods
- * ({@link IEmailIdentityBuilder.domain | `.domain()`} etc.); every other
- * {@link EmailIdentityProps} field passes through unchanged.
+ * Configuration for the SES email-identity builder. The `identity`,
+ * `dkimIdentity`, and `configurationSet` props are owned by the builder's fluent
+ * methods ({@link IEmailIdentityBuilder.domain | `.domain()`},
+ * {@link IEmailIdentityBuilder.configurationSet | `.configurationSet()`}, etc.);
+ * every other {@link EmailIdentityProps} field passes through unchanged.
  */
-export type EmailIdentityBuilderProps = Omit<EmailIdentityProps, "identity" | "dkimIdentity">;
+export type EmailIdentityBuilderProps = Omit<
+  EmailIdentityProps,
+  "identity" | "dkimIdentity" | "configurationSet"
+>;
 
 /** The build output of an {@link IEmailIdentityBuilder}. */
 export interface EmailIdentityBuilderResult {
@@ -77,6 +82,7 @@ class EmailIdentityBuilder implements Lifecycle<EmailIdentityBuilderResult> {
   /** Set when BYODKIM is selected; `undefined` means Easy DKIM. */
   #byoDkim?: { readonly selector: string; readonly publicKey?: string };
   #publishZone?: Resolvable<IHostedZone>;
+  #configurationSet?: Resolvable<IConfigurationSet>;
 
   /** Verify a whole domain (or subdomain). Publish DKIM with `.publishDkim()`. */
   domain(domain: string): this {
@@ -125,12 +131,25 @@ class EmailIdentityBuilder implements Lifecycle<EmailIdentityBuilderResult> {
     return this;
   }
 
+  /**
+   * Associate the identity with an SES configuration set, so every message sent
+   * from this identity is tracked and controlled by that set (TLS, reputation
+   * metrics, event routing). Accepts a {@link Resolvable}, so a sibling
+   * configuration set built by {@link createConfigurationSetBuilder} can be wired
+   * in with `ref()`.
+   */
+  configurationSet(configurationSet: Resolvable<IConfigurationSet>): this {
+    this.#configurationSet = configurationSet;
+    return this;
+  }
+
   /** @internal — see ADR-0005. */
   [COPY_STATE](target: EmailIdentityBuilder): void {
     target.#source = this.#source;
     target.#dkim = this.#dkim;
     target.#byoDkim = this.#byoDkim;
     target.#publishZone = this.#publishZone;
+    target.#configurationSet = this.#configurationSet;
   }
 
   build(
@@ -162,11 +181,15 @@ class EmailIdentityBuilder implements Lifecycle<EmailIdentityBuilderResult> {
       this.props.mailFromBehaviorOnMxFailure === undefined
         ? { mailFromBehaviorOnMxFailure: DEFAULT_MAIL_FROM_BEHAVIOR_ON_MX_FAILURE }
         : {};
+    const configurationSet = this.#configurationSet
+      ? resolve(this.#configurationSet, context)
+      : undefined;
     const props: EmailIdentityProps = {
       ...mailFromDefault,
       ...this.props,
       identity,
       dkimIdentity: this.#dkim,
+      ...(configurationSet && { configurationSet }),
     };
     const emailIdentity = new EmailIdentity(scope, id, props);
 

--- a/packages/ses/src/event-destinations/cloudwatch-destination.ts
+++ b/packages/ses/src/event-destinations/cloudwatch-destination.ts
@@ -1,0 +1,17 @@
+import { type CloudWatchDimension, EventDestination } from "aws-cdk-lib/aws-ses";
+
+/**
+ * Publishes configuration-set send events to CloudWatch as metric dimensions,
+ * so bounce/complaint/delivery counts can be segmented (e.g. by message tag or
+ * source IP) and alarmed on. Dimensions are static configuration, so no `ref()`
+ * is involved.
+ *
+ * Pass to {@link IConfigurationSetBuilder.addEventDestination} together with the
+ * {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.EmailSendingEvent.html | EmailSendingEvent}s
+ * to publish.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/event-publishing-add-event-destination-cloudwatch.html
+ */
+export function cloudWatchDestination(dimensions: CloudWatchDimension[]): EventDestination {
+  return EventDestination.cloudWatchDimensions(dimensions);
+}

--- a/packages/ses/src/event-destinations/event-bus-destination.ts
+++ b/packages/ses/src/event-destinations/event-bus-destination.ts
@@ -1,0 +1,20 @@
+import { type IEventBus } from "aws-cdk-lib/aws-events";
+import { EventDestination } from "aws-cdk-lib/aws-ses";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Publishes configuration-set send events to an EventBridge event bus. The bus
+ * accepts a {@link Resolvable}, so it can wire to a sibling component via
+ * `ref()`. Use EventBridge when several independent consumers need to filter and
+ * react to send events with their own rules.
+ *
+ * Pass to {@link IConfigurationSetBuilder.addEventDestination} together with the
+ * {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.EmailSendingEvent.html | EmailSendingEvent}s
+ * to publish.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/event-publishing-add-event-destination-eventbridge.html
+ */
+export function eventBusDestination(bus: Resolvable<IEventBus>): Resolvable<EventDestination> {
+  const build = (resolved: IEventBus): EventDestination => EventDestination.eventBus(resolved);
+  return isRef(bus) ? bus.map(build) : build(bus);
+}

--- a/packages/ses/src/event-destinations/index.ts
+++ b/packages/ses/src/event-destinations/index.ts
@@ -1,0 +1,3 @@
+export { snsDestination } from "./sns-destination.js";
+export { eventBusDestination } from "./event-bus-destination.js";
+export { cloudWatchDestination } from "./cloudwatch-destination.js";

--- a/packages/ses/src/event-destinations/sns-destination.ts
+++ b/packages/ses/src/event-destinations/sns-destination.ts
@@ -1,0 +1,19 @@
+import { EventDestination } from "aws-cdk-lib/aws-ses";
+import { type ITopic } from "aws-cdk-lib/aws-sns";
+import { isRef, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Publishes configuration-set send events to an SNS topic. The topic accepts a
+ * {@link Resolvable}, so it can wire to a sibling component via `ref()` — e.g. a
+ * topic feeding a bounce/complaint suppression workflow.
+ *
+ * Pass to {@link IConfigurationSetBuilder.addEventDestination} together with the
+ * {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ses.EmailSendingEvent.html | EmailSendingEvent}s
+ * to publish.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/event-publishing-add-event-destination-sns.html
+ */
+export function snsDestination(topic: Resolvable<ITopic>): Resolvable<EventDestination> {
+  const build = (resolved: ITopic): EventDestination => EventDestination.snsTopic(resolved);
+  return isRef(topic) ? topic.map(build) : build(topic);
+}

--- a/packages/ses/src/grants.ts
+++ b/packages/ses/src/grants.ts
@@ -1,0 +1,54 @@
+import { Grant, type IGrantable } from "aws-cdk-lib/aws-iam";
+import { type IEmailIdentity } from "aws-cdk-lib/aws-ses";
+import { type Grant as DeferredGrant, grantVia, type Resolvable } from "@composurecdk/core";
+
+/**
+ * The IAM actions CDK's `EmailIdentity.grantSendEmail` grants. `sendFrom` cannot
+ * delegate to that method (it needs a `ses:FromAddress` condition the native
+ * grant does not accept), so it reproduces the action set here. This list must
+ * stay in lock-step with `grantSendEmail` — a drift-guard test asserts `send`
+ * and `sendFrom` grant identical actions.
+ */
+const SEND_ACTIONS = ["ses:SendEmail", "ses:SendRawEmail"];
+
+/**
+ * Consumer-side grant helpers for an SES email identity. Pass one to a grantee
+ * builder's `grant(...)` — e.g.
+ * `sender.grant(identityGrants.send(ref("identity", (r) => r.emailIdentity)))`.
+ *
+ * Sending is authorised on the **identity** resource, not the configuration set
+ * (which has no ARN). See ADR-0013.
+ */
+export const identityGrants = {
+  /**
+   * Grant permission to send email as this identity (`ses:SendEmail` +
+   * `ses:SendRawEmail`), scoped to the identity's ARN. Delegates to the
+   * construct's native `grantSendEmail`.
+   */
+  send: (identity: Resolvable<IEmailIdentity>): DeferredGrant<IGrantable> =>
+    grantVia(identity, (resolved, grantee: IGrantable) => {
+      resolved.grantSendEmail(grantee);
+    }),
+
+  /**
+   * Grant sending scoped to specific `From` addresses via a `ses:FromAddress`
+   * condition (StringLike, so wildcards like `alerts+*@example.com` work) — the
+   * least-privilege posture for a role that should only ever send from known
+   * addresses (Well-Architected Security Pillar). A leaked credential then can't
+   * send as arbitrary addresses on the identity.
+   *
+   * @see https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-policy-examples.html
+   */
+  sendFrom: (
+    identity: Resolvable<IEmailIdentity>,
+    fromAddresses: string[],
+  ): DeferredGrant<IGrantable> =>
+    grantVia(identity, (resolved, grantee: IGrantable) => {
+      Grant.addToPrincipal({
+        grantee,
+        actions: SEND_ACTIONS,
+        resourceArns: [resolved.emailIdentityArn],
+        conditions: { StringLike: { "ses:FromAddress": fromAddresses } },
+      });
+    }),
+};

--- a/packages/ses/src/index.ts
+++ b/packages/ses/src/index.ts
@@ -35,3 +35,28 @@ export {
 } from "./actions/index.js";
 export { DEFAULT_RECEIPT_RULE, DEFAULT_MAIL_FROM_BEHAVIOR_ON_MX_FAILURE } from "./defaults.js";
 export { SES_RECEIVING_REGIONS, RECEIVING_REGION_WARNING } from "./region-support.js";
+
+// Sending-side builders.
+export {
+  createConfigurationSetBuilder,
+  type ConfigurationSetBuilderProps,
+  type ConfigurationSetBuilderResult,
+  type EventDestinationOptions,
+  type IConfigurationSetBuilder,
+} from "./configuration-set-builder.js";
+export { CONFIGURATION_SET_DEFAULTS } from "./configuration-set-defaults.js";
+export {
+  snsDestination,
+  eventBusDestination,
+  cloudWatchDestination,
+} from "./event-destinations/index.js";
+export { identityGrants } from "./grants.js";
+export {
+  createReputationAlarmBuilder,
+  type ReputationAlarmBuilderProps,
+  type ReputationAlarmBuilderResult,
+  type IReputationAlarmBuilder,
+} from "./reputation-alarm-builder.js";
+export { type ReputationAlarmConfig } from "./reputation-alarm-config.js";
+export { REPUTATION_ALARM_DEFAULTS } from "./reputation-alarm-defaults.js";
+export { createReputationAlarms, resolveReputationAlarmDefinitions } from "./reputation-alarms.js";

--- a/packages/ses/src/reputation-alarm-builder.ts
+++ b/packages/ses/src/reputation-alarm-builder.ts
@@ -1,0 +1,94 @@
+import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
+import { type IConstruct } from "constructs";
+import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
+import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
+import type { ReputationAlarmConfig } from "./reputation-alarm-config.js";
+import { createReputationAlarms } from "./reputation-alarms.js";
+
+/**
+ * Configuration for the account-level SES reputation alarm builder.
+ */
+export interface ReputationAlarmBuilderProps {
+  /**
+   * Configuration for the AWS-recommended reputation alarms.
+   *
+   * By default the builder creates both recommended alarms (bounce rate and
+   * complaint rate) with AWS-recommended thresholds. Individual alarms can be
+   * customized or disabled. Set to `false` to disable all alarms.
+   *
+   * No alarm actions are configured by default since notification methods are
+   * user-specific. Access alarms from the build result or use an `afterBuild`
+   * hook to apply actions.
+   *
+   * @see https://docs.aws.amazon.com/ses/latest/dg/reputationdashboard-cloudwatch-alarm.html
+   */
+  recommendedAlarms?: ReputationAlarmConfig | false;
+}
+
+/** The build output of an {@link IReputationAlarmBuilder}. */
+export interface ReputationAlarmBuilderResult {
+  /**
+   * The reputation alarms created, keyed by alarm name (`bounceRate`,
+   * `complaintRate`, plus any custom alarm keys). Always present — `{}` when
+   * alarms were disabled.
+   */
+  alarms: Record<string, Alarm>;
+}
+
+/**
+ * A fluent builder for the account-level SES reputation alarms — the sending
+ * safety net. `Reputation.BounceRate` and `Reputation.ComplaintRate` are
+ * account/Region-scoped metrics, so this builder creates alarms in whatever
+ * scope it is built into, independent of any configuration set or identity, and
+ * only **once per account/Region** is needed.
+ *
+ * @example
+ * ```ts
+ * const { alarms } = createReputationAlarmBuilder().build(stack, "SesReputation");
+ * ```
+ */
+export type IReputationAlarmBuilder = ITaggedBuilder<
+  ReputationAlarmBuilderProps,
+  ReputationAlarmBuilder
+>;
+
+class ReputationAlarmBuilder implements Lifecycle<ReputationAlarmBuilderResult> {
+  props: Partial<ReputationAlarmBuilderProps> = {};
+  readonly #customAlarms: AlarmDefinitionBuilder<void>[] = [];
+
+  /**
+   * Add a custom alarm alongside the recommended ones. The metric factory
+   * receives no target (SES reputation metrics are account-level), so build the
+   * metric directly — e.g. a `Reject`-count or `RenderingFailure` alarm.
+   */
+  addAlarm(
+    key: string,
+    configure: (alarm: AlarmDefinitionBuilder<void>) => AlarmDefinitionBuilder<void>,
+  ): this {
+    this.#customAlarms.push(configure(new AlarmDefinitionBuilder<void>(key)));
+    return this;
+  }
+
+  /** @internal — see ADR-0005. */
+  [COPY_STATE](target: ReputationAlarmBuilder): void {
+    target.#customAlarms.push(...this.#customAlarms);
+  }
+
+  build(scope: IConstruct, id: string): ReputationAlarmBuilderResult {
+    const alarms = createReputationAlarms(
+      scope,
+      id,
+      this.props.recommendedAlarms,
+      this.#customAlarms,
+    );
+    return { alarms };
+  }
+}
+
+/**
+ * Creates a fluent builder for the account-level SES reputation alarms.
+ */
+export function createReputationAlarmBuilder(): IReputationAlarmBuilder {
+  return taggedBuilder<ReputationAlarmBuilderProps, ReputationAlarmBuilder>(ReputationAlarmBuilder);
+}

--- a/packages/ses/src/reputation-alarm-builder.ts
+++ b/packages/ses/src/reputation-alarm-builder.ts
@@ -15,7 +15,9 @@ export interface ReputationAlarmBuilderProps {
    *
    * By default the builder creates both recommended alarms (bounce rate and
    * complaint rate) with AWS-recommended thresholds. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
+   * customized or disabled. Set to `false` to disable the recommended alarms;
+   * custom alarms added via {@link IReputationAlarmBuilder.addAlarm} are an
+   * explicit opt-in and are still created.
    *
    * No alarm actions are configured by default since notification methods are
    * user-specific. Access alarms from the build result or use an `afterBuild`
@@ -30,8 +32,8 @@ export interface ReputationAlarmBuilderProps {
 export interface ReputationAlarmBuilderResult {
   /**
    * The reputation alarms created, keyed by alarm name (`bounceRate`,
-   * `complaintRate`, plus any custom alarm keys). Always present — `{}` when
-   * alarms were disabled.
+   * `complaintRate`, plus any custom alarm keys). Always present — `{}` when no
+   * alarms were created (recommended disabled and no custom alarms added).
    */
   alarms: Record<string, Alarm>;
 }

--- a/packages/ses/src/reputation-alarm-config.ts
+++ b/packages/ses/src/reputation-alarm-config.ts
@@ -1,0 +1,45 @@
+import type { AlarmConfig } from "@composurecdk/cloudwatch";
+
+/**
+ * Controls which recommended account-level SES reputation alarms are created by
+ * {@link createReputationAlarmBuilder}. Both alarms are enabled by default with
+ * the AWS-recommended thresholds. Set an individual alarm to `false` to disable
+ * it, or provide an {@link AlarmConfig} to tune its threshold.
+ *
+ * `Reputation.BounceRate` and `Reputation.ComplaintRate` are **account-level**,
+ * dimensionless metrics, so these alarms monitor the whole account's sending
+ * reputation in the Region — not any single configuration set or identity.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/reputationdashboard-cloudwatch-alarm.html
+ */
+export interface ReputationAlarmConfig {
+  /**
+   * Master switch: set to `false` to disable both recommended alarms.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Alarm when the account's hard-bounce rate reaches the threshold. SES places
+   * an account under review at 5% and may pause sending at 10%, so the default
+   * fires at the review boundary to leave headroom.
+   *
+   * Metric: `AWS/SES Reputation.BounceRate`, statistic Average, period 1 hour.
+   * Default threshold: `>= 0.05` (5%).
+   *
+   * @see https://docs.aws.amazon.com/ses/latest/dg/reputationdashboardmessages.html
+   */
+  bounceRate?: AlarmConfig | false;
+
+  /**
+   * Alarm when the account's complaint rate reaches the threshold. SES places an
+   * account under review at 0.1% and may pause sending at 0.5%, so the default
+   * fires at the review boundary.
+   *
+   * Metric: `AWS/SES Reputation.ComplaintRate`, statistic Average, period 1 hour.
+   * Default threshold: `>= 0.001` (0.1%).
+   *
+   * @see https://docs.aws.amazon.com/ses/latest/dg/reputationdashboardmessages.html
+   */
+  complaintRate?: AlarmConfig | false;
+}

--- a/packages/ses/src/reputation-alarm-config.ts
+++ b/packages/ses/src/reputation-alarm-config.ts
@@ -14,7 +14,9 @@ import type { AlarmConfig } from "@composurecdk/cloudwatch";
  */
 export interface ReputationAlarmConfig {
   /**
-   * Master switch: set to `false` to disable both recommended alarms.
+   * Master switch for the recommended alarms: set to `false` to disable both
+   * the bounce-rate and complaint-rate alarms. Custom alarms added via
+   * `addAlarm()` are an explicit opt-in and are unaffected by this switch.
    * @default true
    */
   enabled?: boolean;

--- a/packages/ses/src/reputation-alarm-defaults.ts
+++ b/packages/ses/src/reputation-alarm-defaults.ts
@@ -1,0 +1,37 @@
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import type { AlarmConfigDefaults } from "@composurecdk/cloudwatch";
+
+interface ReputationAlarmDefaults {
+  enabled: true;
+  bounceRate: AlarmConfigDefaults;
+  complaintRate: AlarmConfigDefaults;
+}
+
+/**
+ * AWS-recommended default alarm configuration for account-level SES reputation.
+ *
+ * `treatMissingData` is `IGNORE` ("maintain the alarm state") on AWS's explicit
+ * recommendation — reputation metrics only appear once the first bounce/complaint
+ * occurs, so missing data must not be read as a breach or reset the state.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/reputationdashboard-cloudwatch-alarm.html
+ */
+export const REPUTATION_ALARM_DEFAULTS: ReputationAlarmDefaults = {
+  enabled: true,
+
+  /** SES reviews the account at a 5% bounce rate; alarm at that boundary. */
+  bounceRate: {
+    threshold: 0.05,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.IGNORE,
+  },
+
+  /** SES reviews the account at a 0.1% complaint rate; alarm at that boundary. */
+  complaintRate: {
+    threshold: 0.001,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: TreatMissingData.IGNORE,
+  },
+};

--- a/packages/ses/src/reputation-alarms.ts
+++ b/packages/ses/src/reputation-alarms.ts
@@ -77,9 +77,13 @@ export function resolveReputationAlarmDefinitions(
  * Creates AWS-recommended account-level SES reputation alarms, merging the
  * recommended definitions with any custom alarm builders.
  *
+ * Disabling the recommended alarms (`config === false` or `config.enabled ===
+ * false`) suppresses only the recommended definitions — custom alarms added via
+ * `addAlarm()` are always created, since they are an explicit, separate opt-in.
+ *
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - Recommended-alarm configuration, or `false` to disable the recommended alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
@@ -91,12 +95,8 @@ export function createReputationAlarms(
   config: ReputationAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<void>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? REPUTATION_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveReputationAlarmDefinitions(config);
+  const recommended =
+    config === false || config?.enabled === false ? [] : resolveReputationAlarmDefinitions(config);
   const custom = customAlarms.map((b) => b.resolve(undefined));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/ses/src/reputation-alarms.ts
+++ b/packages/ses/src/reputation-alarms.ts
@@ -1,0 +1,103 @@
+import { Duration } from "aws-cdk-lib";
+import { type Alarm, ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import type { IConstruct } from "constructs";
+import type { AlarmDefinition } from "@composurecdk/cloudwatch";
+import { AlarmDefinitionBuilder, createAlarms, resolveAlarmConfig } from "@composurecdk/cloudwatch";
+import type { ReputationAlarmConfig } from "./reputation-alarm-config.js";
+import { REPUTATION_ALARM_DEFAULTS } from "./reputation-alarm-defaults.js";
+
+/** SES namespace for account-level reputation metrics. */
+const NAMESPACE = "AWS/SES";
+/** AWS recommends a 1-hour period for the reputation-rate alarms. */
+const METRIC_PERIOD = Duration.hours(1);
+
+/** Builds an account-level (dimensionless) `AWS/SES` reputation-rate metric. */
+function reputationMetric(metricName: string): Metric {
+  return new Metric({
+    namespace: NAMESPACE,
+    metricName,
+    statistic: "Average",
+    period: METRIC_PERIOD,
+  });
+}
+
+function asPercent(rate: number): string {
+  return `${String(rate * 100)}%`;
+}
+
+/**
+ * Resolves the recommended reputation alarm configuration into fully-resolved
+ * {@link AlarmDefinition}s. Returns `[]` when alarms are disabled.
+ */
+export function resolveReputationAlarmDefinitions(
+  config: ReputationAlarmConfig | undefined,
+): AlarmDefinition[] {
+  if (config?.enabled === false) return [];
+
+  const definitions: AlarmDefinition[] = [];
+
+  if (config?.bounceRate !== false) {
+    const cfg = resolveAlarmConfig(config?.bounceRate, REPUTATION_ALARM_DEFAULTS.bounceRate);
+    definitions.push({
+      key: "bounceRate",
+      alarmName: cfg.alarmName,
+      metric: reputationMetric("Reputation.BounceRate"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `Account hard-bounce rate has reached ${asPercent(cfg.threshold)}. SES places an ` +
+        `account under review at 5% and may pause sending at 10%.`,
+    });
+  }
+
+  if (config?.complaintRate !== false) {
+    const cfg = resolveAlarmConfig(config?.complaintRate, REPUTATION_ALARM_DEFAULTS.complaintRate);
+    definitions.push({
+      key: "complaintRate",
+      alarmName: cfg.alarmName,
+      metric: reputationMetric("Reputation.ComplaintRate"),
+      threshold: cfg.threshold,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      evaluationPeriods: cfg.evaluationPeriods,
+      datapointsToAlarm: cfg.datapointsToAlarm,
+      treatMissingData: cfg.treatMissingData,
+      description:
+        `Account complaint rate has reached ${asPercent(cfg.threshold)}. SES places an ` +
+        `account under review at 0.1% and may pause sending at 0.5%.`,
+    });
+  }
+
+  return definitions;
+}
+
+/**
+ * Creates AWS-recommended account-level SES reputation alarms, merging the
+ * recommended definitions with any custom alarm builders.
+ *
+ * @param scope - CDK construct scope for creating alarm constructs.
+ * @param id - Base identifier for alarm construct ids.
+ * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param customAlarms - Custom alarm builders added via `addAlarm()`.
+ * @returns A record mapping alarm keys to their created Alarm constructs.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/reputationdashboard-cloudwatch-alarm.html
+ */
+export function createReputationAlarms(
+  scope: IConstruct,
+  id: string,
+  config: ReputationAlarmConfig | false | undefined,
+  customAlarms: AlarmDefinitionBuilder<void>[] = [],
+): Record<string, Alarm> {
+  if (config === false) return {};
+
+  const enabled = config?.enabled ?? REPUTATION_ALARM_DEFAULTS.enabled;
+  if (!enabled) return {};
+
+  const recommended = resolveReputationAlarmDefinitions(config);
+  const custom = customAlarms.map((b) => b.resolve(undefined));
+
+  return createAlarms(scope, id, [...recommended, ...custom]);
+}

--- a/packages/ses/test/configuration-set-builder.test.ts
+++ b/packages/ses/test/configuration-set-builder.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { EventBus, type IEventBus } from "aws-cdk-lib/aws-events";
+import { ConfigurationSetTlsPolicy, EmailSendingEvent } from "aws-cdk-lib/aws-ses";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { ref } from "@composurecdk/core";
+import { createConfigurationSetBuilder } from "../src/configuration-set-builder.js";
+import { eventBusDestination, snsDestination } from "../src/event-destinations/index.js";
+
+function newStack(): Stack {
+  return new Stack(new App(), "TestStack", {
+    env: { account: "111111111111", region: "us-east-1" },
+  });
+}
+
+describe("ConfigurationSetBuilder", () => {
+  it("requires TLS and enables reputation metrics by default", () => {
+    const stack = newStack();
+    createConfigurationSetBuilder().build(stack, "MailConfig");
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::ConfigurationSet", {
+      DeliveryOptions: { TlsPolicy: "REQUIRE" },
+      ReputationOptions: { ReputationMetricsEnabled: true },
+    });
+  });
+
+  it("lets the caller override the TLS policy", () => {
+    const stack = newStack();
+    createConfigurationSetBuilder()
+      .tlsPolicy(ConfigurationSetTlsPolicy.OPTIONAL)
+      .build(stack, "MailConfig");
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::ConfigurationSet", {
+      DeliveryOptions: { TlsPolicy: "OPTIONAL" },
+    });
+  });
+
+  it("passes through a configuration set name", () => {
+    const stack = newStack();
+    createConfigurationSetBuilder()
+      .configurationSetName("transactional")
+      .build(stack, "MailConfig");
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::ConfigurationSet", {
+      Name: "transactional",
+    });
+  });
+
+  it("wires an SNS event destination filtered to bounce/complaint events", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Feedback");
+    const { eventDestinations } = createConfigurationSetBuilder()
+      .addEventDestination("feedback", {
+        destination: snsDestination(topic),
+        events: [EmailSendingEvent.BOUNCE, EmailSendingEvent.COMPLAINT],
+      })
+      .build(stack, "MailConfig");
+
+    expect(eventDestinations.feedback).toBeDefined();
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::ConfigurationSetEventDestination", {
+      EventDestination: Match.objectLike({
+        Enabled: true,
+        MatchingEventTypes: ["bounce", "complaint"],
+        SnsDestination: Match.anyValue(),
+      }),
+    });
+  });
+
+  it("resolves a Resolvable destination from the build context", () => {
+    const stack = newStack();
+    // SES event destinations can only target the account's default event bus.
+    const bus = EventBus.fromEventBusName(stack, "DefaultBus", "default");
+    createConfigurationSetBuilder()
+      .addEventDestination("bus", {
+        destination: eventBusDestination(
+          ref<{ bus: IEventBus }, IEventBus>("busComp", (r) => r.bus),
+        ),
+      })
+      .build(stack, "MailConfig", { busComp: { bus } });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::ConfigurationSetEventDestination", {
+      EventDestination: Match.objectLike({ EventBridgeDestination: Match.anyValue() }),
+    });
+  });
+
+  it("passes through a disabled event destination", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Feedback");
+    createConfigurationSetBuilder()
+      .addEventDestination("feedback", { destination: snsDestination(topic), enabled: false })
+      .build(stack, "MailConfig");
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::ConfigurationSetEventDestination", {
+      EventDestination: Match.objectLike({ Enabled: false }),
+    });
+  });
+
+  it("rejects a duplicate event-destination key", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Feedback");
+    expect(() =>
+      createConfigurationSetBuilder()
+        .addEventDestination("feedback", { destination: snsDestination(topic) })
+        .addEventDestination("feedback", { destination: snsDestination(topic) })
+        .build(stack, "MailConfig"),
+    ).toThrow(/duplicate key "feedback"/);
+  });
+
+  it("copies accumulated event destinations on .copy()", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Feedback");
+    const base = createConfigurationSetBuilder().addEventDestination("feedback", {
+      destination: snsDestination(topic),
+    });
+    base.copy().build(stack, "MailConfig");
+    Template.fromStack(stack).resourceCountIs("AWS::SES::ConfigurationSetEventDestination", 1);
+  });
+});

--- a/packages/ses/test/email-identity-builder.test.ts
+++ b/packages/ses/test/email-identity-builder.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import { App, SecretValue, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { PublicHostedZone } from "aws-cdk-lib/aws-route53";
-import { EasyDkimSigningKeyLength, MailFromBehaviorOnMxFailure } from "aws-cdk-lib/aws-ses";
+import {
+  ConfigurationSet,
+  EasyDkimSigningKeyLength,
+  MailFromBehaviorOnMxFailure,
+} from "aws-cdk-lib/aws-ses";
+import { ref } from "@composurecdk/core";
 import { createEmailIdentityBuilder } from "../src/email-identity-builder.js";
 
 function newStack(): Stack {
@@ -113,6 +118,23 @@ describe("EmailIdentityBuilder", () => {
       .build(stack, "MailIdentity");
     Template.fromStack(stack).hasResourceProperties("AWS::SES::EmailIdentity", {
       MailFromAttributes: Match.objectLike({ BehaviorOnMxFailure: "USE_DEFAULT_VALUE" }),
+    });
+  });
+
+  it("associates a Resolvable configuration set from the build context", () => {
+    const stack = newStack();
+    const configurationSet = new ConfigurationSet(stack, "MailConfig");
+    createEmailIdentityBuilder()
+      .domain("example.com")
+      .configurationSet(
+        ref<{ configurationSet: ConfigurationSet }, ConfigurationSet>(
+          "config",
+          (r) => r.configurationSet,
+        ),
+      )
+      .build(stack, "MailIdentity", { config: { configurationSet } });
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::EmailIdentity", {
+      ConfigurationSetAttributes: Match.objectLike({ ConfigurationSetName: Match.anyValue() }),
     });
   });
 

--- a/packages/ses/test/event-destinations.test.ts
+++ b/packages/ses/test/event-destinations.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { EventBus } from "aws-cdk-lib/aws-events";
+import { CloudWatchDimensionSource } from "aws-cdk-lib/aws-ses";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { isRef, ref } from "@composurecdk/core";
+import {
+  cloudWatchDestination,
+  eventBusDestination,
+  snsDestination,
+} from "../src/event-destinations/index.js";
+
+function newStack(): Stack {
+  return new Stack(new App(), "S", { env: { account: "111111111111", region: "us-east-1" } });
+}
+
+describe("event destination helpers", () => {
+  it("snsDestination returns a concrete destination for a concrete topic and a ref for a ref", () => {
+    const stack = newStack();
+    const topic = new Topic(stack, "Topic");
+    expect(isRef(snsDestination(topic))).toBe(false);
+    expect(isRef(snsDestination(ref("topic")))).toBe(true);
+  });
+
+  it("eventBusDestination returns a concrete destination for a concrete bus and a ref for a ref", () => {
+    const stack = newStack();
+    const bus = EventBus.fromEventBusName(stack, "DefaultBus", "default");
+    expect(isRef(eventBusDestination(bus))).toBe(false);
+    expect(isRef(eventBusDestination(ref("bus")))).toBe(true);
+  });
+
+  it("cloudWatchDestination builds a CloudWatch dimensions destination", () => {
+    const destination = cloudWatchDestination([
+      { name: "campaign", source: CloudWatchDimensionSource.MESSAGE_TAG, defaultValue: "default" },
+    ]);
+    expect(destination.dimensions).toHaveLength(1);
+  });
+});

--- a/packages/ses/test/grants.test.ts
+++ b/packages/ses/test/grants.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { EmailIdentity, Identity } from "aws-cdk-lib/aws-ses";
+import { ref } from "@composurecdk/core";
+import { identityGrants } from "../src/grants.js";
+
+function setup() {
+  const app = new App();
+  const stack = new Stack(app, "S", { env: { account: "111111111111", region: "us-east-1" } });
+  const identity = new EmailIdentity(stack, "Identity", {
+    identity: Identity.domain("example.com"),
+  });
+  const role = new Role(stack, "Role", { assumedBy: new ServicePrincipal("lambda.amazonaws.com") });
+  return { stack, identity, role };
+}
+
+const policyJson = (stack: Stack) => JSON.stringify(Template.fromStack(stack).toJSON());
+
+/** Extracts the actions of the IAM statement that grants SES sending. */
+function sesSendActions(stack: Stack): string[] {
+  const policies = Template.fromStack(stack).findResources("AWS::IAM::Policy") as Record<
+    string,
+    { Properties: { PolicyDocument: { Statement: { Action: string | string[] }[] } } }
+  >;
+  for (const policy of Object.values(policies)) {
+    for (const statement of policy.Properties.PolicyDocument.Statement) {
+      const actions = Array.isArray(statement.Action) ? statement.Action : [statement.Action];
+      if (actions.includes("ses:SendEmail")) return actions;
+    }
+  }
+  throw new Error("no SES send statement found");
+}
+
+describe("identityGrants", () => {
+  it("send grants ses:SendEmail and ses:SendRawEmail on the identity", () => {
+    const { stack, identity, role } = setup();
+
+    identityGrants.send(identity).applyTo(role, {});
+
+    const json = policyJson(stack);
+    expect(json).toContain("ses:SendEmail");
+    expect(json).toContain("ses:SendRawEmail");
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
+  });
+
+  it("resolves a Resolvable identity from the build context before granting", () => {
+    const { stack, identity, role } = setup();
+
+    identityGrants
+      .send(ref<{ identity: EmailIdentity }, EmailIdentity>("mail", (r) => r.identity))
+      .applyTo(role, { mail: { identity } });
+
+    expect(policyJson(stack)).toContain("ses:SendEmail");
+  });
+
+  it("sendFrom scopes the grant with a ses:FromAddress condition", () => {
+    const { stack, identity, role } = setup();
+
+    identityGrants.sendFrom(identity, ["alerts@example.com"]).applyTo(role, {});
+
+    Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: ["ses:SendEmail", "ses:SendRawEmail"],
+            Condition: { StringLike: { "ses:FromAddress": ["alerts@example.com"] } },
+          }),
+        ]),
+      },
+    });
+  });
+
+  it("send (native grantSendEmail) and sendFrom grant identical actions", () => {
+    // Drift guard: sendFrom hand-rolls the action set (it needs a condition the
+    // native grant can't express), so pin it to what grantSendEmail actually
+    // grants — if CDK changes grantSendEmail, this fails rather than silently
+    // diverging.
+    const sendCase = setup();
+    identityGrants.send(sendCase.identity).applyTo(sendCase.role, {});
+
+    const sendFromCase = setup();
+    identityGrants
+      .sendFrom(sendFromCase.identity, ["alerts@example.com"])
+      .applyTo(sendFromCase.role, {});
+
+    expect(sesSendActions(sendCase.stack)).toEqual(sesSendActions(sendFromCase.stack));
+    expect(sesSendActions(sendCase.stack)).toEqual(["ses:SendEmail", "ses:SendRawEmail"]);
+  });
+});

--- a/packages/ses/test/reputation-alarm-builder.test.ts
+++ b/packages/ses/test/reputation-alarm-builder.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { createReputationAlarmBuilder } from "../src/reputation-alarm-builder.js";
+import { resolveReputationAlarmDefinitions } from "../src/reputation-alarms.js";
+
+function newStack(): Stack {
+  return new Stack(new App(), "TestStack", {
+    env: { account: "111111111111", region: "us-east-1" },
+  });
+}
+
+describe("ReputationAlarmBuilder", () => {
+  it("creates bounce and complaint rate alarms with AWS-recommended thresholds", () => {
+    const stack = newStack();
+    const { alarms } = createReputationAlarmBuilder().build(stack, "SesReputation");
+
+    expect(Object.keys(alarms).sort()).toEqual(["bounceRate", "complaintRate"]);
+    const t = Template.fromStack(stack);
+    t.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    t.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "Reputation.BounceRate",
+      Namespace: "AWS/SES",
+      Threshold: 0.05,
+      ComparisonOperator: "GreaterThanOrEqualToThreshold",
+      TreatMissingData: "ignore",
+      Statistic: "Average",
+      Period: 3600,
+    });
+    t.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "Reputation.ComplaintRate",
+      Threshold: 0.001,
+    });
+  });
+
+  it("emits the reputation metrics without dimensions (account-scoped)", () => {
+    const stack = newStack();
+    createReputationAlarmBuilder().build(stack, "SesReputation");
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "Reputation.BounceRate",
+      Dimensions: Match.absent(),
+    });
+  });
+
+  it("disables all alarms when recommendedAlarms is false", () => {
+    const stack = newStack();
+    const { alarms } = createReputationAlarmBuilder()
+      .recommendedAlarms(false)
+      .build(stack, "SesReputation");
+    expect(alarms).toEqual({});
+    Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
+  it("disables only the bounce-rate alarm", () => {
+    const stack = newStack();
+    const { alarms } = createReputationAlarmBuilder()
+      .recommendedAlarms({ bounceRate: false })
+      .build(stack, "SesReputation");
+    expect(Object.keys(alarms)).toEqual(["complaintRate"]);
+    Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("disables a single alarm and tunes the other's threshold", () => {
+    const stack = newStack();
+    createReputationAlarmBuilder()
+      .recommendedAlarms({ complaintRate: false, bounceRate: { threshold: 0.08 } })
+      .build(stack, "SesReputation");
+    const t = Template.fromStack(stack);
+    t.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    t.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "Reputation.BounceRate",
+      Threshold: 0.08,
+    });
+  });
+
+  it("disables all alarms via the config enabled switch", () => {
+    const stack = newStack();
+    const { alarms } = createReputationAlarmBuilder()
+      .recommendedAlarms({ enabled: false })
+      .build(stack, "SesReputation");
+    expect(alarms).toEqual({});
+    Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
+  it("copies accumulated custom alarms on .copy()", () => {
+    const stack = newStack();
+    const base = createReputationAlarmBuilder().addAlarm("rejects", (a) =>
+      a
+        .metric(
+          () =>
+            new Metric({
+              namespace: "AWS/SES",
+              metricName: "Reject",
+              statistic: "Sum",
+              period: Duration.minutes(5),
+            }),
+        )
+        .threshold(1)
+        .greaterThan()
+        .description("SES rejected a message."),
+    );
+    const { alarms } = base.copy().build(stack, "SesReputation");
+    expect(alarms.rejects).toBeDefined();
+  });
+
+  it("adds a custom alarm alongside the recommended ones", () => {
+    const stack = newStack();
+    const { alarms } = createReputationAlarmBuilder()
+      .addAlarm("rejects", (a) =>
+        a
+          .metric(
+            () =>
+              new Metric({
+                namespace: "AWS/SES",
+                metricName: "Reject",
+                statistic: "Sum",
+                period: Duration.minutes(5),
+              }),
+          )
+          .threshold(1)
+          .greaterThan()
+          .description("SES rejected a message (virus/content)."),
+      )
+      .build(stack, "SesReputation");
+
+    expect(alarms.rejects).toBeDefined();
+    Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 3);
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "Reject",
+    });
+  });
+});
+
+describe("resolveReputationAlarmDefinitions", () => {
+  it("returns no definitions when disabled via the enabled switch", () => {
+    expect(resolveReputationAlarmDefinitions({ enabled: false })).toEqual([]);
+  });
+
+  it("returns both recommended definitions by default", () => {
+    expect(resolveReputationAlarmDefinitions(undefined).map((d) => d.key)).toEqual([
+      "bounceRate",
+      "complaintRate",
+    ]);
+  });
+});

--- a/packages/ses/test/reputation-alarm-builder.test.ts
+++ b/packages/ses/test/reputation-alarm-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import { createReputationAlarmBuilder } from "../src/reputation-alarm-builder.js";
 import { resolveReputationAlarmDefinitions } from "../src/reputation-alarms.js";
 
@@ -9,6 +10,23 @@ function newStack(): Stack {
   return new Stack(new App(), "TestStack", {
     env: { account: "111111111111", region: "us-east-1" },
   });
+}
+
+/** A target-less custom alarm on the SES `Reject` count, for reuse in tests. */
+function rejectAlarm(a: AlarmDefinitionBuilder<void>): AlarmDefinitionBuilder<void> {
+  return a
+    .metric(
+      () =>
+        new Metric({
+          namespace: "AWS/SES",
+          metricName: "Reject",
+          statistic: "Sum",
+          period: Duration.minutes(5),
+        }),
+    )
+    .threshold(1)
+    .greaterThan()
+    .description("SES rejected a message.");
 }
 
 describe("ReputationAlarmBuilder", () => {
@@ -43,13 +61,35 @@ describe("ReputationAlarmBuilder", () => {
     });
   });
 
-  it("disables all alarms when recommendedAlarms is false", () => {
+  it("disables the recommended alarms when recommendedAlarms is false", () => {
     const stack = newStack();
     const { alarms } = createReputationAlarmBuilder()
       .recommendedAlarms(false)
       .build(stack, "SesReputation");
     expect(alarms).toEqual({});
     Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
+  it("keeps custom alarms when the recommended alarms are disabled with false", () => {
+    const stack = newStack();
+    const { alarms } = createReputationAlarmBuilder()
+      .recommendedAlarms(false)
+      .addAlarm("rejects", rejectAlarm)
+      .build(stack, "SesReputation");
+    // recommendedAlarms(false) suppresses only the recommended set — the
+    // explicitly-added custom alarm must survive.
+    expect(Object.keys(alarms)).toEqual(["rejects"]);
+    Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps custom alarms when the recommended alarms are disabled with enabled:false", () => {
+    const stack = newStack();
+    const { alarms } = createReputationAlarmBuilder()
+      .recommendedAlarms({ enabled: false })
+      .addAlarm("rejects", rejectAlarm)
+      .build(stack, "SesReputation");
+    expect(Object.keys(alarms)).toEqual(["rejects"]);
+    Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 1);
   });
 
   it("disables only the bounce-rate alarm", () => {
@@ -85,21 +125,7 @@ describe("ReputationAlarmBuilder", () => {
 
   it("copies accumulated custom alarms on .copy()", () => {
     const stack = newStack();
-    const base = createReputationAlarmBuilder().addAlarm("rejects", (a) =>
-      a
-        .metric(
-          () =>
-            new Metric({
-              namespace: "AWS/SES",
-              metricName: "Reject",
-              statistic: "Sum",
-              period: Duration.minutes(5),
-            }),
-        )
-        .threshold(1)
-        .greaterThan()
-        .description("SES rejected a message."),
-    );
+    const base = createReputationAlarmBuilder().addAlarm("rejects", rejectAlarm);
     const { alarms } = base.copy().build(stack, "SesReputation");
     expect(alarms.rejects).toBeDefined();
   });
@@ -107,21 +133,7 @@ describe("ReputationAlarmBuilder", () => {
   it("adds a custom alarm alongside the recommended ones", () => {
     const stack = newStack();
     const { alarms } = createReputationAlarmBuilder()
-      .addAlarm("rejects", (a) =>
-        a
-          .metric(
-            () =>
-              new Metric({
-                namespace: "AWS/SES",
-                metricName: "Reject",
-                statistic: "Sum",
-                period: Duration.minutes(5),
-              }),
-          )
-          .threshold(1)
-          .greaterThan()
-          .description("SES rejected a message (virus/content)."),
-      )
+      .addAlarm("rejects", rejectAlarm)
       .build(stack, "SesReputation");
 
     expect(alarms.rejects).toBeDefined();


### PR DESCRIPTION
## What & why

Extends `@composurecdk/ses` beyond the receiving path (#279) with the outbound **sending** surface. Design, research, and the key decisions (each compared to two alternatives) are in **#303**.

A production sender needs a configuration set to track its mail, a least-privilege grant to whatever role sends, event routing so bounces/complaints can drive suppression, and an account-level reputation safety net — all raw `aws-cdk-lib` until now. This adds:

- **`createConfigurationSetBuilder()`** — the unit that tracks a stream of outbound mail. Secure defaults: `tlsPolicy: REQUIRE` (encrypt in transit) and `reputationMetrics: true` (per-config-set bounce/complaint metrics), both overridable. `.addEventDestination(key, { destination, events })` routes send events, with `snsDestination` / `eventBusDestination` / `cloudWatchDestination` helpers that accept `Resolvable`s so a destination can `ref()` a sibling topic or bus (mirrors the existing receipt-`actions/` helpers).
- **`identityGrants`** — consumer-side send grants ([ADR-0013](../blob/main/docs/adr/0013-consumer-side-grants.md)). `identityGrants.send(ref)` delegates to the identity's native `grantSendEmail` (`ses:SendEmail` + `ses:SendRawEmail`); `identityGrants.sendFrom(ref, addresses)` scopes the grant with a `ses:FromAddress` condition for least privilege.
- **`createReputationAlarmBuilder()`** — the AWS-recommended account-level alarms: `Reputation.BounceRate` (`>= 0.05`) and `Reputation.ComplaintRate` (`>= 0.001`), `Average`/1 hr, `treatMissingData: IGNORE`, per the [SES reputation-alarm guidance](https://docs.aws.amazon.com/ses/latest/dg/reputationdashboard-cloudwatch-alarm.html). These metrics are **account/Region-scoped and dimensionless**, so this builder is deliberately independent of any configuration set (build it once per account/Region) — that's the main design decision called out in #303.
- **`EmailIdentity` builder** gains a `Resolvable` **`.configurationSet()`** method to associate an identity with a sibling-built configuration set.

Adds `@composurecdk/cloudformation` and `@composurecdk/cloudwatch` as peer dependencies (for `taggedBuilder` and the shared alarm helpers). SES sending is available in all commercial Regions, so no region-gating is needed (unlike receiving).

**Deferred to follow-ups** (noted in #303): dedicated IP pool builder, account-level `VdmAttributes`, SES templates (L1-only), and production-access/quota/suppression-list domain actions (SDK-only, ADR-0016). An example stack under `packages/examples/` will follow.

Refs #303.

## Checklist

- [x] Linked to an issue (#303)
- [x] `npm run verify` passes locally (also enforced by the pre-push hook across all 23 projects)
- [x] Tests added/updated for the change — 79 tests in the package, 100% coverage of the new files, including a drift-guard test that pins `sendFrom`'s hand-rolled action set to `grantSendEmail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBxdtvvDwVrZYBans46a7r)_