### PR TITLE
fix(sqs): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/sqs/src/queue-alarms.ts
+++ b/packages/sqs/src/queue-alarms.ts
@@ -75,7 +75,8 @@ export function resolveQueueAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param queue - The SQS queue to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @param profile - The builder's alarm profile; see
  *   {@link resolveQueueAlarmDefinitions}.
@@ -91,10 +92,10 @@ export function createQueueAlarms(
   customAlarms: AlarmDefinitionBuilder<IQueue>[],
   profile: QueueAlarmProfile,
 ): Record<string, Alarm> {
-  if (config === false) return {};
-  if (!(config?.enabled ?? true)) return {};
-
-  const recommended = resolveQueueAlarmDefinitions(queue, config, profile);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveQueueAlarmDefinitions(queue, config, profile);
   const custom = customAlarms.map((b) => b.resolve(queue));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/sqs/src/queue-props.ts
+++ b/packages/sqs/src/queue-props.ts
@@ -41,7 +41,8 @@ export interface QueueBuilderExtensionProps {
    * By default, the builder creates recommended alarms with sensible
    * thresholds for every applicable metric — which alarms apply depends
    * on the queue's role (primary vs. dead-letter). Individual alarms can
-   * be customized or disabled. Set to `false` to disable all alarms.
+   * be customized or disabled. Set to `false` to disable the recommended
+   * alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification
    * methods are user-specific. Access alarms from the build result

--- a/packages/sqs/test/queue-alarms.test.ts
+++ b/packages/sqs/test/queue-alarms.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { Queue } from "aws-cdk-lib/aws-sqs";
 import { createQueueBuilder } from "../src/queue-builder.js";
+import { resolveQueueAlarmDefinitions } from "../src/queue-alarms.js";
+import { PRIMARY_ALARM_PROFILE } from "../src/queue-alarm-profiles.js";
 
 function buildResult(configureFn?: (builder: ReturnType<typeof createQueueBuilder>) => void) {
   const app = new App();
@@ -159,5 +162,50 @@ describe("addAlarm duplicate-key safety", () => {
         );
       }),
     ).toThrow(/Duplicate alarm key "approximateAgeOfOldestMessage"/);
+  });
+});
+
+// Regression: disabling the recommended alarms must not drop custom alarms
+// added via addAlarm() — see issue #305.
+describe("custom alarms survive disabled recommended alarms", () => {
+  function customAlarm(builder: ReturnType<typeof createQueueBuilder>) {
+    return builder.addAlarm("backlogDepth", (alarm) =>
+      alarm
+        .metric((queue) => queue.metricApproximateNumberOfMessagesVisible())
+        .threshold(1000)
+        .greaterThan()
+        .description("Queue backlog is deep"),
+    );
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    const { result, template } = buildResult((b) => {
+      customAlarm(b.recommendedAlarms(false));
+    });
+
+    expect(result.alarms.backlogDepth).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["backlogDepth"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildResult((b) => {
+      customAlarm(b.recommendedAlarms({ enabled: false }));
+    });
+
+    expect(result.alarms.backlogDepth).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["backlogDepth"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+});
+
+describe("resolveQueueAlarmDefinitions", () => {
+  it("returns no definitions when explicitly disabled", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const queue = new Queue(stack, "Queue");
+
+    expect(resolveQueueAlarmDefinitions(queue, { enabled: false }, PRIMARY_ALARM_PROFILE)).toEqual(
+      [],
+    );
   });
 });


### PR DESCRIPTION
## What & why

Part of #305.

`createQueueAlarms` short-circuited to an empty record whenever the recommended
alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createQueueAlarms` in line with the ADR-0004 split-alarm builders:
disabling the recommended set now zeroes out only the recommended definitions,
and the custom alarms are always concatenated.

The `recommendedAlarms` prop doc — which previously said "Set to `false` to
disable all alarms" — is corrected to reflect that custom alarms are unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/sqs` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_