### PR TITLE
fix(scripts): restore the workspace after a local cdk-floors enforce

### DIFF
--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -159,14 +159,9 @@ function resolvedVersionFor(pkgName, dep = "aws-cdk-lib") {
 }
 
 /**
- * Reinstalls node_modules from the restored manifest, returning whether it
- * worked. `npm ci` first — it installs exactly the committed lockfile — with
- * `npm install` as the fallback, because `npm ci` refuses a lockfile its own
- * npm major would resolve differently. Ours is generated under npm 11, and
- * npm 10 (what Node 20/22 ship) rejects it with `Missing: yaml@2.9.0 from lock
- * file`; `ci.yml` sidesteps the same clash by pinning npm 11 before its
- * install. Without the fallback, a restore on a Node 20/22 machine throws from
- * `enforce`'s `finally` and leaves the tree pinned to the floor.
+ * Reinstalls node_modules after a floor run, returning whether it worked.
+ * `npm ci` first (exact lockfile), falling back to `npm install`: npm 10
+ * rejects our npm 11-generated lockfile, the clash `ci.yml` avoids by pinning.
  */
 function reinstall() {
   for (const mode of ["ci", "install"]) {
@@ -181,17 +176,12 @@ function reinstall() {
 }
 
 /**
- * For each target floor: temporarily force aws-cdk-lib to that floor via npm
- * `overrides` on a from-scratch install (overrides only bind on a clean tree),
- * assert a package in the group actually resolves the floor, then run that
- * group's unit suite. With no arg, runs every floor; with a floor arg or
- * `CDK_FLOORS_FLOOR`, just that one (a CI matrix shard).
- *
- * Mutates package.json / package-lock.json / node_modules. They are restored
- * on completion and on SIGINT/SIGTERM, so a local run never leaves a stray
- * `overrides` entry or a floor-pinned install behind — and if the reinstall
- * cannot restore node_modules, the run says so loudly rather than exiting as
- * though it had.
+ * For each target floor: pin aws-cdk-lib to it via a temporary npm `overrides`
+ * on a from-scratch install (they only bind on a clean tree), assert the pin
+ * bound, then run that floor group's unit suite. No arg runs every floor; a
+ * floor arg or `CDK_FLOORS_FLOOR` runs one (a CI matrix shard). Mutates
+ * package.json / package-lock.json / node_modules, restoring them on
+ * completion and on SIGINT/SIGTERM — and saying so loudly if it cannot.
  */
 function enforce() {
   const requested = process.env.CDK_FLOORS_FLOOR ?? process.argv[3];
@@ -303,9 +293,7 @@ function enforce() {
   } finally {
     restoreManifest();
     if (mutated && local) {
-      // Before the reinstall, which is the step most likely to fail: a failed
-      // floor build leaves a `.tshy-build` dir behind, which would break the
-      // next `npm run lint`.
+      // Before the reinstall, which can fail: stale tshy dirs break the next lint.
       for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
         if (!entry.isDirectory()) continue;
         rmSync(join(PACKAGES_DIR, entry.name, ".tshy"), { recursive: true, force: true });
@@ -313,9 +301,7 @@ function enforce() {
       }
       console.log("\nRestoring workspace …");
       restored = reinstall();
-      // `npm install` rewrites the lockfile it just resolved; put the committed
-      // one back so the restored tree is clean in git.
-      restoreManifest();
+      restoreManifest(); // `npm install` rewrites the lockfile; put the committed one back.
     }
   }
 

--- a/scripts/cdk-floors.mjs
+++ b/scripts/cdk-floors.mjs
@@ -159,6 +159,28 @@ function resolvedVersionFor(pkgName, dep = "aws-cdk-lib") {
 }
 
 /**
+ * Reinstalls node_modules from the restored manifest, returning whether it
+ * worked. `npm ci` first — it installs exactly the committed lockfile — with
+ * `npm install` as the fallback, because `npm ci` refuses a lockfile its own
+ * npm major would resolve differently. Ours is generated under npm 11, and
+ * npm 10 (what Node 20/22 ship) rejects it with `Missing: yaml@2.9.0 from lock
+ * file`; `ci.yml` sidesteps the same clash by pinning npm 11 before its
+ * install. Without the fallback, a restore on a Node 20/22 machine throws from
+ * `enforce`'s `finally` and leaves the tree pinned to the floor.
+ */
+function reinstall() {
+  for (const mode of ["ci", "install"]) {
+    try {
+      execFileSync("npm", [mode, "--no-audit", "--no-fund"], { cwd: REPO_ROOT, stdio: "inherit" });
+      return true;
+    } catch {
+      console.error(`  npm ${mode} failed`);
+    }
+  }
+  return false;
+}
+
+/**
  * For each target floor: temporarily force aws-cdk-lib to that floor via npm
  * `overrides` on a from-scratch install (overrides only bind on a clean tree),
  * assert a package in the group actually resolves the floor, then run that
@@ -167,7 +189,9 @@ function resolvedVersionFor(pkgName, dep = "aws-cdk-lib") {
  *
  * Mutates package.json / package-lock.json / node_modules. They are restored
  * on completion and on SIGINT/SIGTERM, so a local run never leaves a stray
- * `overrides` entry or a floor-pinned install behind.
+ * `overrides` entry or a floor-pinned install behind — and if the reinstall
+ * cannot restore node_modules, the run says so loudly rather than exiting as
+ * though it had.
  */
 function enforce() {
   const requested = process.env.CDK_FLOORS_FLOOR ?? process.argv[3];
@@ -220,6 +244,7 @@ function enforce() {
   process.on("SIGTERM", onSignal);
 
   let exitCode = 0;
+  let restored = true;
   try {
     for (const [floor, group] of targets) {
       console.log(`\n=== Enforcing aws-cdk-lib@${floor} for ${group.length} package(s) ===`);
@@ -278,22 +303,31 @@ function enforce() {
   } finally {
     restoreManifest();
     if (mutated && local) {
-      console.log("\nRestoring workspace (npm ci) …");
-      execFileSync("npm", ["ci", "--no-audit", "--no-fund"], { cwd: REPO_ROOT, stdio: "inherit" });
-      // A failed floor build leaves a `.tshy-build` dir behind, which would
-      // break the next `npm run lint`; clear tshy intermediates so the
-      // restored tree is clean.
+      // Before the reinstall, which is the step most likely to fail: a failed
+      // floor build leaves a `.tshy-build` dir behind, which would break the
+      // next `npm run lint`.
       for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
         if (!entry.isDirectory()) continue;
         rmSync(join(PACKAGES_DIR, entry.name, ".tshy"), { recursive: true, force: true });
         rmSync(join(PACKAGES_DIR, entry.name, ".tshy-build"), { recursive: true, force: true });
       }
+      console.log("\nRestoring workspace …");
+      restored = reinstall();
+      // `npm install` rewrites the lockfile it just resolved; put the committed
+      // one back so the restored tree is clean in git.
+      restoreManifest();
     }
   }
 
   if (exitCode === 0) {
     console.log(
       "\ncdk-floors enforce passed (every package's unit suite ran against its declared floor)",
+    );
+  }
+  if (!restored) {
+    console.error(
+      "\n⚠ node_modules is still pinned to a floor — neither `npm ci` nor `npm install` " +
+        "restored it. Fix the install and re-run one before trusting a local test run.",
     );
   }
   process.exit(exitCode);


### PR DESCRIPTION
## What & why

Split out of #364, where a local `cdk-floors enforce` run surfaced this.

`enforce` mutates the workspace (an `overrides` pin plus a from-scratch install per floor) and undoes it in a `finally` that reinstalls with `npm ci`. That reinstall fails under **npm 10**: our lockfile is generated under npm 11, the two majors disagree about how `vitest`'s optional `yaml` peer is pinned, and npm 10 refuses the tree with `Missing: yaml@2.9.0 from lock file`. This is a known clash — [`ci.yml`](.github/workflows/ci.yml) pins npm 11 globally before its own `npm ci` and the comment there names this exact error — but the restore path had no equivalent guard. Node 20 and 22 both ship npm 10, so on those machines the restore throws from inside `finally`, leaving three things behind:

1. **`node_modules` pinned to the floor.** [ADR-0008](docs/adr/0008-aws-cdk-lib-version-floors.md) states a local run "never leaves … a floor-pinned install behind". It does. This is the one that bites: subsequent local test runs then execute against the floor while looking like ordinary runs.
2. **`.tshy` / `.tshy-build` intermediates.** Their cleanup loop sits *after* the failing `npm ci` line, so it never runs — and per its own comment, those leftovers break the next `npm run lint`.
3. **A stack trace instead of the verdict.** Throwing from `finally` discards `process.exit(exitCode)`, so a run that already printed `✓ aws-cdk-lib@… ok` dies as though it had failed.

## The change

- Move the tshy cleanup **before** the reinstall — it is the step least likely to fail and the one whose leftovers break the next command.
- Add a small `reinstall()` helper: `npm ci` first (exact lockfile), falling back to `npm install` when npm refuses the lockfile, then re-restore the committed lock since `npm install` rewrites it.
- If neither install works, warn loudly **after** the verdict rather than throwing, so the floor result is still reported and the stale pin is never silent.

No behaviour change for CI: the enforce shard runs no restore at all (`ci.yml` — "No `npm ci` — enforce does the floor-pinned install itself") and each shard is a throwaway checkout, which is why this only ever bit locally.

## Verification

Ran `node scripts/cdk-floors.mjs enforce 2.1.0 --force` on this branch:

```
=== Enforcing aws-cdk-lib@2.1.0 for 2 package(s) ===
  @composurecdk/cloudformation resolves aws-cdk-lib 2.1.0 ✓
✓ aws-cdk-lib@2.1.0 (2 package(s)) ok
Restoring workspace …
  npm ci failed
cdk-floors enforce passed (every package's unit suite ran against its declared floor)
exit=0
```

`npm ci` failed exactly as described, the fallback took over, and afterwards the workspace was fully clean: `aws-cdk-lib` back to 2.263.0, `git status` showing only this script's own edit (lockfile restored), zero `.tshy`/`.tshy-build` directories, and exit code 0 carrying the enforce verdict rather than a stack trace.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix) — small fix, split out of #364
- [x] `npm run verify` passes locally — except `actionlint`, which cannot run here because the pinned `shellcheck` binary download is blocked (HTTP 403 through the egress proxy). No workflow files are touched.
- [x] Tests added/updated for the change — none; `scripts/` has no test harness and the change is exercised by running `enforce` itself, as above
- [x] If it adds an example stack — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8auHukxhDS6VjuBrT3t8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8auHukxhDS6VjuBrT3t8F)_