### PR TITLE
feat(route53): add consumer-side hostedZoneGrants.delegation

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -65,10 +65,13 @@
         "@aws-cdk/aws-neptune-alpha": "2.190.0-alpha.0"
       }
     },
-    "route53": { "floor": "2.216.0", "gatedBy": "aws-route53.HttpsRecord (introduced 2.216.0)" },
+    "route53": {
+      "floor": "2.225.0",
+      "gatedBy": "aws-route53.GrantDelegationOptions and the second parameter of IHostedZone.grantDelegation, which hostedZoneGrants.delegation forwards for least-privilege delegatedZoneNames scoping — both introduced in 2.225.0 (2.224.0 has the single-argument grantDelegation only), so the package does not compile below it. Also aws-route53.HttpsRecord (2.216.0)."
+    },
     "ses": {
-      "floor": "2.216.0",
-      "gatedBy": "Peers @composurecdk/route53 and consumes its `/zone` DSL (zoneRecords/CNAME/TXT with the absoluteName primitive) for .publishDkim(), so ses cannot install below route53's own floor of 2.216.0 (aws-route53.HttpsRecord). The SES APIs themselves are all lower: EmailIdentity + DkimIdentity (2.51.0), EmailIdentityProps.mailFromBehaviorOnMxFailure (~2.130.0), the aws-ses-actions module, ReceiptRuleSet/ReceiptRule/ReceiptFilter, and custom_resources.Provider. Also Annotations.addWarningV2 (2.93.0)."
+      "floor": "2.225.0",
+      "gatedBy": "Peers @composurecdk/route53 and consumes its `/zone` DSL (zoneRecords/CNAME/TXT with the absoluteName primitive) for .publishDkim(), so ses cannot install below route53's own floor of 2.225.0 (aws-route53.GrantDelegationOptions). The SES APIs themselves are all lower: EmailIdentity + DkimIdentity (2.51.0), EmailIdentityProps.mailFromBehaviorOnMxFailure (~2.130.0), the aws-ses-actions module, ReceiptRuleSet/ReceiptRule/ReceiptFilter, and custom_resources.Provider. Also Annotations.addWarningV2 (2.93.0)."
     },
     "custom-resources": {
       "floor": "2.37.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10759,7 +10759,7 @@
         "@composurecdk/cloudwatch": "^0.9.0",
         "@composurecdk/core": "^0.9.0",
         "@composurecdk/logs": "^0.9.0",
-        "aws-cdk-lib": "^2.216.0",
+        "aws-cdk-lib": "^2.225.0",
         "constructs": "^10.0.0"
       }
     },
@@ -10803,7 +10803,7 @@
       "peerDependencies": {
         "@composurecdk/core": "^0.9.0",
         "@composurecdk/route53": "^0.9.0",
-        "aws-cdk-lib": "^2.216.0",
+        "aws-cdk-lib": "^2.225.0",
         "constructs": "^10.0.0"
       }
     },

--- a/packages/route53/README.md
+++ b/packages/route53/README.md
@@ -72,6 +72,44 @@ If the stack's region resolves to a known non-`us-east-1` region, `build()` thro
 
 Default-on query logging adds two long-lived resources per stack: the log group (charged per ingested GB and per stored GB after retention) and the resource policy (free). For high-traffic zones consider lowering retention via the `configure` callback or disabling logging on zones with low security/audit value.
 
