### PR TITLE
feat(ci): comment on issues a release addressed

### DIFF
--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -54,14 +54,16 @@ jobs:
         id: release
         env:
           TAG: ${{ inputs.tag || github.event.workflow_run.head_branch }}
+        shell: bash
         run: |
-          case "$TAG" in
-            v[0-9]*.[0-9]*.[0-9]*) ;;
-            *)
-              echo "::error::Refusing to announce: '$TAG' is not a vX.Y.Z release tag."
-              exit 1
-              ;;
-          esac
+          # The same SemVer shape release-tag.yml parses out of the release
+          # commit subject — MAJOR.MINOR.PATCH with optional -prerelease and
+          # +build — so the two ends of the chain accept exactly one set of
+          # tags between them.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Refusing to announce: '$TAG' is not a vX.Y.Z release tag."
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -1,0 +1,77 @@
+name: Release Notify
+
+# Comments on every issue a release addressed, once the packages are live.
+#
+# A workflow_run listener rather than a job inside release.yml, for the same
+# reason coverage-comment.yml sits outside ci.yml — plus two specific to the
+# release path:
+#
+#   - release.yml's conclusion answers "did the publish work?". A rate-limited
+#     or otherwise failed comment must not turn it red after the packages are
+#     already on npm.
+#   - release.yml is the npm trusted-publisher anchor (trust is pinned to its
+#     job_workflow_ref), so it is the one file worth keeping free of unrelated
+#     write scopes.
+#
+# Listening also buys a re-run path for free — see the workflow_dispatch input
+# below, which is what the script's marker idempotency is built for.
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to announce (e.g. v0.9.1)."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-notify-${{ inputs.tag || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Comment on released issues
+    # Never announce a release that failed to publish. A manual dispatch names
+    # the tag itself, so it is trusted to know what it is doing.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # gh release view
+      issues: write # post the comments
+      pull-requests: read # resolve each PR's linked closing issues
+    steps:
+      # release.yml only ever runs on a tag push, which sets head_branch to the
+      # tag name — validated here rather than trusted, the same way
+      # coverage-comment.yml validates the PR number it reads from an artifact.
+      - name: Resolve release tag
+        id: release
+        env:
+          TAG: ${{ inputs.tag || github.event.workflow_run.head_branch }}
+        run: |
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::Refusing to announce: '$TAG' is not a vX.Y.Z release tag."
+              exit 1
+              ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # No `npm ci` or setup-node: the script has no dependencies and drives the
+      # preinstalled gh CLI, so installing the workspace would cost minutes for
+      # nothing.
+      - name: Comment on released issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: npm run release:issue-comments -- --tag="$TAG"

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -54,12 +54,9 @@ jobs:
         id: release
         env:
           TAG: ${{ inputs.tag || github.event.workflow_run.head_branch }}
-        shell: bash
         run: |
-          # The same SemVer shape release-tag.yml parses out of the release
-          # commit subject — MAJOR.MINOR.PATCH with optional -prerelease and
-          # +build — so the two ends of the chain accept exactly one set of
-          # tags between them.
+          # Same SemVer shape release-tag.yml requires of the release commit
+          # subject — the two ends of the chain must accept one set of tags.
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Refusing to announce: '$TAG' is not a vX.Y.Z release tag."
             exit 1
@@ -70,8 +67,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # No `npm ci` or setup-node: the script has no dependencies and drives the
-      # preinstalled gh CLI, so installing the workspace would cost minutes for
-      # nothing.
+      # preinstalled gh CLI.
       - name: Comment on released issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,7 +4,7 @@ CI/CD pipeline for ComposureCDK: how the workflows chain, how to bootstrap AWS a
 
 ## Pipeline overview
 
