### PR TITLE
feat(cloudformation): add templateTextPolicy, an opt-in guard for template text

### DIFF
--- a/docs/adr/0002-policies.md
+++ b/docs/adr/0002-policies.md
@@ -1,6 +1,6 @@
 # ADR 0002: Policies — cross-cutting helpers applied to a construct subtree
 
-- **Status:** Accepted
+- **Status:** Accepted (§5 amended by [ADR-0017](0017-template-text-policy.md))
 - **Date:** 2026-04-23
 
 ## Context

--- a/docs/adr/0010-aws-property-constraints.md
+++ b/docs/adr/0010-aws-property-constraints.md
@@ -45,7 +45,7 @@ Two axes had to be decided: **where the constraint catalogue lives**, and **how/
 - A shared fragment graduates to `cloudformation`'s `char-sets` only once a _second_ property needs it — promotion is a one-line move plus an import change, with no builder API change and no dependency inversion (arrows only point service → cloudformation).
 - `validateTag` keeps its public signature; `taggedBuilder` and all callers are untouched. The empty-key and reserved-`aws:`-prefix rules remain tag-specific and bespoke.
 - Branded types (`AlarmName`, `Email`) remain valid where compile-time guarantees matter; they layer over `validateString` rather than competing with it. Migrating them is deferred.
-- A holistic synth-time Aspect keyed by CFN resource type (catching raw CDK and late-added constructs) remains a complementary, opt-in follow-up. When built it should consume a registry or CFN-spec-generated map, not import each package.
+- A holistic synth-time Aspect keyed by CFN resource type (catching raw CDK and late-added constructs) remains a complementary, opt-in follow-up. When built it should consume a registry or CFN-spec-generated map, not import each package. Built as `templateTextPolicy` — see [ADR-0017](0017-template-text-policy.md).
 
 ## Alternatives considered
 

