### PR TITLE
build(lint): make eslint a cached per-project nx target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,11 @@ Fix any issues before moving on. Use npm run lint:fix and npm run format to auto
 
 Use npx nx to run build/test scripts — this is an nx monorepo.
 
-Lint is an nx target too: `npm run lint` runs `nx run-many -t lint`, which caches per project so unchanged packages fast-succeed. Two things make this correct rather than merely fast:
+Lint is an nx target too: `npm run lint` runs `nx run-many -t lint`, which caches per project so unchanged packages fast-succeed. Each package carries a `"lint": "eslint ."` script, so nx infers a `lint` target the same way it infers `build`/`test`/`typecheck` from package.json scripts — add that line when you create a package. Three things make this correct rather than merely fast:
 
-- **Loose top-level files** (`eslint.config.mjs`, `scripts/**`, `vitest.config.base.ts`) belong to no package, so they are linted by the `workspace-root` project defined in the root [`project.json`](project.json). If you add a source file outside `packages/` and outside those globs, extend that project's `lint` target so it stays covered — the goal is that every file the old `eslint .` linted is still linted.
-- **The custom rules** in `@composurecdk/eslint-plugin` drive every package's lint result, so `targetDefaults.lint` in [`nx.json`](nx.json) both depends on that package's `build` (the config imports its compiled output) and lists its `src/**` as a lint input, so a rule change busts the dependent lint caches.
+- **Loose top-level files** (`eslint.config.mjs`, `scripts/**`, `vitest.config.base.ts`) belong to no package, so they are linted by the `workspace-root` project defined in the root [`project.json`](project.json). If you add a source file outside `packages/` and outside those globs, extend that project's `lint` target so it stays covered.
+- **The custom rules** in `@composurecdk/eslint-plugin` drive every package's lint result, so `targetDefaults.lint` in [`nx.json`](nx.json) both depends on that package's `build` (the flat config imports its compiled output) and lists its `src/**` as a lint input, so a rule change busts the dependent lint caches.
+- **Not the `@nx/eslint` inference plugin.** It would auto-create the `lint` targets, but it evaluates the root flat config during graph construction (to skip projects with no lintable files). That imports `@composurecdk/eslint-plugin` before it is built, so every nx command fails on a fresh checkout. Per-package scripts avoid loading the config until lint actually runs — by which point `dependsOn` has built the plugin.
 
 ## Publishing & module format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ Fix any issues before moving on. Use npm run lint:fix and npm run format to auto
 
 Use npx nx to run build/test scripts — this is an nx monorepo.
 
+Lint is an nx target too: `npm run lint` runs `nx run-many -t lint`, which caches per project so unchanged packages fast-succeed. Two things make this correct rather than merely fast:
+
+- **Loose top-level files** (`eslint.config.mjs`, `scripts/**`, `vitest.config.base.ts`) belong to no package, so they are linted by the `workspace-root` project defined in the root [`project.json`](project.json). If you add a source file outside `packages/` and outside those globs, extend that project's `lint` target so it stays covered — the goal is that every file the old `eslint .` linted is still linted.
+- **The custom rules** in `@composurecdk/eslint-plugin` drive every package's lint result, so `targetDefaults.lint` in [`nx.json`](nx.json) both depends on that package's `build` (the config imports its compiled output) and lists its `src/**` as a lint input, so a rule change busts the dependent lint caches.
+
 ## Publishing & module format
 
 Every publishable package ships dual ESM/CJS, built by `tshy` — see [ADR-0007](docs/adr/0007-dual-esm-cjs-publishing.md). When touching a builder package:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -245,6 +245,12 @@ locally means a green CI. A husky `pre-push` hook runs `npm run verify`
 automatically — a regression cannot reach GitHub without the maintainer seeing
 it first. The only check `verify` cannot reproduce is CI's Node 20 + 24 matrix.
 