-Five GitHub Actions workflows chain together, with `coverage-comment.yml` hanging off CI as a listener rather than a link in the chain:
+Five GitHub Actions workflows chain together, with `coverage-comment.yml` and `release-notify.yml` hanging off CI and Release as listeners rather than links in the chain:
 
 ```
 ci.yml ──► deploy-test.yml ──► release-tag.yml ──► release.yml
@@ -24,6 +24,7 @@ coverage-comment.yml                  │
 - **`release-prepare.yml`** — manual `workflow_dispatch`. Runs `nx release version` + `nx release changelog`, pushes branch `release/vX.Y.Z`, opens a PR titled `chore(release): vX.Y.Z`. The PR is the integration point that lets release coexist with branch protection on `main`.
 - **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it runs deploy-test and then tags the commit. The tag is the release gate: it is only created once the example fleet has deployed and smoke-tested cleanly, so a bad release never leaves a dangling tag to clean up. It is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
 - **`release.yml`** — triggered by `v*.*.*` tag pushes (from release-tag.yml or a manual `git push origin vX.Y.Z`). Creates the GitHub Release from the matching `CHANGELOG.md` section, then runs `npx nx release publish` to npm with provenance, authenticated via [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC) in the `npm` environment. Trust is configured against this workflow file (`release.yml`), so both the automated chain and the manual escape hatch resolve to the same OIDC `job_workflow_ref` claim.
+- **`release-notify.yml`** — `workflow_run` listener on Release. Comments on the issues the release addressed (see [Release notifications](#release-notifications)).
 
 ## Coverage reporting
 
@@ -122,6 +123,27 @@ Create a fine-grained PAT (or GitHub App) scoped to this repo with `contents:wri
 `release.yml` keeps its `push: tags: v*.*.*` trigger as an escape hatch — pushing a `vX.Y.Z` tag manually (typically by an admin with permission to push tags through branch protection) bypasses the automated chain and goes straight to Release + publish. deploy-test gates the tag, not the publish, so a hand-pushed tag skips it entirely: run **Deploy Test** via `workflow_dispatch` first if you take this route.
 
 [gha-token-rules]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+
