### PR TITLE
test: disable CDK default validation in unit tests

### DIFF
--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -17,6 +17,16 @@ export function withCoverage(
   return mergeConfig(
     defineConfig({
       test: {
+        env: {
+          // aws-cdk-lib >= 2.262.0 validates every synth() against a default
+          // CloudFormation ruleset: ~600ms per synth against ~15ms without. On
+          // a 4-vCPU CI runner that pushes ordinary tests past vitest's 5s
+          // testTimeout. These suites assert on synthesised output directly, so
+          // the pass adds nothing here — it stays on for real `cdk synth`.
+          // CDK_VALIDATION is the only off switch; the feature flag named in
+          // the warning text only promotes findings to errors.
+          CDK_VALIDATION: "false",
+        },
         coverage: {
           provider: "v8",
           enabled: true,


### PR DESCRIPTION
Unblocks #329, which currently fails on **every** Node leg. No assertion or snapshot in that PR is wrong — the whole suite fails on `Error: Test timed out in 5000ms`.

## Cause

`aws-cdk-lib` 2.262.0 added a CloudFormation template validation pass that runs on every `synth()` by default, and writes a `validation-report.json` to disk each time. Benchmarked against 2.258.1 on identical code:

| | 2.258.1 | 2.262.1 | 2.262.1 + `CDK_VALIDATION=false` |
| --- | --- | --- | --- |
| `import` | 4.4ms | 4.4ms | 3.3ms |
| construct | 72ms | 72ms | 48ms |
| **`synth()`** | **17.8ms** | **610ms** | **14.4ms** |

A ~40× regression on an operation these suites perform once or more per assertion. Import and construction are untouched.

On a 4-vCPU GitHub runner, with nx running several vitest processes that each hold their own worker pool, that pushes ordinary tests past vitest's 5s default `testTimeout`. Tests that normally take milliseconds land at 6–13s.

Two things confirm the version as the trigger rather than runner flake:

- All four Node legs **and** the coverage job failed on #329 — systematic, not flaky.
- All twelve `Enforce aws-cdk-lib@<old>` jobs **passed** on the same 4-vCPU runners, running the same tests with older CDK pinned.

## Fix

`CDK_VALIDATION=false` via `vitest.config.base.ts`, so it applies uniformly to every package locally and in CI.

Measured on the #329 head at `--parallel=8` (which reproduces the CI starvation on a 10-core machine):

| | timeouts | result |
| --- | --- | --- |
| #329 as-is | 29 | fail |
| #329 + this change | **0** | **all 23 projects green** |

## Why scoped to unit tests

These suites assert on synthesised output directly via `Template.fromStack`, so the validation pass tells them nothing they do not already check. It stays enabled for real `cdk synth`, including the example stacks in `deploy-test`, where it is worth having.

I checked the example stacks synth clean under validation today, so nothing is being suppressed.

## On the feature flag

The warning text points at `@aws-cdk/core:validateAgainstDefaultRules`, but that flag only promotes findings from warnings to errors — per AWS's own docs the CDK *always* validates during synthesis. `CDK_VALIDATION` is the only off switch. Older aws-cdk-lib ignores the variable, so this is safe to land ahead of the bump.

Adopting the ruleset deliberately (as a build/CI step rather than an implicit tax on every `synth()`) is worth doing, but as its own change rather than inside a dependency bump.

## Merge order

Land this first, then rebase #329 — it should go green without further changes.

## Second commit: examples enforce the ruleset

Disabling validation everywhere would throw away real signal, so the two suites are split:

| | validation | findings |
| --- | --- | --- |
| builder packages | **off** | throwaway fixtures — noise |
| `@composurecdk/examples` | **on, enforcing** | whole applications — meaningful |

Of the 44 findings in #329's CI run, **42** were `Resources section must exist and be non-empty` from deliberately empty test stacks, and the other 2 were unreferenced parameters in an alarm fixture. None describe a real defect — they are artefacts of minimal test scaffolding.

The example stacks are different: they are complete applications. So `packages/examples/vitest.config.ts` re-enables validation and sets `@aws-cdk/core:validateAgainstDefaultRules`, which makes findings **throw** instead of scrolling past as warnings. A warning nobody reads is not a gate.

Verified all 13 example stacks synth with **zero** violations today, so this starts green and only fires on regressions.

Full suite on the #329 head with both commits applied, at `--parallel=8`: **0 timeouts, all 23 projects green** (49.6s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
