### PR TITLE
feat(lambda): invoke a function during deployment with `.invokeOnDeploy()`

### DIFF
--- a/docs/adr/0016-domain-action-custom-resource.md
+++ b/docs/adr/0016-domain-action-custom-resource.md
@@ -1,6 +1,6 @@
 # ADR 0016: Encapsulate SDK-only operations as domain actions on the owning builder
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-12
 
 ## Context
@@ -26,5 +26,6 @@ The first application is `@composurecdk/ses` `.activate()`: a receipt rule set i
 
 - SDK-only operations a domain builder owns are expressed as domain actions, not consumer-assembled plumbing — encapsulated, in-domain, IAM-scoped, and surfaced on the build result.
 - The stateless-vs-stateful backing is implementation guidance, not part of the core decision: the same `.activate()` encapsulation would hold even if activation used an unconditional stateless `AwsCustomResource`.
-- **Proposed** until a second SDK-only operation is encapsulated this way. The second instance prices whether to extract shared scaffolding — a `domainActionProvider(scope, id, { handler, actions })` for the stateful case, and/or handler-serialisation helpers — rather than each builder rolling its own.
+- **Accepted.** The second instance is `@composurecdk/lambda` `.invokeOnDeploy()` (invoke this function during deployment, and fail the deployment if it fails — an operation with no CloudFormation resource, owned by the builder that owns the Lambda domain). It settles the pricing question the **Proposed** status was held open for: **no shared scaffolding is extracted yet.** Both instances so far need a different backing, and neither reuses the other's plumbing — so `domainActionProvider(...)` and handler-serialisation helpers stay unbuilt until two actions actually want the same one.
+- The backing categories are **three**, not two: alongside the stateless single call (case 1) and the bespoke `Provider` (case 2) sits **case 3 — an upstream `aws-cdk-lib` construct that already implements the operation** (here `triggers.Trigger`, which invokes synchronously and reports `FAILED` on a handler error). Prefer it when one exists: it is the least code and the semantics are maintained upstream. The domain action's job is then to express the operation in domain language, apply the defaults, and wire the ordering the raw construct leaves to the consumer.
 - Consumers running multiple instances of an account-global operation (e.g. several SES rule sets across stacks) must understand the shared-state arbitration; document it on the builder, and keep `createAwsCustomResourceBuilder` as the escape hatch for bespoke behaviour.

--- a/packages/custom-resources/README.md
+++ b/packages/custom-resources/README.md
@@ -8,6 +8,8 @@ This package wraps `AwsCustomResource` as a builder so those calls become first-
 
 > **When a domain builder already covers the call you need, prefer it** — it scopes IAM automatically and reads as intent rather than plumbing (e.g. a future SES `.activate()`). This builder is for the long tail of one-off SDK calls that don't justify a domain builder.
 
