### PR TITLE
ci: trim the CI run inside deploy-test to one Node leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,24 @@ on:
   pull_request:
     branches: [main]
   workflow_call:
+    # Both inputs default to the full run, so `push`/`pull_request` are
+    # unaffected — those events carry no inputs at all, and the expressions
+    # below fall back accordingly. Only a caller that opts out gets less.
+    inputs:
+      node-versions:
+        description: "JSON array of Node major versions to run the matrix on."
+        required: false
+        default: "[20, 22, 24, 26]"
+        type: string
+      skip-cdk-floors:
+        # Phrased as a skip, not a run, deliberately. On a push or
+        # pull_request every input is unset, and GitHub expressions coerce an
+        # unset input to false — so false has to be the value that means "do
+        # the normal thing".
+        description: "Skip the aws-cdk-lib floor-enforcement shards."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -26,7 +44,7 @@ jobs:
       matrix:
         # Node 20 is the supported floor; 24 is current LTS; 26 is next.
         # Dual-published packages must resolve on all — see ADR-0007.
-        node-version: [20, 22, 24, 26]
+        node-version: ${{ fromJSON(inputs.node-versions || '[20, 22, 24, 26]') }}
 
     steps:
       - name: Checkout
@@ -135,6 +153,8 @@ jobs:
   # stays in sync without duplicating values in YAML.
   cdk-floors-list:
     name: List CDK floors
