### PR TITLE
test(examples): gate example stacks on CloudFormation Validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Check CDK floor ranges in sync
         run: npm run cdk-floors:check
 
+      # Synthesises the example stacks once and fails on any CloudFormation
+      # Validate finding. Same step `npm run verify` runs locally, so this
+      # should only ever fire for something that skipped the pre-push hook.
+      - name: Validate example stacks
+        run: npm run validate
+
       # id: test — the coverage steps below key off whether this actually ran.
       - name: Test
         id: test

--- a/nx.json
+++ b/nx.json
@@ -20,6 +20,12 @@
       "inputs": ["{projectRoot}/dist/**/*", "{projectRoot}/package.json"],
       "cache": true
     },
+    "validate": {
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/dist/**/*", "{projectRoot}/cdk.json"],
+      "outputs": ["{projectRoot}/cdk.out"],
+      "cache": true
+    },
     "lint": {
       "dependsOn": [{ "projects": ["@composurecdk/eslint-plugin"], "target": "build" }],
       "cache": true,

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "cdk-floor:validate": "node scripts/cdk-floor-validate.mjs",
     "build": "npx nx run-many -t build",
     "check:exports": "npx nx run-many -t check:exports",
+    "validate": "npx nx run-many -t validate",
     "catalogue": "node scripts/gen-constraint-catalogue.mjs",
     "catalogue:check": "node scripts/gen-constraint-catalogue.mjs --check",
     "clean": "npx nx run-many -t clean && npx nx reset && rm -rf node_modules",
-    "verify": "npm run format:check && npm run build && npm run catalogue:check && npm run check:exports && npm run lint && npm run cdk-floors:check && npm run test",
+    "verify": "npm run format:check && npm run build && npm run catalogue:check && npm run check:exports && npm run lint && npm run cdk-floors:check && npm run validate && npm run test",
     "release:dryrun": "node scripts/release-dryrun.mjs",
     "prepare": "husky"
   },

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -13,7 +13,8 @@
     "test:watch": "vitest",
     "cdk": "cdk",
     "deploy": "cdk deploy",
-    "synth": "cdk synth"
+    "synth": "cdk synth",
+    "validate": "cdk synth --quiet && node ../../scripts/check-validation-report.mjs cdk.out/validation-report.json"
   },
   "author": "Jason Duffett (https://github.com/laazyj)",
   "license": "MIT",

--- a/scripts/check-validation-report.mjs
+++ b/scripts/check-validation-report.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Fails the build when `cdk synth` produced CloudFormation Validate findings.
+//
+// The report has to be inspected explicitly because synth exits 0 regardless.
+// The `@aws-cdk/core:validateAgainstDefaultRules` flag only stops aws-cdk-lib
+// downgrading *error*-severity findings, and every rule this ruleset currently
+// raises against the examples is warning severity (W2001, W3010, ...).
+//
+// Usage: node scripts/check-validation-report.mjs <validation-report.json>
+import { readFileSync } from "node:fs";
+
+const reportPath = process.argv[2];
+let report;
+
+try {
+  report = JSON.parse(readFileSync(reportPath, "utf8"));
+} catch (error) {
+  // No report means the plugin never ran — fail rather than pass silently.
+  console.error(`Cannot read validation report at ${reportPath}: ${error.message}`);
+  process.exit(1);
+}
+
+const violations = (report.pluginReports ?? []).flatMap((plugin) => plugin.violations ?? []);
+
+if (violations.length === 0) {
+  console.log("CloudFormation Validate: no findings.");
+  process.exit(0);
+}
+
+console.error(`CloudFormation Validate reported ${violations.length} finding(s):\n`);
+for (const violation of violations) {
+  const rule = violation.ruleMetadata?.ruleId ?? violation.ruleName ?? "unknown";
+  console.error(`  [${violation.severity}] ${rule}: ${violation.description ?? ""}`);
+  for (const target of violation.violatingConstructs ?? []) {
+    console.error(`      at ${target.constructPath ?? target.resourceLogicalId ?? "?"}`);
+  }
+}
+process.exit(1);


### PR DESCRIPTION
Adds a `validate` target to `@composurecdk/examples` that synthesises the 13 example stacks once and fails on any CloudFormation Validate finding. Wired into `npm run verify` — so the `pre-push` hook catches it locally — and into `ci.yml` for parity.

## Why not validate inside vitest

An earlier revision of this PR turned validation on in `packages/examples/vitest.config.ts`. Its CI run failed, and the reason was instructive on two counts.

**Cost.** The ruleset is a 7.5 MB WASM Rego engine (`@aws/cloudformation-validate`). Measured:

| | synth #1 | #2 | #3 | #4 | #5 |
| --- | --- | --- | --- | --- | --- |
| validation **on** | **628ms** | 8ms | 9ms | 7ms | 8ms |
| validation **off** | 17ms | 3ms | 3ms | 2ms | 3ms |

~610ms to instantiate the engine per *process*, then ~5ms per synth. vitest forks a worker per test file, so examples paid it **12 times** — lazily, inside whichever test synthesised first. On a 4-vCPU runner that blew the 5s default `testTimeout` and surfaced as two unrelated-looking tests hanging. One synth of the whole app pays it once: **3.1s total**.

Worth noting it is not a hang and not a permissions problem — I scanned the engine for `https://`, `fetch(`, `node:http`, `child_process` and DNS: no network access at all.

**Altitude.** Validating test fixtures reports on scaffolding rather than shipped infrastructure. It raised W3010 (`Avoid hardcoding availability zones 'us-east-1a'`) against `clean-desk-policy.test.ts`, while the real `agent-volume-app.ts` correctly resolves `vpc.availabilityZones[0]`. Same category as the 42 `F0001`s from deliberately empty builder-test stacks.

## Why the check reads the report

`cdk synth` exits 0 regardless of findings. The obvious lever, `@aws-cdk/core:validateAgainstDefaultRules`, does **not** help: it only stops aws-cdk-lib downgrading *error*-severity findings, and every rule this ruleset currently raises against the examples is *warning* severity (W2001, W3010). Setting it alone would gate nothing.

From `synthesis-validation.js`:

```js
const validateFlagExplicitlyEnabled = root.node.tryGetContext(VALIDATE_AGAINST_DEFAULT_RULES) === true;
validateFlagExplicitlyEnabled || (warningifiedAnyErrors = downgradeCfnValidateErrorsToWarnings(reports));
```

So `scripts/check-validation-report.mjs` inspects `validation-report.json` and fails on any violation of any severity. The flag is deliberately **not** set — one mechanism rather than two half-working ones. A missing report is treated as a failure, so the gate cannot silently rot into decoration.

## Verification

- Clean tree: `CloudFormation Validate: no findings.`, exit 0 — starts green.
- Injected an unreferenced `CfnParameter` into an example: **exit 1**, naming `W2001` and the construct path.
- `npm run verify` passes end to end with `validate` in the chain; `pre-push` ran it on this push with no bypass.

## Relates to

- #340, #341 — the two warnings surfaced by this investigation
- Supersedes the vitest approach entirely; nothing from it remains on the branch