+`npm run lint` is `nx run-many -t lint` — a cached nx target like build and
+test, so re-running it after an unrelated change fast-succeeds from cache
+instead of re-linting the whole tree. Coverage is unchanged from the old
+`eslint .`: every package is linted in place, and loose top-level files are
+linted by the `workspace-root` project (see [AGENTS.md](../AGENTS.md#build-system)).
+
 `check:exports` runs `attw` + `publint` per package against the built `dist/`,
 catching broken or masquerading `exports` maps and dual-package issues. The
 `@composurecdk/module-compat` package (run by `npm run test`) spawns `node` to

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -247,9 +247,9 @@ it first. The only check `verify` cannot reproduce is CI's Node 20 + 24 matrix.
 
 `npm run lint` is `nx run-many -t lint` — a cached nx target like build and
 test, so re-running it after an unrelated change fast-succeeds from cache
-instead of re-linting the whole tree. Coverage is unchanged from the old
-`eslint .`: every package is linted in place, and loose top-level files are
-linted by the `workspace-root` project (see [AGENTS.md](../AGENTS.md#build-system)).
+instead of re-linting the whole tree. Every package is linted in place, and
+loose top-level files are linted by the `workspace-root` project (see
+[AGENTS.md](../AGENTS.md#build-system)).
 
 `check:exports` runs `attw` + `publint` per package against the built `dist/`,
 catching broken or masquerading `exports` maps and dual-package issues. The

--- a/nx.json
+++ b/nx.json
@@ -1,13 +1,5 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "plugins": [
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    }
-  ],
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,13 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "plugins": [
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    }
+  ],
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
@@ -19,6 +27,17 @@
       "dependsOn": ["build"],
       "inputs": ["{projectRoot}/dist/**/*", "{projectRoot}/package.json"],
       "cache": true
+    },
+    "lint": {
+      "dependsOn": [{ "projects": ["@composurecdk/eslint-plugin"], "target": "build" }],
+      "cache": true,
+      "inputs": [
+        "default",
+        "^default",
+        "{workspaceRoot}/eslint.config.mjs",
+        "{workspaceRoot}/packages/eslint-plugin/src/**/*",
+        { "externalDependencies": ["eslint"] }
+      ]
     },
     "test:update": {
       "dependsOn": ["^build", "typecheck"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@composurecdk/eslint-plugin": "*",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "^10.0.1",
+        "@nx/eslint": "23.0.1",
         "@nx/eslint-plugin": "23.0.1",
         "@nx/js": "23.0.1",
         "@vitest/coverage-v8": "^4.1.8",
@@ -2355,6 +2356,33 @@
         "nx": ">= 22 <= 24 || ^23.0.0-0"
       }
     },
+    "node_modules/@nx/eslint": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-23.0.1.tgz",
+      "integrity": "sha512-/P+iXDUsXHeqU7NMDviE/tjJkaVWssc7TLcCoJ6TRy/p+U7HaigLx57VAogBIznldHiyL7KbM7Y0fzqo/hPofw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "23.0.1",
+        "@nx/js": "23.0.1",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "typescript": "~5.9.2"
+      },
+      "peerDependencies": {
+        "@nx/jest": "23.0.1",
+        "@zkochan/js-yaml": "0.0.7",
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nx/jest": {
+          "optional": true
+        },
+        "@zkochan/js-yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nx/eslint-plugin": {
       "version": "23.0.1",
       "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-23.0.1.tgz",
@@ -2385,6 +2413,20 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@nx/js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@composurecdk/eslint-plugin": "*",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "^10.0.1",
-        "@nx/eslint": "23.0.1",
         "@nx/eslint-plugin": "23.0.1",
         "@nx/js": "23.0.1",
         "@vitest/coverage-v8": "^4.1.8",
@@ -2356,33 +2355,6 @@
         "nx": ">= 22 <= 24 || ^23.0.0-0"
       }
     },
-    "node_modules/@nx/eslint": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-23.0.1.tgz",
-      "integrity": "sha512-/P+iXDUsXHeqU7NMDviE/tjJkaVWssc7TLcCoJ6TRy/p+U7HaigLx57VAogBIznldHiyL7KbM7Y0fzqo/hPofw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nx/devkit": "23.0.1",
-        "@nx/js": "23.0.1",
-        "semver": "^7.6.3",
-        "tslib": "^2.3.0",
-        "typescript": "~5.9.2"
-      },
-      "peerDependencies": {
-        "@nx/jest": "23.0.1",
-        "@zkochan/js-yaml": "0.0.7",
-        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@nx/jest": {
-          "optional": true
-        },
-        "@zkochan/js-yaml": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nx/eslint-plugin": {
       "version": "23.0.1",
       "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-23.0.1.tgz",
