### PR TITLE
fix(s3): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/s3/src/bucket-alarms.ts
+++ b/packages/s3/src/bucket-alarms.ts
@@ -96,7 +96,8 @@ export function resolveBucketAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param bucket - The S3 bucket to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param metricsConfigs - The bucket's request metrics configurations.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
@@ -111,12 +112,10 @@ export function createBucketAlarms(
   metricsConfigs: BucketMetrics[],
   customAlarms: AlarmDefinitionBuilder<Bucket>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? BUCKET_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveBucketAlarmDefinitions(bucket, config, metricsConfigs);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveBucketAlarmDefinitions(bucket, config, metricsConfigs);
   const custom = customAlarms.map((b) => b.resolve(bucket));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/s3/test/bucket-alarms.test.ts
+++ b/packages/s3/test/bucket-alarms.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { Bucket } from "aws-cdk-lib/aws-s3";
 import { createBucketBuilder } from "../src/bucket-builder.js";
+import { resolveBucketAlarmDefinitions } from "../src/bucket-alarms.js";
 
 function buildResult(configureFn: (builder: ReturnType<typeof createBucketBuilder>) => void) {
   const app = new App();
@@ -272,5 +274,56 @@ describe("addAlarm", () => {
           );
       }),
     ).toThrow(/Duplicate alarm key "serverErrors:EntireBucket"/);
+  });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  function customAlarm(builder: ReturnType<typeof createBucketBuilder>) {
+    return builder.serverAccessLogs(false).addAlarm("totalRequests", (alarm) =>
+      alarm
+        .metric(
+          (bucket) =>
+            new Metric({
+              namespace: "AWS/S3",
+              metricName: "GetRequests",
+              dimensionsMap: { BucketName: bucket.bucketName, FilterId: "EntireBucket" },
+              period: Duration.minutes(5),
+            }),
+        )
+        .threshold(100)
+        .lessThan()
+        .description("Bucket traffic has dropped below expected level"),
+    );
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    const { result, template } = buildResult((b) => {
+      customAlarm(b.recommendedAlarms(false).metrics([{ id: "EntireBucket" }]));
+    });
+
+    expect(result.alarms.totalRequests).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["totalRequests"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildResult((b) => {
+      customAlarm(b.recommendedAlarms({ enabled: false }).metrics([{ id: "EntireBucket" }]));
+    });
+
+    expect(result.alarms.totalRequests).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["totalRequests"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+});
+
+describe("resolveBucketAlarmDefinitions", () => {
+  it("returns no definitions when explicitly disabled", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const bucket = new Bucket(stack, "Bucket");
+
+    expect(
+      resolveBucketAlarmDefinitions(bucket, { enabled: false }, [{ id: "EntireBucket" }]),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## What & why

Part of #305.

`createBucketAlarms` short-circuited to an empty record whenever the recommended
alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createBucketAlarms` in line with the ADR-0004 split-alarm builders:
disabling the recommended set now zeroes out only the recommended definitions,
and the custom alarms are always concatenated.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/s3` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_