### PR TITLE
chore(release): v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.9.2 (2026-07-27)
+
+### 🚀 Features
+
+- **lambda:** harden dynamo stream event source failure handling ([3436376](https://github.com/laazyj/composureCDK/commit/3436376))
+
+### 🩹 Fixes
+
+- **examples:** address PR feedback on dynamo stream example ([5f3bea6](https://github.com/laazyj/composureCDK/commit/5f3bea6))
+- **examples:** make the dynamo stream smoke check survive LATEST ([ec8477b](https://github.com/laazyj/composureCDK/commit/ec8477b))
+
+### 💀 Thank You
+
+- Claude
+- Claude Opus 4.8
+- Jason Duffett
+
 ## 0.9.1 (2026-07-25)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -8943,7 +8943,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -8965,7 +8965,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -8988,7 +8988,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9010,7 +9010,7 @@
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9030,7 +9030,7 @@
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9053,7 +9053,7 @@
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9073,7 +9073,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -9092,7 +9092,7 @@
     },
     "packages/custom-resources": {
       "name": "@composurecdk/custom-resources",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9112,7 +9112,7 @@
     },
     "packages/dynamodb": {
       "name": "@composurecdk/dynamodb",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9134,7 +9134,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9157,7 +9157,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/estree": "^1.0.6",
@@ -9173,7 +9173,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9194,7 +9194,7 @@
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9227,7 +9227,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9248,7 +9248,7 @@
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@composurecdk/iam": "^0.9.0",
@@ -9273,7 +9273,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9294,7 +9294,7 @@
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9332,7 +9332,7 @@
     },
     "packages/neptune": {
       "name": "@composurecdk/neptune",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9356,7 +9356,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9379,7 +9379,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9402,7 +9402,7 @@
     },
     "packages/ses": {
       "name": "@composurecdk/ses",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9423,7 +9423,7 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9445,7 +9445,7 @@
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/custom-resources/package.json
+++ b/packages/custom-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/custom-resources",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Compose-native AwsCustomResource builder for AWS operations with no CloudFormation resource",
   "repository": {
     "type": "git",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/dynamodb",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable DynamoDB table builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/neptune",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable Amazon Neptune cluster builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ses",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Compose-native builders for AWS SES — email identities, receipt rule sets, filters, and rule actions",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.9.2**.

Generated by `release-prepare` workflow run [#30281842122](https://github.com/laazyj/composureCDK/actions/runs/30281842122).

## Merge checklist

- [ ] CI is green
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow will deploy-test the examples and, if that passes, push tag `v0.9.2` — which triggers `release.yml` (GitHub Release → npm publish).