### PR TITLE
feat(apigateway): accept a resolvable apiDefinition on the spec REST API builder

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,6 +338,8 @@ api.addMethod(
 
 Internally, the builder stores the `Resolvable<T>` as-is. At build time, it calls `resolve(value, context)`, which either returns the concrete value unchanged or evaluates the `Ref`.
 
+A `.map()` transform receives only the build context — not the scope the component builds into — so `Stack.of(scope)` is not available inside one. Where a transform needs the account, region or partition, use the scope-free pseudo-parameter tokens (`Aws.ACCOUNT_ID`, `Aws.REGION`, `Aws.PARTITION`), which resolve at synth wherever they end up.
+
 `resolve` distinguishes a `Ref` from a concrete value via the `isRef` guard. `isRef` recognises a `Ref` by a `Symbol.for("composurecdk.ref")` brand rather than `instanceof` — because packages are published dual ESM/CJS ([ADR-0007](adr/0007-dual-esm-cjs-publishing.md)), the ESM and CommonJS copies of `@composurecdk/core` can both load in one process, and `instanceof` is realm-bound. The `Symbol.for(...)` brand is shared across realms, so a `Ref` minted by either copy is still recognised.
 
 ### Combining refs — one consumer, many dependencies

--- a/packages/apigateway/README.md
+++ b/packages/apigateway/README.md
@@ -33,9 +33,6 @@ Every [RestApiProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws
 `createSpecRestApiBuilder` builds a [SpecRestApi](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.SpecRestApi.html) — a REST API whose resources, methods and integrations come entirely from an OpenAPI specification rather than from `addResource`/`addMethod` calls. Every [SpecRestApiProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.SpecRestApiProps.html) property is a fluent setter, and the same secure defaults, access logging and recommended alarms apply as for `createRestApiBuilder`.
 
 ```ts
-import { ApiDefinition } from "aws-cdk-lib/aws-apigateway";
-import { createSpecRestApiBuilder } from "@composurecdk/apigateway";
-
 const api = createSpecRestApiBuilder()
   .restApiName("PetStore")
   .apiDefinition(ApiDefinition.fromInline(petstoreSpec))
@@ -49,27 +46,23 @@ A model-first spec — a Smithy or OpenAPI export, or a hand-written document �
 `apiDefinition` therefore accepts a `Resolvable<ApiDefinition>` — a concrete definition, or a `ref`/`combine` that produces one at build time. The specification stays declarative, the substitution stays a plain function you can test on its own, and the whole API stays inside `compose`:
 
 ```ts
-import { ApiDefinition } from "aws-cdk-lib/aws-apigateway";
-import { combine, compose, ref } from "@composurecdk/core";
-import { createSpecRestApiBuilder } from "@composurecdk/apigateway";
-import {
-  createFunctionBuilder,
-  functionGrants,
-  type FunctionBuilderResult,
-} from "@composurecdk/lambda";
-import { createServiceRoleBuilder, type RoleBuilderResult } from "@composurecdk/iam";
+// Substitution is an ordinary function of its inputs — no CDK scope, no builder.
+const withIntegration = (spec: object, arns: Record<string, string>) =>
+  JSON.parse(
+    Object.entries(arns).reduce(
+      (doc, [name, arn]) => doc.split(name).join(arn),
+      JSON.stringify(spec),
+    ),
+  );
 
 compose(
   {
-    handler: createFunctionBuilder()
-      .runtime(Runtime.NODEJS_22_X)
-      .handler("index.handler")
-      .code(code),
+    handler: createFunctionBuilder().handler("index.handler").code(code),
 
     // The role API Gateway assumes to invoke the handler — an ordinary
     // sibling, wired with a consumer-side grant (ADR-0013).
     gatewayRole: createServiceRoleBuilder("apigateway.amazonaws.com").grant(
-      functionGrants.invoke(ref<FunctionBuilderResult>("handler", (r) => r.function)),
+      functionGrants.invoke(ref("handler", (r: FunctionBuilderResult) => r.function)),
     ),
 
     api: createSpecRestApiBuilder()
@@ -83,8 +76,8 @@ compose(
           ({ handler, gatewayRole }) =>
             ApiDefinition.fromInline(
               withIntegration(petstoreSpec, {
-                functionArn: handler.function.functionArn,
-                credentialsArn: gatewayRole.role.roleArn,
+                "${PetFunction.Arn}": handler.function.functionArn,
+                "${ApiGatewayRole.Arn}": gatewayRole.role.roleArn,
               }),
             ),
         ),

--- a/packages/apigateway/README.md
+++ b/packages/apigateway/README.md
@@ -28,6 +28,79 @@ Every [RestApiProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws
 
 - [**CrudApiStack**](../examples/src/crud-api-app.ts) — a complete CRUD REST API wired straight to DynamoDB via `AwsIntegration` and VTL mapping templates (`Scan`/`PutItem`/`GetItem`/`DeleteItem`), with the credentials role assembled from sibling builders using `combine` and granted via consumer-side `tableGrants`. Start here for the `AwsIntegration` → DynamoDB pattern.
 
+## Spec REST API Builder
+
+`createSpecRestApiBuilder` builds a [SpecRestApi](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.SpecRestApi.html) — a REST API whose resources, methods and integrations come entirely from an OpenAPI specification rather than from `addResource`/`addMethod` calls. Every [SpecRestApiProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.SpecRestApiProps.html) property is a fluent setter, and the same secure defaults, access logging and recommended alarms apply as for `createRestApiBuilder`.
+
+```ts
+import { ApiDefinition } from "aws-cdk-lib/aws-apigateway";
+import { createSpecRestApiBuilder } from "@composurecdk/apigateway";
+
+const api = createSpecRestApiBuilder()
+  .restApiName("PetStore")
+  .apiDefinition(ApiDefinition.fromInline(petstoreSpec))
+  .build(stack, "PetStoreApi");
+```
+
+### Specs that reference sibling resources
+
+A model-first spec — a Smithy or OpenAPI export, or a hand-written document — usually names the resources its integrations call: the ARN of the Lambda to invoke, the role API Gateway assumes to invoke it. Those values do not exist while the builder is being configured. They exist only once the siblings have been built.
+
+`apiDefinition` therefore accepts a `Resolvable<ApiDefinition>` — a concrete definition, or a `ref`/`combine` that produces one at build time. The specification stays declarative, the substitution stays a plain function you can test on its own, and the whole API stays inside `compose`:
+
+```ts
+import { ApiDefinition } from "aws-cdk-lib/aws-apigateway";
+import { combine, compose, ref } from "@composurecdk/core";
+import { createSpecRestApiBuilder } from "@composurecdk/apigateway";
+import {
+  createFunctionBuilder,
+  functionGrants,
+  type FunctionBuilderResult,
+} from "@composurecdk/lambda";
+import { createServiceRoleBuilder, type RoleBuilderResult } from "@composurecdk/iam";
+
+compose(
+  {
+    handler: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_22_X)
+      .handler("index.handler")
+      .code(code),
+
+    // The role API Gateway assumes to invoke the handler — an ordinary
+    // sibling, wired with a consumer-side grant (ADR-0013).
+    gatewayRole: createServiceRoleBuilder("apigateway.amazonaws.com").grant(
+      functionGrants.invoke(ref<FunctionBuilderResult>("handler", (r) => r.function)),
+    ),
+
+    api: createSpecRestApiBuilder()
+      .restApiName("PetStore")
+      .apiDefinition(
+        combine(
+          {
+            handler: ref<FunctionBuilderResult>("handler"),
+            gatewayRole: ref<RoleBuilderResult>("gatewayRole"),
+          },
+          ({ handler, gatewayRole }) =>
+            ApiDefinition.fromInline(
+              withIntegration(petstoreSpec, {
+                functionArn: handler.function.functionArn,
+                credentialsArn: gatewayRole.role.roleArn,
+              }),
+            ),
+        ),
+      ),
+  },
+  { handler: [], gatewayRole: ["handler"], api: ["handler", "gatewayRole"] },
+);
+```
+
+A single dependency needs only a `ref`; `combine` is for the case above, where one definition is assembled from two or more siblings ([ADR-0015](../../docs/adr/0015-combine-multi-ref-combinator.md)).
+
+Two things to know when writing the substitution:
+
+- **Reach for the account, region or partition via `Aws.*`.** A transform receives the build context, not a construct scope, so `Stack.of(scope)` is not available to it — see [Resolvable](../../docs/architecture.md#resolvable). `Aws.PARTITION` and `Aws.REGION` need no scope and resolve correctly inside the API body.
+- **An inline body is embedded in the CloudFormation template.** A large generated specification counts against the template size limit; load it from S3 with `ApiDefinition.fromBucket` if it grows (at the cost of the in-process substitution shown here).
+
 ## Invoke grants
 
 To let a principal call an IAM-authorized API (`authorizationType: AuthorizationType.IAM`), `restApiGrants` provides a consumer-side grant helper — the mirror of DynamoDB's `tableGrants`. Declare it on the **grantee** (the caller), pointing at the API via a `ref`, exactly as you would any other grant ([ADR-0013](../../docs/adr/0013-consumer-side-grants.md)):

--- a/packages/apigateway/src/spec-rest-api-builder.ts
+++ b/packages/apigateway/src/spec-rest-api-builder.ts
@@ -39,7 +39,7 @@ export interface SpecRestApiBuilderProps
    *
    * // Resolvable — the spec is finished once the handler exists
    * .apiDefinition(
-   *   ref<FunctionBuilderResult>("handler", (r) =>
+   *   ref("handler", (r: FunctionBuilderResult) =>
    *     ApiDefinition.fromInline(withIntegration(spec, r.function.functionArn))),
    * )
    * ```

--- a/packages/apigateway/src/spec-rest-api-builder.ts
+++ b/packages/apigateway/src/spec-rest-api-builder.ts
@@ -1,6 +1,11 @@
-import { type RestApiBase, SpecRestApi, type SpecRestApiProps } from "aws-cdk-lib/aws-apigateway";
+import {
+  type ApiDefinition,
+  type RestApiBase,
+  SpecRestApi,
+  type SpecRestApiProps,
+} from "aws-cdk-lib/aws-apigateway";
 import { type IConstruct } from "constructs";
-import { COPY_STATE, type Lifecycle } from "@composurecdk/core";
+import { COPY_STATE, type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { AlarmDefinitionBuilder } from "@composurecdk/cloudwatch";
 import type { RestApiBuilderPropsBase, RestApiBuilderResultBase } from "./builder-common.js";
@@ -12,9 +17,35 @@ import { createRestApiAlarms } from "./rest-api-alarms.js";
  * Configuration properties for the spec-driven REST API builder.
  *
  * Extends the CDK {@link SpecRestApiProps} with additional builder-specific
- * options.
+ * options. `apiDefinition` is widened to a {@link Resolvable} so the
+ * specification can be assembled from sibling components at build time.
  */
-export interface SpecRestApiBuilderProps extends SpecRestApiProps, RestApiBuilderPropsBase {}
+export interface SpecRestApiBuilderProps
+  extends Omit<SpecRestApiProps, "apiDefinition">, RestApiBuilderPropsBase {
+  /**
+   * The OpenAPI specification that defines the API.
+   *
+   * Accepts a concrete {@link ApiDefinition} or a {@link Resolvable} — a
+   * {@link ref} or {@link combine} that produces one once its dependencies
+   * have been built. A resolvable definition is how a spec whose integrations
+   * name sibling resources (a Lambda ARN to invoke, the role API Gateway
+   * assumes to invoke it) stays inside `compose`: the values are unknown when
+   * the builder is configured and only exist after the siblings are built.
+   *
+   * @example
+   * ```ts
+   * // Concrete — the spec needs nothing from its siblings
+   * .apiDefinition(ApiDefinition.fromInline(spec))
+   *
+   * // Resolvable — the spec is finished once the handler exists
+   * .apiDefinition(
+   *   ref<FunctionBuilderResult>("handler", (r) =>
+   *     ApiDefinition.fromInline(withIntegration(spec, r.function.functionArn))),
+   * )
+   * ```
+   */
+  apiDefinition?: Resolvable<ApiDefinition>;
+}
 
 /**
  * The build output of a {@link ISpecRestApiBuilder}. Contains the CDK
@@ -29,7 +60,7 @@ export type SpecRestApiBuilderResult = RestApiBuilderResultBase<SpecRestApi>;
  * Configuration properties from CDK {@link SpecRestApiProps} are exposed as
  * overloaded getter/setter methods via the builder proxy. The API structure
  * is defined entirely by the OpenAPI specification provided via
- * {@link apiDefinition}.
+ * {@link SpecRestApiBuilderProps.apiDefinition | apiDefinition}.
  *
  * The builder implements {@link Lifecycle}, so it can be used directly as a
  * component in a {@link compose | composed system}. When built, it creates
@@ -62,8 +93,25 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
     target.#customAlarms.push(...this.#customAlarms);
   }
 
-  build(scope: IConstruct, id: string): SpecRestApiBuilderResult {
-    const { accessLogging, recommendedAlarms: alarmConfig, ...specRestApiProps } = this.props;
+  build(scope: IConstruct, id: string, context?: Record<string, object>): SpecRestApiBuilderResult {
+    const {
+      accessLogging,
+      recommendedAlarms: alarmConfig,
+      apiDefinition,
+      ...specRestApiProps
+    } = this.props;
+
+    if (!apiDefinition) {
+      throw new Error(
+        `SpecRestApiBuilder "${id}" requires an apiDefinition. ` +
+          `Call .apiDefinition() with an ApiDefinition or a Ref to one.`,
+      );
+    }
+
+    // Resolved before anything is created, so an unresolvable ref fails
+    // without leaving a half-built access log group in the scope.
+    const resolvedDefinition = resolve(apiDefinition, context);
+
     const { accessLogGroup, deployOptions } = resolveDeployOptions(
       scope,
       id,
@@ -74,8 +122,9 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
 
     const api = new SpecRestApi(scope, id, {
       ...specRestApiProps,
+      apiDefinition: resolvedDefinition,
       deployOptions,
-    } as SpecRestApiProps);
+    });
 
     const alarms = createRestApiAlarms(scope, id, api, alarmConfig, this.#customAlarms);
 
@@ -92,9 +141,10 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
  * setter/getter. It implements {@link Lifecycle} for use with {@link compose}.
  *
  * The API structure — resources, methods, and integrations — is defined
- * entirely by the OpenAPI specification passed to {@link apiDefinition}.
- * Use CDK's {@link ApiDefinition} static methods to load the spec from an
- * inline object, a local file, or an S3 bucket.
+ * entirely by the OpenAPI specification passed to
+ * {@link SpecRestApiBuilderProps.apiDefinition | apiDefinition}. Use CDK's
+ * {@link ApiDefinition} static methods to load the spec from an inline object,
+ * a local file, or an S3 bucket.
  *
  * @returns A fluent builder for a spec-driven API Gateway REST API.
  *

--- a/packages/apigateway/test/spec-rest-api-builder.test.ts
+++ b/packages/apigateway/test/spec-rest-api-builder.test.ts
@@ -9,11 +9,19 @@ import {
 } from "aws-cdk-lib/aws-apigateway";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { combine, compose, type Lifecycle, ref } from "@composurecdk/core";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createSpecRestApiBuilder } from "../src/spec-rest-api-builder.js";
 
-/** Minimal OpenAPI 3.0 spec with a single mock-integrated GET /pets endpoint. */
-function minimalOpenApiSpec() {
+/** Minimal OpenAPI 3.0 spec with a single GET /pets endpoint, mock-integrated
+ * unless the caller supplies an integration of its own. */
+function minimalOpenApiSpec(
+  integration: object = {
+    type: "MOCK",
+    requestTemplates: { "application/json": '{ "statusCode": 200 }' },
+    responses: { default: { statusCode: "200" } },
+  },
+) {
   return {
     openapi: "3.0.2",
     info: { title: "TestApi", version: "1.0" },
@@ -21,11 +29,7 @@ function minimalOpenApiSpec() {
       "/pets": {
         get: {
           responses: { "200": { description: "OK" } },
-          "x-amazon-apigateway-integration": {
-            type: "MOCK",
-            requestTemplates: { "application/json": '{ "statusCode": 200 }' },
-            responses: { default: { statusCode: "200" } },
-          },
+          "x-amazon-apigateway-integration": integration,
         },
       },
     },
@@ -34,12 +38,13 @@ function minimalOpenApiSpec() {
 
 function synthTemplate(
   configureFn: (builder: ReturnType<typeof createSpecRestApiBuilder>) => void,
+  context?: Record<string, object>,
 ): Template {
   const app = new App();
   const stack = new Stack(app, "TestStack");
   const builder = createSpecRestApiBuilder();
   configureFn(builder);
-  builder.build(stack, "TestApi");
+  builder.build(stack, "TestApi", context);
   return Template.fromStack(stack);
 }
 
@@ -136,6 +141,137 @@ describe("SpecRestApiBuilder", () => {
       const template = synthTemplate((b) => withStubDefinition(b.restApiName("My Service")));
 
       template.resourceCountIs("AWS::ApiGateway::RestApi", 1);
+    });
+  });
+
+  describe("resolvable apiDefinition", () => {
+    const HANDLER_ARN = "arn:aws:lambda:us-east-1:123456789012:function:Handler";
+    const ROLE_ARN = "arn:aws:iam::123456789012:role/GatewayRole";
+
+    /** Asserts the synthesised `Body` carries the given integration fields. */
+    function expectIntegration(template: Template, integration: Record<string, unknown>) {
+      template.hasResourceProperties("AWS::ApiGateway::RestApi", {
+        Body: Match.objectLike({
+          paths: {
+            "/pets": {
+              get: { "x-amazon-apigateway-integration": Match.objectLike(integration) },
+            },
+          },
+        }),
+      });
+    }
+
+    it("resolves a ref against the build context", () => {
+      const template = synthTemplate(
+        (b) =>
+          b
+            .restApiName("My Service")
+            .apiDefinition(
+              ref("handler", (r: { functionArn: string }) =>
+                ApiDefinition.fromInline(
+                  minimalOpenApiSpec({ type: "AWS_PROXY", uri: r.functionArn }),
+                ),
+              ),
+            ),
+        { handler: { functionArn: HANDLER_ARN } },
+      );
+
+      expectIntegration(template, { uri: HANDLER_ARN });
+    });
+
+    it("resolves a combine of several siblings into one definition", () => {
+      const template = synthTemplate(
+        (b) =>
+          b.restApiName("My Service").apiDefinition(
+            combine(
+              {
+                handler: ref<{ functionArn: string }>("handler"),
+                gatewayRole: ref<{ roleArn: string }>("gatewayRole"),
+              },
+              ({ handler, gatewayRole }) =>
+                ApiDefinition.fromInline(
+                  minimalOpenApiSpec({
+                    type: "AWS_PROXY",
+                    uri: handler.functionArn,
+                    credentials: gatewayRole.roleArn,
+                  }),
+                ),
+            ),
+          ),
+        {
+          handler: { functionArn: HANDLER_ARN },
+          gatewayRole: { roleArn: ROLE_ARN },
+        },
+      );
+
+      expectIntegration(template, { uri: HANDLER_ARN, credentials: ROLE_ARN });
+    });
+
+    it("carries a CDK token from a sibling into the synthesised body", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const sibling = new LogGroup(stack, "SiblingLogGroup");
+      const builder = createSpecRestApiBuilder()
+        .restApiName("My Service")
+        .apiDefinition(
+          ref("sibling", (r: { arn: string }) =>
+            ApiDefinition.fromInline(
+              minimalOpenApiSpec({ type: "AWS_PROXY", uri: `${r.arn}/invoke` }),
+            ),
+          ),
+        );
+
+      builder.build(stack, "TestApi", { sibling: { arn: sibling.logGroupArn } });
+
+      // An unresolved token would stringify to "${Token[...]}"; a Fn::Join
+      // proves the sibling's Fn::GetAtt survived into the API body.
+      expectIntegration(Template.fromStack(stack), { uri: { "Fn::Join": Match.anyValue() } });
+    });
+
+    it("throws when a ref names a component that is not a dependency", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const builder = createSpecRestApiBuilder()
+        .restApiName("My Service")
+        .apiDefinition(
+          ref("handler", (r: { functionArn: string }) =>
+            ApiDefinition.fromInline(minimalOpenApiSpec({ uri: r.functionArn })),
+          ),
+        );
+
+      expect(() => builder.build(stack, "TestApi")).toThrow(
+        /"handler" cannot be resolved: component not found in context/,
+      );
+    });
+
+    it("throws a descriptive error when no apiDefinition is set", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const builder = createSpecRestApiBuilder().restApiName("My Service");
+
+      expect(() => builder.build(stack, "TestApi")).toThrow(/requires an apiDefinition/);
+    });
+
+    it("resolves against a sibling built by compose", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const handler: Lifecycle<{ functionArn: string }> = {
+        build: () => ({ functionArn: HANDLER_ARN }),
+      };
+
+      compose(
+        {
+          handler,
+          api: createSpecRestApiBuilder()
+            .restApiName("My Service")
+            .apiDefinition(
+              ref("handler", (r: { functionArn: string }) =>
+                ApiDefinition.fromInline(
+                  minimalOpenApiSpec({ type: "AWS_PROXY", uri: r.functionArn }),
+                ),
+              ),
+            ),
+        },
+        { handler: [], api: ["handler"] },
+      ).build(stack, "System");
+
+      expectIntegration(Template.fromStack(stack), { uri: HANDLER_ARN });
     });
   });
 


### PR DESCRIPTION
## What & why

Closes #355.

A spec-driven REST API whose integrations name sibling resources — the ARN of the Lambda to invoke, the role API Gateway assumes to invoke it — could not be built inside `compose`. `apiDefinition` accepted only a concrete `ApiDefinition`, and `SpecRestApiBuilder.build()` never declared the `context` parameter, so the values the specification needs did not exist when the builder was configured. The reporter's workaround was to build the `SpecRestApi` outside `compose` and lose the dependency graph.

**The change:** widen `apiDefinition` to `Resolvable<ApiDefinition>` and resolve it against the build context — the three-step pattern `docs/architecture.md` prescribes and that `DistributionBuilder.certificate` and `CertificateBuilder.validationZone` already follow (`Omit<CdkProps, "x">` + a `Resolvable` re-declaration, resolved in `build`).

```ts
api: createSpecRestApiBuilder()
  .restApiName("PetStore")
  .apiDefinition(
    combine(
      {
        handler: ref<FunctionBuilderResult>("handler"),
        gatewayRole: ref<RoleBuilderResult>("gatewayRole"),
      },
      ({ handler, gatewayRole }) =>
        ApiDefinition.fromInline(
          withIntegration(spec, {
            functionArn: handler.function.functionArn,
            credentialsArn: gatewayRole.role.roleArn,
          }),
        ),
    ),
  ),
```

The substitution stays a plain function the consumer can test on its own, and a definition assembled from several siblings needs no further builder support — `combine` returns an ordinary `Ref` and drops into the widened seam (ADR-0015). No new seam, no spec-parsing in the builder, and `ApiDefinition.fromAsset`/`fromBucket` keep working unchanged.

### Notes on the details

- **Rejected the issue's proposed `transformSpec(spec, context)` callback.** It would be a second resolution mechanism with its own context object, duplicating `ref`/`combine`, and it assumes the definition is a parseable object — untrue for asset- and bucket-backed specs. Discussed on the issue.
- **The definition resolves before any construct is created**, so an unresolvable ref fails without leaving an orphan access log group grafted onto the scope.
- **A missing definition now throws** `SpecRestApiBuilder "<id>" requires an apiDefinition. Call .apiDefinition() with an ApiDefinition or a Ref to one.` — the repo's standard wording — instead of failing inside CDK. `apiDefinition` is declared optional on the props type to match every other widened-and-checked prop in the repo; the builder enforces it at build.
- **No ADR.** Applying an existing pattern to one more prop is not architecturally significant (AGENTS.md); documented in the package README instead.
- **Semver:** the setter widens (compatible). The getter `.apiDefinition()` now returns `Resolvable<ApiDefinition>`, a minor break for anyone reading it back.

### Docs

- `packages/apigateway/README.md` — new **Spec REST API Builder** section (the package had none), including the resolvable-definition pattern, the `Aws.*`-vs-`Stack.of(scope)` gotcha, and the inline-body template size caveat.
- `docs/architecture.md` §Resolvable — one paragraph noting that a `.map()` transform sees the build context but not the scope, so `Aws.*` pseudo-parameters are how to reach account/region/partition from one. That is a property of the `Ref` mechanism, not of this builder, so it belongs in the shared doc.

### Tests

Six cases in `spec-rest-api-builder.test.ts`: a `ref` resolved against the context, a `combine` of two siblings, a CDK token surviving into the synthesised `Body` as an `Fn::Join`, resolution driven by `compose` rather than a hand-passed context, an undeclared-dependency ref, and the missing-definition error. Package coverage stays at 100%.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change
- [x] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack here; a Lambda-backed example follows in a separate PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3a7Z1pDEpLEL2H8z7vzJ3)_