### PR TITLE
ci: gate the release tag on deploy-test

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -99,6 +99,7 @@ jobs:
         run: node ../../scripts/smoke-test.mjs
 
       # Destroy runs in a separate sandbox-cleanup workflow (triggered by
-      # workflow_run on this workflow plus a nightly cron safety net). Keeping
+      # workflow_run on this workflow and on release-tag.yml, which calls it,
+      # plus a nightly cron safety net). Keeping
       # destroy off the critical path lets developer feedback land in ~10 min
       # instead of waiting for CloudFront propagation during teardown.

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -120,7 +120,7 @@ jobs:
           - [ ] Changelog reads correctly
           - [ ] Version bumps match expectations
 
-          On merge, the \`release-tag\` workflow will push tag \`v${VERSION}\`, which triggers \`release.yml\` (deploy-test → npm publish).
+          On merge, the \`release-tag\` workflow will deploy-test the examples and, if that passes, push tag \`v${VERSION}\` — which triggers \`release.yml\` (GitHub Release → npm publish).
           EOF
           )
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,22 +4,29 @@ on:
   push:
     branches: [main]
 
+# The ceiling for every job below, narrowed per job: a reusable-workflow call
+# cannot be granted a scope the calling workflow does not hold.
 permissions:
-  contents: write
+  contents: write # tag push
+  id-token: write # AWS OIDC, for the deploy-test call
 
 concurrency:
   group: release-tag
   cancel-in-progress: false
 
 jobs:
-  tag:
-    name: Create and push release tag
-    # Cheap workflow-level filter so non-release pushes never spin up a runner.
-    # Assumes squash-merge of the release PR — the strict regex parse below is
-    # the authoritative validation.
+  # Validate before committing 45 minutes of sandbox deploy to the commit. This
+  # is also the only place the release-commit filter is written — `needs`
+  # propagates the skip to both jobs below.
+  parse:
+    name: Parse release version
+    # Cheap prefix filter so non-release pushes never spin up a runner; the
+    # strict regex below is the authoritative validation. Assumes squash-merge
+    # of the release PR.
     if: "${{ startsWith(github.event.head_commit.message, 'chore(release): v') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {} # reads the event payload only
     outputs:
       version: ${{ steps.parse.outputs.version }}
     steps:
@@ -40,6 +47,25 @@ jobs:
             exit 1
           fi
 
+  # The tag is the release gate: it exists only once the example fleet has
+  # deployed and smoke-tested cleanly, so a failed deploy leaves main untagged
+  # with nothing to unpick.
+  deploy-test:
+    name: Deploy Test
+    needs: parse
+    uses: ./.github/workflows/deploy-test.yml
+    permissions:
+      contents: read
+      id-token: write
+
+  tag:
+    name: Create and push release tag
+    needs: [parse, deploy-test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
       - name: Checkout
         # Authenticate with RELEASE_PR_TOKEN (a PAT) so the tag push below triggers
         # release.yml's `push: tags` workflow. Pushes authenticated with the default
@@ -56,7 +82,7 @@ jobs:
 
       - name: Create and push tag
         env:
-          VERSION: ${{ steps.parse.outputs.version }}
+          VERSION: ${{ needs.parse.outputs.version }}
         run: |
           tag="v${VERSION}"
           if git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then
@@ -65,6 +91,5 @@ jobs:
           fi
           git tag -a "$tag" -m "Release $tag"
           git push origin "$tag"
-          # The GitHub Release itself is created by release.yml, gated behind a
-          # successful deploy-test (just before npm publish), so we never
-          # advertise a release whose artefacts failed to deploy.
+          # The push triggers release.yml, which creates the GitHub Release and
+          # publishes to npm.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    # deploy-test gates the tag, in release-tag.yml — so a tag pushed by hand
+    # skips it. See docs/ci.md#manual-fallback.
     tags:
       - "v*.*.*"
 
@@ -10,21 +12,13 @@ permissions:
   id-token: write # For npm provenance
 
 jobs:
-  deploy-test:
-    name: Deploy Test
-    uses: ./.github/workflows/deploy-test.yml
-    permissions:
-      contents: read
-      id-token: write
-
   publish:
     name: Publish to npm
-    needs: deploy-test
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
     permissions:
-      contents: write # Create the GitHub Release once the deploy has passed
+      contents: write # Create the GitHub Release
       id-token: write
 
     steps:
@@ -45,8 +39,8 @@ jobs:
         env:
           NX_DAEMON: false
 
-      # Created here, after deploy-test has passed, rather than at tag time —
-      # so a release is only published once its artefacts have deployed cleanly.
+      # Created here rather than at tag time so the Release and the npm publish
+      # land together — a Release always has packages behind it.
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-cleanup.yml
+++ b/.github/workflows/sandbox-cleanup.yml
@@ -6,7 +6,12 @@ name: Sandbox Cleanup
 
 on:
   workflow_run:
-    workflows: [Deploy Test, Release]
+    # The callers of deploy-test.yml, not deploy-test itself: a reusable
+    # workflow raises workflow_run for the top-level caller only. `Release Tag`
+    # covers the release path in both directions — a failed deploy stops there
+    # and never reaches `Release`, and that is exactly when a half-deployed
+    # fleet is left standing.
+    workflows: [Deploy Test, Release Tag]
     types: [completed]
   schedule:
     # Daily safety net at 06:00 UTC.
@@ -35,6 +40,10 @@ concurrency:
 jobs:
   cleanup:
     name: Destroy ComposureCDK example stacks
+    # Release Tag runs on every push to main and skips its own jobs on
+    # non-release commits. An all-skipped run still reports `completed`, so
+    # ignore it — nothing deployed, nothing to tear down.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ inputs.environment || 'sandbox' }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,23 +7,23 @@ CI/CD pipeline for ComposureCDK: how the workflows chain, how to bootstrap AWS a
 Five GitHub Actions workflows chain together, with `coverage-comment.yml` hanging off CI as a listener rather than a link in the chain:
 
 ```