--- a/docs/adr/0017-template-text-policy.md
+++ b/docs/adr/0017-template-text-policy.md
@@ -1,0 +1,55 @@
+# ADR 0017: Template-text validity as an opt-in Aspect, not builder enforcement
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+
+## Context
+
+CloudFormation stores template text as ASCII. A non-ASCII character in a free-text field — an em-dash, a curly quote — is accepted at synth and **silently transliterated to `?`** when CloudFormation stores the template. Nothing fails. The deployed template simply stops matching the synthesised one, so `cdk diff` reports a change on every run afterwards, forever, on a stack nobody touched ([issue #336](https://github.com/laazyj/composureCDK/issues/336)).
+
+This is the same root cause as the `GroupDescription` failure behind [ADR-0010](0010-aws-property-constraints.md), with a worse failure mode: EC2 rejected that value outright with `CREATE_FAILED`, so it was noticed. Here there is nothing to notice.
+
+Two facts shaped the response.
+
+**The catalogue could not have caught it.** ADR-0010 puts a `validate*` call in each builder's `build()`. That only covers fields someone remembered to wire one into. The field that actually bit a consumer was the stack-level `Description`, which `StackBuilder` passes straight through to `StackProps` and no validator ever sees. Six library-shipped alarm descriptions carried the same character, as did four example stacks CI deploys — all fixed separately in [#351](https://github.com/laazyj/composureCDK/pull/351). A mechanism that depends on remembering is the mechanism that let this through.
+
+**Enforcing it now would break working stacks.** Consumers are deploying today with transliterated descriptions. The deployments succeed; only the diff is noisy. Turning that into a synth failure is a breaking change delivered as a bug fix.
+
+## Decision
+
+**Template-text validity is enforced by an opt-in Aspect keyed by CloudFormation resource type, not by builder-level validators.**
+
+1. **`templateTextPolicy(scope, config?)` in `@composurecdk/cloudformation`**, under `src/policies/`. A Policy in the [ADR-0002](0002-policies.md) sense: a free function returning `void`, backed by `Aspects`, with no `compose()` dependency.
+
+2. **Opt-in, with three modes.** `throw` (default) fails synth at the authoring call site; `sanitize` rewrites the value so the emitted template matches what CloudFormation will store; `warn` annotates every violation in one pass. `warn` exists because `throw` reports only the first violation — the adoption path on an existing estate is `warn`, fix the list, switch to `throw`.
+
+3. **Builder-level enforcement is retained only where the violation is deploy-fatal.** An EC2 `GroupDescription` fails `CREATE_FAILED`, so `validateSecurityGroupDescription` stays in `build()` and is not optional. A field that is merely coerced is the Aspect's job. The dividing line is _broken stack_ versus _noisy diff_.
+
+4. **The registry is keyed by resource-type string, so it imports no service package.** `TEMPLATE_TEXT_FIELDS` names `AWS::Lambda::Function` without importing `@composurecdk/lambda`. This is what ADR-0010's consequences called for — "a registry or CFN-spec-generated map, not import each package" — and it is why the policy can live centrally without inverting the dependency graph.
+
+5. **It amends [ADR-0002](0002-policies.md) §5.** That decision routes pan-domain policies to `packages/examples/` until ≥ 2 justify a `@composurecdk/policies` package. The rationale there is peer-dependency surface: a policy spanning services would make that package peer-depend on all of them. A resource-type-string-keyed policy has no such surface, so the rule does not apply to it. Such policies live in `@composurecdk/cloudformation`, next to the constraint mechanism.
+
+6. **One cross-cutting rule, not the whole catalogue at template level.** The Aspect enforces a single invariant — template text is ASCII — across many fields. Per-property character classes and length limits stay in their owning packages, applied at `build()`, exactly as ADR-0010 §2 decided. Registry entries are property _names_, not `StringConstraint`s.
+
+7. **Three node kinds, because only one is a `CfnResource`.** A stack's `Description` lives on `templateOptions`; `CfnOutput` and `CfnParameter` are `CfnElement`s with their own accessor. A registry keyed by resource type alone would miss both — including the field that prompted this ADR.
+
+## Consequences
+
+- Adding a newly-discovered field is one line in `TEMPLATE_TEXT_FIELDS`. The const is module-internal, not exported, so the registry's shape stays changeable; consumers extend it via `config.fields` without waiting for a release.
+- The catalogue gains a cross-cutting entry (`constraints.validate.templateText` / `constraints.sanitize.templateText`) alongside tags, which is the existing precedent for a constraint that is not per-resource.
+- Coverage is honest but partial, and the README says so: values resolving to a CloudFormation intrinsic, values written via `addPropertyOverride`, nested property paths, and unregistered resource types are all outside it. A guard whose gaps are undocumented gets over-trusted.
+- Because the policy is opt-in, the library's own shipped defaults are not protected by it. They are protected by being ASCII, verified by the synth-time test over the example stacks added in [#351](https://github.com/laazyj/composureCDK/pull/351).
+- Nested paths (`DistributionConfig.Comment`, `HostedZoneConfig.Comment`) need a resolve on read and an `addPropertyOverride` on write. They are deferred rather than approximated.
+- The seeded registry is 15 resource types against the several hundred that declare a free-text property. It is a starting point sized to what has been reasoned about, not a claim of completeness — see the name-predicate alternative below.
+- `warn` mode degrades to the 2.0-era `Annotations.addWarning` when `addWarningV2` is absent. This package's floor is `aws-cdk-lib` 2.1.0, the lowest in the repo because every other package peer-depends on it, and `addWarningV2` only arrived in 2.93.0 (ADR-0008); raising the floor for one optional mode would drag the whole library up with it.
+- A future policy that is genuinely pan-domain — one that must import service packages — still follows ADR-0002 §5 unchanged.
+
+## Alternatives considered
+
+- **Validate in every builder that emits a description.** Rejected: breaking for existing consumers, and structurally unable to cover the field that caused the bug (`StackProps.description` is a passthrough) or any construct the library did not build.
+- **An ESLint rule banning non-ASCII string literals in `src/`.** Rejected: a syntactic proxy for a semantic property. A blanket rule fires on ~35 legitimate error-message strings that never reach a template; narrowing it to `description`-named properties misses helpers like `describeInFlight` that return one. It also cannot see consumer-supplied text at all. Two mechanisms for one invariant is enough.
+- **`Annotations.addError` instead of throwing for `throw` mode.** Rejected: only the CDK CLI acts on error metadata, so `app.synth()` and `Template.fromStack()` would sail past it — a guard that does not fire in unit tests. Throwing fails everywhere and matches how the rest of the catalogue reports.
+- **Sanitising by collapsing runs, as `sanitizeString` does.** Rejected for text: a run-collapse turns a quoted phrase into a single `-`, losing more than CloudFormation itself does. Replacement is per character, with `?` — CloudFormation's own substitution — as the fallback for anything unmapped.
+- **Deriving the registry from a CloudFormation spec.** Rejected: no spec ships at runtime — `@aws-cdk/` provides only `cloud-assembly-schema` and asset packages — so deriving means vendoring a spec, a codegen script, and a staleness gate, for a list that changes slowly.
+- **Detecting free-text fields by name predicate** (`/[Dd]escription$/`, `displayName`, `comment`) against each L1's accessor names, instead of an allowlist. Rejected for v1, but it is the strongest alternative and the likeliest successor: `aws-cdk-lib` declares such a property on roughly 550 `Cfn*Props` interfaces against the 15 seeded here, and it would need no codegen. It is deferred because a predicate decides _for_ the consumer which properties are prose — the failure mode of a false positive is a synth error on a legal value, which is worse than the silent gap it replaces — and because the seed list is the honest scope of what has been reasoned about. `config.fields` is the escape hatch until then, and `TEMPLATE_TEXT_FIELDS` is deliberately not exported so the registry's shape can change without a breaking release.
+- **Making the policy on by default.** Rejected: it is a breaking change to working deployments, and the failure it prevents is a noisy diff, not an outage. The consumer decides.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,3 +63,4 @@ ADRs are append-only. To change a decision, write a new ADR that supersedes the 
 - [ADR-0014: Role-parameterized builders for mutually-exclusive L2 surfaces](0014-role-parameterized-queue-builder.md)
 - [ADR-0015: Combining multiple refs into one — the `combine()` Ref combinator](0015-combine-multi-ref-combinator.md)
 - [ADR-0016: Encapsulate SDK-only operations as domain actions on the owning builder](0016-domain-action-custom-resource.md)
+- [ADR-0017: Template-text validity as an opt-in Aspect, not builder enforcement](0017-template-text-policy.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -454,7 +454,7 @@ alarmActionsPolicy(app, {
 
 ### Design rationale
 
-- **Single-domain policies live in their package** under `src/policies/`, co-located with the detection logic and types they rely on (e.g. `alarmActionsPolicy` in `@composurecdk/cloudwatch`). Pan-domain policies that span services stay in `packages/examples/` until ≥ 2 of them justify a dedicated `@composurecdk/policies` package.
+- **Single-domain policies live in their package** under `src/policies/`, co-located with the detection logic and types they rely on (e.g. `alarmActionsPolicy` in `@composurecdk/cloudwatch`). Pan-domain policies that span services stay in `packages/examples/` until ≥ 2 of them justify a dedicated `@composurecdk/policies` package — unless the policy is keyed by CloudFormation resource-type _string_ and so imports no service package at all, in which case it lives in `@composurecdk/cloudformation` (e.g. `templateTextPolicy`). See [ADR-0017](adr/0017-template-text-policy.md).
 - **Named with a `<noun>Policy` suffix** to signal a scope-wide side effect applied at setup, distinct from builders and factories.
 
 See [ADR-0002](adr/0002-policies.md).

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -17,9 +17,10 @@ character set and links the relevant AWS doc.
 Cross-cutting tag key/value validation is not listed here; it is applied automatically by
 `taggedBuilder` and reachable directly via `validateTag` in `@composurecdk/cloudformation`.
 
-| Package                    | Constraint                 | Validate                                        | Sanitize |
-| -------------------------- | -------------------------- | ----------------------------------------------- | -------- |
-| `@composurecdk/budgets`    | `email`                    | `constraints.validate.email`                    | —        |
-| `@composurecdk/cloudwatch` | `alarmName`                | `constraints.validate.alarmName`                | —        |
-| `@composurecdk/ec2`        | `securityGroupDescription` | `constraints.validate.securityGroupDescription` | —        |
-| `@composurecdk/ec2`        | `securityGroupName`        | `constraints.validate.securityGroupName`        | —        |
+| Package                        | Constraint                 | Validate                                        | Sanitize                            |
+| ------------------------------ | -------------------------- | ----------------------------------------------- | ----------------------------------- |
+| `@composurecdk/budgets`        | `email`                    | `constraints.validate.email`                    | —                                   |
+| `@composurecdk/cloudformation` | `templateText`             | `constraints.validate.templateText`             | `constraints.sanitize.templateText` |
+| `@composurecdk/cloudwatch`     | `alarmName`                | `constraints.validate.alarmName`                | —                                   |
+| `@composurecdk/ec2`            | `securityGroupDescription` | `constraints.validate.securityGroupDescription` | —                                   |
+| `@composurecdk/ec2`            | `securityGroupName`        | `constraints.validate.securityGroupName`        | —                                   |

--- a/packages/cloudformation/README.md
+++ b/packages/cloudformation/README.md
@@ -118,6 +118,71 @@ compose(
   .build(stack, "StaticWebsite");
 ```
 
+## templateTextPolicy
+
+CloudFormation stores template text as ASCII. An em-dash, a curly quote or an ellipsis is **silently transliterated to `?` at deploy time** — no error, no `CREATE_FAILED`. The deployed template simply stops matching the synthesised one, so `cdk diff` reports a change on every run afterwards, forever, on a stack nobody touched. The only way out is to notice the character and strip it by hand.
+
+`templateTextPolicy` is a [Policy](../../docs/architecture.md#policies) that finds those characters at synth time instead.
+
+```ts
+import { templateTextPolicy } from "@composurecdk/cloudformation";
+
+templateTextPolicy(app); // fail synth on anything CloudFormation would rewrite
+```
+
+### Modes
+
+| `onViolation`         | Behaviour                                                                                         | Use it when                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `"throw"` _(default)_ | Fails synth, naming the construct path, the field and the offending character.                    | You want the text fixed at the source.                     |
+| `"sanitize"`          | Rewrites the value so the synthesised template matches what CloudFormation stores. Nothing fails. | A large existing estate you cannot chase string by string. |
+| `"warn"`              | Annotates every violation and carries on.                                                         | Adoption: run it, fix the list, then switch to `"throw"`.  |
+
+`sanitize` replaces per character, not per run — `“value”` becomes `"value"`, not a single `-`. Common typographic characters map to readable ASCII; anything else becomes `?`, which is what CloudFormation would have stored anyway. Override with `replace`:
+
+```ts
+templateTextPolicy(app, {
+  onViolation: "sanitize",
+  replace: (char) => (char === "€" ? "EUR" : transliterate(char)),
+});
+```
+
+### Why it is opt-in
+
+Enforcing this inside every builder would turn a working — if diff-noisy — deployment into a synth failure for anyone who has been living with the transliteration. Installing the policy is how you say you would rather know. Constraints whose violation fails the _deploy_ rather than merely the diff, such as an EC2 `GroupDescription`, stay enforced at the builder regardless ([ADR-0010](../../docs/adr/0010-aws-property-constraints.md)).
+
+An Aspect also reaches further than a builder can. A per-builder validator only covers fields someone remembered to wire one into — which is exactly how the stack-level `Description` slipped through, since `StackBuilder` passes `description` straight to `StackProps`. The Aspect walks the whole construct tree, so for the resource types it knows about it also catches constructs this library never built: raw L1s and other libraries' L2s alike.
+
+### What it checks
+
+The stack's own `Description`, every `CfnOutput` / `CfnParameter` description, and these resource properties:
+
+| Resource type                                                                             | Property           |
+| ----------------------------------------------------------------------------------------- | ------------------ |
+| `AWS::CloudWatch::Alarm`, `AWS::CloudWatch::CompositeAlarm`                               | `alarmDescription` |
+| `AWS::Lambda::Function`, `AWS::Events::Rule`, `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` | `description`      |
+| `AWS::ApiGateway::RestApi`, `Stage`, `Deployment`, `UsagePlan`, `ApiKey`                  | `description`      |
+| `AWS::Neptune::DBClusterParameterGroup`, `AWS::Neptune::DBParameterGroup`                 | `description`      |
+| `AWS::EC2::SecurityGroup`                                                                 | `groupDescription` |
+| `AWS::SNS::Topic`                                                                         | `displayName`      |
+
+That is a seed list, not the whole of CloudFormation — several hundred resource types declare a free-text property. Add the ones you use:
+
+```ts
+templateTextPolicy(app, { fields: { "AWS::Custom::Widget": ["notes"] } });
+```
+
+Keys are CloudFormation resource types; values are **CDK L1 property names** (camelCase — `alarmDescription`, not `AlarmDescription`).
+
+### What it does not cover
+
+- Values that resolve to a CloudFormation intrinsic (`Ref`, `Fn::ImportValue`) — the text is not knowable at synth. A `Lazy` that resolves to a plain string **is** checked.
+- Values written through `addPropertyOverride`, or set on a bare `CfnResource`'s `properties`. Both bypass the typed L1 accessor the policy reads.
+- Nested properties such as `DistributionConfig.Comment`.
+- Resource types and properties not in the table above, until you add them. A property name that does not match an L1 accessor is skipped silently — the same outcome as not listing it.
+
+To check a single value directly rather than a whole tree, use `constraints.validate.templateText` / `constraints.sanitize.templateText` ([catalogue](../../docs/constraints.md)).
+
 ## Examples
 
 - [MultiStackApp](../examples/src/multi-stack-app.ts) — REST API + Lambda split across stacks via `.withStacks()`

--- a/packages/cloudformation/src/constraints/index.ts
+++ b/packages/cloudformation/src/constraints/index.ts
@@ -6,3 +6,4 @@ export {
 } from "./string-constraint.js";
 export { charSets } from "./char-sets.js";
 export { type ConstraintNamespace } from "./namespace.js";
+export { validateTemplateText, sanitizeTemplateText, transliterate } from "./template-text.js";

--- a/packages/cloudformation/src/constraints/template-text.ts
+++ b/packages/cloudformation/src/constraints/template-text.ts
@@ -1,0 +1,169 @@
+import { Token } from "aws-cdk-lib";
+import { stringConstraint } from "./string-constraint.js";
+
+/**
+ * The character set CloudFormation stores verbatim in template text.
+ *
+ * Printable ASCII plus the three whitespace characters a multi-line
+ * description legitimately contains (tab, LF, CR). Anything else is
+ * transliterated to `?` when CloudFormation stores the template, so the
+ * deployed template stops matching the synthesised one.
+ */
+const CHAR_CLASS = "\\x09\\x0a\\x0d\\x20-\\x7e";
+
+/**
+ * Matches one disallowed character at a time. The constraint's own
+ * `sanitizePattern` collapses a *run* into a single replacement, which loses
+ * more than CloudFormation does — see {@link sanitizeTemplateText}. The `u`
+ * flag is load-bearing: without it an astral character matches as two lone
+ * surrogates and {@link describeOffenders} reports a garbage code point.
+ */
+const DISALLOWED = new RegExp(`[^${CHAR_CLASS}]`, "gu");
+
+/**
+ * The same class without `g`, for a cheap "is there anything to report?" test.
+ * `matchAll` species-constructs a fresh RegExp and an iterator on every call,
+ * which is wasted on the overwhelmingly common clean value.
+ */
+const HAS_DISALLOWED = new RegExp(`[^${CHAR_CLASS}]`, "u");
+
+const TEMPLATE_TEXT = stringConstraint({
+  name: "CloudFormation template text",
+  charClass: CHAR_CLASS,
+  allowed: "ASCII text - printable characters, tab and newline",
+  source:
+    "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html#template-description-structure",
+  // Keeps the catalogue's derived patterns matching by code point, as
+  // `DISALLOWED` does, so `validateString(v, TEMPLATE_TEXT)` and this module
+  // cannot disagree about the same declared character class.
+  flags: "u",
+});
+
+/**
+ * ASCII stand-ins for common typographic characters. Keys are written as
+ * `\\u` escapes so an invisible character — the five space variants especially
+ * — cannot hide in this table, or be duplicated in it unnoticed.
+ *
+ * Anything not listed falls back to `?`, which is what CloudFormation itself
+ * would have stored: the sanitised template matches the deployed one either
+ * way, and an unmapped character stays visible instead of quietly becoming a
+ * plausible-looking hyphen.
+ */
+const TRANSLITERATIONS: Readonly<Record<string, string>> = {
+  "\u2010": "-", // hyphen
+  "\u2011": "-", // non-breaking hyphen
+  "\u2012": "-", // figure dash
+  "\u2013": "-", // en dash
+  "\u2014": "-", // em dash
+  "\u2015": "-", // horizontal bar
+  "\u2018": "'", // left single quote
+  "\u2019": "'", // right single quote / apostrophe
+  "\u201a": "'", // single low-9 quote
+  "\u201b": "'", // single high-reversed-9 quote
+  "\u201c": '"', // left double quote
+  "\u201d": '"', // right double quote
+  "\u201e": '"', // double low-9 quote
+  "\u201f": '"', // double high-reversed-9 quote
+  "\u2026": "...", // ellipsis
+  "\u2022": "*", // bullet
+  "\u00b7": ".", // middle dot
+  "\u00a0": " ", // non-breaking space
+  "\u2002": " ", // en space
+  "\u2003": " ", // em space
+  "\u2009": " ", // thin space
+  "\u202f": " ", // narrow no-break space
+  "\u2190": "<-", // left arrow
+  "\u2192": "->", // right arrow
+  "\u2264": "<=", // less-than or equal
+  "\u2265": ">=", // greater-than or equal
+  "\u00d7": "x", // multiplication sign
+};
+
+/**
+ * The default {@link sanitizeTemplateText} replacement — maps the common
+ * typographic characters to readable ASCII and everything else to `?`.
+ *
+ * @param char - A single disallowed character.
+ * @returns Its ASCII stand-in.
+ */
+export function transliterate(char: string): string {
+  return TRANSLITERATIONS[char] ?? "?";
+}
+
+/** How many offending characters a message lists before summarising the rest. */
+const MAX_LISTED = 3;
+
+function codePoint(char: string): string {
+  return `U+${(char.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
+/**
+ * Describes every character in `raw` that CloudFormation will not store
+ * verbatim, or `undefined` when there are none.
+ *
+ * @internal
+ */
+export function describeOffenders(raw: string): string | undefined {
+  if (!HAS_DISALLOWED.test(raw)) return undefined;
+
+  const listed = [...raw.matchAll(DISALLOWED)];
+  const formatted = listed
+    .slice(0, MAX_LISTED)
+    .map(
+      ({ 0: char, index }) =>
+        `${codePoint(char)} ${JSON.stringify(char)} at index ${String(index)}`,
+    );
+  const rest = listed.length - formatted.length;
+
+  return rest > 0 ? `${formatted.join(", ")} and ${String(rest)} more` : formatted.join(", ");
+}
+
+/**
+ * Builds the shared diagnostic. `templateTextPolicy` passes a label naming the
+ * construct path and field; the standalone validator names the constraint.
+ *
+ * @internal
+ */
+export function templateTextMessage(label: string, offenders: string): string {
+  return (
+    `${label} contains ${offenders}. CloudFormation stores template text as ASCII and ` +
+    `transliterates anything else to "?", so the deployed template will never match the ` +
+    `synthesised one and \`cdk diff\` will report a change on every run. ` +
+    `Allowed: ${TEMPLATE_TEXT.allowed}. See ${TEMPLATE_TEXT.source}.`
+  );
+}
+
+/**
+ * Validates a string destined for CloudFormation template text. Unresolved
+ * CDK tokens are skipped — their value is not knowable at synth (ADR-0010).
+ *
+ * @param raw - The value to check.
+ * @param label - What to name in the error. Defaults to the constraint name.
+ * @throws If `raw` contains a character CloudFormation will not store verbatim.
+ */
+export function validateTemplateText(raw: string, label = TEMPLATE_TEXT.name): void {
+  if (Token.isUnresolved(raw)) return;
+  const offenders = describeOffenders(raw);
+  if (offenders === undefined) return;
+  throw new Error(templateTextMessage(label, offenders));
+}
+
+/**
+ * Returns a copy of `raw` with every character CloudFormation would not store
+ * verbatim replaced, so the synthesised template matches the deployed one.
+ *
+ * Replacement is per character, not per run: collapsing a run the way
+ * `sanitizeString` does would turn a quoted phrase into a single `-`, losing
+ * more than CloudFormation itself does.
+ *
+ * @param raw - The value to clean. Unresolved tokens are returned unchanged.
+ * @param replace - Maps one disallowed character to its ASCII stand-in.
+ * @returns The cleaned value.
+ */
+export function sanitizeTemplateText(
+  raw: string,
+  replace: (char: string) => string = transliterate,
+): string {
+  if (Token.isUnresolved(raw)) return raw;
+  return raw.replace(DISALLOWED, replace);
+}

--- a/packages/cloudformation/src/index.ts
+++ b/packages/cloudformation/src/index.ts
@@ -1,3 +1,6 @@
+import type { ConstraintNamespace } from "./constraints/index.js";
+import { sanitizeTemplateText, validateTemplateText } from "./constraints/template-text.js";
+
 export {
   createStackBuilder,
   type IStackBuilder,
@@ -15,5 +18,30 @@ export {
   validateString,
   sanitizeString,
   charSets,
+  transliterate,
   type ConstraintNamespace,
 } from "./constraints/index.js";
+export {
+  templateTextPolicy,
+  type TemplateTextPolicyConfig,
+  type TemplateTextViolationMode,
+  TEMPLATE_TEXT_WARNING_NAME,
+} from "./policies/template-text-policy.js";
+export { type TemplateTextFields } from "./policies/template-text-fields.js";
+
+/**
+ * This package's AWS-property constraints, grouped by application strategy.
+ * The `constraints.validate.*` / `constraints.sanitize.*` shape is identical
+ * in every builder package, so it is discoverable without importing anything
+ * beyond the package you already use. See ADR-0010.
+ *
+ * `templateText` is cross-cutting rather than per-resource — it is the same
+ * rule for every free-text field in the template — so it lives here with the
+ * mechanism rather than in a service package, as tag validation does.
+ * {@link templateTextPolicy} applies it across a whole construct tree; these
+ * functions are for validating a single value directly.
+ */
+export const constraints = {
+  validate: { templateText: validateTemplateText },
+  sanitize: { templateText: sanitizeTemplateText },
+} satisfies ConstraintNamespace;

--- a/packages/cloudformation/src/policies/template-text-fields.ts
+++ b/packages/cloudformation/src/policies/template-text-fields.ts
@@ -1,0 +1,42 @@
+/**
+ * Free-text properties keyed by CloudFormation resource type, with **CDK L1
+ * property names** (camelCase) as values — the policy reads and writes them
+ * through the L1 accessor, so `alarmDescription`, not `AlarmDescription`.
+ *
+ * This is also the shape of {@link TemplateTextPolicyConfig.fields}, which is
+ * merged over the built-in registry.
+ */
+export type TemplateTextFields = Readonly<Record<string, readonly string[]>>;
+
+/**
+ * The fields {@link templateTextPolicy} checks by default.
+ *
+ * Keying by resource-type string is what keeps this registry in
+ * `@composurecdk/cloudformation` without inverting the dependency graph: it
+ * names `AWS::Lambda::Function` without importing `@composurecdk/lambda`, so a
+ * consumer of one service does not transitively pull in every other
+ * (ADR-0010, ADR-0017 §4).
+ *
+ * Only top-level scalar properties are listed. Nested paths
+ * (`DistributionConfig.Comment`, `HostedZoneConfig.Comment`) need a resolve on
+ * the way in and an `addPropertyOverride` on the way out; they are a separate
+ * change. A field earns a place here if a consumer can put arbitrary prose in
+ * it.
+ */
+export const TEMPLATE_TEXT_FIELDS: TemplateTextFields = {
+  "AWS::ApiGateway::ApiKey": ["description"],
+  "AWS::ApiGateway::Deployment": ["description"],
+  "AWS::ApiGateway::RestApi": ["description"],
+  "AWS::ApiGateway::Stage": ["description"],
+  "AWS::ApiGateway::UsagePlan": ["description"],
+  "AWS::CloudWatch::Alarm": ["alarmDescription"],
+  "AWS::CloudWatch::CompositeAlarm": ["alarmDescription"],
+  "AWS::EC2::SecurityGroup": ["groupDescription"],
+  "AWS::Events::Rule": ["description"],
+  "AWS::IAM::ManagedPolicy": ["description"],
+  "AWS::IAM::Role": ["description"],
+  "AWS::Lambda::Function": ["description"],
+  "AWS::Neptune::DBClusterParameterGroup": ["description"],
+  "AWS::Neptune::DBParameterGroup": ["description"],
+  "AWS::SNS::Topic": ["displayName"],
+};

--- a/packages/cloudformation/src/policies/template-text-policy.ts
+++ b/packages/cloudformation/src/policies/template-text-policy.ts
@@ -1,0 +1,242 @@
+import { Annotations, Aspects, CfnElement, CfnResource, Stack, Token } from "aws-cdk-lib";
+import { type IConstruct } from "constructs";
+import {
+  describeOffenders,
+  sanitizeTemplateText,
+  templateTextMessage,
+  transliterate,
+} from "../constraints/template-text.js";
+import { TEMPLATE_TEXT_FIELDS, type TemplateTextFields } from "./template-text-fields.js";
+
+/**
+ * Merges consumer-supplied fields over the built-in registry, unioning the
+ * property list for a resource type present in both. A `Map` rather than an
+ * object so a lookup miss is `undefined` in the type system as well as at
+ * runtime, which a `Record`'s index signature does not express.
+ */
+function mergeFields(
+  extra: TemplateTextFields | undefined,
+): ReadonlyMap<string, readonly string[]> {
+  const merged = new Map<string, readonly string[]>(Object.entries(TEMPLATE_TEXT_FIELDS));
+  for (const [type, properties] of Object.entries(extra ?? {})) {
+    merged.set(type, [...new Set([...(merged.get(type) ?? []), ...properties])]);
+  }
+  return merged;
+}
+
+/**
+ * The warning id `warn` mode annotates with, where the running `aws-cdk-lib`
+ * supports acknowledgeable warnings. Pass it to
+ * `Annotations.of(scope).acknowledgeWarning(...)` to silence a known case.
+ */
+export const TEMPLATE_TEXT_WARNING_NAME = "composurecdk:templateText";
+
+interface WarningAnnotations {
+  addWarningV2?: (id: string, message: string) => void;
+  addWarning: (message: string) => void;
+}
+
+/**
+ * Emits an acknowledgeable warning where the runtime has one.
+ *
+ * `Annotations.addWarningV2` only exists from aws-cdk-lib 2.93.0, and this
+ * package's declared floor is 2.1.0 — the lowest in the repo, because every
+ * other package peer-depends on it (ADR-0008). Raising the floor for one
+ * optional mode would drag the whole library up with it, so this degrades to
+ * the 2.0-era `addWarning` instead. Same version-portability reasoning as the
+ * `isCfnAlarm` shim in `@composurecdk/cloudwatch`.
+ */
+function warn(node: IConstruct, message: string): void {
+  const annotations = Annotations.of(node) as unknown as WarningAnnotations;
+  if (typeof annotations.addWarningV2 === "function") {
+    annotations.addWarningV2(TEMPLATE_TEXT_WARNING_NAME, message);
+    return;
+  }
+  annotations.addWarning(message);
+}
+
+/**
+ * What the policy does with a value CloudFormation would transliterate.
+ *
+ * - `throw` — fail synth at the first violation, naming the construct path,
+ *   the field and the offending character.
+ * - `sanitize` — rewrite the value in place so the synthesised template
+ *   matches what CloudFormation will store. Nothing fails.
+ * - `warn` — annotate every violation and carry on. The diff stays, but the
+ *   whole list is visible in one pass, which is how to adopt `throw` on an
+ *   existing estate: run `warn`, fix the list, then switch.
+ */
+export type TemplateTextViolationMode = "throw" | "sanitize" | "warn";
+
+/** Configuration for {@link templateTextPolicy}. */
+export interface TemplateTextPolicyConfig {
+  /**
+   * How to handle a violation.
+   * @default "throw"
+   */
+  onViolation?: TemplateTextViolationMode;
+
+  /**
+   * Maps one disallowed character to its ASCII stand-in, in `sanitize` mode.
+   * @default transliterate - common typographic characters, then `?`
+   */
+  replace?: (char: string) => string;
+
+  /**
+   * Extra free-text properties to check, keyed by CloudFormation resource type
+   * with CDK L1 (camelCase) property names. Merged over the built-in registry.
+   *
+   * @example
+   * ```ts
+   * { fields: { "AWS::Custom::Widget": ["notes"] } }
+   * ```
+   */
+  fields?: TemplateTextFields;
+}
+
+/**
+ * The checkable fields on one node: the object holding them, their keys, and a
+ * qualifier that names the kind in a diagnostic. The label itself is composed
+ * only on a violation — `node.path` walks and joins the ancestor chain on every
+ * access, which is far too expensive to pay for every field of every construct.
+ */
+interface FieldSet {
+  readonly target: Record<string, unknown>;
+  readonly properties: readonly string[];
+  readonly qualifier: string;
+}
+
+const DESCRIPTION: readonly string[] = ["description"];
+
+/**
+ * Narrows a raw property value to the concrete string CloudFormation will
+ * store, or `undefined` when there is nothing to check.
+ *
+ * A token-free string is returned as-is: `resolve()` builds a resolution
+ * context and scans for token fragments, which is the most expensive step in
+ * the visit and pure waste on a plain literal. Everything else is resolved,
+ * because an L1 property is often `Lazy`-wrapped even when plainly set. A
+ * `Lazy` producing a string is deliberately *not* skipped — that string is what
+ * deploys, so it is exactly what to check. What is skipped is a value that
+ * resolves to a CloudFormation intrinsic (a `Ref`, an `Fn::ImportValue`), which
+ * resolves to an object rather than a string and whose text is not knowable at
+ * synth (ADR-0010).
+ */
+function concrete(node: IConstruct, value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (!Token.isUnresolved(value)) return value;
+  const resolved: unknown = Stack.of(node).resolve(value);
+  if (typeof resolved !== "string" || Token.isUnresolved(resolved)) return undefined;
+  return resolved;
+}
+
+/**
+ * The fields on `node` worth checking, or `undefined` for the great majority of
+ * constructs that carry no template text. Three node kinds carry it and only
+ * one is a `CfnResource`, so the registry alone is not enough — see ADR-0017 §7.
+ */
+function fieldsOf(
+  node: IConstruct,
+  registry: ReadonlyMap<string, readonly string[]>,
+): FieldSet | undefined {
+  if (Stack.isStack(node)) {
+    return {
+      target: node.templateOptions as unknown as Record<string, unknown>,
+      properties: DESCRIPTION,
+      qualifier: "template ",
+    };
+  }
+
+  const target = node as unknown as Record<string, unknown>;
+
+  if (CfnResource.isCfnResource(node)) {
+    const properties = registry.get(node.cfnResourceType);
+    if (properties === undefined || properties.length === 0) return undefined;
+    return { target, properties, qualifier: `${node.cfnResourceType} ` };
+  }
+
+  // A non-resource CfnElement with a string `description` is a CfnOutput or
+  // CfnParameter; the other element kinds (mappings, conditions, rules) have
+  // no free-text property, so duck-typing costs nothing and stays portable.
+  if (CfnElement.isCfnElement(node) && typeof target.description === "string") {
+    return { target, properties: DESCRIPTION, qualifier: "" };
+  }
+
+  return undefined;
+}
+
+/**
+ * Fails synth — or quietly repairs the template — when a value CloudFormation
+ * cannot store verbatim reaches a free-text field.
+ *
+ * CloudFormation stores template text as ASCII, silently transliterating
+ * anything else (an em-dash, a curly quote) to `?` at deploy time. There is no
+ * error: the deployed template simply stops matching the synthesised one, and
+ * `cdk diff` reports a change on every run afterwards, forever, on a stack
+ * nobody touched.
+ *
+ * Installs a CDK
+ * {@link https://docs.aws.amazon.com/cdk/v2/guide/aspects.html | Aspect}, so it
+ * sees the whole subtree at synth time — including raw L1 constructs, L2s from
+ * other libraries, and fields no builder validates. Call it once on any scope
+ * before `app.synth()`; constructs added afterwards are still covered, so
+ * ordering does not matter.
+ *
+ * Coverage is deliberately partial — values resolving to a CloudFormation
+ * intrinsic, values written via `addPropertyOverride`, nested property paths,
+ * and unregistered resource types are all outside it. The package README lists
+ * the gaps in full and ADR-0017 records why the policy is opt-in rather than
+ * enforced at every builder.
+ *
+ * @param scope - Any construct; the policy applies to its whole subtree.
+ * @param config - Mode, replacement function, and extra fields.
+ *
+ * @example
+ * ```ts
+ * // Fail synth on anything CloudFormation would rewrite.
+ * templateTextPolicy(app);
+ *
+ * // Or repair it, so the template matches what gets deployed.
+ * templateTextPolicy(app, { onViolation: "sanitize" });
+ *
+ * // Adopting on an existing estate: list everything first.
+ * templateTextPolicy(app, { onViolation: "warn" });
+ * ```
+ */
+export function templateTextPolicy(scope: IConstruct, config: TemplateTextPolicyConfig = {}): void {
+  const { onViolation = "throw", replace = transliterate } = config;
+  const registry = mergeFields(config.fields);
+
+  Aspects.of(scope).add({
+    visit(node: IConstruct): void {
+      const fields = fieldsOf(node, registry);
+      if (fields === undefined) return;
+      const { target, properties, qualifier } = fields;
+
+      for (const property of properties) {
+        const value = concrete(node, target[property]);
+        if (value === undefined) continue;
+
+        if (onViolation === "sanitize") {
+          const cleaned = sanitizeTemplateText(value, replace);
+          // Only write on a change: assigning back would freeze a clean `Lazy`
+          // into the literal it happened to produce at visit time.
+          if (cleaned !== value) target[property] = cleaned;
+          continue;
+        }
+
+        const offenders = describeOffenders(value);
+        if (offenders === undefined) continue;
+
+        const label = `${node.node.path || node.node.id}: ${qualifier}${property}`;
+        const message = templateTextMessage(label, offenders);
+        // `Annotations.addError` would report every violation in one pass, but
+        // only the CDK CLI acts on error metadata — `app.synth()` and
+        // `Template.fromStack()` would sail past it. Throwing fails everywhere,
+        // and matches how the rest of the constraint catalogue reports (ADR-0010).
+        if (onViolation === "throw") throw new Error(message);
+        warn(node, message);
+      }
+    },
+  });
+}

--- a/packages/cloudformation/test/template-text-policy.test.ts
+++ b/packages/cloudformation/test/template-text-policy.test.ts
@@ -10,7 +10,8 @@ import {
   Stack,
 } from "aws-cdk-lib";
 import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
-import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import type { IConstruct } from "constructs";
+import { Template } from "aws-cdk-lib/assertions";
 import {
   TEMPLATE_TEXT_WARNING_NAME,
   templateTextPolicy,
@@ -27,6 +28,19 @@ function alarm(scope: Stack, id: string, description: string): Alarm {
     evaluationPeriods: 1,
     alarmDescription: description,
   });
+}
+
+/**
+ * Warnings recorded anywhere under `node`, read from construct metadata rather
+ * than `aws-cdk-lib/assertions`' `Annotations`. That helper — and
+ * `Match.stringLikeRegexp` — postdate this package's declared aws-cdk-lib floor
+ * of 2.1.0, and the floor guard typechecks the suite against it (ADR-0008).
+ */
+function warnings(node: IConstruct): { path: string; message: string }[] {
+  const here = node.node.metadata
+    .filter((entry) => entry.type === "aws:cdk:warning")
+    .map((entry) => ({ path: node.node.path, message: String(entry.data) }));
+  return [here, ...node.node.children.map(warnings)].flat();
 }
 
 /** A one-stack app; pass a description to put non-ASCII on the stack itself. */
@@ -89,10 +103,10 @@ describe("templateTextPolicy — sanitize mode", () => {
 
   it("rewrites a CfnOutput description", () => {
     const { app, stack } = tree();
-    new CfnOutput(stack, "Url", { value: "https://example.com", description: DIRTY });
+    const url = new CfnOutput(stack, "Url", { value: "https://example.com", description: DIRTY });
     templateTextPolicy(app, { onViolation: "sanitize" });
     app.synth();
-    Template.fromStack(stack).hasOutput("Url", { Description: CLEAN });
+    expect(url.description).toBe(CLEAN);
   });
 
   it("honours a custom replacement", () => {
@@ -106,30 +120,55 @@ describe("templateTextPolicy — warn mode", () => {
   it("reports every violation in one pass, without failing synth", () => {
     const { app, stack } = dirtyTree({ onViolation: "warn" });
     expect(() => app.synth()).not.toThrow();
-    Annotations.fromStack(stack).hasWarning(
-      "/TestStack/Alarm/Resource",
-      Match.stringLikeRegexp(".*U\\+2014.*"),
-    );
+
+    const reported = warnings(stack);
+    expect(reported.map((w) => w.path)).toEqual(["TestStack", "TestStack/Alarm/Resource"]);
+    expect(reported.every((w) => w.message.includes("U+2014"))).toBe(true);
   });
 
   it("uses an acknowledgeable warning id", () => {
     expect(TEMPLATE_TEXT_WARNING_NAME).toBe("composurecdk:templateText");
   });
 
-  it("degrades to addWarning below aws-cdk-lib 2.93.0, this package's floor being 2.1.0", () => {
+  /**
+   * Swaps the annotation methods on the shared prototype for the duration of
+   * `run`. Both branches of the version shim have to be forced: `addWarningV2`
+   * does not exist at this package's 2.1.0 floor, and the `addWarning`
+   * fallback is unreachable on a current aws-cdk-lib — so whichever version
+   * the suite happens to run against, one branch is dead without this.
+   */
+  function withAnnotationMethods(methods: Record<string, unknown>, run: () => void): void {
     const proto = CdkAnnotations.prototype as unknown as Record<string, unknown>;
-    const addWarningV2 = proto.addWarningV2;
-    const addWarning = vi.fn();
+    const original = { addWarningV2: proto.addWarningV2, addWarning: proto.addWarning };
     delete proto.addWarningV2;
-    proto.addWarning = addWarning;
-
+    Object.assign(proto, methods);
     try {
+      run();
+    } finally {
+      delete proto.addWarningV2;
+      Object.assign(proto, original);
+    }
+  }
+
+  it("uses addWarningV2 with the acknowledgeable id where the runtime has it", () => {
+    const addWarningV2 = vi.fn();
+    withAnnotationMethods({ addWarningV2 }, () => {
+      const { app } = dirtyTree({ onViolation: "warn" });
+      expect(() => app.synth()).not.toThrow();
+      expect(addWarningV2).toHaveBeenCalledWith(
+        TEMPLATE_TEXT_WARNING_NAME,
+        expect.stringContaining("U+2014"),
+      );
+    });
+  });
+
+  it("degrades to addWarning below aws-cdk-lib 2.93.0, this package's floor being 2.1.0", () => {
+    const addWarning = vi.fn();
+    withAnnotationMethods({ addWarning }, () => {
       const { app } = dirtyTree({ onViolation: "warn" });
       expect(() => app.synth()).not.toThrow();
       expect(addWarning).toHaveBeenCalledWith(expect.stringContaining("U+2014"));
-    } finally {
-      proto.addWarningV2 = addWarningV2;
-    }
+    });
   });
 });
 

--- a/packages/cloudformation/test/template-text-policy.test.ts
+++ b/packages/cloudformation/test/template-text-policy.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  Annotations as CdkAnnotations,
+  App,
+  CfnOutput,
+  CfnParameter,
+  CfnResource,
+  Fn,
+  Lazy,
+  Stack,
+} from "aws-cdk-lib";
+import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import {
+  TEMPLATE_TEXT_WARNING_NAME,
+  templateTextPolicy,
+  type TemplateTextPolicyConfig,
+} from "../src/policies/template-text-policy.js";
+
+const DIRTY = "low — baseline";
+const CLEAN = "low - baseline";
+
+function alarm(scope: Stack, id: string, description: string): Alarm {
+  return new Alarm(scope, id, {
+    metric: new Metric({ namespace: "Test", metricName: "Errors" }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: description,
+  });
+}
+
+/** A one-stack app; pass a description to put non-ASCII on the stack itself. */
+function tree(description?: string) {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", description === undefined ? {} : { description });
+  return { app, stack };
+}
+
+/** The common case: non-ASCII on both the stack description and an alarm. */
+function dirtyTree(config: TemplateTextPolicyConfig = {}) {
+  const { app, stack } = tree(DIRTY);
+  alarm(stack, "Alarm", DIRTY);
+  templateTextPolicy(app, config);
+  return { app, stack };
+}
+
+describe("templateTextPolicy — throw mode", () => {
+  it("fails synth on a stack description", () => {
+    const { app } = dirtyTree();
+    expect(() => app.synth()).toThrow("U+2014");
+  });
+
+  it("names the construct path and the field", () => {
+    const { app, stack } = tree();
+    alarm(stack, "Alarm", DIRTY);
+    templateTextPolicy(app);
+    expect(() => app.synth()).toThrow(
+      "TestStack/Alarm/Resource: AWS::CloudWatch::Alarm alarmDescription contains",
+    );
+  });
+
+  it("is the default mode", () => {
+    const { app } = dirtyTree({ onViolation: "throw" });
+    expect(() => app.synth()).toThrow("U+2014");
+  });
+
+  it("passes a clean tree", () => {
+    const { app, stack } = tree(CLEAN);
+    alarm(stack, "Alarm", CLEAN);
+    templateTextPolicy(app);
+    expect(() => app.synth()).not.toThrow();
+  });
+});
+
+describe("templateTextPolicy — sanitize mode", () => {
+  it("rewrites the value so the template matches what CloudFormation stores", () => {
+    const { app, stack } = dirtyTree({ onViolation: "sanitize" });
+    app.synth();
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmDescription: CLEAN,
+    });
+  });
+
+  it("rewrites the stack description", () => {
+    const { app, stack } = dirtyTree({ onViolation: "sanitize" });
+    app.synth();
+    expect(stack.templateOptions.description).toBe(CLEAN);
+  });
+
+  it("rewrites a CfnOutput description", () => {
+    const { app, stack } = tree();
+    new CfnOutput(stack, "Url", { value: "https://example.com", description: DIRTY });
+    templateTextPolicy(app, { onViolation: "sanitize" });
+    app.synth();
+    Template.fromStack(stack).hasOutput("Url", { Description: CLEAN });
+  });
+
+  it("honours a custom replacement", () => {
+    const { app, stack } = dirtyTree({ onViolation: "sanitize", replace: () => "~" });
+    app.synth();
+    expect(stack.templateOptions.description).toBe("low ~ baseline");
+  });
+});
+
+describe("templateTextPolicy — warn mode", () => {
+  it("reports every violation in one pass, without failing synth", () => {
+    const { app, stack } = dirtyTree({ onViolation: "warn" });
+    expect(() => app.synth()).not.toThrow();
+    Annotations.fromStack(stack).hasWarning(
+      "/TestStack/Alarm/Resource",
+      Match.stringLikeRegexp(".*U\\+2014.*"),
+    );
+  });
+
+  it("uses an acknowledgeable warning id", () => {
+    expect(TEMPLATE_TEXT_WARNING_NAME).toBe("composurecdk:templateText");
+  });
+
+  it("degrades to addWarning below aws-cdk-lib 2.93.0, this package's floor being 2.1.0", () => {
+    const proto = CdkAnnotations.prototype as unknown as Record<string, unknown>;
+    const addWarningV2 = proto.addWarningV2;
+    const addWarning = vi.fn();
+    delete proto.addWarningV2;
+    proto.addWarning = addWarning;
+
+    try {
+      const { app } = dirtyTree({ onViolation: "warn" });
+      expect(() => app.synth()).not.toThrow();
+      expect(addWarning).toHaveBeenCalledWith(expect.stringContaining("U+2014"));
+    } finally {
+      proto.addWarningV2 = addWarningV2;
+    }
+  });
+});
+
+describe("templateTextPolicy — coverage", () => {
+  it("checks CfnOutput descriptions", () => {
+    const { app, stack } = tree();
+    new CfnOutput(stack, "Url", { value: "https://example.com", description: DIRTY });
+    templateTextPolicy(app);
+    expect(() => app.synth()).toThrow("TestStack/Url: description contains");
+  });
+
+  it("checks CfnParameter descriptions", () => {
+    const { app, stack } = tree();
+    new CfnParameter(stack, "Stage", { type: "String", description: DIRTY });
+    templateTextPolicy(app);
+    expect(() => app.synth()).toThrow("TestStack/Stage: description contains");
+  });
+
+  it("checks raw L1 constructs the library never built", () => {
+    const { app, stack } = tree();
+    new CfnResource(stack, "Fn", {
+      type: "AWS::Lambda::Function",
+      properties: { Description: DIRTY },
+    });
+    templateTextPolicy(app);
+    // A bare CfnResource carries its props in `properties`, not on a typed
+    // accessor, so this documents the boundary rather than a catch.
+    expect(() => app.synth()).not.toThrow();
+  });
+
+  it("checks a consumer-supplied field", () => {
+    const { app, stack } = tree();
+    const widget = new CfnResource(stack, "Widget", { type: "AWS::Custom::Widget" });
+    (widget as unknown as Record<string, unknown>).notes = DIRTY;
+    templateTextPolicy(app, { fields: { "AWS::Custom::Widget": ["notes"] } });
+    expect(() => app.synth()).toThrow("AWS::Custom::Widget notes contains");
+  });
+
+  it("unions consumer fields with the built-in list for the same type", () => {
+    const { app, stack } = tree();
+    alarm(stack, "Alarm", DIRTY);
+    templateTextPolicy(app, { fields: { "AWS::CloudWatch::Alarm": ["alarmName"] } });
+    expect(() => app.synth()).toThrow("alarmDescription contains");
+  });
+
+  it("ignores resource types outside the registry", () => {
+    const { app, stack } = tree();
+    const bucket = new CfnResource(stack, "Bucket", { type: "AWS::S3::Bucket" });
+    (bucket as unknown as Record<string, unknown>).description = DIRTY;
+    templateTextPolicy(app);
+    expect(() => app.synth()).not.toThrow();
+  });
+
+  it("checks a Lazy, because its resolved value is what deploys", () => {
+    const { app, stack } = tree();
+    alarm(stack, "Alarm", Lazy.string({ produce: () => DIRTY }));
+    templateTextPolicy(app);
+    expect(() => app.synth()).toThrow("U+2014");
+  });
+
+  it("skips a value that resolves to a CloudFormation intrinsic", () => {
+    const { app, stack } = tree();
+    alarm(stack, "Alarm", Fn.importValue("SomeExport"));
+    templateTextPolicy(app);
+    expect(() => app.synth()).not.toThrow();
+  });
+
+  it("covers constructs added after the policy is installed", () => {
+    const { app, stack } = tree();
+    templateTextPolicy(app);
+    alarm(stack, "Alarm", DIRTY);
+    expect(() => app.synth()).toThrow("U+2014");
+  });
+});

--- a/packages/cloudformation/test/template-text.test.ts
+++ b/packages/cloudformation/test/template-text.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { Lazy } from "aws-cdk-lib";
+import {
+  sanitizeTemplateText,
+  transliterate,
+  validateTemplateText,
+} from "../src/constraints/template-text.js";
+
+describe("validateTemplateText", () => {
+  it("accepts printable ASCII", () => {
+    expect(() => {
+      validateTemplateText("Order processor - consumes and processes order messages");
+    }).not.toThrow();
+  });
+
+  it("accepts tab, newline and carriage return", () => {
+    expect(() => {
+      validateTemplateText("line one\nline\ttwo\r\n");
+    }).not.toThrow();
+  });
+
+  it.each([
+    ["em dash", "low — baseline", "U+2014"],
+    ["en dash", "3 – 5 minutes", "U+2013"],
+    ["left curly quote", "the “value”", "U+201C"],
+    ["right curly quote", "the value’s length", "U+2019"],
+    ["ellipsis", "and so on…", "U+2026"],
+  ])("rejects %s", (_name, value, codePoint) => {
+    expect(() => {
+      validateTemplateText(value);
+    }).toThrow(codePoint);
+  });
+
+  it("names the character, its index and the AWS doc", () => {
+    expect(() => {
+      validateTemplateText("ab—cd");
+    }).toThrow(/U\+2014 "—" at index 2[\s\S]*template-anatomy/);
+  });
+
+  it("lists at most three offenders and counts the rest", () => {
+    expect(() => {
+      validateTemplateText("—————");
+    }).toThrow("and 2 more");
+  });
+
+  it("uses the supplied label so a caller can name the field", () => {
+    expect(() => {
+      validateTemplateText("—", "Stack/Alarm: AWS::CloudWatch::Alarm alarmDescription");
+    }).toThrow("Stack/Alarm: AWS::CloudWatch::Alarm alarmDescription contains");
+  });
+
+  it("skips unresolved tokens — their value is not knowable at synth", () => {
+    expect(() => {
+      validateTemplateText(Lazy.string({ produce: () => "—" }));
+    }).not.toThrow();
+  });
+});
+
+describe("sanitizeTemplateText", () => {
+  it("leaves legal text untouched", () => {
+    expect(sanitizeTemplateText("plain ASCII")).toBe("plain ASCII");
+  });
+
+  it("replaces per character, not per run, so a quoted phrase survives", () => {
+    expect(sanitizeTemplateText("the “value” of x")).toBe('the "value" of x');
+  });
+
+  it("maps the common typographic characters to readable ASCII", () => {
+    expect(sanitizeTemplateText("low — baseline… x ≥ 5")).toBe("low - baseline... x >= 5");
+  });
+
+  it("falls back to `?` — exactly what CloudFormation would have stored", () => {
+    expect(sanitizeTemplateText("status: 🚀")).toBe("status: ?");
+  });
+
+  it("accepts a custom replacement", () => {
+    expect(sanitizeTemplateText("a—b", () => "~")).toBe("a~b");
+  });
+
+  it("returns unresolved tokens unchanged", () => {
+    const token = Lazy.string({ produce: () => "—" });
+    expect(sanitizeTemplateText(token)).toBe(token);
+  });
+
+  it("produces output that validates", () => {
+    expect(() => {
+      validateTemplateText(sanitizeTemplateText("— “x” … 🚀"));
+    }).not.toThrow();
+  });
+});
+
+describe("transliterate", () => {
+  it("maps a known character", () => {
+    expect(transliterate("—")).toBe("-");
+  });
+
+  it("maps an unknown character to `?`", () => {
+    expect(transliterate("漢")).toBe("?");
+  });
+});


### PR DESCRIPTION
## What & why

CloudFormation stores template text as ASCII and **silently transliterates anything else to `?`** at deploy time. No error, no `CREATE_FAILED` — the deployed template just stops matching the synthesised one, so `cdk diff` reports a change on every run afterwards, forever, on a stack nobody touched.

This is the underlying-problem half of #336. The shipped-defaults half is #351.

```ts
import { templateTextPolicy } from "@composurecdk/cloudformation";

templateTextPolicy(app); // fail synth on anything CloudFormation would rewrite
```

| `onViolation` | Behaviour | Use it when |
| --- | --- | --- |
| `"throw"` _(default)_ | Fails synth, naming the construct path, field and offending character. | You want the text fixed at the source. |
| `"sanitize"` | Rewrites the value so the emitted template matches what CloudFormation stores. | A large existing estate you can't chase string by string. |
| `"warn"` | Lists every violation in one pass. | Adoption: run it, fix the list, switch to `"throw"`. |

### Design

**Opt-in, per the plan.** Enforcing this at every builder would turn a working — if diff-noisy — deployment into a synth failure for anyone living with the transliteration. Constraints whose violation fails the *deploy* rather than the diff (an EC2 `GroupDescription`, which the service rejects outright) stay enforced at the builder regardless.

**An Aspect, because a builder validator structurally can't do this.** It only covers fields someone remembered to wire one into — which is precisely how the stack-level `Description` slipped through: `StackBuilder` passes `description` straight to `StackProps` and no validator ever sees it. The Aspect walks the tree, so for registered types it also catches constructs this library never built.

**Keyed by resource-type string, so it imports no service package** — the registry names `AWS::Lambda::Function` without importing `@composurecdk/lambda`. That's what ADR-0010's consequences called for and why the policy can live in `cloudformation` without inverting the dependency graph.

**Three node kinds**, because only one is a `CfnResource`: the stack's `Description` lives on `templateOptions`, and `CfnOutput`/`CfnParameter` are `CfnElement`s with their own accessor. A registry keyed by resource type alone would miss both — including the field that caused the bug.

**Per-character sanitisation**, not `sanitizeString`'s run-collapse, which would turn a quoted phrase into a single `-`. Unmapped characters become `?` — CloudFormation's own substitution — so the template byte-matches the deployed value either way.

### Notable implementation points

- **`warn` degrades to `Annotations.addWarning`** where `addWarningV2` is missing. This package's floor is `aws-cdk-lib` 2.1.0 — the lowest in the repo, because every other package peer-depends on it — and `addWarningV2` only arrived in 2.93.0 (see `cdk-floors.json`). Raising the floor for one optional mode would drag the whole library up with it. Covered by a test that deletes the method from the prototype.
- **`throw` throws rather than `Annotations.addError`.** Only the CDK CLI acts on error metadata, so `app.synth()` and `Template.fromStack()` would sail past an annotation — a guard that doesn't fire in unit tests. Cost: only the first violation is reported, which is what `warn` mode exists for.
- **A `Lazy` resolving to a plain string is checked, not skipped** — that string is what deploys. Only values resolving to a CloudFormation intrinsic are skipped.
- **`TEMPLATE_TEXT_FIELDS` is not exported.** Exporting it would lock the registry's shape in as public API and foreclose a future switch to name-based detection. `config.fields` is the extension point; the default list is documented as a README table.

### Scope and honest limits

The registry seeds **15 resource types**; `aws-cdk-lib` declares a free-text property on roughly 550. That is a starting point sized to what has been reasoned about, not a claim of completeness — the README says so, and ADR-0017 records the name-predicate alternative (`/[Dd]escription$/`, `displayName`, `comment`) as the likeliest successor, with why it's deferred.

Also outside coverage, and documented: values resolving to intrinsics, values written via `addPropertyOverride` or a bare `CfnResource`'s `properties`, and nested paths like `DistributionConfig.Comment` (deferred — they need a resolve on read and a property override on write).

**Not yet verified against live AWS.** The plan's Phase 0 called for confirming which fields CloudFormation actually coerces; only the template-level `Description` has direct evidence. The rest are listed because they carry the same author-written prose through the same document. The `cdk diff` idempotence check that would settle it is Phase 3 and depends on #351 landing first.

### Docs

- `packages/cloudformation/README.md` — new `templateTextPolicy` section: failure mode, mode table, what it checks, what it doesn't.
- `docs/adr/0017-template-text-policy.md` — new.
- `docs/adr/0002-policies.md` — §5 marked amended; a resource-type-keyed policy has no peer-dependency surface, so the "pan-domain policies wait in `examples/`" rule doesn't apply to it.
- `docs/adr/0010-aws-property-constraints.md` — its named follow-up now points here.
- `docs/architecture.md` §Policies and `docs/constraints.md` (regenerated) updated.

### Follow-ups

1. Nested property paths (Phase 2).
2. Post-deploy `cdk diff` idempotence check in `deploy-test` (Phase 3) — the empirical proof of acceptance criterion #2, blocked on #351.
3. Name-predicate detection, if the seed registry proves too narrow in practice.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test — n/a, no new example

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoEijXK47YPhca1Zbp2C3P)_