+## Delegation grants
+
+Handing a subdomain to another account means letting that account write the subdomain's `NS` records into the parent zone. The account's role is the consumer and the zone is the resource, so the grant is declared on the **role**, pointing at the zone via a `ref` — the same consumer-side shape as every other grant in the library ([ADR-0013](../../docs/adr/0013-consumer-side-grants.md)):
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createRoleBuilder } from "@composurecdk/iam";
+import { AccountPrincipal } from "aws-cdk-lib/aws-iam";
+import {
+  createHostedZoneBuilder,
+  hostedZoneGrants,
+  type HostedZoneBuilderResult,
+} from "@composurecdk/route53";
+
+compose(
+  {
+    rootZone: createHostedZoneBuilder().zoneName("example.com"),
+
+    betaDelegationRole: createRoleBuilder()
+      .roleName("delegation-beta")
+      .assumedBy(new AccountPrincipal(betaAccountId))
+      .grant(
+        hostedZoneGrants.delegation(
+          ref("rootZone", (r: HostedZoneBuilderResult) => r.hostedZone),
+          { delegatedZoneNames: ["beta.example.com"] },
+        ),
+      ),
+  },
+  { rootZone: [], betaDelegationRole: ["rootZone"] }, // role → zone; no reverse edge
+);
+```
+
+`hostedZoneGrants.delegation(zone)` delegates to the zone's native `grantDelegation`, which grants `route53:ChangeResourceRecordSets` on the zone — conditioned to `UPSERT`/`DELETE` of `NS` records — plus `route53:ListHostedZonesByName`. `IHostedZone` is implemented by `PublicHostedZone`, `PrivateHostedZone`, and zones imported via `fromLookup`/`fromHostedZoneAttributes`, so the same helper serves any of them.
+
+**Name the delegated zones.** Without `delegatedZoneNames` the grantee may replace or remove the `NS` records of any name in the parent zone, including delegations belonging to other accounts — one over-broad role is enough to take a sibling account's subdomain offline. Passing the names adds the `route53:ChangeResourceRecordSetsNormalizedRecordNames` condition, confining each role to the subdomain it owns. Each name must be lowercase, carry no trailing dot, and be a subdomain of the granting zone; CDK validates all three at synth.
+
+Publishing the delegated zone's own `NS` records into a parent zone owned by **another** account is the other half of this story, and has no builder yet — use CDK's `CrossAccountZoneDelegationRecord` with the role granted above.
+
 ## Record Builders
 
 ```ts

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -53,7 +53,7 @@
     "@composurecdk/cloudwatch": "^0.9.0",
     "@composurecdk/core": "^0.9.0",
     "@composurecdk/logs": "^0.9.0",
-    "aws-cdk-lib": "^2.216.0",
+    "aws-cdk-lib": "^2.225.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/route53/src/grants.ts
+++ b/packages/route53/src/grants.ts
@@ -1,0 +1,30 @@
+import type { IGrantable } from "aws-cdk-lib/aws-iam";
+import type { GrantDelegationOptions, IHostedZone } from "aws-cdk-lib/aws-route53";
+import { type Grant, grantVia, type Resolvable } from "@composurecdk/core";
+
+/**
+ * Consumer-side grant helpers for a Route 53 hosted zone. Pass one to a grantee
+ * builder's `grant(...)` so that grantee may write into the zone — e.g.
+ * `role.grant(hostedZoneGrants.delegation(ref("zone", (r) => r.hostedZone)))`.
+ *
+ * `IHostedZone` is implemented by `PublicHostedZone` (what the hosted zone
+ * builder returns), `PrivateHostedZone`, and zones imported via `fromLookup` /
+ * `fromHostedZoneAttributes`, so one namespace serves every zone flavour. Each
+ * delegates to the zone's native `grant*` method. See ADR-0013.
+ */
+export const hostedZoneGrants = {
+  /**
+   * Write the NS record sets that delegate a subdomain of this zone
+   * (`route53:ChangeResourceRecordSets`, conditioned to `UPSERT`/`DELETE` of
+   * `NS` records, plus `route53:ListHostedZonesByName`). By default the grant
+   * covers every name in the zone; pass {@link GrantDelegationOptions.delegatedZoneNames}
+   * to confine it to the subdomains the grantee actually owns.
+   */
+  delegation: (
+    hostedZone: Resolvable<IHostedZone>,
+    options?: GrantDelegationOptions,
+  ): Grant<IGrantable> =>
+    grantVia(hostedZone, (zone, grantee: IGrantable) => {
+      zone.grantDelegation(grantee, options);
+    }),
+};

--- a/packages/route53/src/index.ts
+++ b/packages/route53/src/index.ts
@@ -5,6 +5,7 @@ export {
   type IHostedZoneBuilder,
 } from "./hosted-zone-builder.js";
 export { type QueryLoggingConfig } from "./query-logging.js";
