### PR TITLE
fix(apigateway): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/apigateway/src/builder-common.ts
+++ b/packages/apigateway/src/builder-common.ts
@@ -29,7 +29,8 @@ export interface RestApiBuilderPropsBase {
    *
    * By default, the builder creates recommended alarms for client error rate,
    * server error rate, and latency. Individual alarms can be customized or
-   * disabled. Set to `false` to disable all alarms.
+   * disabled. Set to `false` to disable the recommended alarms; custom
+   * alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification
    * methods are user-specific. Access alarms from the build result

--- a/packages/apigateway/src/rest-api-alarms.ts
+++ b/packages/apigateway/src/rest-api-alarms.ts
@@ -94,7 +94,8 @@ export function resolveRestApiAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param api - The REST API to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
  *
@@ -107,12 +108,10 @@ export function createRestApiAlarms(
   config: RestApiAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<RestApiBase>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? REST_API_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveRestApiAlarmDefinitions(api, config);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveRestApiAlarmDefinitions(api, config);
   const custom = customAlarms.map((b) => b.resolve(api));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/apigateway/test/rest-api-alarms.test.ts
+++ b/packages/apigateway/test/rest-api-alarms.test.ts
@@ -300,6 +300,53 @@ describe("addAlarm", () => {
       }),
     ).toThrow(/Duplicate alarm key "serverError"/);
   });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  function withCustomAlarm(builder: ReturnType<typeof createRestApiBuilder>) {
+    withStubMethod(builder);
+    builder.addAlarm("integrationLatency", (alarm) =>
+      alarm
+        .metric(
+          (api) =>
+            new Metric({
+              namespace: "AWS/ApiGateway",
+              metricName: "IntegrationLatency",
+              dimensionsMap: {
+                ApiName: api.restApiName,
+                Stage: api.deploymentStage.stageName,
+              },
+              statistic: "p90",
+              period: Duration.minutes(1),
+            }),
+        )
+        .threshold(2000)
+        .greaterThanOrEqual()
+        .description("Integration latency is elevated"),
+    );
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    const { result, template } = buildResult((b) => {
+      b.recommendedAlarms(false);
+      withCustomAlarm(b);
+    });
+
+    expect(result.alarms.integrationLatency).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["integrationLatency"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildResult((b) => {
+      b.recommendedAlarms({ enabled: false });
+      withCustomAlarm(b);
+    });
+
+    expect(result.alarms.integrationLatency).toBeDefined();
+    expect(Object.keys(result.alarms)).toEqual(["integrationLatency"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
 });
 
 describe("SpecRestApiBuilder alarms", () => {


### PR DESCRIPTION
## What & why

Part of #305.

`createRestApiAlarms` short-circuited to an empty record whenever the recommended
alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createRestApiAlarms` in line with the ADR-0004 split-alarm builders:
disabling the recommended set now zeroes out only the recommended definitions,
and the custom alarms are always concatenated. Applies to both the REST API and
Spec REST API builders (they share the alarm helper via `builder-common`).

The shared `recommendedAlarms` prop doc — which previously said "Set to `false`
to disable all alarms" — is corrected to reflect that custom alarms are
unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/apigateway` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_