### PR TITLE
fix(acm): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/acm/src/certificate-alarms.ts
+++ b/packages/acm/src/certificate-alarms.ts
@@ -46,7 +46,8 @@ export function resolveCertificateAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param certificate - The ACM certificate to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
@@ -59,12 +60,10 @@ export function createCertificateAlarms(
   config: CertificateAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<ICertificate>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? CERTIFICATE_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveCertificateAlarmDefinitions(certificate, config);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveCertificateAlarmDefinitions(certificate, config);
   const custom = customAlarms.map((b) => b.resolve(certificate));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/acm/src/certificate-builder.ts
+++ b/packages/acm/src/certificate-builder.ts
@@ -53,7 +53,8 @@ export interface CertificateBuilderProps extends CertificateProps {
    *
    * By default, the builder creates a recommended `daysToExpiry` alarm
    * at 45 days. The alarm can be customized or disabled. Set to `false`
-   * to disable all alarms.
+   * to disable the recommended alarms; custom alarms added via
+   * `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification
    * methods are user-specific. Access alarms from the build result

--- a/packages/acm/test/certificate-alarms.test.ts
+++ b/packages/acm/test/certificate-alarms.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
-import type { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
+import { Certificate, type ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { PublicHostedZone } from "aws-cdk-lib/aws-route53";
 import { createCertificateBuilder } from "../src/certificate-builder.js";
+import { resolveCertificateAlarmDefinitions } from "../src/certificate-alarms.js";
 
 function buildResult(configureFn?: (builder: ReturnType<typeof createCertificateBuilder>) => void) {
   const app = new App();
@@ -164,5 +165,57 @@ describe("recommended alarms", () => {
       // Sanity: the public enum value we rely on resolves to 'notBreaching'.
       expect(TreatMissingData.NOT_BREACHING).toBe("notBreaching");
     });
+  });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  describe("custom alarms survive disabled recommended alarms", () => {
+    function customAlarm(builder: ReturnType<typeof createCertificateBuilder>) {
+      return builder.addAlarm("custom", (alarm) =>
+        alarm
+          .metric(
+            (cert: ICertificate) =>
+              new Metric({
+                namespace: "AWS/CertificateManager",
+                metricName: "DaysToExpiry",
+                dimensionsMap: { CertificateArn: cert.certificateArn },
+                statistic: "Minimum",
+                period: Duration.days(1),
+              }),
+          )
+          .threshold(10)
+          .lessThanOrEqual()
+          .description("Certificate very close to expiry"),
+      );
+    }
+
+    it("keeps a custom alarm when recommendedAlarms is false", () => {
+      const { result, template } = buildResult((b) => {
+        customAlarm(b.recommendedAlarms(false));
+      });
+
+      expect(result.alarms.custom).toBeDefined();
+      expect(Object.keys(result.alarms)).toEqual(["custom"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+      const { result, template } = buildResult((b) => {
+        customAlarm(b.recommendedAlarms({ enabled: false }));
+      });
+
+      expect(result.alarms.custom).toBeDefined();
+      expect(Object.keys(result.alarms)).toEqual(["custom"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+  });
+});
+
+describe("resolveCertificateAlarmDefinitions", () => {
+  it("returns no definitions when explicitly disabled", () => {
+    const stack = new Stack(new App(), "TestStack");
+    const certificate = new Certificate(stack, "Certificate", { domainName: "example.com" });
+
+    expect(resolveCertificateAlarmDefinitions(certificate, { enabled: false })).toEqual([]);
   });
 });


### PR DESCRIPTION
## What & why

Part of #305.

`createCertificateAlarms` short-circuited to an empty record whenever the
recommended alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createCertificateAlarms` in line with the ADR-0004 split-alarm
builders: disabling the recommended set now zeroes out only the recommended
definitions, and the custom alarms are always concatenated.

The `recommendedAlarms` prop doc — which previously said "Set to `false` to
disable all alarms" — is corrected to reflect that custom alarms are unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/acm` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_