+    # Skipping this skips cdk-floors-enforce with it, via `needs`.
+    if: ${{ !inputs.skip-cdk-floors }}
     runs-on: ubuntu-latest
     outputs:
       floors: ${{ steps.read.outputs.floors }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -33,6 +33,16 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    # A pre-deploy sanity check, not a second full CI run. The deploy runs on
+    # Node 24 against the pinned aws-cdk-lib, so the other matrix legs (which
+    # exist to prove dual ESM/CJS resolution across runtimes, ADR-0007) and the
+    # floor shards (which pin aws-cdk-lib down to each package's declared
+    # minimum, ADR-0008) cannot say anything about whether these stacks deploy.
+    # The Node 24 leg still runs the whole verify chain — including `npm run
+    # validate`, the synth + CloudFormation Validate pass that actually can.
+    with:
+      node-versions: "[24]"
+      skip-cdk-floors: true
 
   deploy-test:
     name: Deploy and Verify Examples

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -20,7 +20,7 @@ coverage-comment.yml                  │
 
 - **`ci.yml`** — runs format/typecheck/build/`check:exports`/lint/test on a Node 20/22/24/26 matrix, on every push and PR. Also `workflow_call`-able. Quality gate for everything downstream. The steps are just `npm run` scripts — the same ones `npm run verify` chains locally — so CI executes the gate, it does not _define_ it (see [ADR-0007](adr/0007-dual-esm-cjs-publishing.md)). The Node 24 leg also reports test coverage on PRs (see [Coverage reporting](#coverage-reporting)). It holds no write scopes, so it stays callable from `deploy-test.yml`.
 - **`coverage-comment.yml`** — `workflow_run` listener on CI. Posts the coverage table as a sticky PR comment (see [Coverage reporting](#coverage-reporting)).
-- **`deploy-test.yml`** — manual `workflow_dispatch`, and called by `release-tag.yml`. Calls CI, then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation.
+- **`deploy-test.yml`** — manual `workflow_dispatch`, and called by `release-tag.yml`. Calls CI as a pre-deploy sanity check (Node 24 only, no floor shards — see [Trimming CI for deploy-test](#trimming-ci-for-deploy-test)), then deploys all example stacks to the `sandbox` environment via OIDC, runs `scripts/smoke-test.mjs`, and exits. Teardown runs separately in `sandbox-cleanup.yml` so developer feedback lands in ~10 min instead of waiting on CloudFront propagation.
 - **`release-prepare.yml`** — manual `workflow_dispatch`. Runs `nx release version` + `nx release changelog`, pushes branch `release/vX.Y.Z`, opens a PR titled `chore(release): vX.Y.Z`. The PR is the integration point that lets release coexist with branch protection on `main`.
 - **`release-tag.yml`** — runs on every push to `main`. If the head commit subject matches `chore(release): vX.Y.Z` (squash-merge required), it runs deploy-test and then tags the commit. The tag is the release gate: it is only created once the example fleet has deployed and smoke-tested cleanly, so a bad release never leaves a dangling tag to clean up. It is pushed authenticated with `RELEASE_PR_TOKEN` (a PAT) so it triggers `release.yml`'s `push: tags` workflow — pushes authenticated with the default `GITHUB_TOKEN` do not fire downstream triggers.
 - **`release.yml`** — triggered by `v*.*.*` tag pushes (from release-tag.yml or a manual `git push origin vX.Y.Z`). Creates the GitHub Release from the matching `CHANGELOG.md` section, then runs `npx nx release publish` to npm with provenance, authenticated via [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC) in the `npm` environment. Trust is configured against this workflow file (`release.yml`), so both the automated chain and the manual escape hatch resolve to the same OIDC `job_workflow_ref` claim.
@@ -43,6 +43,21 @@ Notes:
 - `coverage-comment.yml` must exist on the **default branch** to fire; `workflow_run` always dispatches the default-branch copy. Changes to it are not exercised by the PR that introduces them.
 - The summary and upload steps run with `if: always()`, so when a package dips below its threshold and fails `npm run test`, reviewers still see the table (with the offending package flagged). The job status still reflects the failure — the gate is unchanged. Because they now share a job with the earlier gates, they additionally guard on `steps.test.conclusion != 'skipped'`: a typecheck or lint failure skips `Test`, leaving no `coverage-summary.json` to merge, and the reporting steps should stay quiet rather than fail a second time on the same root cause.
 - **A missing artifact is a normal outcome, not a failure of the listener.** A cancelled CI run (push-over-push) or one that fails an earlier gate in the Node 24 leg uploads nothing, so `coverage-comment.yml` tolerates the download (`continue-on-error`) and gates its posting steps on that step's `outcome`: no artifact, no comment, run stays green. Hard-failing there would report the same root cause a second time, as a separate red run alongside the CI failure that caused it. The listener is deliberately **not** gated on `workflow_run.conclusion == 'success'` — a coverage threshold miss fails `Test` but still uploads the table, and that is exactly the run whose comment reviewers want.
+
+## Trimming CI for deploy-test
+
+`ci.yml` takes two `workflow_call` inputs, both defaulting to the full run so `push` and `pull_request` are untouched — those events carry no inputs, and the expressions fall back accordingly:
+
+| Input             | Default              | Effect                                           |
+| ----------------- | -------------------- | ------------------------------------------------ |
+| `node-versions`   | `"[20, 22, 24, 26]"` | JSON array driving the matrix                    |
+| `skip-cdk-floors` | `false`              | Skips `cdk-floors-list` and its `enforce` shards |
+
+`deploy-test.yml` passes `"[24]"` and `true`, taking that call from 17 jobs to 1.
+
+The trimmed-away work cannot tell you whether the examples deploy. The Node 20/22/26 legs exist to prove dual ESM/CJS resolution across runtimes ([ADR-0007](adr/0007-dual-esm-cjs-publishing.md)); the floor shards pin `aws-cdk-lib` down to each package's declared minimum ([ADR-0008](adr/0008-aws-cdk-lib-version-floors.md)). A deploy runs on Node 24 against the installed `aws-cdk-lib` and touches neither dimension. What is kept is the whole `verify` chain on Node 24 — format, typecheck, build, `check:exports`, lint, `cdk-floors:check`, `validate` (synth + CloudFormation Validate), test — which is the part that can.
+
+`skip-cdk-floors` is phrased as a skip rather than a run because an unset input coerces to `false` in GitHub expressions, so `false` has to be the value that means "do the normal thing".
 
 ## Versioning
 


### PR DESCRIPTION
## What & why

`deploy-test.yml` called `ci.yml` wholesale: **17 jobs** — four Node legs (20/22/24/26) each running the full `verify` chain, plus `cdk-floors-list` and 12 `cdk-floors-enforce` shards. Almost none of it bears on the question deploy-test is asking.

- The Node 20/22/26 legs exist to prove dual ESM/CJS resolution across runtimes ([ADR-0007](docs/adr/0007-dual-esm-cjs-publishing.md)).
- The floor shards pin `aws-cdk-lib` down to each package's declared minimum ([ADR-0008](docs/adr/0008-aws-cdk-lib-version-floors.md)).

A deploy runs on **Node 24** against the **installed** `aws-cdk-lib` and touches neither dimension.

`ci.yml` gains two `workflow_call` inputs; `deploy-test.yml` passes `"[24]"` and `true`, taking that call **from 17 jobs to 1**.

| Input | Default | Effect |
| --- | --- | --- |
| `node-versions` | `"[20, 22, 24, 26]"` | JSON array driving the matrix |
| `skip-cdk-floors` | `false` | Skips `cdk-floors-list` and its `enforce` shards |

What's kept is the entire `verify` chain on Node 24 — format, typecheck, build, `check:exports`, lint, `cdk-floors:check`, **`validate` (synth + CloudFormation Validate)**, test. That last one is the check that actually predicts a deploy.

## Nothing changes for PRs or pushes

Both inputs default to today's behaviour, and `push`/`pull_request` events carry no inputs at all — the expressions fall back to the full matrix. The four required status checks on `main` (`Lint, Format, Typecheck, Test, Build (Node 20|22|24|26)`) are unaffected; you can see all four on this PR.

One subtlety worth knowing: `skip-cdk-floors` is phrased as a *skip* rather than a *run* because an unset input coerces to `false` in GitHub expressions — so `false` has to be the value that means "do the normal thing". A positively-named boolean would silently disable the shards on every push. There's a comment in `ci.yml` saying so.

## Verification

`actionlint` clean (the pre-existing SC2016 note in `ci.yml` is untouched); `npm run verify` passes. The reduced call is exercised the next time Deploy Test runs — expect a single `CI / Lint, Format, Typecheck, Test, Build (Node 24)` job under it and no floor shards.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [ ] Tests added/updated for the change — n/a, workflow-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)