### PR TITLE
ci(dependabot): separate @nx group from other npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
           - "aws-cdk"
           - "aws-cdk*"
           - "@aws-cdk/*"
+      nx:
+        patterns:
+          - "nx"
+          - "@nx/*"
       npm-dependencies:
         patterns:
           - "*"
@@ -25,3 +29,5 @@ updates:
           - "aws-cdk"
           - "aws-cdk*"
           - "@aws-cdk/*"
+          - "nx"
+          - "@nx/*"


### PR DESCRIPTION
Nx packages are pinned to the same version and should be bumped
together in their own PR, matching the existing aws-cdk grouping.
Add a dedicated nx group (nx, @nx/*) and exclude those patterns
from the catch-all npm-dependencies group.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HdJsFsqDMv83wLnEAn8iLk