@@ -2413,20 +2385,6 @@
         "eslint-config-prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nx/eslint/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@nx/js": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "composurecdk",
   "description": "Composable, lifecycle-managed AWS infrastructure built on AWS CDK — monorepo for the @composurecdk/* packages.",
   "scripts": {
-    "lint": "nx show projects > /dev/null 2>&1 && eslint .",
-    "lint:fix": "nx show projects > /dev/null 2>&1 && eslint --fix .",
+    "lint": "npx nx run-many -t lint",
+    "lint:fix": "npx nx run-many -t lint -- --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "npx nx run-many -t typecheck",
@@ -54,6 +54,7 @@
     "@composurecdk/eslint-plugin": "*",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint/js": "^10.0.1",
+    "@nx/eslint": "23.0.1",
     "@nx/eslint-plugin": "23.0.1",
     "@nx/js": "23.0.1",
     "@vitest/coverage-v8": "^4.1.8",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@composurecdk/eslint-plugin": "*",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint/js": "^10.0.1",
-    "@nx/eslint": "23.0.1",
     "@nx/eslint-plugin": "23.0.1",
     "@nx/js": "23.0.1",
     "@vitest/coverage-v8": "^4.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "composurecdk",
   "description": "Composable, lifecycle-managed AWS infrastructure built on AWS CDK — monorepo for the @composurecdk/* packages.",
+  "nx": {
+    "includedScripts": []
+  },
   "scripts": {
     "lint": "npx nx run-many -t lint",
     "lint:fix": "npx nx run-many -t lint -- --fix",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/custom-resources/package.json
+++ b/packages/custom-resources/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -21,6 +21,7 @@
     "README.md"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -4,6 +4,7 @@
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist cdk.out",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/module-compat"
   },
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf node_modules/.vite",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "lint": "eslint .",
     "clean": "rm -rf dist .tshy .tshy-build",
     "build": "tshy",
     "typecheck": "tsc --noEmit",

--- a/project.json
+++ b/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "workspace-root",
+  "$schema": "node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "lint": {
+      "command": "eslint eslint.config.mjs scripts vitest.config.base.ts",
+      "inputs": [
+        "{workspaceRoot}/eslint.config.mjs",
+        "{workspaceRoot}/scripts/**/*",
+        "{workspaceRoot}/vitest.config.base.ts",
+        { "externalDependencies": ["eslint"] }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Why

Lint had become the slowest gate: `npm run lint` was a single root `eslint .`
that re-lints the entire tree on every invocation with **no nx caching** —
unlike `build`, `test`, and `typecheck`, which are cached nx targets that
fast-succeed on unchanged projects. This makes lint a cached per-project nx
target while keeping coverage identical.

## Approach (and one it deliberately avoids)

nx derives every target in this repo from **package.json scripts** — there are
no inference plugins. So each package gets a `"lint": "eslint ."` script and nx
infers a cached `lint` target for it, exactly like `build`/`test`/`typecheck`.

I first tried the idiomatic `@nx/eslint` **inference plugin**, but it evaluates
the root flat config during *graph construction* (`ESLint.isPathIgnored`, to
skip projects with nothing to lint). That runs
`import "@composurecdk/eslint-plugin"` before the package is compiled, so **every
nx command fails on a fresh checkout** — it only appeared to work locally
because a stale `dist/` was lying around. Per-package scripts don't load the
config until lint actually runs, by which point `dependsOn` has built the
plugin. This is documented in `AGENTS.md` so it isn't re-introduced.

## What changed

- **Per-package `lint` scripts** — `"lint": "eslint ."` in each package.json;
  `npm run lint` / `lint:fix` run `nx run-many -t lint`.
- **`workspace-root` project** (root `project.json`) — a cached `lint` target
  for the loose top-level files no package owns (`eslint.config.mjs`,
  `scripts/**`, `vitest.config.base.ts`), so the whole repo is still linted.
- **`targetDefaults.lint`** — `dependsOn` the `@composurecdk/eslint-plugin`
  build (the flat config imports its compiled output) and keys its cache on
  that package's `src/**`, so a rule change busts dependent lint caches.
  (`dist` is gitignored → invisible to nx's file hasher, so source is the
  correct key.)
- **`nx.includedScripts: []` on the root package.json** — stops the root
  project from turning root scripts (`build`, `test`, `verify`, the root `lint`)
  into `workspace-root` targets, which would otherwise recurse.
- **Docs** — `AGENTS.md` and `docs/ci.md`.

## Results

| Run | Before (`eslint .`) | After (`nx run-many -t lint`) |
| --- | --- | --- |
| Warm (no changes) | ~18s, full re-lint | **<1s**, 25/25 from cache |
| One package changed | ~18s, full re-lint | only that package re-lints |
| Cold / CI | ~18s | comparable (24 projects in parallel) |

## Verification

Validated from a simulated fresh checkout (`rm -rf packages/eslint-plugin/dist
.nx`):

- `typecheck`, `build`, and `lint` all pass — the graph loads without evaluating
  the flat config (this is the exact failure the inference-plugin attempt hit).
- Cold lint runs all 24 projects (23 packages + `workspace-root`); warm run is
  25/25 from cache.
- A lint error in a package fails **only** that package's task; a root-file
  error fails `workspace-root:lint`.
- Editing a rule in `@composurecdk/eslint-plugin/src` rebuilds it and busts the
  dependent lint caches.
- `build` / `typecheck` / `test` run-many exclude `workspace-root`; it is
  outside the `packages/*` release glob.

## Notes / follow-ups

- No ADR: this reuses the existing package.json-script → cached-nx-target
  pattern rather than introducing a new mechanism.
- CI caching is unchanged. Runners are ephemeral, so cross-run cache reuse would
  need Nx Cloud or an `actions/cache` step on `.nx/cache` — a separate decision,
  out of scope here.