+> **Invoking your own Lambda during deployment is a different job** — use [`.invokeOnDeploy()`](../lambda/README.md#deploy-time-invocation-invokeondeploy) on the function builder. Reaching for `onCreate: { service: "Lambda", action: "invoke" }` here **will not fail the deployment when your handler fails**: the provider only reports `FAILED` when the _SDK call_ throws, and a handler that throws still returns HTTP 200 with a `FunctionError` field, so the deploy goes green.
+
 ## Usage
 
 ```ts

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -379,6 +379,101 @@ today (the queue often arrives as an unresolved `ref()`); they are tracked in
 `kinesisEventSource` is still deferred — see
 [#120](https://github.com/laazyj/composureCDK/issues/120).
 
+## Deploy-time invocation: `.invokeOnDeploy()`
+
+Some work has to happen _as part of shipping the stack_, and its outcome has to
+gate the deployment: registering the release with an external service, calling
+the system you just deployed to prove it answers, seeding reference data through
+a service API. `.invokeOnDeploy()` invokes the function once during deployment
+and **fails the deployment if the function fails** — the stack rolls back and
+the handler's error message lands in the CloudFormation events.
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createFunctionBuilder } from "@composurecdk/lambda";
+
+compose(
+  {
+    register: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_22_X)
+      .handler("index.handler")
+      .code(Code.fromAsset("register"))
+      .timeout(Duration.seconds(30))
+      .environment({ API_URL: "https://releases.example.com/v1/register" })
+      .invokeOnDeploy({ after: [ref("api", (r: RestApiBuilderResult) => r.api)] }),
+
+    api: createRestApiBuilder().restApiName("Orders"),
+  },
+  { api: [], register: ["api"] },
+).build(stack, "Release");
+```
+
+It is a domain action on the function builder ([ADR-0016](../../docs/adr/0016-domain-action-custom-resource.md)),
+backed by the CDK [`Trigger`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.triggers-readme.html)
+construct. The custom resource is exposed on the build result as
+`deploymentTrigger`, so a sibling can be ordered against the call itself
+(`deploymentTrigger.executeBefore(...)`).
+
+### The handler must throw
+
+**A handler that returns an error rather than throwing does not fail the
+deployment.** Lambda considers an invocation that returns successful no matter
+what the payload says, so an HTTP-shaped `{ statusCode: 500 }` — or a caught
+error folded into the response — deploys green:
+
+```ts
+export const handler = async () => {
+  const response = await fetch(process.env.API_URL, { method: "POST" });
+  if (!response.ok) {
+    // Throw. Returning `{ statusCode: response.status }` here would deploy green.
+    throw new Error(`Registration failed: ${response.status} ${await response.text()}`);
+  }
+};
+```
+
+### Ordering
+
+The function's own execution role is always waited for, so policies attached by
+`.grant()` and `.configureRole()` exist before the handler runs — CloudFormation
+does not otherwise sequence those ahead of a custom resource, and the handler
+would race them. Everything else the call depends on goes in `after`, as
+concrete constructs or `ref(...)` references to sibling components.
+
+### Defaults
+
+| Option                   | Default                          | Rationale                                                                                                                                                                                |
+| ------------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| invocation type          | `RequestResponse` (not settable) | The deployment waits for the result. An asynchronous invocation returns before the work happens, reporting success whatever the handler did — the opposite of the point.                 |
+| `timeout`                | function `timeout` + 30s         | The deployment outlives the handler, so a handler that runs to its limit reports _its_ error ("Task timed out after …") instead of the deployment abandoning the call. Capped at 15 min. |
+| `executeOnHandlerChange` | `true`                           | Re-invokes when the handler's code or configuration changes; a no-op on unrelated stack updates.                                                                                         |
+
+The derivation values are exported as `DEPLOYMENT_INVOKE_DEFAULTS`. With no
+function `timeout` set (or a token one), the wait falls back to 2 minutes,
+matching CDK's own `Trigger` default.
+
+Whenever the wait ends up at or below the function's own timeout, a suppressible
+warning fires under `DEPLOY_INVOKE_TIMEOUT_WARNING_ID` — the deployment would
+stop waiting while the handler is still running, so a slow call fails the stack
+as an abandoned invocation rather than reporting the handler's error. That
+covers an explicit `timeout` set too low, and also a function at Lambda's
+15-minute maximum, where the 15-minute cap leaves no margin to add.
+
+### What it does not do
+
+- **It does not invoke on every deployment.** With `executeOnHandlerChange: true`
+  the invocation re-runs when the handler changes; with `false` it runs only on
+  the stack's first deployment. CDK's `Trigger` offers no "always" mode.
+- **It does not invoke on stack deletion.** For teardown-time work, use
+  [`@composurecdk/custom-resources`](../custom-resources/README.md), which has
+  create/update/**delete** semantics.
+- **It creates no alarms.** The custom resource runs once per deployment, not
+  continuously; there is no steady-state signal to alarm on. Failures surface as
+  a failed deployment.
+- **It is not a general SDK-call escape hatch.** A call that has no
+  CloudFormation resource but needs no handler of yours belongs in
+  `createAwsCustomResourceBuilder()` — that builder invokes an AWS API directly,
+  no Lambda of yours involved.
+
 ## Examples
 
 - [DualFunctionStack](../examples/src/dual-function-app.ts) — Two Lambda functions with recommended alarms, custom alarms, and SNS alarm actions

--- a/packages/lambda/src/deployment-invocation.ts
+++ b/packages/lambda/src/deployment-invocation.ts
@@ -1,0 +1,169 @@
+import { Annotations, Duration } from "aws-cdk-lib";
+import type { IRole } from "aws-cdk-lib/aws-iam";
+import type { Function as LambdaFunction } from "aws-cdk-lib/aws-lambda";
+import { InvocationType, Trigger } from "aws-cdk-lib/triggers";
+import type { IConstruct } from "constructs";
+import { resolve, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Suppression id for the deploy-time invocation timeout guard. Stable and part
+ * of the public surface — silence the warning with
+ * `Annotations.of(scope).acknowledgeWarning(DEPLOY_INVOKE_TIMEOUT_WARNING_ID)`,
+ * so it must not be renamed casually.
+ */
+export const DEPLOY_INVOKE_TIMEOUT_WARNING_ID = "@composurecdk/lambda:deploy-invoke-timeout";
+
+/**
+ * The deployment waits for the handler's response, so a handler that throws
+ * fails the stack. An invariant of the action rather than a default: the
+ * asynchronous alternative returns before the work happens, reporting success
+ * whatever the handler did, so there is nothing to override to.
+ *
+ * @see https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/rel_tracking_change_management_deployment_management.html
+ */
+const DEPLOYMENT_INVOCATION_TYPE = InvocationType.REQUEST_RESPONSE;
+
+/**
+ * How {@link IFunctionBuilder.invokeOnDeploy | `.invokeOnDeploy()`} derives the
+ * wait when the caller sets no {@link InvokeOnDeployOptions.timeout}. Exported
+ * for visibility and testing.
+ */
+export const DEPLOYMENT_INVOKE_DEFAULTS = {
+  /**
+   * Added to the function's own `timeout` to derive how long the deployment
+   * waits, so a handler that runs to its limit still reports *its* error
+   * ("Task timed out after …") rather than the deployment abandoning the call
+   * first and reporting a less actionable trigger timeout.
+   */
+  timeoutMargin: Duration.seconds(30),
+
+  /**
+   * The wait applied when the function's own timeout is unset or a token, and
+   * so yields no concrete value to derive from. Matches the CDK `Trigger`
+   * default.
+   */
+  fallbackTimeout: Duration.minutes(2),
+
+  /**
+   * Ceiling for the derived wait: the CDK trigger provider's own Lambda runs
+   * with a 15-minute timeout, so waiting longer is not something the library
+   * can honour.
+   */
+  maxTimeout: Duration.minutes(15),
+} as const;
+
+/**
+ * Options for {@link IFunctionBuilder.invokeOnDeploy | `.invokeOnDeploy()`}.
+ */
+export interface InvokeOnDeployOptions {
+  /**
+   * Constructs that must be fully provisioned before the handler runs, as
+   * concrete constructs or {@link Resolvable} references to sibling components
+   * (`ref("api", (r) => r.api)`).
+   *
+   * The function's own execution role — and therefore every policy attached to
+   * it by `.grant()` or `.configureRole()` — is always waited for; this is for
+   * everything else the call depends on, such as the API it will call or the
+   * table it will seed.
+   */
+  readonly after?: Resolvable<IConstruct>[];
+
+  /**
+   * How long the deployment waits for the handler before failing the stack.
+   *
+   * Defaults to the function's own `timeout` plus
+   * {@link DEPLOYMENT_INVOKE_DEFAULTS.timeoutMargin}, capped at
+   * {@link DEPLOYMENT_INVOKE_DEFAULTS.maxTimeout}. Setting this at or below the
+   * function's timeout warns under {@link DEPLOY_INVOKE_TIMEOUT_WARNING_ID}.
+   */
+  readonly timeout?: Duration;
+
+  /**
+   * Re-invoke the handler whenever its code or configuration changes.
+   *
+   * `true` (the default) binds the invocation to the function's current
+   * version, so it re-runs on a handler change and is a no-op on unrelated
+   * stack updates — right for an idempotent registration. `false` invokes only
+   * on the stack's *first* deployment. Neither setting invokes on every
+   * deployment; that is not something CDK's `Trigger` offers.
+   */
+  readonly executeOnHandlerChange?: boolean;
+}
+
+/**
+ * Creates the custom resource that invokes `handler` during deployment and
+ * fails the stack if it errors.
+ *
+ * The invocation is ordered after the function's execution role, so policies
+ * attached by `.grant()` / `.configureRole()` — which CloudFormation does not
+ * otherwise sequence ahead of a custom resource — exist by the time the handler
+ * runs. Anything else the call needs comes through
+ * {@link InvokeOnDeployOptions.after}.
+ *
+ * @internal
+ */
+export function createDeploymentInvocation(
+  scope: IConstruct,
+  id: string,
+  handler: LambdaFunction,
+  executionRole: IRole,
+  options: InvokeOnDeployOptions,
+  context: Record<string, object>,
+): Trigger {
+  const timeout = options.timeout ?? derivedWait(handler.timeout);
+  warnOnShortWait(handler, id, timeout);
+
+  return new Trigger(scope, `${id}DeploymentTrigger`, {
+    handler,
+    invocationType: DEPLOYMENT_INVOCATION_TYPE,
+    timeout,
+    executeOnHandlerChange: options.executeOnHandlerChange,
+    executeAfter: [executionRole, ...(options.after ?? []).map((t) => resolve(t, context))],
+  });
+}
+
+/**
+ * The wait derived from the function's own timeout when the caller did not set
+ * one: long enough for the handler to reach its limit and report its own error,
+ * and never longer than the trigger provider can honour.
+ */
+function derivedWait(handlerTimeout: Duration | undefined): Duration {
+  const handlerSeconds = concreteSeconds(handlerTimeout);
+  if (handlerSeconds === undefined) return DEPLOYMENT_INVOKE_DEFAULTS.fallbackTimeout;
+
+  const derived = handlerSeconds + DEPLOYMENT_INVOKE_DEFAULTS.timeoutMargin.toSeconds();
+  return Duration.seconds(Math.min(derived, DEPLOYMENT_INVOKE_DEFAULTS.maxTimeout.toSeconds()));
+}
+
+/** A `Duration` in seconds, or `undefined` when it is unset or a token. */
+function concreteSeconds(duration: Duration | undefined): number | undefined {
+  if (duration === undefined || duration.isUnresolved()) return undefined;
+  return duration.toSeconds();
+}
+
+/**
+ * Warns when the deployment would stop waiting before the handler's own timeout
+ * — a handler that runs long then fails the stack as an abandoned invocation
+ * rather than reporting the error it was about to produce.
+ *
+ * Checked against the final wait, whether the caller set it or it was derived,
+ * because the derived path can land here too: the cap leaves no margin for a
+ * function timeout at Lambda's 15-minute maximum. Silent whenever either value
+ * is a token, with nothing to compare.
+ */
+function warnOnShortWait(handler: LambdaFunction, id: string, wait: Duration): void {
+  const waitSeconds = concreteSeconds(wait);
+  const handlerSeconds = concreteSeconds(handler.timeout);
+  if (waitSeconds === undefined || handlerSeconds === undefined) return;
+  if (waitSeconds > handlerSeconds) return;
+
+  Annotations.of(handler).addWarningV2(
+    DEPLOY_INVOKE_TIMEOUT_WARNING_ID,
+    `FunctionBuilder "${id}": .invokeOnDeploy() waits ${String(waitSeconds)}s but the function's ` +
+      `own timeout is ${String(handlerSeconds)}s — the deployment stops waiting while the handler ` +
+      `is still running, so a slow call fails the stack as an abandoned invocation instead of ` +
+      `reporting the handler's error. Give the deployment longer than the function's timeout (up ` +
+      `to ${String(DEPLOYMENT_INVOKE_DEFAULTS.maxTimeout.toMinutes())} minutes), shorten the ` +
+      `function's timeout, or acknowledge "${DEPLOY_INVOKE_TIMEOUT_WARNING_ID}".`,
+  );
+}

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -6,6 +6,7 @@ import {
   type IEventSource,
 } from "aws-cdk-lib/aws-lambda";
 import type { ILogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
+import type { Trigger } from "aws-cdk-lib/triggers";
 import { type IConstruct } from "constructs";
 import {
   COPY_STATE,
@@ -33,6 +34,7 @@ import {
   isComposureEventSource,
 } from "./event-sources/composure-event-source.js";
 import { EVENT_SOURCE_RELATIONSHIP_GUARDS } from "./event-sources/event-source-relationship-guards.js";
+import { createDeploymentInvocation, type InvokeOnDeployOptions } from "./deployment-invocation.js";
 
 const LOGS_WRITER_POLICY_NAME = "LogsWriter";
 
@@ -142,6 +144,16 @@ export interface FunctionBuilderResult {
    * Always present — `{}` when no event sources were added.
    */
   eventSources: Record<string, IEventSource>;
+
+  /**
+   * The custom resource that invokes the function during deployment, or
+   * `undefined` unless {@link IFunctionBuilder.invokeOnDeploy} was called.
+   *
+   * Exposed so a sibling can be ordered against the invocation — e.g.
+   * `deploymentTrigger.executeBefore(...)` to gate another resource on the
+   * call having succeeded.
+   */
+  deploymentTrigger?: Trigger;
 }
 
 /**
@@ -213,6 +225,7 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
   readonly #grants = new GrantQueue<IGrantable>();
   #configureRole?: (rb: IRoleBuilder) => unknown;
   #useCdkAutoRole = false;
+  #invokeOnDeploy?: InvokeOnDeployOptions;
 
   addAlarm(
     key: string,
@@ -289,6 +302,45 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
   }
 
   /**
+   * Invoke this function once during deployment, and **fail the deployment if
+   * it fails** — a domain action for work that must happen as part of shipping
+   * the stack, such as registering the release with an external service,
+   * verifying the deployed system answers correctly, or seeding reference data
+   * through a service API (ADR-0016).
+   *
+   * The deployment waits for the handler's response. If the handler throws or
+   * times out, the stack fails and rolls back, and the handler's error message
+   * reaches the CloudFormation stack events.
+   *
+   * **The handler must throw to fail the deployment.** Returning an error
+   * object — an HTTP-shaped `{ statusCode: 500 }`, or a caught error swallowed
+   * into the response — is a *successful* invocation as far as Lambda is
+   * concerned, and the deployment goes green.
+   *
+   * Ordering is data: the function's own execution role is always waited for,
+   * and anything else the call needs is declared with
+   * {@link InvokeOnDeployOptions.after}.
+   *
+   * Calling this more than once replaces the previous options. The resulting
+   * custom resource is exposed on
+   * {@link FunctionBuilderResult.deploymentTrigger}.
+   *
+   * @example
+   * ```ts
+   * createFunctionBuilder()
+   *   .runtime(Runtime.NODEJS_22_X)
+   *   .handler("index.handler")
+   *   .code(Code.fromAsset("register"))
+   *   .timeout(Duration.seconds(30))
+   *   .invokeOnDeploy({ after: [ref("api", (r: RestApiBuilderResult) => r.api)] });
+   * ```
+   */
+  invokeOnDeploy(options: InvokeOnDeployOptions = {}): this {
+    this.#invokeOnDeploy = options;
+    return this;
+  }
+
+  /**
    * Grant this function's execution role access to a resource built by a
    * sibling component.
    *
@@ -319,6 +371,7 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
     this.#grants.copyInto(target.#grants);
     target.#configureRole = this.#configureRole;
     target.#useCdkAutoRole = this.#useCdkAutoRole;
+    target.#invokeOnDeploy = this.#invokeOnDeploy;
   }
 
   build(
@@ -417,7 +470,13 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
       throw new Error(`FunctionBuilder "${id}": Lambda function has no execution role.`);
     }
 
-    return { function: fn, role: resolvedRole, logGroup, alarms, eventSources };
+    // Built last so the invocation is ordered after everything the builder
+    // attached to the function — grants included.
+    const deploymentTrigger = this.#invokeOnDeploy
+      ? createDeploymentInvocation(scope, id, fn, resolvedRole, this.#invokeOnDeploy, context)
+      : undefined;
+
+    return { function: fn, role: resolvedRole, logGroup, alarms, eventSources, deploymentTrigger };
   }
 
   #buildDefaultRole(

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -6,6 +6,11 @@ export {
 } from "./function-builder.js";
 export { functionGrants } from "./grants.js";
 export { FUNCTION_DEFAULTS } from "./defaults.js";
+export {
+  DEPLOY_INVOKE_TIMEOUT_WARNING_ID,
+  DEPLOYMENT_INVOKE_DEFAULTS,
+  type InvokeOnDeployOptions,
+} from "./deployment-invocation.js";
 export { type FunctionAlarmConfig, type PercentageAlarmConfig } from "./alarm-config.js";
 export { FUNCTION_ALARM_DEFAULTS } from "./alarm-defaults.js";
 export {

--- a/packages/lambda/test/deployment-invocation.test.ts
+++ b/packages/lambda/test/deployment-invocation.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from "vitest";
+import {
+  Annotations as CdkAnnotations,
+  App,
+  CfnParameter,
+  type CfnResource,
+  Duration,
+  Stack,
+} from "aws-cdk-lib";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import type { IConstruct } from "constructs";
+import { compose, ref } from "@composurecdk/core";
+import { assertCopyPreservesState } from "@composurecdk/core/testing";
+import { createFunctionBuilder } from "../src/function-builder.js";
+import { DEPLOY_INVOKE_TIMEOUT_WARNING_ID } from "../src/deployment-invocation.js";
+
+const TRIGGER = "Custom::Trigger";
+
+/** A minimal, deployable function builder — every test starts from this. */
+function handlerBuilder(): ReturnType<typeof createFunctionBuilder> {
+  return createFunctionBuilder()
+    .runtime(Runtime.NODEJS_22_X)
+    .handler("index.handler")
+    .code(Code.fromInline("exports.handler = async () => {}"));
+}
+
+function synthStack(
+  configureFn: (builder: ReturnType<typeof createFunctionBuilder>) => void,
+): Stack {
+  const stack = new Stack(new App(), "TestStack");
+  const builder = handlerBuilder();
+  configureFn(builder);
+  builder.build(stack, "TestFunction");
+  return stack;
+}
+
+const synthTemplate = (
+  configureFn: (builder: ReturnType<typeof createFunctionBuilder>) => void,
+): Template => Template.fromStack(synthStack(configureFn));
+
+/** A stack whose function timeout is an unresolved token. */
+function tokenTimeoutStack(
+  invoke: (builder: ReturnType<typeof createFunctionBuilder>) => void,
+): Stack {
+  const stack = new Stack(new App(), "TestStack");
+  const seconds = new CfnParameter(stack, "TimeoutParam", { type: "Number" });
+  const builder = handlerBuilder().timeout(Duration.seconds(seconds.valueAsNumber));
+  invoke(builder);
+  builder.build(stack, "TestFunction");
+  return stack;
+}
+
+interface TriggerResource {
+  readonly Properties: { readonly Timeout: string };
+  readonly DependsOn?: string[];
+}
+
+function triggerResource(template: Template): TriggerResource {
+  const [trigger] = Object.values(template.findResources(TRIGGER));
+  return trigger as TriggerResource;
+}
+
+/** The `Timeout` property is milliseconds, rendered as a string. */
+const triggerTimeout = (template: Template): string => triggerResource(template).Properties.Timeout;
+
+const dependsOn = (template: Template): string[] => triggerResource(template).DependsOn ?? [];
+
+/** The logical id a construct's L1 resource lands on, for exact DependsOn assertions. */
+const logicalId = (stack: Stack, construct: IConstruct): string =>
+  stack.getLogicalId(construct.node.defaultChild as CfnResource);
+
+const findTimeoutWarnings = (stack: Stack): unknown[] =>
+  Annotations.fromStack(stack).findWarning(
+    "*",
+    Match.stringLikeRegexp(DEPLOY_INVOKE_TIMEOUT_WARNING_ID),
+  );
+
+describe("invokeOnDeploy", () => {
+  describe("build", () => {
+    it("creates no deploy-time invocation unless asked for", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const result = handlerBuilder().build(stack, "TestFunction");
+
+      expect(result.deploymentTrigger).toBeUndefined();
+      Template.fromStack(stack).resourceCountIs(TRIGGER, 0);
+    });
+
+    it("exposes the custom resource on the build result", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const result = handlerBuilder().invokeOnDeploy().build(stack, "TestFunction");
+
+      expect(result.deploymentTrigger).toBeDefined();
+      Template.fromStack(stack).resourceCountIs(TRIGGER, 1);
+    });
+
+    it("replaces the options when called twice", () => {
+      const template = synthTemplate((b) => {
+        b.timeout(Duration.seconds(30))
+          .invokeOnDeploy({ timeout: Duration.minutes(9) })
+          .invokeOnDeploy({ timeout: Duration.minutes(4) });
+      });
+
+      template.resourceCountIs(TRIGGER, 1);
+      expect(triggerTimeout(template)).toBe("240000");
+    });
+  });
+
+  describe("failure propagation", () => {
+    it("invokes synchronously so a failing handler fails the deployment", () => {
+      const template = synthTemplate((b) => b.invokeOnDeploy());
+
+      template.hasResourceProperties(TRIGGER, { InvocationType: "RequestResponse" });
+    });
+
+    it("re-invokes on handler change by default", () => {
+      const template = synthTemplate((b) => b.invokeOnDeploy());
+
+      template.hasResourceProperties(TRIGGER, { ExecuteOnHandlerChange: true });
+    });
+
+    it("invokes only on first deployment when executeOnHandlerChange is false", () => {
+      const template = synthTemplate((b) => b.invokeOnDeploy({ executeOnHandlerChange: false }));
+
+      template.hasResourceProperties(TRIGGER, { ExecuteOnHandlerChange: false });
+    });
+  });
+
+  describe("how long the deployment waits", () => {
+    it("derives the wait from the function timeout plus the margin", () => {
+      const template = synthTemplate((b) => b.timeout(Duration.seconds(30)).invokeOnDeploy());
+
+      expect(triggerTimeout(template)).toBe("60000");
+    });
+
+    it("falls back to two minutes when the function has no timeout", () => {
+      const template = synthTemplate((b) => b.invokeOnDeploy());
+
+      expect(triggerTimeout(template)).toBe("120000");
+    });
+
+    it("falls back when the function timeout is a token", () => {
+      const stack = tokenTimeoutStack((b) => b.invokeOnDeploy());
+
+      expect(triggerTimeout(Template.fromStack(stack))).toBe("120000");
+    });
+
+    it("caps the derived wait at the trigger provider's own timeout", () => {
+      const template = synthTemplate((b) => b.timeout(Duration.minutes(15)).invokeOnDeploy());
+
+      expect(triggerTimeout(template)).toBe("900000");
+    });
+
+    it("honours an explicit wait", () => {
+      const template = synthTemplate((b) =>
+        b.timeout(Duration.seconds(30)).invokeOnDeploy({ timeout: Duration.minutes(5) }),
+      );
+
+      expect(triggerTimeout(template)).toBe("300000");
+    });
+  });
+
+  describe("timeout guard", () => {
+    it("warns when the wait is shorter than the function's own timeout", () => {
+      const stack = synthStack((b) =>
+        b.timeout(Duration.minutes(5)).invokeOnDeploy({ timeout: Duration.minutes(1) }),
+      );
+
+      expect(findTimeoutWarnings(stack)).toHaveLength(1);
+    });
+
+    it("warns when the wait exactly equals the function's own timeout", () => {
+      const stack = synthStack((b) =>
+        b.timeout(Duration.minutes(5)).invokeOnDeploy({ timeout: Duration.minutes(5) }),
+      );
+
+      expect(findTimeoutWarnings(stack)).toHaveLength(1);
+    });
+
+    it("warns on the derived wait too, when the cap leaves no margin", () => {
+      const stack = synthStack((b) => b.timeout(Duration.minutes(15)).invokeOnDeploy());
+
+      expect(findTimeoutWarnings(stack)).toHaveLength(1);
+    });
+
+    it("stays quiet when the explicit wait is longer", () => {
+      const stack = synthStack((b) =>
+        b.timeout(Duration.minutes(5)).invokeOnDeploy({ timeout: Duration.minutes(6) }),
+      );
+
+      expect(findTimeoutWarnings(stack)).toEqual([]);
+    });
+
+    it("stays quiet on the derived wait, which carries the margin", () => {
+      const stack = synthStack((b) => b.timeout(Duration.minutes(5)).invokeOnDeploy());
+
+      expect(findTimeoutWarnings(stack)).toEqual([]);
+    });
+
+    it("stays quiet when the function timeout is a token, with nothing to compare", () => {
+      const stack = tokenTimeoutStack((b) => b.invokeOnDeploy({ timeout: Duration.seconds(1) }));
+
+      expect(findTimeoutWarnings(stack)).toEqual([]);
+    });
+
+    it("stays quiet when the wait itself is a token", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const millis = new CfnParameter(stack, "WaitParam", { type: "Number" });
+
+      handlerBuilder()
+        .timeout(Duration.minutes(5))
+        // `Duration.millis` is the only unit CDK can render from a token here.
+        .invokeOnDeploy({ timeout: Duration.millis(millis.valueAsNumber) })
+        .build(stack, "TestFunction");
+
+      expect(findTimeoutWarnings(stack)).toEqual([]);
+    });
+
+    it("is suppressed by acknowledging the warning id", () => {
+      const stack = new Stack(new App(), "TestStack");
+      CdkAnnotations.of(stack).acknowledgeWarning(DEPLOY_INVOKE_TIMEOUT_WARNING_ID);
+
+      handlerBuilder()
+        .timeout(Duration.minutes(5))
+        .invokeOnDeploy({ timeout: Duration.minutes(1) })
+        .build(stack, "TestFunction");
+
+      expect(findTimeoutWarnings(stack)).toEqual([]);
+    });
+  });
+
+  describe("ordering", () => {
+    it("waits for the execution role, so grants are in place before the call", () => {
+      const template = synthTemplate((b) => b.invokeOnDeploy());
+
+      expect(dependsOn(template)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("TestFunctionExecutionRole"),
+          expect.stringContaining("TestFunctionExecutionRoleDefaultPolicy"),
+        ]),
+      );
+    });
+
+    it("waits for the CDK auto-role when that escape hatch is used", () => {
+      const template = synthTemplate((b) => b.useCdkAutoRole().invokeOnDeploy());
+
+      expect(dependsOn(template)).toEqual(
+        expect.arrayContaining([expect.stringContaining("ServiceRole")]),
+      );
+    });
+
+    it("waits for a concrete construct passed to after", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const queue = new Queue(stack, "SeedQueue");
+
+      handlerBuilder()
+        .invokeOnDeploy({ after: [queue] })
+        .build(stack, "TestFunction");
+
+      expect(dependsOn(Template.fromStack(stack))).toContain(logicalId(stack, queue));
+    });
+
+    it("resolves a ref passed to after against the compose context", () => {
+      const stack = new Stack(new App(), "TestStack");
+
+      const results = compose(
+        {
+          queue: {
+            build: (scope: Stack, id: string) => ({ queue: new Queue(scope, id) }),
+          },
+          handler: handlerBuilder().invokeOnDeploy({
+            after: [ref("queue", (r: { queue: Queue }) => r.queue)],
+          }),
+        },
+        { queue: [], handler: ["queue"] },
+      ).build(stack, "System");
+
+      expect(dependsOn(Template.fromStack(stack))).toContain(logicalId(stack, results.queue.queue));
+    });
+  });
+
+  describe("[COPY_STATE]", () => {
+    it("preserves #invokeOnDeploy across .copy()", () => {
+      assertCopyPreservesState({
+        factory: () => handlerBuilder(),
+        configure: (b) => {
+          b.invokeOnDeploy({ timeout: Duration.minutes(4) });
+        },
+        mutate: (b) => {
+          b.invokeOnDeploy({ timeout: Duration.minutes(9) });
+        },
+        build: (b) => b.build(new Stack(new App(), "S"), "Function"),
+        inspect: (r) => triggerTimeout(Template.fromStack(Stack.of(r.function))),
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Closes #365.

Some work has to happen *as part of shipping a stack*, and its outcome has to gate the deployment: registering a release with an external service, calling the deployed system to prove it answers, seeding reference data through a service API. Nothing in the library covered that, and **the nearest existing tool gets it silently wrong** — an `AwsCustomResource` running `Lambda.invoke` only reports `FAILED` when the *SDK call* throws, and a handler that throws still returns HTTP 200 with a `FunctionError` field, so the deploy goes green.

`.invokeOnDeploy()` invokes the function once during deployment and fails the deployment if the handler fails:

```ts
compose(
  {
    register: createFunctionBuilder()
      .runtime(Runtime.NODEJS_22_X)
      .handler("index.handler")
      .code(Code.fromAsset("register"))
      .timeout(Duration.seconds(30))
      .environment({ API_URL: "https://releases.example.com/v1/register" })
      .invokeOnDeploy({ after: [ref("api", (r: RestApiBuilderResult) => r.api)] }),

    api: createRestApiBuilder().restApiName("Orders"),
  },
  { api: [], register: ["api"] },
).build(stack, "Release");
```

### Shape: a domain action, not a standalone component

The issue left the shape open. This is a `<verb>()` on the function builder per [ADR-0016](https://github.com/laazyj/composureCDK/blob/main/docs/adr/0016-domain-action-custom-resource.md): "invoke this function during deployment" has no CloudFormation resource, and the builder that owns the Lambda domain owns the operation. The consumer declares intent; the builder owns the invocation semantics, the wait derivation, the execution-role ordering, and the IAM. The custom resource lands on the build result as `deploymentTrigger`, so a sibling can be ordered against the call itself (`deploymentTrigger.executeBefore(...)`).

It stays in `@composurecdk/lambda` rather than becoming a package: it uses only `aws-cdk-lib` types (`triggers` ships inside `aws-cdk-lib`), so it adds no dependency and no new-package machinery. `cdk-floors.json` is unchanged — `TriggerProps.invocationType`, `.timeout` and `.executeOnHandlerChange` all exist at lambda's declared floor of 2.168.0, verified by unpacking that version rather than assuming.

### Defaults and guards

| Behaviour | Default | Rationale |
| --- | --- | --- |
| Invocation type | `RequestResponse`, **fixed** | The deployment waits for the result. The asynchronous alternative returns before the work happens and would report success whatever the handler did — the opposite of the point. Not exposed as an option; raw `Trigger` remains the escape hatch. |
| Wait | function `timeout` + 30s, capped at 15 min | The deployment outlives the handler, so a handler that runs to its limit reports *its* error ("Task timed out after …") instead of the deployment abandoning the call and surfacing an unactionable provider timeout. The cap is the trigger provider's own Lambda timeout. Falls back to 2 min (CDK's default) when the function timeout is unset or a token. |
| `executeOnHandlerChange` | `true` | Re-invokes on a handler change, no-op on unrelated updates. |

A suppressible warning (`DEPLOY_INVOKE_TIMEOUT_WARNING_ID`) fires whenever the final wait is at or below the function's own timeout. It is checked against the *derived* wait too, not just an explicit one — at Lambda's 15-minute maximum the cap leaves no margin, which is exactly the state the guard exists to flag. Both operands belong to this builder and are final at `build()`, so it is a build-time warn like `warnIfLowMaxReceiveCount` in `@composurecdk/sqs`, not an ADR-0011 synth-time Aspect (which is for values owned by *another* component) and not an ADR-0010 throw (the configuration is deployable).

Ordering is data, not glue: the function's execution role is always waited for — CloudFormation does not otherwise sequence `.grant()`/`.configureRole()` policies ahead of a custom resource, and the handler would race them — and everything else goes in `after` as concrete constructs or `ref(...)` to siblings.

### Documentation

Both READMEs now document the trap that sinks this: **a handler that returns an error instead of throwing is a successful invocation and deploys green.** The `@composurecdk/custom-resources` README says why `Lambda.invoke` there is not the tool, since that is where a consumer looks first.

### ADR-0016 → Accepted

ADR-0016 was `Proposed` "until a second SDK-only operation is encapsulated this way. The second instance prices whether to extract shared scaffolding." This is that second instance, so the ADR is updated as it asked: status `Accepted`, no scaffolding extracted (both instances need different backings and share no plumbing), plus a third backing category — **an upstream `aws-cdk-lib` construct that already implements the operation** — which is what `triggers.Trigger` is here. Happy to drop that commit range from the PR if you would rather record it separately.

### Deliberately not included

- **No example stack.** The example bar wants a deployable, smoke-testable system; a deploy-time call needs a reachable endpoint at deploy time, and pointing CI at an external one is not something to bake into `deploy-test`. The natural in-repo version — call the API this stack just deployed — needs the API's URL in the handler's environment, and `FunctionBuilderProps.environment` is not `Resolvable`, so it cannot be wired under `compose` today. Worth a follow-up (widen `environment` to `Resolvable`), and then this earns an example that proves failure propagation end to end against live AWS.
- **`after` takes `Resolvable<IConstruct>[]`, not `Ref<object>[]`** like `.dependsOn()` in `@composurecdk/custom-resources`. Aligning them means promoting that package's `collectConstructs`/`addDependenciesFromRefs` into `@composurecdk/core` and widening its parameter — a change to two packages' published surface that does not belong in this PR. Follow-up if you want the two seams spelled the same way.

## Checklist

- [x] Linked to an issue (#365)
- [x] `npm run verify` passes locally — **except `actionlint`**, whose `shellcheck` binary download is blocked by this environment's network policy (403 from the proxy). No workflow files are touched by this PR. Every other gate in the chain was run individually and passes: `format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test` (162 tests in `@composurecdk/lambda`, coverage thresholds met). The pre-push hook was bypassed for the same reason.
- [x] Tests added/updated for the change — 24 new tests covering failure propagation, wait derivation and the cap, the timeout guard (including suppression and token cases), execution-role and `after` ordering, and `[COPY_STATE]`
- [x] N/A — adds no example stack (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eSCRnprW4KKddjs7NQs5J

---
_Generated by [Claude Code](https://claude.ai/code/session_013eSCRnprW4KKddjs7NQs5J)_