+export { hostedZoneGrants } from "./grants.js";
 export {
   createARecordBuilder,
   type ARecordBuilderProps,

--- a/packages/route53/test/grants.test.ts
+++ b/packages/route53/test/grants.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { PublicHostedZone } from "aws-cdk-lib/aws-route53";
+import { ref } from "@composurecdk/core";
+import { hostedZoneGrants } from "../src/grants.js";
+
+function setup() {
+  const app = new App();
+  const stack = new Stack(app, "S");
+  const hostedZone = new PublicHostedZone(stack, "Zone", { zoneName: "example.com" });
+  const role = new Role(stack, "Role", { assumedBy: new ServicePrincipal("lambda.amazonaws.com") });
+  return { stack, hostedZone, role };
+}
+
+// The granted actions land on the role's policy; asserting on the rendered
+// template keeps us decoupled from CDK's exact statement and condition shape.
+const policyJson = (stack: Stack) => JSON.stringify(Template.fromStack(stack).toJSON());
+
+describe("hostedZoneGrants", () => {
+  it("delegation delegates to the zone's native grantDelegation", () => {
+    const { stack, hostedZone, role } = setup();
+
+    hostedZoneGrants.delegation(hostedZone).applyTo(role, {});
+
+    const json = policyJson(stack);
+    expect(json).toContain("route53:ChangeResourceRecordSets");
+    expect(json).toContain("route53:ListHostedZonesByName");
+    // The native grant conditions the change to NS record sets only, and with
+    // no delegatedZoneNames it does not narrow which names they may cover.
+    expect(json).toContain("route53:ChangeResourceRecordSetsRecordTypes");
+    expect(json).not.toContain("ChangeResourceRecordSetsNormalizedRecordNames");
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
+  });
+
+  it("delegation forwards delegatedZoneNames so the grant is scoped to those zones", () => {
+    const { stack, hostedZone, role } = setup();
+
+    hostedZoneGrants
+      .delegation(hostedZone, { delegatedZoneNames: ["beta.example.com"] })
+      .applyTo(role, {});
+
+    const json = policyJson(stack);
+    expect(json).toContain("route53:ChangeResourceRecordSetsNormalizedRecordNames");
+    expect(json).toContain("beta.example.com");
+  });
+
+  it("resolves a Resolvable hosted zone from the build context before granting", () => {
+    const { stack, hostedZone, role } = setup();
+
+    hostedZoneGrants
+      .delegation(
+        ref<{ hostedZone: PublicHostedZone }, PublicHostedZone>("root", (r) => r.hostedZone),
+      )
+      .applyTo(role, { root: { hostedZone } });
+
+    expect(policyJson(stack)).toContain("route53:ChangeResourceRecordSets");
+  });
+});

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@composurecdk/core": "^0.9.0",
     "@composurecdk/route53": "^0.9.0",
-    "aws-cdk-lib": "^2.216.0",
+    "aws-cdk-lib": "^2.225.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What & why

Closes #374.

`@composurecdk/route53` had no grant namespace, so a hosted zone could not be handed to a grantee builder the [ADR-0013](https://github.com/laazyj/composureCDK/blob/main/docs/adr/0013-consumer-side-grants.md) way. Declaring a cross-account sub-delegation role meant wrapping it in a bespoke `Lifecycle` purely to reach the zone at build time — hand-rolling what `GrantQueue`/`grantVia` already do, losing `RoleBuilder`'s fluent surface and `.copy()` semantics, and putting `resolve(...)` in application code.

**New `packages/route53/src/grants.ts`** — `hostedZoneGrants.delegation(zone, options?)`, a `grantVia` wrapper over the zone's own `grantDelegation`, so the library holds no policy of its own (ADR-0013's second principle: defer to the construct's own authority). No addendum-style exception is needed here, unlike `restApiGrants.invoke`.

```ts
compose(
  {
    rootZone: createHostedZoneBuilder().zoneName("example.com"),

    betaDelegationRole: createRoleBuilder()
      .roleName("delegation-beta")
      .assumedBy(new AccountPrincipal(betaAccountId))
      .grant(
        hostedZoneGrants.delegation(
          ref("rootZone", (r: HostedZoneBuilderResult) => r.hostedZone),
          { delegatedZoneNames: ["beta.example.com"] },
        ),
      ),
  },
  { rootZone: [], betaDelegationRole: ["rootZone"] }, // role → zone, no reverse edge
);
```

Two details worth calling out:

- **`GrantDelegationOptions` is forwarded, and that matters for least privilege.** Without `delegatedZoneNames` the grant lets the grantee `UPSERT`/`DELETE` NS records for *any* name in the parent zone — including delegations belonging to other accounts — which is well past what one downstream account needs. Passing the names adds the `route53:ChangeResourceRecordSetsNormalizedRecordNames` condition. The README section says so plainly rather than leaving the safe path as the undocumented one.
- **Typing against `IHostedZone`** covers `HostedZoneBuilderResult.hostedZone` (a `PublicHostedZone`), private zones, and `fromLookup`/`fromHostedZoneAttributes` imports — one namespace per zone flavour, the way one `tableGrants` serves `Table` and `TableV2` via `ITable`.

No grantee-side work was needed: `RoleBuilder` already has `#grants`/`grant()`/`copyInto`/`applyTo`, and `FunctionBuilder` gets it for free.

### aws-cdk-lib floor: route53 and ses move 2.216.0 → 2.225.0

`GrantDelegationOptions`, and the second parameter of `IHostedZone.grantDelegation` that carries it, were introduced in **aws-cdk-lib 2.225.0**. Bisected against real installs: 2.224.0 and below expose the single-argument `grantDelegation` only, so the package does not compile there.

Per [ADR-0008](https://github.com/laazyj/composureCDK/blob/main/docs/adr/0008-aws-cdk-lib-version-floors.md), this is a floor-gating API rather than graceful degradation — a silently unscoped delegation grant is a security defect, not a cosmetic gap — so `cdk-floors.json` raises route53's floor, and `ses` moves with it because it peers route53 and cannot install below it. Both `peerDependencies` ranges were written by `cdk-floors apply`; `cdk-floors:check` passes. The CI `enforce` matrix derives its shards from the manifest, so route53 and ses continue to share one shard and no workflow changes are needed.

**Consumer impact:** anyone on `@composurecdk/route53` or `@composurecdk/ses` with aws-cdk-lib 2.216–2.224 is pushed up nine minors, including consumers who never call this helper. The alternative — restating CDK's options shape locally to hold the old floor — would ship a grant that silently drops its scoping on those versions, which is exactly what the floor mechanism exists to prevent.

### Not in this PR

- `CrossAccountZoneDelegationRecord` still has no builder, so publishing the delegated zone's NS records into a parent zone owned by another account remains a custom lifecycle. That is a resource-builder gap, not a grant-direction one (noted as out of scope on the issue); the README points at the CDK construct in the meantime.
- No ADR: applying an existing pattern to a new resource is not an architecturally significant decision, and this one delegates to a native `grant*` method, so ADR-0013 needs no amendment.
- No example stack: cross-account delegation needs a second account to be exercised, so it could not carry a smoke test that proves anything beyond "the role synthesised".
- A follow-up worth filing separately: `cdk-floors check` compares the manifest against `package.json` only, never against `max(own, @composurecdk peers')`, so the ses-follows-route53 invariant lives as prose in `gatedBy` and nothing would catch a future bump that forgot its dependent.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one caveat: `actionlint` cannot run in this environment because the pinned `shellcheck` binary download is blocked by the network proxy (HTTP 403). No files under `.github/workflows/` were touched. Every other stage of `verify` was run and passes: `format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test`.
- [x] Tests added/updated for the change — `packages/route53/test/grants.test.ts`, alongside the other packages' grant tests: the native delegation actions and NS-record-type condition, the absence of a record-name condition when `delegatedZoneNames` is omitted, the presence of it when supplied, and `Ref` resolution from the build context. route53 stays above its 90% branch floor.
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfBrYLvFMrF8ejLw4JUJnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfBrYLvFMrF8ejLw4JUJnr)_