### PR TITLE
fix(dynamodb): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/dynamodb/src/table-alarms.ts
+++ b/packages/dynamodb/src/table-alarms.ts
@@ -136,7 +136,8 @@ export function resolveTableAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param table - The DynamoDB table to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
@@ -149,12 +150,10 @@ export function createTableAlarms(
   config: TableAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<ITable>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? TABLE_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveTableAlarmDefinitions(table, config);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveTableAlarmDefinitions(table, config);
   const custom = customAlarms.map((b) => b.resolve(table));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/dynamodb/src/table-builder.ts
+++ b/packages/dynamodb/src/table-builder.ts
@@ -19,7 +19,8 @@ export interface TableBuilderProps extends TableProps {
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds for server-side errors and read/write throttling. Individual
-   * alarms can be customized or disabled. Set to `false` to disable all alarms.
+   * alarms can be customized or disabled. Set to `false` to disable the
+   * recommended alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification methods are
    * user-specific. Access alarms from the build result or use an `afterBuild`

--- a/packages/dynamodb/src/table-v2-builder.ts
+++ b/packages/dynamodb/src/table-v2-builder.ts
@@ -19,7 +19,8 @@ export interface TableV2BuilderProps extends TablePropsV2 {
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds for server-side errors and read/write throttling. Individual
-   * alarms can be customized or disabled. Set to `false` to disable all alarms.
+   * alarms can be customized or disabled. Set to `false` to disable the
+   * recommended alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification methods are
    * user-specific. Access alarms from the build result or use an `afterBuild`

--- a/packages/dynamodb/test/table-alarms.test.ts
+++ b/packages/dynamodb/test/table-alarms.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from "vitest";
 import { type Lifecycle } from "@composurecdk/core";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
+import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
 import { createTableBuilder, type ITableBuilder } from "../src/table-builder.js";
 import { createTableV2Builder, type ITableV2Builder } from "../src/table-v2-builder.js";
+import { resolveTableAlarmDefinitions } from "../src/table-alarms.js";
 
 const PK = { name: "pk", type: AttributeType.STRING };
 
@@ -139,5 +140,50 @@ describe.each(builders)("$name table alarms", ({ create }) => {
         ComparisonOperator: "GreaterThanThreshold",
       });
     });
+
+    // Regression: disabling the recommended alarms must not drop custom alarms
+    // added via addAlarm() — see issue #305.
+    it("keeps a custom alarm when recommendedAlarms is false", () => {
+      const { result, template } = build((b) => {
+        b.recommendedAlarms(false);
+        b.addAlarm("userErrors", (a) =>
+          a
+            .metric((table) => table.metricUserErrors({ period: Duration.minutes(5) }))
+            .threshold(5)
+            .greaterThan()
+            .description("Table is returning client-side (HTTP 400) errors."),
+        );
+      });
+
+      expect(result.alarms.userErrors).toBeDefined();
+      expect(Object.keys(result.alarms)).toEqual(["userErrors"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+      const { result, template } = build((b) => {
+        b.recommendedAlarms({ enabled: false });
+        b.addAlarm("userErrors", (a) =>
+          a
+            .metric((table) => table.metricUserErrors({ period: Duration.minutes(5) }))
+            .threshold(5)
+            .greaterThan()
+            .description("Table is returning client-side (HTTP 400) errors."),
+        );
+      });
+
+      expect(result.alarms.userErrors).toBeDefined();
+      expect(Object.keys(result.alarms)).toEqual(["userErrors"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+  });
+});
+
+describe("resolveTableAlarmDefinitions", () => {
+  it("returns no definitions when explicitly disabled", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const table = new Table(stack, "Table", { partitionKey: PK });
+
+    expect(resolveTableAlarmDefinitions(table, { enabled: false })).toEqual([]);
   });
 });


### PR DESCRIPTION
## What & why

Part of #305.

`createTableAlarms` short-circuited to an empty record whenever the recommended
alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createTableAlarms` in line with the ADR-0004 split-alarm builders:
disabling the recommended set now zeroes out only the recommended definitions,
and the custom alarms are always concatenated. This covers both the v1 `Table`
and v2 `TableV2` builders (they share the alarm helper).

The `recommendedAlarms` prop docs on both builders — which previously said "Set
to `false` to disable all alarms" — are corrected to reflect that custom alarms
are unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/dynamodb` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_