### PR TITLE
fix(sns): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/sns/src/topic-alarms.ts
+++ b/packages/sns/src/topic-alarms.ts
@@ -112,7 +112,8 @@ export function resolveTopicAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param topic - The SNS topic to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
@@ -125,12 +126,10 @@ export function createTopicAlarms(
   config: TopicAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<ITopic>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? TOPIC_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveTopicAlarmDefinitions(topic, config);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveTopicAlarmDefinitions(topic, config);
   const custom = customAlarms.map((b) => b.resolve(topic));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/sns/src/topic-builder.ts
+++ b/packages/sns/src/topic-builder.ts
@@ -26,7 +26,8 @@ export interface TopicBuilderProps extends TopicProps {
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds for every applicable metric. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
+   * customized or disabled. Set to `false` to disable the recommended
+   * alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification
    * methods are user-specific. Access alarms from the build result

--- a/packages/sns/test/topic-alarms.test.ts
+++ b/packages/sns/test/topic-alarms.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { Topic } from "aws-cdk-lib/aws-sns";
 import { createTopicBuilder } from "../src/topic-builder.js";
+import { resolveTopicAlarmDefinitions } from "../src/topic-alarms.js";
 
 function buildResult(configureFn?: (builder: ReturnType<typeof createTopicBuilder>) => void) {
   const app = new App();
@@ -248,5 +250,55 @@ describe("addAlarm", () => {
         );
       }),
     ).toThrow(/Duplicate alarm key "numberOfNotificationsFailed"/);
+  });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  function customAlarm(builder: ReturnType<typeof createTopicBuilder>) {
+    return builder.addAlarm("numberOfMessagesPublished", (alarm) =>
+      alarm
+        .metric(
+          (topic) =>
+            new Metric({
+              namespace: "AWS/SNS",
+              metricName: "NumberOfMessagesPublished",
+              dimensionsMap: { TopicName: topic.topicName },
+              statistic: "Sum",
+              period: Duration.minutes(1),
+            }),
+        )
+        .threshold(10000)
+        .greaterThanOrEqual()
+        .description("Topic receiving unusually high message volume"),
+    );
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    const { result, template } = buildResult((b) => {
+      customAlarm(b.recommendedAlarms(false));
+    });
+
+    expect(result.alarms.numberOfMessagesPublished).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["numberOfMessagesPublished"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildResult((b) => {
+      customAlarm(b.recommendedAlarms({ enabled: false }));
+    });
+
+    expect(result.alarms.numberOfMessagesPublished).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["numberOfMessagesPublished"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+});
+
+describe("resolveTopicAlarmDefinitions", () => {
+  it("returns no definitions when explicitly disabled", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const topic = new Topic(stack, "Topic");
+
+    expect(resolveTopicAlarmDefinitions(topic, { enabled: false })).toEqual([]);
   });
 });


### PR DESCRIPTION
## What & why

Part of #305.

`createTopicAlarms` short-circuited to an empty record whenever the recommended
alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning:

```ts
const { alarms } = createTopicBuilder()
  .recommendedAlarms(false)
  .addAlarm("custom", (a) => a.metric(() => myMetric).threshold(1).greaterThan())
  .build(stack, "T");
// Before: {}   — custom alarm dropped
// After:  { custom: Alarm }
```

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createTopicAlarms` in line with the ADR-0004 split-alarm builders
(cloudfront/route53/budgets): disabling the recommended set now zeroes out only
the recommended definitions, and the custom alarms are always concatenated.

The `TopicBuilderProps.recommendedAlarms` doc — which previously said "Set to
`false` to disable all alarms" — is corrected to reflect that custom alarms are
unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/sns` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_