-ci.yml ──► deploy-test.yml ──► release.yml ◄── tag push (PAT or manual)
-   ▲              ▲                              ▲
-   │              │                              │
- PRs/push    workflow_dispatch              release-tag.yml ◄── push to main
-   │                                        (filters chore(release): commits,
-   │ workflow_run                            pushes tag with RELEASE_PR_TOKEN)
-   ▼                                              ▲
-coverage-comment.yml                              │
-                                          release-prepare.yml (workflow_dispatch → opens PR)
+ci.yml ──► deploy-test.yml ──► release-tag.yml ──► release.yml
+   ▲              ▲                   ▲                 ▲
+   │              │                   │                 │
+ PRs/push  workflow_dispatch    push to main       tag push (PAT
+   │                            (chore(release):    or manual)
+   │ workflow_run                vX.Y.Z commits)
+   ▼                                  ▲
+coverage-comment.yml                  │
+                              release-prepare.yml (workflow_dispatch → opens PR)
 ```
 
-- **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20/22/24/26 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)). The Node 24 leg also reports test coverage on PRs (see [Coverage reporting](#coverage-reporting)). It holds no write scopes, so it stays callable from `release.yml`.
+- **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20/22/24/26 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)). The Node 24 leg also reports test coverage on PRs (see [Coverage reporting](#coverage-reporting)). It holds no write scopes, so it stays callable from `deploy-test.yml`.
 - **`coverage-comment.yml`** — `workflow_run` listener on CI. Posts the coverage table as a sticky PR comment (see [Coverage reporting](#coverage-reporting)).
-- **`deploy-test.yml`** — manual `workflow_dispatch`. Calls CI, then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation.
+- **`deploy-test.yml`** — manual `workflow_dispatch`, and called by `release-tag.yml`. Calls CI, then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation.
 - **`release-prepare.yml`** — manual `workflow_dispatch`. Runs `nx release version` + `nx release changelog`, pushes branch `release/vX.Y.Z`, opens a PR titled `chore(release): vX.Y.Z`. The PR is the integration point that lets release coexist with branch protection on `main`.
-- **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it tags the commit and creates a GitHub Release from the matching `CHANGELOG.md` section. The tag is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
-- **`release.yml`** — triggered by `v*.*.*` tag pushes (from release-tag.yml or a manual `git push origin vX.Y.Z`). Runs deploy-test, then `npx nx release publish` to npm with provenance, authenticated via [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC) in the `npm` environment. Trust is configured against this workflow file (`release.yml`), so both the automated chain and the manual escape hatch resolve to the same OIDC `job_workflow_ref` claim.
+- **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it runs deploy-test and then tags the commit. The tag is the release gate: it is only created once the example fleet has deployed and smoke-tested cleanly, so a bad release never leaves a dangling tag to clean up. It is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
+- **`release.yml`** — triggered by `v*.*.*` tag pushes (from release-tag.yml or a manual `git push origin vX.Y.Z`). Creates the GitHub Release from the matching `CHANGELOG.md` section, then runs `npx nx release publish` to npm with provenance, authenticated via [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC) in the `npm` environment. Trust is configured against this workflow file (`release.yml`), so both the automated chain and the manual escape hatch resolve to the same OIDC `job_workflow_ref` claim.
 
 ## Coverage reporting
 
@@ -38,7 +38,7 @@ How it fits together:
 
 Notes:
 
-- **Why two workflows.** `ci.yml` is `workflow_call`-able from `release.yml`, and GitHub only ever _narrows_ permissions down a reusable-workflow chain. A job inside `ci.yml` declaring `pull-requests: write` therefore fails validation for any caller that lacks that scope — statically, at parse time, regardless of whether the posting step's `if:` would ever let it run. Keeping `ci.yml` at `contents: read` makes it callable from anywhere; the write scope lives only in `coverage-comment.yml`.
+- **Why two workflows.** `ci.yml` is `workflow_call`-able from `deploy-test.yml` (which `release-tag.yml` calls in turn), and GitHub only ever _narrows_ permissions down a reusable-workflow chain. A job inside `ci.yml` declaring `pull-requests: write` therefore fails validation for any caller that lacks that scope — statically, at parse time, regardless of whether the posting step's `if:` would ever let it run. Keeping `ci.yml` at `contents: read` makes it callable from anywhere; the write scope lives only in `coverage-comment.yml`.
 - **Fork PRs** now get a comment too. `workflow_run` executes in the base-repo context with a writable `GITHUB_TOKEN`, which the old in-line comment step could not obtain. The listener never checks out or executes PR code — it only reads the uploaded markdown and the PR number, which it validates is numeric before use.
 - `coverage-comment.yml` must exist on the **default branch** to fire; `workflow_run` always dispatches the default-branch copy. Changes to it are not exercised by the PR that introduces them.
 - The summary and upload steps run with `if: always()`, so when a package dips below its threshold and fails `npm run test`, reviewers still see the table (with the offending package flagged). The job status still reflects the failure — the gate is unchanged. Because they now share a job with the earlier gates, they additionally guard on `steps.test.conclusion != 'skipped'`: a typecheck or lint failure skips `Test`, leaving no `coverage-summary.json` to merge, and the reporting steps should stay quiet rather than fail a second time on the same root cause.
@@ -76,7 +76,7 @@ Scopes are optional and do not affect the bump.
 
 3. **Review and merge.** CI runs against the PR; squash-merge it once green. (The release-tag filter assumes the release commit is HEAD on `main`.)
 
-4. **Tag, deploy-test, publish — automatic.** `release-tag.yml` tags the commit and invokes `release.yml`, which runs deploy-test then publishes to npm.
+4. **Deploy-test, tag, publish — automatic.** `release-tag.yml` deploys the examples to the sandbox and only tags the commit if that passes (allow ~40 min); the tag then invokes `release.yml`, which creates the GitHub Release and publishes to npm. A deploy failure leaves `main` untagged — fix forward and re-run the workflow on the same commit.
 
 #### Bumping the minor version in 0.x (breaking change)
 
@@ -104,7 +104,7 @@ Create a fine-grained PAT (or GitHub App) scoped to this repo with `contents:wri
 
 #### Manual fallback
 
