### PR TITLE
ci: gate the release branch on deploy-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       # vitest.config.base, so the table is a by-product of the Test step.
       #
       # The sticky PR comment is posted by coverage-comment.yml, not here: this
-      # workflow is workflow_call-able from release.yml, and a job requesting
+      # workflow is workflow_call-able from deploy-test.yml, and a job requesting
       # `pull-requests: write` fails validation under that caller's narrower
       # permission ceiling — even when the posting step could never run.
       #

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -4,7 +4,7 @@ name: Coverage Comment
 # comment.
 #
 # This lives outside ci.yml because ci.yml is workflow_call-able from
-# release.yml, and permissions only narrow down a reusable-workflow chain: a
+# deploy-test.yml, and permissions only narrow down a reusable-workflow chain: a
 # `pull-requests: write` job inside ci.yml fails validation for every caller
 # that does not itself hold that scope. Splitting the write here keeps ci.yml
 # at `contents: read` and safe to call from anywhere.

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,6 +1,16 @@
 name: Deploy Test
 
 on:
+  # The release gate. A release branch is the only ref holding exactly what
+  # ships — version bumps and CHANGELOG.md included — so it is the only ref
+  # worth deploying: `main`'s HEAD is a different tree, and tag time is too
+  # late to gate anything. The result lands as a check on the release PR.
+  #
+  # Fires because release-prepare.yml pushes the branch authenticated with
+  # RELEASE_PR_TOKEN; a push made with the default GITHUB_TOKEN would not
+  # trigger it. See docs/ci.md#release_pr_token-required.
+  push:
+    branches: ["release/**"]
   workflow_dispatch:
     inputs:
       environment:
@@ -51,7 +61,10 @@ jobs:
     # Neptune DB instance provisioning alone is a >15 min long pole; 30 min
     # left too little slack for a clean deploy of the full example fleet.
     timeout-minutes: 45
-    environment: ${{ inputs.environment }}
+    # Same fallback as the concurrency group above: a `push` event carries no
+    # inputs, and losing the environment binding would silently drop the AWS
+    # role and region vars with it.
+    environment: ${{ inputs.environment || 'sandbox' }}
 
     steps:
       - name: Checkout
@@ -109,7 +122,6 @@ jobs:
         run: node ../../scripts/smoke-test.mjs
 
       # Destroy runs in a separate sandbox-cleanup workflow (triggered by
-      # workflow_run on this workflow and on release-tag.yml, which calls it,
-      # plus a nightly cron safety net). Keeping
+      # workflow_run on this workflow, plus a nightly cron safety net). Keeping
       # destroy off the critical path lets developer feedback land in ~10 min
       # instead of waiting for CloudFront propagation during teardown.

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -117,10 +117,11 @@ jobs:
           ## Merge checklist
 
           - [ ] CI is green
+          - [ ] **Deploy Test** is green — it deploys this branch's examples to the sandbox and smoke-tests them
           - [ ] Changelog reads correctly
           - [ ] Version bumps match expectations
 
