### PR TITLE
fix(neptune): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/neptune/src/cluster-alarms.ts
+++ b/packages/neptune/src/cluster-alarms.ts
@@ -142,7 +142,8 @@ export function resolveClusterAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param cluster - The Neptune cluster to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param serverlessScaling - The cluster's serverless scaling config, if any.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
@@ -155,12 +156,10 @@ export function createClusterAlarms(
   serverlessScaling: ServerlessScalingConfiguration | undefined,
   customAlarms: AlarmDefinitionBuilder<IDatabaseCluster>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? CLUSTER_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveClusterAlarmDefinitions(cluster, config, serverlessScaling);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveClusterAlarmDefinitions(cluster, config, serverlessScaling);
   const custom = customAlarms.map((b) => b.resolve(cluster));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/neptune/src/cluster-builder.ts
+++ b/packages/neptune/src/cluster-builder.ts
@@ -70,7 +70,8 @@ export interface ClusterBuilderProps extends Omit<DatabaseClusterProps, "vpc" | 
    *
    * By default the builder creates recommended alarms with sensible
    * thresholds for every applicable metric. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
+   * customized or disabled. Set to `false` to disable the recommended
+   * alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification methods
    * are user-specific. Access alarms from the build result or use an

--- a/packages/neptune/test/cluster-builder.test.ts
+++ b/packages/neptune/test/cluster-builder.test.ts
@@ -234,6 +234,36 @@ describe("ClusterBuilder", () => {
 
       expect(result.alarms.gremlinErrors).toBeDefined();
     });
+
+    // Regression: disabling the recommended alarms must not drop custom alarms
+    // added via addAlarm() — see issue #305.
+    it("keeps a custom alarm when recommendedAlarms is false", () => {
+      const { result, template } = buildCluster((b) =>
+        b.recommendedAlarms(false).addAlarm("gremlinErrors", (a) =>
+          a
+            .metric((cluster) => cluster.metric("NumGremlinErrorsPerSec"))
+            .threshold(0)
+            .greaterThan(),
+        ),
+      );
+
+      expect(Object.keys(result.alarms)).toEqual(["gremlinErrors"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+      const { result, template } = buildCluster((b) =>
+        b.recommendedAlarms({ enabled: false }).addAlarm("gremlinErrors", (a) =>
+          a
+            .metric((cluster) => cluster.metric("NumGremlinErrorsPerSec"))
+            .threshold(0)
+            .greaterThan(),
+        ),
+      );
+
+      expect(Object.keys(result.alarms)).toEqual(["gremlinErrors"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
   });
 
   describe("allowAccessFrom", () => {


### PR DESCRIPTION
## What & why

Part of #305.

`createClusterAlarms` short-circuited to an empty record whenever the recommended
alarms were switched off — either `recommendedAlarms(false)` or
`recommendedAlarms({ enabled: false })` — returning **before** the custom alarms
were appended. Any alarm the user deliberately added via `.addAlarm()` was
silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings `createClusterAlarms` in line with the ADR-0004 split-alarm builders:
disabling the recommended set now zeroes out only the recommended definitions,
and the custom alarms are always concatenated.

The `recommendedAlarms` prop doc — which previously said "Set to `false` to
disable all alarms" — is corrected to reflect that custom alarms are unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/neptune` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_