### PR TITLE
fix(events): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/events/src/rule-alarms.ts
+++ b/packages/events/src/rule-alarms.ts
@@ -113,7 +113,8 @@ export function resolveRuleAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param rule - The EventBridge rule to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
@@ -126,12 +127,8 @@ export function createRuleAlarms(
   config: RuleAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<IRule>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? RULE_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveRuleAlarmDefinitions(rule, config);
+  const recommended =
+    config === false || config?.enabled === false ? [] : resolveRuleAlarmDefinitions(rule, config);
   const custom = customAlarms.map((b) => b.resolve(rule));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/events/src/rule-builder.ts
+++ b/packages/events/src/rule-builder.ts
@@ -43,7 +43,8 @@ export interface RuleBuilderProps extends Omit<RuleProps, "targets" | "eventBus"
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds for every applicable metric. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
+   * customized or disabled. Set to `false` to disable the recommended
+   * alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification methods
    * are user-specific. Access alarms from the build result or apply them

--- a/packages/events/test/rule-alarms.test.ts
+++ b/packages/events/test/rule-alarms.test.ts
@@ -178,4 +178,49 @@ describe("RuleBuilder recommended alarms", () => {
       Threshold: 10,
     });
   });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  function buildWithCustomAlarm(disable: false | { enabled: false }) {
+    const stack = newStack();
+    const fn = makeFn(stack);
+
+    const result = createRuleBuilder()
+      .schedule(Schedule.rate(Duration.minutes(15)))
+      .addTarget("h", new LambdaFunction(fn))
+      .recommendedAlarms(disable)
+      .addAlarm("retryAttempts", (alarm) =>
+        alarm
+          .metric(
+            (rule) =>
+              new Metric({
+                namespace: "AWS/Events",
+                metricName: "RetryInvocationAttempts",
+                dimensionsMap: { RuleName: rule.ruleName },
+                statistic: "Sum",
+                period: Duration.minutes(1),
+              }),
+          )
+          .threshold(10)
+          .greaterThan()
+          .description("Targets are being undersized; retries are climbing."),
+      )
+      .build(stack, "TestRule");
+
+    return { result, template: Template.fromStack(stack) };
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    const { result, template } = buildWithCustomAlarm(false);
+
+    expect(Object.keys(result.alarms)).toEqual(["retryAttempts"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildWithCustomAlarm({ enabled: false });
+
+    expect(Object.keys(result.alarms)).toEqual(["retryAttempts"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
 });


### PR DESCRIPTION
## What & why

Part of #305.

`createRuleAlarms` short-circuited to an empty record whenever the recommended
alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createRuleAlarms` in line with the ADR-0004 split-alarm builders:
disabling the recommended set now zeroes out only the recommended definitions,
and the custom alarms are always concatenated.

The `recommendedAlarms` prop doc — which previously said "Set to `false` to
disable all alarms" — is corrected to reflect that custom alarms are unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/events` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_