### PR TITLE
test(dynamodb): avoid union setter call broken by TS 7

### DIFF
--- a/packages/dynamodb/test/table-alarms.test.ts
+++ b/packages/dynamodb/test/table-alarms.test.ts
@@ -27,7 +27,11 @@ describe.each(builders)("$name table alarms", ({ create }) => {
   } {
     const app = new App();
     const stack = new Stack(app, "TestStack");
-    const builder = create().partitionKey(PK);
+    // `partitionKey` is optional on TableProps but required on TablePropsV2, so
+    // the two setters differ and TS 7 mis-pairs them across the union. Setters
+    // mutate in place, so annotate up front and discard the return value.
+    const builder: AnyTableBuilder = create();
+    builder.partitionKey(PK);
     configureFn?.(builder);
     // `builder` is a union of the two builder types, so `.build()` is a union of
     // two call signatures. typescript-eslint's project service can intermittently


### PR DESCRIPTION
Unblocks the `typescript` 6.0.3 → 7.0.2 bump in #332, which fails `Typecheck` on all three Node legs with a single error:

```
test/table-alarms.test.ts(31,19): error TS2345: Argument of type
  'Attribute | ITaggedBuilder<TableBuilderProps, TableBuilder>'
  is not assignable to parameter of type 'AnyTableBuilder'.
```

## Cause

The shared `build()` helper calls a setter on a **union** of the two builder factories:

```ts
const builder = create().partitionKey(PK);   // (() => ITableBuilder) | (() => ITableV2Builder)
```

`ITaggedBuilder` models each prop as an intersection of a setter and a getter signature:

```ts
[K in keyof Props]-?: ((arg: Props[K]) => ITaggedBuilder<Props, T>) & (() => Props[K]);
```

`partitionKey` is the one prop the two CDK types disagree on:

| | declaration | setter param after `-?` |
|---|---|---|
| `TableProps` | `partitionKey?: Attribute` | `Attribute \| undefined` |
| `TablePropsV2` | `partitionKey: Attribute` | `Attribute` |

`-?` strips the declared optionality but not the `undefined` inside `Props[K]` in a template position, so the two constituents' setters are structurally different. Pairing signatures across the union, TS 6 matched setter↔setter and returned `ITableBuilder | ITableV2Builder`; TS 7 matches the classic setter with the V2 **getter** and returns `Attribute | ITableBuilder`.

`sortKey` and `tableName` are optional on both prop types, so their signatures match and resolve correctly — which is why exactly one line fails.

Minimal repro, independent of this repo and of the CDK — clean on 6.0.3, failing on 7.0.2:

```ts
type Tagged<P extends object, T> = {
  [K in keyof P]-?: ((arg: P[K]) => Tagged<P, T>) & (() => P[K]);
};
interface PA { pk?: Attr; sk?: Attr }   // classic: optional
interface PB { pk: Attr;  sk?: Attr }   // v2: required
declare const create: (() => Tagged<PA, "A">) | (() => Tagged<PB, "B">);

create().pk(a);   // TS7: Attr | Tagged<PA,"A">   TS6: Tagged<PA,"A"> | Tagged<PB,"B">
create().sk(a);   // both: Tagged<PA,"A"> | Tagged<PB,"B">
```

TS 7.0 is the native Go rewrite, so this looks like a resolution-order regression in the port rather than an intentional break — worth filing upstream separately.

## Fix

Setters mutate in place and return the same builder (`tagged-builder.ts`: `ret === inner ? outer : ret`), so the union call never has to produce the value:

```ts
const builder: AnyTableBuilder = create();
builder.partitionKey(PK);
```

No behaviour change, no production code touched, and it compiles under both compilers — so this can land on `main` ahead of the bump rather than riding on the dependabot branch.

`ITaggedBuilder` could instead take `Required<Props>[K]` as the setter parameter, making optional and required props emit identical setter signatures and fixing the whole class of problem. That removes the ability to pass `undefined` explicitly to any optional setter across every builder package, which is too broad a change to make in service of one test.

## Verification

- `tsc --noEmit` clean under **typescript 6.0.3** and **7.0.2**
- `npm run lint` — 24 projects pass (no `no-unsafe-call` regression, the hazard the existing comment in this helper warns about)
- `npm run format:check` clean
- `nx run @composurecdk/dynamodb:test` — 23 tests pass, 100% coverage thresholds met

## Caveat

CI on #332 aborts at `Typecheck`, so **Build, Check exports, Lint, Validate example stacks, and Test have never run under TS 7.0.2**. A major compiler rewrite plus `typescript-eslint` 8.61 → 8.65 may well surface more once this line is fixed; expect at least one more round on that branch.