-          On merge, the \`release-tag\` workflow will deploy-test the examples and, if that passes, push tag \`v${VERSION}\` — which triggers \`release.yml\` (GitHub Release → npm publish).
+          On merge, the \`release-tag\` workflow pushes tag \`v${VERSION}\`, which triggers \`release.yml\` (GitHub Release → npm publish). Neither re-runs the deploy — merging this PR is the release decision.
           EOF
           )
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,31 +4,22 @@ on:
   push:
     branches: [main]
 
-# The ceiling for every job below, narrowed per job: a reusable-workflow call
-# cannot be granted a scope the calling workflow does not hold.
 permissions:
-  contents: write # tag push
-  id-token: write # AWS OIDC, for the deploy-test call
+  contents: write
 
 concurrency:
   group: release-tag
   cancel-in-progress: false
 
 jobs:
-  # Validate before committing 45 minutes of sandbox deploy to the commit. This
-  # is also the only place the release-commit filter is written — `needs`
-  # propagates the skip to both jobs below.
-  parse:
-    name: Parse release version
+  tag:
+    name: Create and push release tag
     # Cheap prefix filter so non-release pushes never spin up a runner; the
-    # strict regex below is the authoritative validation. Assumes squash-merge
-    # of the release PR.
+    # strict regex parse below is the authoritative validation. Assumes
+    # squash-merge of the release PR.
     if: "${{ startsWith(github.event.head_commit.message, 'chore(release): v') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {} # reads the event payload only
-    outputs:
-      version: ${{ steps.parse.outputs.version }}
     steps:
       - name: Parse version from commit subject
         id: parse
@@ -47,25 +38,6 @@ jobs:
             exit 1
           fi
 
-  # The tag is the release gate: it exists only once the example fleet has
-  # deployed and smoke-tested cleanly, so a failed deploy leaves main untagged
-  # with nothing to unpick.
-  deploy-test:
-    name: Deploy Test
-    needs: parse
-    uses: ./.github/workflows/deploy-test.yml
-    permissions:
-      contents: read
-      id-token: write
-
-  tag:
-    name: Create and push release tag
-    needs: [parse, deploy-test]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-    steps:
       - name: Checkout
         # Authenticate with RELEASE_PR_TOKEN (a PAT) so the tag push below triggers
         # release.yml's `push: tags` workflow. Pushes authenticated with the default
@@ -82,7 +54,7 @@ jobs:
 
       - name: Create and push tag
         env:
-          VERSION: ${{ needs.parse.outputs.version }}
+          VERSION: ${{ steps.parse.outputs.version }}
         run: |
           tag="v${VERSION}"
           if git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    # deploy-test gates the tag, in release-tag.yml — so a tag pushed by hand
-    # skips it. See docs/ci.md#manual-fallback.
+    # deploy-test gates the release branch, not the tag — so a tag pushed by
+    # hand skips it entirely. See docs/ci.md#manual-fallback.
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/sandbox-cleanup.yml
+++ b/.github/workflows/sandbox-cleanup.yml
@@ -6,12 +6,14 @@ name: Sandbox Cleanup
 
 on:
   workflow_run:
-    # The callers of deploy-test.yml, not deploy-test itself: a reusable
-    # workflow raises workflow_run for the top-level caller only. `Release Tag`
-    # covers the release path in both directions — a failed deploy stops there
-    # and never reaches `Release`, and that is exactly when a half-deployed
-    # fleet is left standing.
-    workflows: [Deploy Test, Release Tag]
+    # Every top-level run of deploy-test.yml — its own workflow_dispatch and
+    # its `push: release/**` release gate — fires this, pass or fail. A failed
+    # deploy is exactly when a half-deployed fleet is left standing.
+    #
+    # If deploy-test.yml is ever called as a reusable workflow again, add that
+    # caller's workflow name here: workflow_run only fires for the top-level
+    # caller, so a nested deploy would otherwise never be torn down.
+    workflows: [Deploy Test]
     types: [completed]
   schedule:
     # Daily safety net at 06:00 UTC.
@@ -40,10 +42,6 @@ concurrency:
 jobs:
   cleanup:
     name: Destroy ComposureCDK example stacks
-    # Release Tag runs on every push to main and skips its own jobs on
-    # non-release commits. An all-skipped run still reports `completed`, so
-    # ignore it — nothing deployed, nothing to tear down.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ inputs.environment || 'sandbox' }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,25 +4,40 @@ CI/CD pipeline for ComposureCDK: how the workflows chain, how to bootstrap AWS a
 
 ## Pipeline overview
 
-Five GitHub Actions workflows chain together, with `coverage-comment.yml` and `release-notify.yml` hanging off CI and Release as listeners rather than links in the chain:
+Each arrow below means "causes the thing under it"; the text beside it is the trigger that carries it. `coverage-comment.yml` and `release-notify.yml` hang off CI and Release as `workflow_run` listeners rather than links in the chain.
 
 ```
-ci.yml ──► deploy-test.yml ──► release-tag.yml ──► release.yml
-   ▲              ▲                   ▲                 ▲
-   │              │                   │                 │
- PRs/push  workflow_dispatch    push to main       tag push (PAT
-   │                            (chore(release):    or manual)
-   │ workflow_run                vX.Y.Z commits)
-   ▼                                  ▲
-coverage-comment.yml                  │
-                              release-prepare.yml (workflow_dispatch → opens PR)
+Every PR, and every push to main
+  ci.yml ──workflow_run──► coverage-comment.yml   (sticky coverage comment)
+
+Cutting a release
+  release-prepare.yml            workflow_dispatch, by hand
+    │ pushes release/vX.Y.Z with the PAT, opens the release PR
+    ▼
+  deploy-test.yml                push: release/**    ◄── the release gate,
+    │ uses: ci.yml, then deploys and smoke-tests         a check on the PR
+    │ workflow_run, pass or fail
+    ▼
+  sandbox-cleanup.yml            (also a nightly cron safety net)
+
+    ··········· squash-merge the release PR ···········
+
+  release-tag.yml                push: main, chore(release): vX.Y.Z commits
+    │ pushes tag vX.Y.Z with the PAT
+    ▼
+  release.yml                    push: tags v*.*.* — GitHub Release, then npm
+    │ workflow_run
+    ▼
+  release-notify.yml             (comments on the issues the release addressed)
 ```
+
+`deploy-test.yml` also runs standalone via `workflow_dispatch`.
 
 - **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20/22/24/26 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)). The Node 24 leg also reports test coverage on PRs (see [Coverage reporting](#coverage-reporting)). It holds no write scopes, so it stays callable from `deploy-test.yml`.
 - **`coverage-comment.yml`** — `workflow_run` listener on CI. Posts the coverage table as a sticky PR comment (see [Coverage reporting](#coverage-reporting)).
-- **`deploy-test.yml`** — manual `workflow_dispatch`, and called by `release-tag.yml`. Calls CI as a pre-deploy sanity check (Node 24 only, no floor shards — see [Trimming CI for deploy-test](#trimming-ci-for-deploy-test)), then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation.
-- **`release-prepare.yml`** — manual `workflow_dispatch`. Runs `nx release version` + `nx release changelog`, pushes branch `release/vX.Y.Z`, opens a PR titled `chore(release): vX.Y.Z`. The PR is the integration point that lets release coexist with branch protection on `main`.
-- **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it runs deploy-test and then tags the commit. The tag is the release gate: it is only created once the example fleet has deployed and smoke-tested cleanly, so a bad release never leaves a dangling tag to clean up. It is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
+- **`deploy-test.yml`** — calls CI as a pre-deploy sanity check (Node 24 only, no floor shards — see [Trimming CI for deploy-test](#trimming-ci-for-deploy-test)), then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation. Runs on demand via `workflow_dispatch`, and automatically on any push to `release/**` — **that is the release gate**, and it lands as a check on the release PR next to CI. A release branch is the only ref holding exactly what is being released, version bumps and changelog included; `main`'s HEAD is a different tree, and tag time is too late to gate anything.
+- **`release-prepare.yml`** — manual `workflow_dispatch`. Runs `nx release version` + `nx release changelog`, pushes branch `release/vX.Y.Z`, opens a PR titled `chore(release): vX.Y.Z`. The PR is the integration point that lets release coexist with branch protection on `main`; pushing the branch is also what starts the deploy gate above.
+- **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it tags the commit. The tag is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
 - **`release.yml`** — triggered by `v*.*.*` tag pushes (from release-tag.yml or a manual `git push origin vX.Y.Z`). Creates the GitHub Release from the matching `CHANGELOG.md` section, then runs `npx nx release publish` to npm with provenance, authenticated via [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC) in the `npm` environment. Trust is configured against this workflow file (`release.yml`), so both the automated chain and the manual escape hatch resolve to the same OIDC `job_workflow_ref` claim.
 - **`release-notify.yml`** — `workflow_run` listener on Release. Comments on the issues the release addressed (see [Release notifications](#release-notifications)).
 
@@ -39,7 +54,7 @@ How it fits together:
 
 Notes:
 
-- **Why two workflows.** `ci.yml` is `workflow_call`-able from `deploy-test.yml` (which `release-tag.yml` calls in turn), and GitHub only ever _narrows_ permissions down a reusable-workflow chain. A job inside `ci.yml` declaring `pull-requests: write` therefore fails validation for any caller that lacks that scope — statically, at parse time, regardless of whether the posting step's `if:` would ever let it run. Keeping `ci.yml` at `contents: read` makes it callable from anywhere; the write scope lives only in `coverage-comment.yml`.
+- **Why two workflows.** `ci.yml` is `workflow_call`-able from `deploy-test.yml`, and GitHub only ever _narrows_ permissions down a reusable-workflow chain. A job inside `ci.yml` declaring `pull-requests: write` therefore fails validation for any caller that lacks that scope — statically, at parse time, regardless of whether the posting step's `if:` would ever let it run. Keeping `ci.yml` at `contents: read` makes it callable from anywhere; the write scope lives only in `coverage-comment.yml`.
 - **Fork PRs** now get a comment too. `workflow_run` executes in the base-repo context with a writable `GITHUB_TOKEN`, which the old in-line comment step could not obtain. The listener never checks out or executes PR code — it only reads the uploaded markdown and the PR number, which it validates is numeric before use.
 - `coverage-comment.yml` must exist on the **default branch** to fire; `workflow_run` always dispatches the default-branch copy. Changes to it are not exercised by the PR that introduces them.
 - The summary and upload steps run with `if: always()`, so when a package dips below its threshold and fails `npm run test`, reviewers still see the table (with the offending package flagged). The job status still reflects the failure — the gate is unchanged. Because they now share a job with the earlier gates, they additionally guard on `steps.test.conclusion != 'skipped'`: a typecheck or lint failure skips `Test`, leaving no `coverage-summary.json` to merge, and the reporting steps should stay quiet rather than fail a second time on the same root cause.
@@ -106,9 +121,13 @@ Scopes are optional and do not affect the bump.
    - Set `specifier` (e.g. `0.6.1`) to force an exact version.
    - Set `specifier` _and_ tick `bump-peer-deps` for any 0.x minor bump (see below).
 
-3. **Review and merge.** CI runs against the PR; squash-merge it once green. (The release-tag filter assumes the release commit is HEAD on `main`.)
+   Pushing the `release/vX.Y.Z` branch fires `deploy-test.yml`, so the sandbox deploy starts on its own as soon as the PR exists — allow ~45 min for it alongside CI. The two overlap: the PR's own CI run covers the merge ref, and `deploy-test.yml` calls CI again for the branch tip. On a freshly cut release branch those are the same tree, so expect the trimmed Node 24 leg (see [Trimming CI for deploy-test](#trimming-ci-for-deploy-test)) to run twice per release.
 
-4. **Deploy-test, tag, publish — automatic.** `release-tag.yml` deploys the examples to the sandbox and only tags the commit if that passes (allow ~40 min); the tag then invokes `release.yml`, which creates the GitHub Release and publishes to npm. A deploy failure leaves `main` untagged — fix forward and re-run the workflow on the same commit.
+3. **Review and merge.** Squash-merge once **both** CI and **Deploy Test** are green on the PR. (The release-tag filter assumes the release commit is HEAD on `main`.) Deploy Test ran against the release branch — the exact tree being released — so nothing downstream re-runs it. Pushing a fix to the branch re-runs both checks.
+
+   The merge checklist is the enforcement here, not branch protection: required status checks are configured per _base_ branch, so requiring Deploy Test on `main` would block every PR — the check only ever runs on `release/**`.
+
+4. **Tag and publish — automatic.** `release-tag.yml` tags the merge commit, and the tag invokes `release.yml`, which creates the GitHub Release and publishes to npm. Neither re-runs the deploy: merging the release PR _is_ the release decision.
 
 #### Bumping the minor version in 0.x (breaking change)
 
@@ -127,16 +146,17 @@ Patch releases within the same minor (`0.6.0` → `0.6.1`) need neither input.
 
 #### `RELEASE_PR_TOKEN` (required)
 
-The automated chain depends on a fine-grained PAT stored as repository secret `RELEASE_PR_TOKEN`. Two reasons:
+The automated chain depends on a fine-grained PAT stored as repository secret `RELEASE_PR_TOKEN`. Three reasons, all the same underlying rule — per [GitHub's rules][gha-token-rules], anything authenticated with `GITHUB_TOKEN` does not fire downstream workflow triggers:
 
-- **Tag push triggers `release.yml`.** Per [GitHub's rules][gha-token-rules], pushes authenticated with `GITHUB_TOKEN` do not fire downstream workflow triggers. Without the PAT, `release-tag.yml` would tag the commit but `release.yml` would never publish.
+- **Tag push triggers `release.yml`.** Without the PAT, `release-tag.yml` would tag the commit but `release.yml` would never publish.
+- **Release-branch push triggers `deploy-test.yml`.** Without the PAT, the release gate would silently never run — the PR would simply have no Deploy Test check.
 - **PR auto-CI.** PRs opened by `GITHUB_TOKEN` do not trigger `pull_request` workflows, so CI would not run on the release PR until someone re-opened it. The PAT-opened PR triggers CI normally.
 
 Create a fine-grained PAT (or GitHub App) scoped to this repo with `contents:write` and `pull_requests:write`, store it as `RELEASE_PR_TOKEN`. Track its expiry — when it lapses, both `release-prepare.yml` and `release-tag.yml` will start failing at the checkout step.
 
 #### Manual fallback
 
-`release.yml` keeps its `push: tags: v*.*.*` trigger as an escape hatch — pushing a `vX.Y.Z` tag manually (typically by an admin with permission to push tags through branch protection) bypasses the automated chain and goes straight to Release + publish. deploy-test gates the tag, not the publish, so a hand-pushed tag skips it entirely: run **Deploy Test** via `workflow_dispatch` first if you take this route.
+`release.yml` keeps its `push: tags: v*.*.*` trigger as an escape hatch — pushing a `vX.Y.Z` tag manually (typically by an admin with permission to push tags through branch protection) bypasses the automated chain and goes straight to Release + publish. deploy-test gates the release branch, not the tag or the publish, so a hand-pushed tag skips it entirely: run **Deploy Test** via `workflow_dispatch` first if you take this route.
 
 [gha-token-rules]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -296,7 +296,29 @@ Create a GitHub Environment called `sandbox` with:
 | `AWS_ROLE_ARN` | The `RoleArn` output from the OIDC stack       |
 | `AWS_REGION`   | The region you bootstrapped (e.g. `eu-west-1`) |
 
+Then restrict **which refs may deploy to it**. This is the control that actually holds the AWS credentials: the trust policy in `github-oidc-role.yml` scopes assumption to `repo:<org>/<repo>:environment:sandbox`, so any workflow that reaches the `sandbox` environment can assume the role. Set the environment's deployment branches to _selected branches and tags_ and allow exactly:
+
+| Pattern     | Type   | Why                                               |
+| ----------- | ------ | ------------------------------------------------- |
+| `main`      | branch | Manual **Deploy Test** dispatch                   |
+| `release/*` | branch | The release gate, on every release-branch push    |
+| `v*.*.*`    | tag    | Kept for a hand-pushed tag on the manual fallback |
+
+A wildcard like `*/*` would let any contributor push `anything/x` and obtain sandbox credentials. The flip side of the narrow list: **Deploy Test** can no longer be dispatched from a feature branch — merge to `main` or use a `release/` branch.
+
 Add protection rules (e.g. required reviewers) as desired.
+
+### 3a. Restrict release branches
+
+Because a push to `release/**` now deploys by itself, pair the environment policy with a repository ruleset so contributors cannot create such a branch in the first place:
+
+| Setting | Value                                                    |
+| ------- | -------------------------------------------------------- |
+| Target  | `refs/heads/release/**`                                  |
+| Rules   | Restrict creations, restrict updates, restrict deletions |
+| Bypass  | Repository admin                                         |
+
+`release-prepare.yml` pushes with `RELEASE_PR_TOKEN`, which acts as its owner — so that owner must hold the bypass, or the workflow fails at the branch push. The two controls are complementary: the ruleset governs who can make a release branch, the environment policy governs what a release branch can reach.
 
 ### 4. Trigger the workflow
 


### PR DESCRIPTION
## What & why

Follow-up to #345. Two placements were wrong for the same underlying reason — neither tested the tree being released:

- **In `release-tag.yml`** (#345, on `main`): the deploy runs after the release PR is merged, so feedback lands after the release decision.
- **In `release-prepare.yml`** (this PR's first revision): a reusable workflow runs at the caller's ref, so it would have deployed `main`'s HEAD — a different tree from the release branch.

`deploy-test.yml` now also triggers on **`push: release/**`**. The release branch is the only ref holding exactly what ships, version bumps and `CHANGELOG.md` included, and `release-prepare.yml` pushes it with the PAT — so the deploy starts by itself the moment the release PR exists, and lands as a check on that PR next to CI.

```
release-prepare.yml  ──push release/vX.Y.Z──►  deploy-test.yml   ← the gate
                     └──opens the release PR ──► CI                 (check on the PR)
        │ squash-merge, once both are green
        ▼
release-tag.yml  ──tag──►  release.yml   (GitHub Release → npm)
```

`release-tag.yml` reverts to a single `tag` job; the `parse` split in #345 existed only to protect the deploy it no longer owns.

### A trigger, not a wrapper workflow

The first draft of this was a 35-line `release-deploy-test.yml` that did nothing but `uses: ./.github/workflows/deploy-test.yml`. Adding the trigger to `deploy-test.yml` directly is better: `sandbox-cleanup.yml` keys off top-level workflow *names*, and a second name is one more thing nothing validates when it drifts — rename the wrapper and teardown silently stops firing for the release path. Its listener list goes back to `[Deploy Test]`, with a note about what to do if `deploy-test.yml` is ever called as a reusable workflow again.

That needs one fix: `environment:` gains the `|| 'sandbox'` fallback the concurrency group already had, since a `push` event carries no `inputs` and an empty environment binding would silently drop `AWS_ROLE_ARN`/`AWS_REGION`.

### Worth knowing

- **Enforcement is the merge checklist, not branch protection.** Required status checks are configured per *base* branch, so requiring Deploy Test on `main` would block every PR — it only ever runs on `release/**`. The PR body now lists it explicitly.
- **`RELEASE_PR_TOKEN` gains a third reason to exist.** The branch push only triggers the gate because it is PAT-authenticated; under `GITHUB_TOKEN` the release PR would simply have no Deploy Test check. Documented alongside the other two.
- **CI runs twice on a release branch push** — once for the PR's merge ref, once inside `deploy-test.yml` for the branch tip. On a freshly cut branch those are the same tree. `docs/ci.md` now says so rather than implying otherwise; a `run-ci` input on `deploy-test.yml` would remove it, but that is a separate change.
- Also corrects three places (`ci.yml`, `coverage-comment.yml`, `docs/ci.md`) that still named `release.yml` as `ci.yml`'s `workflow_call` caller — stale since the deploy left that workflow.
- The `docs/ci.md` pipeline diagram is redrawn top-to-bottom with the trigger written on each edge; the old side-by-side layout was built for a linear chain and had edges landing on the wrong boxes.

## Verification

`actionlint` clean on all workflows; `npm run verify` passes. The path is exercised by the next Release Prepare dispatch — the branch push should produce a **Deploy Test** run against `release/vX.Y.Z`, visible in the PR's checks.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [ ] Tests added/updated for the change — n/a, workflow-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)