### PR TITLE
fix(lambda): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/lambda/src/function-alarms.ts
+++ b/packages/lambda/src/function-alarms.ts
@@ -272,7 +272,8 @@ function eventSourceMetric(eventSourceMappingId: string, metricName: string): Me
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param fn - The Lambda function to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param props - The merged function props, used for contextual alarm thresholds.
  * @param eventSources - Event sources attached to the function, used for
  *   per-event-source contextual alarms.
@@ -290,12 +291,10 @@ export function createFunctionAlarms(
   eventSources: AttachedEventSource[] = [],
   customAlarms: AlarmDefinitionBuilder<LambdaFunction>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? FUNCTION_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveFunctionAlarmDefinitions(fn, config, props, eventSources);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveFunctionAlarmDefinitions(fn, config, props, eventSources);
   const custom = customAlarms.map((b) => b.resolve(fn));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -63,7 +63,8 @@ export interface FunctionBuilderProps extends Omit<FunctionProps, "role"> {
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds for every applicable metric. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
+   * customized or disabled. Set to `false` to disable the recommended
+   * alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification
    * methods are user-specific. Access alarms from the build result

--- a/packages/lambda/test/function-alarms.test.ts
+++ b/packages/lambda/test/function-alarms.test.ts
@@ -501,4 +501,39 @@ describe("addAlarm", () => {
       }),
     ).toThrow(/Duplicate alarm key "errors"/);
   });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  function customAlarm(builder: ReturnType<typeof createFunctionBuilder>) {
+    minimalFunction(builder);
+    builder.addAlarm("invocations", (alarm) =>
+      alarm
+        .metric((fn) => fn.metricInvocations({ period: Duration.minutes(1) }))
+        .threshold(1000)
+        .greaterThanOrEqual()
+        .description("High invocation count"),
+    );
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    const { result, template } = buildResult((b) => {
+      b.recommendedAlarms(false);
+      customAlarm(b);
+    });
+
+    expect(result.alarms.invocations).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["invocations"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildResult((b) => {
+      b.recommendedAlarms({ enabled: false });
+      customAlarm(b);
+    });
+
+    expect(result.alarms.invocations).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["invocations"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
 });


### PR DESCRIPTION
## What & why

Part of #305.

`createFunctionAlarms` short-circuited to an empty record whenever the
recommended alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createFunctionAlarms` in line with the ADR-0004 split-alarm
builders: disabling the recommended set now zeroes out only the recommended
definitions, and the custom alarms are always concatenated.

The `recommendedAlarms` prop doc — which previously said "Set to `false` to
disable all alarms" — is corrected to reflect that custom alarms are unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/lambda` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_