+### Release notifications
+
+[`release-notify.yml`](../.github/workflows/release-notify.yml) listens for a successful Release run and posts one comment per issue that release addressed:
+
+> Addressed in **v0.9.1** — see the [release notes](https://github.com/laazyj/composureCDK/releases/tag/v0.9.1).
+>
+> Published to npm as `@composurecdk/*@0.9.1`.
+
+Which issues those are is worked out by [`scripts/release-issue-comments.mjs`](../scripts/release-issue-comments.mjs) (`npm run release:issue-comments`) from the published release body — see its header for the discovery rules and why the release body, rather than `CHANGELOG.md`, is the source. Every comment carries a hidden `<!-- composurecdk-release: vX.Y.Z -->` marker, so nothing is ever posted twice; issues are commented on whatever their state, since a closed one is exactly the case worth announcing.
+
+Notes:
+
+- **Re-running is safe and is the fix for a partial failure.** The script exits non-zero if any comment fails to post, and the release is already out by then. Re-run the workflow, or trigger it by hand: **Actions → Release Notify → Run workflow**, with the tag (e.g. `v0.9.1`).
+- Preview against any past release without posting:
+
+  ```sh
+  node scripts/release-issue-comments.mjs --tag=v0.9.1 --repo=laazyj/composureCDK --dry-run
+  ```
+
+- Like `coverage-comment.yml`, this workflow must exist on the **default branch** to fire — `workflow_run` always dispatches the default-branch copy, so changes to it are not exercised by the PR that introduces them.
 
 ### npm publishing setup
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clean": "npx nx run-many -t clean && npx nx reset && rm -rf node_modules",
     "verify": "npm run format:check && npm run build && npm run catalogue:check && npm run check:exports && npm run lint && npm run cdk-floors:check && npm run validate && npm run test",
     "release:dryrun": "node scripts/release-dryrun.mjs",
+    "release:issue-comments": "node scripts/release-issue-comments.mjs",
     "prepare": "husky"
   },
   "repository": {

--- a/scripts/release-issue-comments.mjs
+++ b/scripts/release-issue-comments.mjs
@@ -22,9 +22,9 @@
  * resolves a PR number just as happily, and the changelog does contain such
  * links.
  *
- * Shells out to the `gh` CLI rather than taking an Octokit dependency — same
- * trade as `smoke-test.mjs` makes with the AWS CLI. Requires `GH_TOKEN` (or an
- * authenticated `gh`) with `issues: write`.
+ * Drives the `gh` CLI, so `scripts/` stays dependency-free — the same way
+ * `smoke-test.mjs` uses the AWS CLI. Requires `GH_TOKEN` (or an authenticated
+ * `gh`) with `issues: write`.
  *
  * Usage:
  *   node scripts/release-issue-comments.mjs                      # $GITHUB_REF_NAME

--- a/scripts/release-issue-comments.mjs
+++ b/scripts/release-issue-comments.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+/**
+ * `release-issue-comments` — tell every issue a release addressed which version
+ * it shipped in.
+ *
+ * The release notes (the workspace `CHANGELOG.md` section, rendered by nx)
+ * already link the issues and PRs behind each entry, but nobody watching an
+ * issue learns that its fix is out. This posts one comment per issue naming the
+ * version and linking the release.
+ *
+ * Issues are discovered from the release body two ways, because neither alone
+ * is complete:
+ *
+ *   1. `…/issues/N` links — what nx renders from `Closes #N` footers in commit
+ *      messages.
+ *   2. `…/pull/N` links, expanded to that PR's linked closing issues. The PR
+ *      template asks for `Closes #123` in the *PR body*, which never reaches
+ *      the squash commit message, so nx cannot see those at all.
+ *
+ * Candidates are then filtered to real issues: GitHub's `/issues/N` URL
+ * resolves a PR number just as happily, and the changelog does contain such
+ * links.
+ *
+ * Shells out to the `gh` CLI rather than taking an Octokit dependency — same
+ * trade as `smoke-test.mjs` makes with the AWS CLI. Requires `GH_TOKEN` (or an
+ * authenticated `gh`) with `issues: write`.
+ *
+ * Usage:
+ *   node scripts/release-issue-comments.mjs                      # $GITHUB_REF_NAME
+ *   node scripts/release-issue-comments.mjs --tag=v0.9.1
+ *   node scripts/release-issue-comments.mjs --tag=v0.9.1 --dry-run
+ */
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+const argv = process.argv.slice(2);
+
+function flag(name, fallback) {
+  const prefix = `--${name}=`;
+  const hit = argv.find((arg) => arg.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : fallback;
+}
+
+function fatal(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+const dryRun = argv.includes("--dry-run");
+const tag = flag("tag", process.env.GITHUB_REF_NAME);
+const repo = flag("repo", process.env.GITHUB_REPOSITORY);
+
+if (!tag) {
+  fatal("No release tag. Pass --tag=vX.Y.Z or run with GITHUB_REF_NAME set.");
+}
+if (!repo || !/^[^/]+\/[^/]+$/.test(repo)) {
+  fatal(`Not an owner/name repository: "${repo ?? ""}". Pass --repo=owner/name.`);
+}
+
+const [owner, name] = repo.split("/");
+const version = tag.replace(/^v/, "");
+// Keys the comment to this release, so a re-run announces nothing twice while
+// a later release still gets its own comment on the same issue.
+const marker = `<!-- composurecdk-release: ${tag} -->`;
+
+/** Runs `gh` and returns trimmed stdout. Throws on any non-zero exit. */
+function gh(args) {
+  try {
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    const stderr = error.stderr?.toString().trim();
+    throw new Error(`gh ${args.join(" ")} failed:\n${stderr ?? String(error)}`, { cause: error });
+  }
+}
+
+const CLOSING_ISSUES_QUERY = `
+  query ($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        closingIssuesReferences(first: 50) {
+          nodes {
+            number
+          }
+        }
+      }
+    }
+  }
+`;
+
+function closingIssues(pull) {
+  const out = gh([
+    "api",
+    "graphql",
+    "-f",
+    `query=${CLOSING_ISSUES_QUERY}`,
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `name=${name}`,
+    "-F",
+    `number=${pull}`,
+    "--jq",
+    ".data.repository.pullRequest.closingIssuesReferences.nodes[].number",
+  ]);
+  return out.split("\n").filter(Boolean).map(Number);
+}
+
+/** Null when the number does not resolve — deleted, or a cross-repo reference. */
+function describe(number) {
+  try {
+    return JSON.parse(
+      gh([
+        "api",
+        `repos/${repo}/issues/${number}`,
+        "--jq",
+        "{ isPullRequest: (.pull_request != null), title: .title }",
+      ]),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function alreadyCommented(number) {
+  const bodies = gh([
+    "api",
+    `repos/${repo}/issues/${number}/comments`,
+    "--paginate",
+    "--jq",
+    ".[].body",
+  ]);
+  return bodies.includes(marker);
+}
+
+const release = JSON.parse(gh(["release", "view", tag, "--repo", repo, "--json", "body,url"]));
+
+// Fixed versioning (nx.json `projectsRelationship: "fixed"`) means every
+// package carries this version, so the npm line can be stated as a wildcard.
+const commentBody = [
+  marker,
+  "",
+  `Addressed in **${tag}** — see the [release notes](${release.url}).`,
+  "",
+  `Published to npm as \`@composurecdk/*@${version}\`.`,
+  "",
+].join("\n");
+
+// Cross-repo links do appear in changelog entries (dependency bumps), so the
+// slug is matched rather than assumed. GitHub treats it case-insensitively.
+const LINK_PATTERN = /https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/(issues|pull)\/(\d+)/g;
+
+const candidates = new Set();
+const pulls = new Set();
+for (const [, slug, kind, number] of release.body.matchAll(LINK_PATTERN)) {
+  if (slug.toLowerCase() !== repo.toLowerCase()) continue;
+  (kind === "issues" ? candidates : pulls).add(Number(number));
+}
+for (const pull of pulls) {
+  for (const issue of closingIssues(pull)) {
+    candidates.add(issue);
+  }
+}
+
+const commented = [];
+const skipped = [];
+const failed = [];
+
+for (const number of [...candidates].sort((a, b) => a - b)) {
+  const issue = describe(number);
+  if (issue === null) {
+    skipped.push(`#${number} — does not resolve in ${repo}`);
+    continue;
+  }
+  if (issue.isPullRequest) {
+    skipped.push(`#${number} — a pull request, not an issue`);
+    continue;
+  }
+  if (alreadyCommented(number)) {
+    skipped.push(`#${number} — already announced for ${tag}`);
+    continue;
+  }
+  try {
+    if (!dryRun) {
+      gh([
+        "api",
+        `repos/${repo}/issues/${number}/comments`,
+        "--method",
+        "POST",
+        "-f",
+        `body=${commentBody}`,
+      ]);
+    }
+    commented.push(`#${number} — ${issue.title}`);
+  } catch (error) {
+    failed.push(`#${number} — ${error.message.split("\n")[0]}`);
+  }
+}
+
+const lines = [
+  `## Release notifications for ${tag}${dryRun ? " (dry run — nothing posted)" : ""}`,
+  "",
+  `${commented.length} commented, ${skipped.length} skipped, ${failed.length} failed.`,
+  "",
+];
+if (dryRun) {
+  lines.push("```markdown", commentBody.trimEnd(), "```", "");
+}
+for (const [heading, entries] of [
+  ["Commented", commented],
+  ["Skipped", skipped],
+  ["Failed", failed],
+]) {
+  if (entries.length === 0) continue;
+  lines.push(`### ${heading}`, "");
+  lines.push(...entries.map((entry) => `- ${entry}`), "");
+}
+
+const summary = lines.join("\n");
+process.stdout.write(summary);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+}
+
+// Partial success is still worth failing on: the release is already out, so an
+// unannounced issue needs a human to notice and re-run.
+if (failed.length > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## What & why

An issue's watchers currently have no way to learn which version their fix shipped in. The release notes carry the links, but only in one direction — nothing points back at the issue.

`release-notify.yml` listens for a successful **Release** run and posts one comment per issue that release addressed:

> Addressed in **v0.9.1** — see the [release notes](https://github.com/laazyj/composureCDK/releases/tag/v0.9.1).
>
> Published to npm as `@composurecdk/*@0.9.1`.

### How issues are found

Two passes over the published release body, because neither alone is complete:

1. **`…/issues/N` links** — what nx renders from `Closes #N` footers in *commit messages*.
2. **`…/pull/N` links, expanded to each PR's linked closing issues** (GraphQL `closingIssuesReferences`). The PR template asks for `Closes #123` in the *PR body*, which never reaches the squash commit message, so nx never sees it.

Candidates are then filtered to real issues — `/issues/N` resolves a PR number just as happily, and the changelog does contain such links (`v0.9.0` renders PR #276 that way). Every comment carries a `<!-- composurecdk-release: vX.Y.Z -->` marker, so re-running posts nothing twice.

### Why a listener, not a job in `release.yml`

Same argument `coverage-comment.yml` makes for sitting outside `ci.yml`, plus two specific to this path: `release.yml`'s conclusion answers *"did the publish work?"*, so a rate-limited comment must not turn it red after the packages are live; and `release.yml` is the npm trusted-publisher anchor, the one file worth keeping free of unrelated write scopes. Listening also buys a `workflow_dispatch` re-run path for free — which is what the marker idempotency exists for.

## Verification

Dry-run against two real past releases (read-only; posts nothing):

```
$ node scripts/release-issue-comments.mjs --tag=v0.9.1 --dry-run
3 commented, 0 skipped, 0 failed.
  #279, #280, #326

$ node scripts/release-issue-comments.mjs --tag=v0.9.0 --dry-run
5 commented, 1 skipped, 0 failed.
  #269, #270, #278, #279, #281
  skipped: #276 — a pull request, not an issue
```

The PR-expansion path is confirmed separately (PR #327 → issue #326); on these two releases it resolves to issues the notes already linked directly, so the union is a no-op there.

`actionlint` clean; `npm run verify` passes.

⚠️ Like `coverage-comment.yml`, this workflow must be on the **default branch** to fire, so it is not exercised by this PR. The first live run is the next release — `Release Notify` can also be dispatched by hand against any tag if it needs a nudge.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [ ] Tests added/updated for the change — n/a, `scripts/` has no test harness in this repo; verified by dry-run above

🤖 Generated with [Claude Code](https://claude.com/claude-code)