### PR TITLE
fix(ec2): keep custom alarms when recommended alarms are disabled

### DIFF
--- a/packages/ec2/src/instance-alarms.ts
+++ b/packages/ec2/src/instance-alarms.ts
@@ -140,7 +140,8 @@ export function resolveInstanceAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param instance - The EC2 instance to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param props - The merged instance props, used for contextual alarm thresholds.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
  * @returns A record mapping alarm keys to their created Alarm constructs.
@@ -155,12 +156,10 @@ export function createInstanceAlarms(
   props: Pick<InstanceProps, "instanceType">,
   customAlarms: AlarmDefinitionBuilder<Instance>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? INSTANCE_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveInstanceAlarmDefinitions(instance, config, props);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveInstanceAlarmDefinitions(instance, config, props);
   const custom = customAlarms.map((b) => b.resolve(instance));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/ec2/src/instance-builder.ts
+++ b/packages/ec2/src/instance-builder.ts
@@ -82,7 +82,8 @@ export interface InstanceBuilderProps extends Omit<
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds for every applicable metric. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
+   * customized or disabled. Set to `false` to disable the recommended
+   * alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification methods
    * are user-specific. Access alarms from the build result or use an

--- a/packages/ec2/src/interface-endpoint-alarms.ts
+++ b/packages/ec2/src/interface-endpoint-alarms.ts
@@ -69,12 +69,10 @@ export function createInterfaceEndpointAlarms(
   config: InterfaceEndpointAlarmConfig | false | undefined,
   customAlarms: AlarmDefinitionBuilder<InterfaceVpcEndpoint>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? INTERFACE_ENDPOINT_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveEndpointAlarmDefinitions(endpoint, config);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveEndpointAlarmDefinitions(endpoint, config);
   const custom = customAlarms.map((b) => b.resolve(endpoint));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/ec2/src/interface-endpoint-builder.ts
+++ b/packages/ec2/src/interface-endpoint-builder.ts
@@ -37,7 +37,8 @@ export interface InterfaceEndpointBuilderProps extends Omit<
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds. Individual alarms can be customized or disabled. Set to
-   * `false` to disable all alarms.
+   * `false` to disable the recommended alarms; custom alarms added via
+   * `addAlarm()` are still created.
    *
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#PrivateLinkEndpoints
    */

--- a/packages/ec2/src/volume-alarms.ts
+++ b/packages/ec2/src/volume-alarms.ts
@@ -87,7 +87,8 @@ export function resolveVolumeAlarmDefinitions(
  * @param scope - CDK construct scope for creating alarm constructs.
  * @param id - Base identifier for alarm construct ids.
  * @param volume - The EBS volume to create alarms for.
- * @param config - User-provided alarm configuration, or `false` to disable all.
+ * @param config - User-provided alarm configuration, or `false` to disable the
+ *   recommended alarms.
  * @param volumeType - Resolved volume type, used to gate the contextual
  *   burst-balance alarm.
  * @param customAlarms - Custom alarm builders added via `addAlarm()`.
@@ -103,12 +104,10 @@ export function createVolumeAlarms(
   volumeType: EbsDeviceVolumeType | undefined,
   customAlarms: AlarmDefinitionBuilder<Volume>[] = [],
 ): Record<string, Alarm> {
-  if (config === false) return {};
-
-  const enabled = config?.enabled ?? VOLUME_ALARM_DEFAULTS.enabled;
-  if (!enabled) return {};
-
-  const recommended = resolveVolumeAlarmDefinitions(volume, config, volumeType);
+  const recommended =
+    config === false || config?.enabled === false
+      ? []
+      : resolveVolumeAlarmDefinitions(volume, config, volumeType);
   const custom = customAlarms.map((b) => b.resolve(volume));
 
   return createAlarms(scope, id, [...recommended, ...custom]);

--- a/packages/ec2/src/volume-builder.ts
+++ b/packages/ec2/src/volume-builder.ts
@@ -49,7 +49,8 @@ export interface VolumeBuilderProps extends Omit<
    *
    * By default, the builder creates recommended alarms with sensible
    * thresholds for every applicable metric. Individual alarms can be
-   * customized or disabled. Set to `false` to disable all alarms.
+   * customized or disabled. Set to `false` to disable the recommended
+   * alarms; custom alarms added via `addAlarm()` are still created.
    *
    * No alarm actions are configured by default since notification methods
    * are user-specific. Access alarms from the build result or use an

--- a/packages/ec2/test/instance-alarms.test.ts
+++ b/packages/ec2/test/instance-alarms.test.ts
@@ -295,4 +295,43 @@ describe("addAlarm", () => {
       AlarmDescription: "High inbound network traffic",
     });
   });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  function customAlarm(builder: ReturnType<typeof createInstanceBuilder>) {
+    return builder.addAlarm("networkIn", (alarm) =>
+      alarm
+        .metric(
+          (instance: Instance) =>
+            new Metric({
+              namespace: "AWS/EC2",
+              metricName: "NetworkIn",
+              dimensionsMap: { InstanceId: instance.instanceId },
+              statistic: Stats.AVERAGE,
+              period: Duration.minutes(1),
+            }),
+        )
+        .threshold(1_000_000_000)
+        .greaterThanOrEqual()
+        .description("High inbound network traffic"),
+    );
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    const { result, template } = buildInstance((b) => {
+      customAlarm(b.recommendedAlarms(false));
+    });
+
+    expect(Object.keys(result.alarms)).toEqual(["networkIn"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildInstance((b) => {
+      customAlarm(b.recommendedAlarms({ enabled: false }));
+    });
+
+    expect(Object.keys(result.alarms)).toEqual(["networkIn"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
 });

--- a/packages/ec2/test/interface-endpoint-builder.test.ts
+++ b/packages/ec2/test/interface-endpoint-builder.test.ts
@@ -324,6 +324,47 @@ describe("InterfaceEndpointBuilder", () => {
       expect(result.alarms.customThrottle).toBeDefined();
       Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 2);
     });
+
+    // Regression: disabling the recommended alarms must not drop custom alarms
+    // added via addAlarm() — see issue #305.
+    function buildWithCustomAlarm(disable: false | { enabled: false }) {
+      const { stack, vpc } = freshScope();
+      const result = createInterfaceEndpointBuilder()
+        .vpc(vpc)
+        .service(InterfaceVpcEndpointAwsService.SSM)
+        .recommendedAlarms(disable)
+        .addAlarm("customThrottle", (alarm) =>
+          alarm
+            .metric(
+              (endpoint) =>
+                new Metric({
+                  namespace: "AWS/PrivateLinkEndpoints",
+                  metricName: "RstPacketsSent",
+                  dimensionsMap: { "VPC Endpoint Id": endpoint.vpcEndpointId },
+                  statistic: "Sum",
+                }),
+            )
+            .threshold(1)
+            .greaterThanOrEqual()
+            .description("Endpoint is resetting connections"),
+        )
+        .build(stack, "Endpoint");
+      return { result, template: Template.fromStack(stack) };
+    }
+
+    it("keeps a custom alarm when recommendedAlarms is false", () => {
+      const { result, template } = buildWithCustomAlarm(false);
+
+      expect(Object.keys(result.alarms)).toEqual(["customThrottle"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
+
+    it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+      const { result, template } = buildWithCustomAlarm({ enabled: false });
+
+      expect(Object.keys(result.alarms)).toEqual(["customThrottle"]);
+      template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+    });
   });
 
   describe("compose integration", () => {

--- a/packages/ec2/test/volume-alarms.test.ts
+++ b/packages/ec2/test/volume-alarms.test.ts
@@ -181,4 +181,47 @@ describe("volume addAlarm", () => {
       AlarmDescription: "EBS volume queue length is high",
     });
   });
+
+  // Regression: disabling the recommended alarms must not drop custom alarms
+  // added via addAlarm() — see issue #305.
+  function customAlarm(builder: ReturnType<typeof createVolumeBuilder>) {
+    return builder.addAlarm("volumeQueueLength", (alarm) =>
+      alarm
+        .metric(
+          (volume: Volume) =>
+            new Metric({
+              namespace: "AWS/EBS",
+              metricName: "VolumeQueueLength",
+              dimensionsMap: { VolumeId: volume.volumeId },
+              statistic: Stats.AVERAGE,
+              period: Duration.minutes(5),
+            }),
+        )
+        .threshold(10)
+        .greaterThan()
+        .description("EBS volume queue length is high"),
+    );
+  }
+
+  it("keeps a custom alarm when recommendedAlarms is false", () => {
+    // GP2 is burstable, so burstBalance would normally be created — proving the
+    // recommended set is fully suppressed while the custom alarm survives.
+    const { result, template } = buildVolume(
+      (b) => customAlarm(b.recommendedAlarms(false)),
+      EbsDeviceVolumeType.GP2,
+    );
+
+    expect(Object.keys(result.alarms)).toEqual(["volumeQueueLength"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
+
+  it("keeps a custom alarm when recommendedAlarms is disabled via enabled:false", () => {
+    const { result, template } = buildVolume(
+      (b) => customAlarm(b.recommendedAlarms({ enabled: false })),
+      EbsDeviceVolumeType.GP2,
+    );
+
+    expect(Object.keys(result.alarms)).toEqual(["volumeQueueLength"]);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 1);
+  });
 });


### PR DESCRIPTION
## What & why

Part of #305.

The EC2 combined-builder alarm helpers — `createInstanceAlarms`,
`createVolumeAlarms`, and `createInterfaceEndpointAlarms` — short-circuited to an
empty record whenever the recommended alarms were switched off (either
`recommendedAlarms(false)` or `recommendedAlarms({ enabled: false })`), returning
**before** the custom alarms were appended. Any alarm the user deliberately
added via `.addAlarm()` was silently dropped, with no error or warning.

Custom alarms are a separate, deliberate opt-in and must always materialize.
This brings all three helpers in line with the ADR-0004 split-alarm builders:
disabling the recommended set now zeroes out only the recommended definitions,
and the custom alarms are always concatenated.

The `recommendedAlarms` prop docs on the instance, volume, and interface-endpoint
builders — which previously said "Set to `false` to disable all alarms" — are
corrected to reflect that custom alarms are unaffected.

## Checklist

- [x] Linked to an issue (#305)
- [x] Lint, format, and `@composurecdk/ec2` tests pass locally
- [x] Tests added/updated for the change


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEDVnuJAM7zgUUgLNnxn9j)_