### PR TITLE
test(lambda): cover a non-queue onFailure destination on dynamoEventSource

### DIFF
--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -339,6 +339,22 @@ in an `SqsDlq` for you, resolving it alongside the table `ref` via `combine`:
 )
 ```
 
+A queue is the common case, not the only one: `onFailure` accepts any
+`IEventSourceDlq` — concrete or behind a `ref()` — and passes it through
+unwrapped. An S3 failure destination, which captures the whole failed batch
+rather than just the record metadata a DLQ message carries, wires up the same
+way:
+
+```ts
+.addEventSource(
+  "orders",
+  dynamoEventSource(ref("orders", (r) => r.table), {
+    retryAttempts: 3,
+    onFailure: ref("failures", (r) => new S3OnFailureDestination(r.bucket)),
+  }),
+)
+```
+
 If retries or record-age are bounded but no `onFailure` destination is set, a
 suppressible synth-time warning (`STREAM_DLQ_WARNING_ID`) fires. Silence it —
 when dropping is intended — with

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -355,6 +355,13 @@ way:
 )
 ```
 
+An S3 destination on a **DynamoDB stream** mapping needs **aws-cdk-lib ≥ 2.184.0**,
+above this package's [floor](../../docs/adr/0008-aws-cdk-lib-version-floors.md) of
+2.168.0. `DynamoEventSource` only opts into S3 destinations from that release;
+below it CDK rejects the pairing at synth with `S3 onFailure Destination is not
+supported for this event source`. The limit is CDK's, not this package's — a
+queue destination works at the floor.
+
 If retries or record-age are bounded but no `onFailure` destination is set, a
 suppressible synth-time warning (`STREAM_DLQ_WARNING_ID`) fires. Silence it —
 when dropping is intended — with

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -630,16 +630,11 @@ describe("SQS visibility-timeout relationship guard", () => {
 
 /**
  * Whether the installed aws-cdk-lib accepts an S3 on-failure destination on a
- * **DynamoDB stream** mapping. CDK's `StreamEventSource.enrichMappingOptions`
- * rejects an `S3OnFailureDestination` unless the concrete source opts in via
- * `supportS3OnFailureDestination`, which `DynamoEventSource` only began passing
- * in aws-cdk-lib 2.184.0 — above this package's 2.168.0 floor, so `cdk-floors
- * enforce` runs this suite on versions that refuse it. (Kinesis opted in
- * earlier, which is why the class imports fine all the way down.)
- *
- * Probing by synthesis rather than comparing version strings follows the
- * graceful-degradation pattern in ADR-0008 — it stays correct without a table
- * of version numbers to maintain.
+ * DynamoDB stream mapping. CDK's `enrichMappingOptions` rejects one unless the
+ * source opts in via `supportS3OnFailureDestination`, which `DynamoEventSource`
+ * only passes from 2.184.0 — above this package's 2.168.0 floor, so `cdk-floors
+ * enforce` runs this suite on versions that refuse it. Probed by synthesis
+ * rather than by version string, per ADR-0008's graceful-degradation pattern.
  */
 function dynamoStreamsAcceptS3OnFailure(): boolean {
   const probe = new Stack(new App(), "S3OnFailureProbe");
@@ -718,11 +713,8 @@ describe("dynamoEventSource onFailure DLQ", () => {
     };
 
     if (!dynamoStreamsAcceptS3OnFailure()) {
-      // Below aws-cdk-lib 2.184.0 CDK itself refuses the combination. That the
-      // error is *this* one still proves this package's half: the `ref`
-      // resolved and the destination reached CDK as an S3OnFailureDestination
-      // — CDK's guard is an `instanceof` check, so a value wrongly wrapped in
-      // an SqsDlq could not have produced it.
+      // CDK's guard is an `instanceof`, so *this* error still proves the ref
+      // resolved and reached it unwrapped.
       expect(build).toThrow(/S3 onFailure Destination is not supported/);
       return;
     }

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from "vitest";
 import { Annotations as CdkAnnotations, App, CfnParameter, Duration, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { AttributeType, type ITable, StreamViewType, Table } from "aws-cdk-lib/aws-dynamodb";
-import { Code, type IEventSource, Runtime, StartingPosition } from "aws-cdk-lib/aws-lambda";
+import {
+  Code,
+  Function as LambdaFunction,
+  type IEventSource,
+  Runtime,
+  StartingPosition,
+} from "aws-cdk-lib/aws-lambda";
 import {
   DynamoEventSource,
   S3OnFailureDestination,
@@ -622,6 +628,40 @@ describe("SQS visibility-timeout relationship guard", () => {
   });
 });
 
+/**
+ * Whether the installed aws-cdk-lib accepts an S3 on-failure destination on a
+ * **DynamoDB stream** mapping. CDK's `StreamEventSource.enrichMappingOptions`
+ * rejects an `S3OnFailureDestination` unless the concrete source opts in via
+ * `supportS3OnFailureDestination`, which `DynamoEventSource` only began passing
+ * in aws-cdk-lib 2.184.0 — above this package's 2.168.0 floor, so `cdk-floors
+ * enforce` runs this suite on versions that refuse it. (Kinesis opted in
+ * earlier, which is why the class imports fine all the way down.)
+ *
+ * Probing by synthesis rather than comparing version strings follows the
+ * graceful-degradation pattern in ADR-0008 — it stays correct without a table
+ * of version numbers to maintain.
+ */
+function dynamoStreamsAcceptS3OnFailure(): boolean {
+  const probe = new Stack(new App(), "S3OnFailureProbe");
+  const fn = new LambdaFunction(probe, "Probe", {
+    runtime: Runtime.NODEJS_22_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => {}"),
+  });
+
+  try {
+    fn.addEventSource(
+      new DynamoEventSource(streamTable(probe, "ProbeTable"), {
+        startingPosition: StartingPosition.LATEST,
+        onFailure: new S3OnFailureDestination(new Bucket(probe, "ProbeBucket")),
+      }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("dynamoEventSource onFailure DLQ", () => {
   it("wraps a bare queue as an SqsDlq destination on the mapping", () => {
     const stack = new Stack(new App(), "S");
@@ -662,19 +702,32 @@ describe("dynamoEventSource onFailure DLQ", () => {
     const stack = new Stack(new App(), "S");
     const bucket = new Bucket(stack, "FailureBucket");
 
-    baseBuilder()
-      .addEventSource(
-        "orders",
-        dynamoEventSource(streamTable(stack), {
-          retryAttempts: 3,
-          onFailure: ref(
-            "failureBucket",
-            (r: { bucket: IBucket }) => new S3OnFailureDestination(r.bucket),
-          ),
-        }),
-      )
-      .build(stack, "Fn", { failureBucket: { bucket } });
+    const build = (): void => {
+      baseBuilder()
+        .addEventSource(
+          "orders",
+          dynamoEventSource(streamTable(stack), {
+            retryAttempts: 3,
+            onFailure: ref(
+              "failureBucket",
+              (r: { bucket: IBucket }) => new S3OnFailureDestination(r.bucket),
+            ),
+          }),
+        )
+        .build(stack, "Fn", { failureBucket: { bucket } });
+    };
 
+    if (!dynamoStreamsAcceptS3OnFailure()) {
+      // Below aws-cdk-lib 2.184.0 CDK itself refuses the combination. That the
+      // error is *this* one still proves this package's half: the `ref`
+      // resolved and the destination reached CDK as an S3OnFailureDestination
+      // — CDK's guard is an `instanceof` check, so a value wrongly wrapped in
+      // an SqsDlq could not have produced it.
+      expect(build).toThrow(/S3 onFailure Destination is not supported/);
+      return;
+    }
+
+    build();
     const template = Template.fromStack(stack);
     // The bucket's own ARN, not an SqsDlq wrapper's queue ARN.
     template.hasResourceProperties("AWS::Lambda::EventSourceMapping", {

--- a/packages/lambda/test/event-sources.test.ts
+++ b/packages/lambda/test/event-sources.test.ts
@@ -3,7 +3,13 @@ import { Annotations as CdkAnnotations, App, CfnParameter, Duration, Stack } fro
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { AttributeType, type ITable, StreamViewType, Table } from "aws-cdk-lib/aws-dynamodb";
 import { Code, type IEventSource, Runtime, StartingPosition } from "aws-cdk-lib/aws-lambda";
-import { DynamoEventSource, SqsDlq, SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import {
+  DynamoEventSource,
+  S3OnFailureDestination,
+  SqsDlq,
+  SqsEventSource,
+} from "aws-cdk-lib/aws-lambda-event-sources";
+import { Bucket, type IBucket } from "aws-cdk-lib/aws-s3";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import { isRef, ref } from "@composurecdk/core";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
@@ -649,6 +655,44 @@ describe("dynamoEventSource onFailure DLQ", () => {
 
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::EventSourceMapping", {
       DestinationConfig: { OnFailure: { Destination: Match.anyValue() } },
+    });
+  });
+
+  it("resolves a Ref to a non-queue destination (an S3 bucket) without wrapping it", () => {
+    const stack = new Stack(new App(), "S");
+    const bucket = new Bucket(stack, "FailureBucket");
+
+    baseBuilder()
+      .addEventSource(
+        "orders",
+        dynamoEventSource(streamTable(stack), {
+          retryAttempts: 3,
+          onFailure: ref(
+            "failureBucket",
+            (r: { bucket: IBucket }) => new S3OnFailureDestination(r.bucket),
+          ),
+        }),
+      )
+      .build(stack, "Fn", { failureBucket: { bucket } });
+
+    const template = Template.fromStack(stack);
+    // The bucket's own ARN, not an SqsDlq wrapper's queue ARN.
+    template.hasResourceProperties("AWS::Lambda::EventSourceMapping", {
+      MaximumRetryAttempts: 3,
+      DestinationConfig: {
+        OnFailure: {
+          Destination: { "Fn::GetAtt": [Match.stringLikeRegexp("FailureBucket"), "Arn"] },
+        },
+      },
+    });
+    // `S3OnFailureDestination.bind` grants the execution role write access, so
+    // the grant proves the destination was bound rather than merely rendered.
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({ Action: Match.arrayWith(["s3:PutObject"]) }),
+        ]),
+      },
     });
   });
 


### PR DESCRIPTION
## What & why

Refs #363.

`dynamoEventSource` has accepted a `Resolvable` for `onFailure` since **0.9.2** — `DynamoStreamEventSourceProps` `Omit`s `onFailure` from CDK's props and re-declares it as `Resolvable<IQueue | IEventSourceDlq>`, resolving it alongside the table via `combine` when either is a `ref()`. So the limitation described in #363 does not exist on `main`, and there is no SQS/S3 asymmetry: `S3OnFailureDestination implements IEventSourceDlq`, and `toDlq()` only wraps values that duck-type as a queue (`"queueArn" in destination`), passing any other destination through unwrapped.

What was missing was evidence. Every test and every doc example used an SQS queue, so the surface read as queue-only — which is a fair reading of what was written, and the likely origin of the issue.

This PR adds that evidence:

- **Test** (`packages/lambda/test/event-sources.test.ts`) — resolves a `ref()` to an `S3OnFailureDestination` built over a sibling bucket and asserts both halves of the behaviour: the mapping's `DestinationConfig.OnFailure.Destination` carries the **bucket's own ARN** (not an `SqsDlq` wrapper's queue ARN), and the execution role picked up the write grant that `S3OnFailureDestination.bind` adds — which proves the destination was actually bound rather than merely rendered into the template. Both assertions were negative-checked (they fail when pointed at a wrong logical id / wrong action).
- **README** (`packages/lambda/README.md`) — the failure-handling section described `onFailure` in terms of a queue wrapped in an `SqsDlq`. It now states that any `IEventSourceDlq`, concrete or behind a `ref()`, is accepted and passed through unwrapped, with an `S3OnFailureDestination` example alongside the existing DLQ one.

No behaviour change — test and docs only.

For completeness on the other half of #363: `sqsEventSource` does pass `SqsEventSourceProps` through verbatim, but CDK's `SqsEventSourceProps` has no `onFailure` member at all (SQS event source mappings do not take an on-failure destination), so there is nothing to widen there.

## The floor finding (second commit)

The first revision failed the **`Enforce aws-cdk-lib@2.168.0`** shard — lambda's floor — and the reason is worth recording, because it is a real capability boundary rather than test noise.

CDK's `StreamEventSource.enrichMappingOptions` rejects an `S3OnFailureDestination` unless the concrete source opts in by passing `supportS3OnFailureDestination: true`, and `DynamoEventSource.bind` only began passing it in **aws-cdk-lib 2.184.0**. Bisected against real npm tarballs: absent in 2.183.0 (2025-03-12), present in 2.184.0 (2025-03-13). Kinesis opted in earlier, which is why the class itself imports fine all the way down to the floor.

So between 2.168.0 and 2.183.0, `dynamoEventSource(..., { onFailure: <an S3 destination> })` throws at synth:

```
S3 onFailure Destination is not supported for this event source
```

The widening itself resolves correctly at the floor — the `ref` resolves and the destination reaches CDK unwrapped. CDK is what refuses the DynamoDB+S3 pairing there.

**The floor is unchanged, deliberately.** Per [ADR-0008](docs/adr/0008-aws-cdk-lib-version-floors.md), a floor guards against the builders hard-failing or silently producing a broken resource. This failure is neither: it is loud, it names its own cause, and it only reaches a consumer who opts into an S3 destination — `src/` requires nothing above 2.168.0. Raising the floor 16 minor releases (2024-11-20 → 2025-03-13) for an opt-in destination would penalise every consumer for a capability most do not use.

Instead the test **probes by synthesis** and branches — the pattern ADR-0008 already describes for tag propagation and that `packages/cloudfront/test/behavior-functions.test.ts` implements for `AWS::CloudFront::Function` tagging. Where the installed CDK supports the pairing, the full assertions run. Where it does not, the test asserts the specific CDK rejection — which still proves this package's half, because CDK's guard is an `instanceof S3OnFailureDestination` check that a wrongly-`SqsDlq`-wrapped value could not have tripped. The README now carries the ≥ 2.184.0 requirement, attributed to CDK rather than to this package.

Verified both ways locally: `nx test lambda` passes at aws-cdk-lib 2.263.0 (139/139), and `node scripts/cdk-floors.mjs enforce 2.168.0 --force` passes with the pin confirmed bound (`@composurecdk/lambda resolves aws-cdk-lib 2.168.0 ✓`), with the floor run confirmed to take the rejection branch rather than passing vacuously.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one exception: `actionlint` cannot run in this environment because the pinned `shellcheck` binary download is blocked (HTTP 403 through the egress proxy). No workflow files are touched by this change. Every other gate (`format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test`) passes, plus `cdk-floors enforce` at the lambda floor.
- [x] Tests added/updated for the change
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack added

## Unrelated observation

Running `cdk-floors enforce` locally leaves the workspace floor-pinned rather than restored. Its `finally` restores package.json correctly, then calls `npm ci` — which fails under npm 10 on this lockfile with `Missing: yaml@2.9.0 from lock file`, the exact drift `ci.yml` already works around by pinning npm 11 before its own `npm ci`. The throw from inside `finally` skips the `.tshy` cleanup that follows it and replaces the run's own exit code with a stack trace, leaving `node_modules` on the floor version. Local-only (the CI shard does no `npm ci` and runs on throwaway checkouts), pre-existing, and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8auHukxhDS6VjuBrT3t8F