-`release.yml` keeps its `push: tags: v*.*.*` trigger as an escape hatch — pushing a `vX.Y.Z` tag manually (typically by an admin with permission to push tags through branch protection) bypasses the automated chain and runs deploy-test → publish directly.
+`release.yml` keeps its `push: tags: v*.*.*` trigger as an escape hatch — pushing a `vX.Y.Z` tag manually (typically by an admin with permission to push tags through branch protection) bypasses the automated chain and goes straight to Release + publish. deploy-test gates the tag, not the publish, so a hand-pushed tag skips it entirely: run **Deploy Test** via `workflow_dispatch` first if you take this route.
 
 [gha-token-rules]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
 


### PR DESCRIPTION
## What & why

`deploy-test` ran in `release.yml`, *after* the tag had already been pushed. A failed sandbox deploy therefore left a dangling `vX.Y.Z` tag on `main` with no GitHub Release and nothing on npm — a state that had to be unpicked by hand.

This moves the `deploy-test.yml` call into `release-tag.yml`, so **the tag is the gate**: it only exists once the example fleet has deployed and smoke-tested cleanly. `release.yml` reduces to creating the GitHub Release and publishing to npm.

```
before:  merge → tag → release.yml: deploy-test → Release + publish
after:   merge → release-tag.yml: parse → deploy-test → tag → release.yml: Release + publish
```

Wall-clock from merge to npm is unchanged (the same steps, serialized the same way); only the point of failure moves earlier.

### Also in here

- **A `parse` job runs first.** The strict commit-subject regex used to live inside the `tag` job, i.e. *after* the deploy under the new ordering. Splitting it out validates the release commit before committing 45 minutes of sandbox deploy to it, and leaves the release-commit `if:` filter written in exactly one place — `needs` propagates the skip to the other two jobs.
- **`sandbox-cleanup` listens on `Release Tag` instead of `Release`.** A reusable workflow raises `workflow_run` for its top-level caller only. With the deploy under `Release Tag`, a *failed* deploy stops before `Release` ever runs — which is precisely when a half-deployed fleet is left standing. Its `cleanup` job now ignores all-skipped runs, since `Release Tag` completes on every push to `main`.
- Permissions are stated once per level: workflow-level is the ceiling the reusable-workflow call needs, and each job narrows to what it actually uses (`parse` gets none).
- `docs/ci.md` — pipeline diagram, the release walkthrough, and the manual-fallback caveat. Two pre-existing drifts fixed while there: `release-tag.yml` was still documented as creating the GitHub Release, and `ci.yml` was documented as being called from `release.yml`.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [ ] Tests added/updated for the change — n/a, workflow-only; validated with `actionlint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)