### PR TITLE
feat(lambda): widen environmentEncryption to Resolvable so a composed CMK can be referenced

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -27,7 +27,7 @@
     },
     "logs": {
       "floor": "2.1.0",
-      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs)"
+      "gatedBy": "aws-cdk-lib ESM subpath exports (aws-cdk-lib/aws-logs). Note LogGroupBuilderProps.encryptionKey deliberately re-declares the prop as Resolvable<NonNullable<LogGroupProps[\"encryptionKey\"]>> rather than naming a key interface: CDK widened this prop from kms.IKey to kms.IKeyRef in 2.215.0, so IKey narrows what a consumer above that release can pass and IKeyRef does not exist at this floor. Do not 'simplify' it to either interface without raising the floor — `enforce` runs the unit suite, which does not typecheck, so nothing catches it here."
     },
     "events": {
       "floor": "2.93.0",
@@ -57,7 +57,10 @@
       "floor": "2.119.0",
       "gatedBy": "aws-certificatemanager.KeyAlgorithm (introduced 2.119.0)"
     },
-    "lambda": { "floor": "2.168.0", "gatedBy": "aws-lambda.MetricType (introduced 2.168.0)" },
+    "lambda": {
+      "floor": "2.168.0",
+      "gatedBy": "aws-lambda.MetricType (introduced 2.168.0). Note FunctionBuilderProps.environmentEncryption deliberately re-declares the prop as Resolvable<NonNullable<FunctionProps[\"environmentEncryption\"]>> rather than naming a key interface: CDK widened this prop from kms.IKey to kms.IKeyRef in 2.215.0, so IKey narrows what a consumer above that release can pass and IKeyRef does not exist at this floor. Do not 'simplify' it to either interface without raising the floor — `enforce` runs the unit suite, which does not typecheck, so nothing catches it here."
+    },
     "dynamodb": {
       "floor": "2.178.0",
       "gatedBy": "aws-dynamodb TableProps.pointInTimeRecoverySpecification and TablePropsV2.pointInTimeRecoverySpecification — the L2 props both builders' PITR default sets — were introduced in 2.178.0 (absent in 2.177.0); below this the prop is silently ignored and the point-in-time-recovery default no-ops. TableV2 / Billing / Capacity / TableEncryptionV2 (2.135.0), metricSystemErrorsForOperations and the Operation enum are all lower; peers @composurecdk/cloudwatch at 2.93.0."

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -414,8 +414,6 @@ class MyBuilder implements Lifecycle<MyResult> {
 
 This is the only change required. The builder does not need to know whether it received a concrete value or a `Ref` — `resolve` handles both uniformly.
 
-When the widened prop is an `Omit`-and-re-declare of a CDK prop, take `T` from the CDK prop itself — `Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>` — rather than naming the interface CDK happens to use today. Re-declaring is the one place a builder stops tracking the consumer's `aws-cdk-lib`, and CDK's prop types move: the key-consuming props are migrating from `kms.IKey` to the wider `kms.IKeyRef` one release at a time, and a hardcoded `Resolvable<IKey>` starts rejecting keys the underlying CDK accepts the moment that prop moves. Reading the type keeps the builder honest above and below the change, and compiles at floors that predate the new interface. See the table in [`@composurecdk/kms`](../packages/kms/README.md#keys-as-components) for which props this currently affects.
-
 ## Policies
 
 Some concerns are not builder-local: they apply to whatever matching constructs happen to exist under a scope, not to any one component. Examples: attaching CloudWatch alarm actions to every `Alarm` in a stack, overriding `removalPolicy` on every stateful resource for a throwaway environment, or enforcing a tagging convention across services.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -414,6 +414,8 @@ class MyBuilder implements Lifecycle<MyResult> {
 
 This is the only change required. The builder does not need to know whether it received a concrete value or a `Ref` — `resolve` handles both uniformly.
 
+When the widened prop is an `Omit`-and-re-declare of a CDK prop, take `T` from the CDK prop itself — `Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>` — rather than naming the interface CDK happens to use today. Re-declaring is the one place a builder stops tracking the consumer's `aws-cdk-lib`, and CDK's prop types move: the key-consuming props are migrating from `kms.IKey` to the wider `kms.IKeyRef` one release at a time, and a hardcoded `Resolvable<IKey>` starts rejecting keys the underlying CDK accepts the moment that prop moves. Reading the type keeps the builder honest above and below the change, and compiles at floors that predate the new interface. See the table in [`@composurecdk/kms`](../packages/kms/README.md#keys-as-components) for which props this currently affects.
+
 ## Policies
 
 Some concerns are not builder-local: they apply to whatever matching constructs happen to exist under a scope, not to any one component. Examples: attaching CloudWatch alarm actions to every `Alarm` in a stack, overriding `removalPolicy` on every stateful resource for a throwaway environment, or enforcing a tagging convention across services.

--- a/packages/kms/README.md
+++ b/packages/kms/README.md
@@ -30,12 +30,12 @@ The key-consuming props on the library's stateful resources accept a `Resolvable
 | `@composurecdk/dynamodb` | `encryptionKey`         | `Resolvable<IKey>` (classic `Table`) |
 | `@composurecdk/sqs`      | `encryptionMasterKey`   | `Resolvable<IKey>`                   |
 | `@composurecdk/sns`      | `masterKey`             | `Resolvable<IKey>`                   |
-| `@composurecdk/logs`     | `encryptionKey`         | `Resolvable<IKey>` \*                |
-| `@composurecdk/lambda`   | `environmentEncryption` | `Resolvable<IKey>` \*                |
+| `@composurecdk/logs`     | `encryptionKey`         | `Resolvable<IKey>`                   |
+| `@composurecdk/lambda`   | `environmentEncryption` | `Resolvable<IKey>`                   |
 
-\* These two accept more than an `IKey`, because CDK is migrating key-consuming props to the wider [`kms.IKeyRef`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.IKeyRef.html) (aws-cdk-lib 2.215.0) and these are the two that have moved. Naming either interface would put the builder at odds with the CDK it is installed against — `IKey` would reject an `IKeyRef` that CDK itself accepts, and `IKeyRef` does not exist at those packages' floors — so their inner type is read from the consumer's own aws-cdk-lib (`Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>`) and tracks the migration in both directions. Passing an `IKey` or a `Ref` to a key builder is unaffected. The `keyGrants` helpers below still take `Resolvable<IKey>`, so a bare `IKeyRef` reaches those two props but not a grant.
+An `IKey` is what these props are written against, but it is not the limit of what they take: where CDK has widened a prop to the broader [`kms.IKeyRef`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.IKeyRef.html), the builder's prop is read from CDK's own type rather than pinned to an interface, so it accepts whatever the `aws-cdk-lib` you have installed accepts. The `keyGrants` helpers below are pinned to `IKey`, so a key that is only an `IKeyRef` reaches a resource prop but not a grant.
 
-One key-consuming prop elsewhere still takes a concrete key — `@composurecdk/neptune`'s `kmsKey` ([#380](https://github.com/laazyj/composureCDK/issues/380)). Build the key as a component and pass `result.key` to it until it is widened.
+For a key-consuming prop not listed above, build the key as a component and pass `result.key` to it.
 
 ```ts
 import { AttributeType, TableEncryptionV2 } from "aws-cdk-lib/aws-dynamodb";

--- a/packages/kms/README.md
+++ b/packages/kms/README.md
@@ -30,10 +30,10 @@ The key-consuming props on the library's stateful resources accept a `Resolvable
 | `@composurecdk/dynamodb` | `encryptionKey`         | `Resolvable<IKey>` (classic `Table`) |
 | `@composurecdk/sqs`      | `encryptionMasterKey`   | `Resolvable<IKey>`                   |
 | `@composurecdk/sns`      | `masterKey`             | `Resolvable<IKey>`                   |
-| `@composurecdk/logs`     | `encryptionKey`         | `Resolvable` of the CDK prop type    |
-| `@composurecdk/lambda`   | `environmentEncryption` | `Resolvable` of the CDK prop type    |
+| `@composurecdk/logs`     | `encryptionKey`         | `Resolvable<IKey>` \*                |
+| `@composurecdk/lambda`   | `environmentEncryption` | `Resolvable<IKey>` \*                |
 
-Two of those rows do not name `IKey`. CDK is migrating key-consuming props from `kms.IKey` to the wider `kms.IKeyRef` ([reference interfaces](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.IKeyRef.html), aws-cdk-lib 2.215.0); `LogGroupProps.encryptionKey` and `FunctionProps.environmentEncryption` have already moved, while the other four have not. Those two props take `Resolvable<NonNullable<LogGroupProps["encryptionKey"]>>` and `Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>` — the inner type is read from the consumer's own aws-cdk-lib, so the builder accepts exactly what CDK accepts at whatever version is installed, above and below the migration. A concrete `IKey` and a `Ref` to a key builder satisfy both spellings, so the wiring below is the same either way.
+\* These two accept more than an `IKey`, because CDK is migrating key-consuming props to the wider [`kms.IKeyRef`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.IKeyRef.html) (aws-cdk-lib 2.215.0) and these are the two that have moved. Naming either interface would put the builder at odds with the CDK it is installed against — `IKey` would reject an `IKeyRef` that CDK itself accepts, and `IKeyRef` does not exist at those packages' floors — so their inner type is read from the consumer's own aws-cdk-lib (`Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>`) and tracks the migration in both directions. Passing an `IKey` or a `Ref` to a key builder is unaffected. The `keyGrants` helpers below still take `Resolvable<IKey>`, so a bare `IKeyRef` reaches those two props but not a grant.
 
 One key-consuming prop elsewhere still takes a concrete key — `@composurecdk/neptune`'s `kmsKey` ([#380](https://github.com/laazyj/composureCDK/issues/380)). Build the key as a component and pass `result.key` to it until it is widened.
 

--- a/packages/kms/README.md
+++ b/packages/kms/README.md
@@ -23,16 +23,19 @@ The point of the builder is that a CMK stops being a construct you create impera
 
 The key-consuming props on the library's stateful resources accept a `Resolvable`, so the key is wired in with `ref()`:
 
-| Package                  | Prop                  | Accepts                              |
-| ------------------------ | --------------------- | ------------------------------------ |
-| `@composurecdk/s3`       | `encryptionKey`       | `Resolvable<IKey>`                   |
-| `@composurecdk/dynamodb` | `encryption` (V2)     | `Resolvable<TableEncryptionV2>`      |
-| `@composurecdk/dynamodb` | `encryptionKey`       | `Resolvable<IKey>` (classic `Table`) |
-| `@composurecdk/sqs`      | `encryptionMasterKey` | `Resolvable<IKey>`                   |
-| `@composurecdk/sns`      | `masterKey`           | `Resolvable<IKey>`                   |
-| `@composurecdk/logs`     | `encryptionKey`       | `Resolvable<IKey>`                   |
+| Package                  | Prop                    | Accepts                              |
+| ------------------------ | ----------------------- | ------------------------------------ |
+| `@composurecdk/s3`       | `encryptionKey`         | `Resolvable<IKey>`                   |
+| `@composurecdk/dynamodb` | `encryption` (V2)       | `Resolvable<TableEncryptionV2>`      |
+| `@composurecdk/dynamodb` | `encryptionKey`         | `Resolvable<IKey>` (classic `Table`) |
+| `@composurecdk/sqs`      | `encryptionMasterKey`   | `Resolvable<IKey>`                   |
+| `@composurecdk/sns`      | `masterKey`             | `Resolvable<IKey>`                   |
+| `@composurecdk/logs`     | `encryptionKey`         | `Resolvable` of the CDK prop type    |
+| `@composurecdk/lambda`   | `environmentEncryption` | `Resolvable` of the CDK prop type    |
 
-Two key-consuming props elsewhere still take a concrete key — `@composurecdk/lambda`'s `environmentEncryption` ([#379](https://github.com/laazyj/composureCDK/issues/379)) and `@composurecdk/neptune`'s `kmsKey` ([#380](https://github.com/laazyj/composureCDK/issues/380)). Build the key as a component and pass `result.key` to those until they are widened.
+Two of those rows do not name `IKey`. CDK is migrating key-consuming props from `kms.IKey` to the wider `kms.IKeyRef` ([reference interfaces](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.IKeyRef.html), aws-cdk-lib 2.215.0); `LogGroupProps.encryptionKey` and `FunctionProps.environmentEncryption` have already moved, while the other four have not. Those two props take `Resolvable<NonNullable<LogGroupProps["encryptionKey"]>>` and `Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>` — the inner type is read from the consumer's own aws-cdk-lib, so the builder accepts exactly what CDK accepts at whatever version is installed, above and below the migration. A concrete `IKey` and a `Ref` to a key builder satisfy both spellings, so the wiring below is the same either way.
+
+One key-consuming prop elsewhere still takes a concrete key — `@composurecdk/neptune`'s `kmsKey` ([#380](https://github.com/laazyj/composureCDK/issues/380)). Build the key as a component and pass `result.key` to it until it is widened.
 
 ```ts
 import { AttributeType, TableEncryptionV2 } from "aws-cdk-lib/aws-dynamodb";

--- a/packages/kms/src/key-builder.ts
+++ b/packages/kms/src/key-builder.ts
@@ -65,12 +65,9 @@ export interface KeyBuilderResult {
  * The builder implements {@link Lifecycle}, so a key can be an ordinary
  * component of a {@link compose | composed system} — placed by the stack
  * strategy, ordered by the dependency graph, and referenced by the resources
- * it encrypts via `ref()`. Key-consuming props across the library
- * (`@composurecdk/s3`'s `encryptionKey`, `@composurecdk/dynamodb`'s
- * `encryption`, `@composurecdk/sqs`'s `encryptionMasterKey`,
- * `@composurecdk/sns`'s `masterKey`, `@composurecdk/logs`'s `encryptionKey`)
- * accept a `Resolvable`, so the edge is declared in the dependency map rather
- * than closed over from an imperative prologue.
+ * it encrypts via `ref()`. The key-consuming props across the library accept a
+ * `Resolvable` — the package README tabulates them — so the edge is declared in
+ * the dependency map rather than closed over from an imperative prologue.
  *
  * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.Key.html
  *

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -49,6 +49,31 @@ const handler = createFunctionBuilder()
   .build(stack, "MyFunction");
 ```
 
+## Environment variable encryption
+
+Lambda encrypts environment variables at rest with an AWS-managed key. `.environmentEncryption(...)` opts into a customer-managed one, and accepts a concrete key or a `Resolvable`, so a key built by [`@composurecdk/kms`](../kms/README.md) can be a component of the same system rather than a construct created before `compose`:
+
+```ts
+import { compose, ref } from "@composurecdk/core";
+import { createKeyBuilder, type KeyBuilderResult } from "@composurecdk/kms";
+
+compose(
+  {
+    envKey: createKeyBuilder().description("Encrypts the checkout handler's environment."),
+    checkout: createFunctionBuilder()
+      .runtime(Runtime.NODEJS_22_X)
+      .handler("index.handler")
+      .code(Code.fromAsset("lambda"))
+      .environmentEncryption(ref<KeyBuilderResult>("envKey").get("key")),
+  },
+  { envKey: [], checkout: ["envKey"] },
+);
+```
+
+CDK grants the function's execution role decrypt on a key it can see, so no extra grant is needed for the function to read its own variables.
+
+The prop's inner type is read from the consumer's own aws-cdk-lib (`NonNullable<FunctionProps["environmentEncryption"]>`) rather than named as `IKey`, because CDK widened `FunctionProps.environmentEncryption` from `kms.IKey` to `kms.IKeyRef` in aws-cdk-lib 2.215.0. Naming either interface would make the builder disagree with the CDK it is installed against — `IKey` would reject an `IKeyRef` that CDK itself accepts, and `IKeyRef` does not exist at this package's 2.168.0 floor.
+
 ## Execution role
 
 By default, `createFunctionBuilder` creates an explicit IAM execution role with an inline `LogsWriter` policy scoped to the function's auto-created log group:

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -70,8 +70,6 @@ compose(
 );
 ```
 
-The prop's inner type is read from CDK's own `FunctionProps["environmentEncryption"]` rather than named as `IKey`, so it tracks CDK's `kms.IKey` → `kms.IKeyRef` migration in either direction — see [the table in `@composurecdk/kms`](../kms/README.md#keys-as-components).
-
 ## Execution role
 
 By default, `createFunctionBuilder` creates an explicit IAM execution role with an inline `LogsWriter` policy scoped to the function's auto-created log group:

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -70,9 +70,7 @@ compose(
 );
 ```
 
-CDK grants the function's execution role decrypt on a key it can see, so no extra grant is needed for the function to read its own variables.
-
-The prop's inner type is read from the consumer's own aws-cdk-lib (`NonNullable<FunctionProps["environmentEncryption"]>`) rather than named as `IKey`, because CDK widened `FunctionProps.environmentEncryption` from `kms.IKey` to `kms.IKeyRef` in aws-cdk-lib 2.215.0. Naming either interface would make the builder disagree with the CDK it is installed against — `IKey` would reject an `IKeyRef` that CDK itself accepts, and `IKeyRef` does not exist at this package's 2.168.0 floor.
+The prop's inner type is read from CDK's own `FunctionProps["environmentEncryption"]` rather than named as `IKey`, so it tracks CDK's `kms.IKey` → `kms.IKeyRef` migration in either direction — see [the table in `@composurecdk/kms`](../kms/README.md#keys-as-components).
 
 ## Execution role
 

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -40,10 +40,14 @@ const LOGS_WRITER_POLICY_NAME = "LogsWriter";
  * Configuration properties for the Lambda function builder.
  *
  * Extends the CDK {@link FunctionProps} with builder-specific options. The
- * `role` prop is widened to {@link Resolvable} so a role built by a sibling
- * component can be referenced via `ref(...)` at configuration time.
+ * `role` and `environmentEncryption` props are widened to {@link Resolvable}
+ * so a role or key built by a sibling component can be referenced via
+ * `ref(...)` at configuration time.
  */
-export interface FunctionBuilderProps extends Omit<FunctionProps, "role"> {
+export interface FunctionBuilderProps extends Omit<
+  FunctionProps,
+  "role" | "environmentEncryption"
+> {
   /**
    * The IAM execution role to attach to the function. When set, the builder
    * skips creating its own role and the auto-created `LogsWriter` inline
@@ -57,6 +61,29 @@ export interface FunctionBuilderProps extends Omit<FunctionProps, "role"> {
    * {@link IFunctionBuilder.useCdkAutoRole}.
    */
   role?: Resolvable<IRole>;
+
+  /**
+   * The customer-managed KMS key used to encrypt the function's environment
+   * variables at rest.
+   *
+   * Accepts a concrete key or a {@link Resolvable} — typically a {@link Ref}
+   * to a composed `@composurecdk/kms` key builder, so the key is a component
+   * of the system rather than a construct built outside it.
+   *
+   * Lambda encrypts environment variables with an AWS-managed key by default,
+   * so this prop opts into a customer-managed one. The key policy must allow
+   * the function's execution role to decrypt — CDK adds that grant for a key
+   * it can see.
+   *
+   * The inner type is read from the consumer's own `aws-cdk-lib` rather than
+   * named as `IKey`: CDK widened this prop from `kms.IKey` to `kms.IKeyRef` in
+   * 2.215.0, and naming either one would make the builder disagree with the
+   * CDK it is installed against — `IKey` narrows what a consumer above 2.215.0
+   * can pass, `IKeyRef` does not exist at this package's floor (2.168.0).
+   *
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-encryption
+   */
+  environmentEncryption?: Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>;
 
   /**
    * Configuration for AWS-recommended CloudWatch alarms.
@@ -326,7 +353,12 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
     id: string,
     context: Record<string, object> = {},
   ): FunctionBuilderResult {
-    const { role: roleResolvable, recommendedAlarms: alarmConfig, ...functionProps } = this.props;
+    const {
+      role: roleResolvable,
+      environmentEncryption,
+      recommendedAlarms: alarmConfig,
+      ...functionProps
+    } = this.props;
 
     const seamCount =
       (roleResolvable !== undefined ? 1 : 0) +
@@ -363,6 +395,9 @@ class FunctionBuilder implements Lifecycle<FunctionBuilderResult> {
       ...logGroupProps,
       ...functionProps,
       ...(role ? { role } : {}),
+      ...(environmentEncryption !== undefined
+        ? { environmentEncryption: resolve(environmentEncryption, context) }
+        : {}),
     } as FunctionProps;
 
     const fn = new LambdaFunction(scope, id, mergedProps);

--- a/packages/lambda/src/function-builder.ts
+++ b/packages/lambda/src/function-builder.ts
@@ -75,11 +75,9 @@ export interface FunctionBuilderProps extends Omit<
    * the function's execution role to decrypt — CDK adds that grant for a key
    * it can see.
    *
-   * The inner type is read from the consumer's own `aws-cdk-lib` rather than
-   * named as `IKey`: CDK widened this prop from `kms.IKey` to `kms.IKeyRef` in
-   * 2.215.0, and naming either one would make the builder disagree with the
-   * CDK it is installed against — `IKey` narrows what a consumer above 2.215.0
-   * can pass, `IKeyRef` does not exist at this package's floor (2.168.0).
+   * The inner type is read from CDK's own prop rather than named as `IKey`, so
+   * it tracks the `kms.IKey` → `kms.IKeyRef` migration in either direction —
+   * see the table in `@composurecdk/kms`'s README.
    *
    * @see https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-encryption
    */

--- a/packages/lambda/test/function-builder.test.ts
+++ b/packages/lambda/test/function-builder.test.ts
@@ -12,6 +12,7 @@ import {
   Runtime,
   Tracing,
 } from "aws-cdk-lib/aws-lambda";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Vpc } from "aws-cdk-lib/aws-ec2";
 import { compose, ref } from "@composurecdk/core";
@@ -673,6 +674,43 @@ describe("FunctionBuilder", () => {
       const serialized = JSON.stringify(Object.values(roles));
       // CDK attaches AWSLambdaVPCAccessExecutionRole when a VPC is set.
       expect(serialized).toContain("AWSLambdaVPCAccessExecutionRole");
+    });
+  });
+
+  describe("environmentEncryption", () => {
+    /** The KmsKeyArn a function encrypted with `Key` (logical id `Key961B73FD`) renders. */
+    const KMS_KEY_ARN = { "Fn::GetAtt": ["Key961B73FD", "Arn"] };
+
+    it("passes a concrete key through to the function", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const key = new Key(stack, "Key");
+
+      createFunctionBuilder()
+        .runtime(Runtime.NODEJS_22_X)
+        .handler("index.handler")
+        .code(Code.fromInline("exports.handler = async () => {}"))
+        .environmentEncryption(key)
+        .build(stack, "TestFunction");
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+        KmsKeyArn: KMS_KEY_ARN,
+      });
+    });
+
+    it("resolves a Resolvable key from the build context", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const key = new Key(stack, "Key");
+
+      createFunctionBuilder()
+        .runtime(Runtime.NODEJS_22_X)
+        .handler("index.handler")
+        .code(Code.fromInline("exports.handler = async () => {}"))
+        .environmentEncryption(ref<{ key: Key }, Key>("envKey", (r) => r.key))
+        .build(stack, "TestFunction", { envKey: { key } });
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+        KmsKeyArn: KMS_KEY_ARN,
+      });
     });
   });
 

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -63,4 +63,4 @@ compose(
 );
 ```
 
-The prop's inner type is read from the consumer's own aws-cdk-lib (`NonNullable<LogGroupProps["encryptionKey"]>`) rather than named as `IKey`, because CDK widened `LogGroupProps.encryptionKey` from `kms.IKey` to `kms.IKeyRef` in aws-cdk-lib 2.215.0. Naming either interface would make the builder disagree with the CDK it is installed against — `IKey` would reject an `IKeyRef` that CDK itself accepts, and `IKeyRef` does not exist at this package's 2.1.0 floor.
+The prop's inner type is read from CDK's own `LogGroupProps["encryptionKey"]` rather than named as `IKey`, so it tracks CDK's `kms.IKey` → `kms.IKeyRef` migration in either direction — see [the table in `@composurecdk/kms`](../kms/README.md#keys-as-components).

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -51,7 +51,7 @@ CloudWatch Logs encrypts all log data at rest using AWS-managed keys. For additi
 const logGroup = createLogGroupBuilder().encryptionKey(myKmsKey).build(stack, "EncryptedLogs");
 ```
 
-`.encryptionKey(...)` accepts a concrete `IKey` or a `Resolvable`, so a key built by [`@composurecdk/kms`](../kms/README.md) can be a component of the same system:
+`.encryptionKey(...)` accepts a concrete key or a `Resolvable`, so a key built by [`@composurecdk/kms`](../kms/README.md) can be a component of the same system:
 
 ```ts
 compose(
@@ -62,3 +62,5 @@ compose(
   { logKey: [], audit: ["logKey"] },
 );
 ```
+
+The prop's inner type is read from the consumer's own aws-cdk-lib (`NonNullable<LogGroupProps["encryptionKey"]>`) rather than named as `IKey`, because CDK widened `LogGroupProps.encryptionKey` from `kms.IKey` to `kms.IKeyRef` in aws-cdk-lib 2.215.0. Naming either interface would make the builder disagree with the CDK it is installed against — `IKey` would reject an `IKeyRef` that CDK itself accepts, and `IKeyRef` does not exist at this package's 2.1.0 floor.

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -62,5 +62,3 @@ compose(
   { logKey: [], audit: ["logKey"] },
 );
 ```
-
-The prop's inner type is read from CDK's own `LogGroupProps["encryptionKey"]` rather than named as `IKey`, so it tracks CDK's `kms.IKey` → `kms.IKeyRef` migration in either direction — see [the table in `@composurecdk/kms`](../kms/README.md#keys-as-components).

--- a/packages/logs/src/log-group-builder.ts
+++ b/packages/logs/src/log-group-builder.ts
@@ -1,4 +1,3 @@
-import { type IKey } from "aws-cdk-lib/aws-kms";
 import { LogGroup, type LogGroupProps } from "aws-cdk-lib/aws-logs";
 import { type IConstruct } from "constructs";
 import { type Lifecycle, resolve, type Resolvable } from "@composurecdk/core";
@@ -15,18 +14,24 @@ export interface LogGroupBuilderProps extends Omit<LogGroupProps, "encryptionKey
   /**
    * The customer-managed KMS key used to encrypt the log group.
    *
-   * Accepts a concrete {@link IKey} or a {@link Resolvable} — typically a
-   * {@link Ref} to a composed `@composurecdk/kms` key builder, so the key is a
-   * component of the system rather than a construct built outside it.
+   * Accepts a concrete key or a {@link Resolvable} — typically a {@link Ref}
+   * to a composed `@composurecdk/kms` key builder, so the key is a component
+   * of the system rather than a construct built outside it.
    *
    * CloudWatch Logs encrypts every log group with a service-managed key by
    * default, so this prop opts into a customer-managed one. The key policy
    * must allow the `logs.<region>.amazonaws.com` service principal — CDK adds
    * that statement for a key it can see.
    *
+   * The inner type is read from the consumer's own `aws-cdk-lib` rather than
+   * named as `IKey`: CDK widened this prop from `kms.IKey` to `kms.IKeyRef` in
+   * 2.215.0, and naming either one would make the builder disagree with the
+   * CDK it is installed against — `IKey` narrows what a consumer above 2.215.0
+   * can pass, `IKeyRef` does not exist at this package's floor (2.1.0).
+   *
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
    */
-  encryptionKey?: Resolvable<IKey>;
+  encryptionKey?: Resolvable<NonNullable<LogGroupProps["encryptionKey"]>>;
 }
 
 /**

--- a/packages/logs/src/log-group-builder.ts
+++ b/packages/logs/src/log-group-builder.ts
@@ -23,11 +23,9 @@ export interface LogGroupBuilderProps extends Omit<LogGroupProps, "encryptionKey
    * must allow the `logs.<region>.amazonaws.com` service principal — CDK adds
    * that statement for a key it can see.
    *
-   * The inner type is read from the consumer's own `aws-cdk-lib` rather than
-   * named as `IKey`: CDK widened this prop from `kms.IKey` to `kms.IKeyRef` in
-   * 2.215.0, and naming either one would make the builder disagree with the
-   * CDK it is installed against — `IKey` narrows what a consumer above 2.215.0
-   * can pass, `IKeyRef` does not exist at this package's floor (2.1.0).
+   * The inner type is read from CDK's own prop rather than named as `IKey`, so
+   * it tracks the `kms.IKey` → `kms.IKeyRef` migration in either direction —
+   * see the table in `@composurecdk/kms`'s README.
    *
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
    */


### PR DESCRIPTION
## What & why

`@composurecdk/lambda` was the one builder left out of #375's sweep, so a function encrypting its environment variables with a customer-managed key still had to take that key as a construct built before `compose` — outside the dependency map, stack placement and build ordering the rest of the system gets. It now takes the same `Omit` + `Resolvable` re-declaration + resolve-in-`build()` shape as `s3`, `sns`, `sqs`, `dynamodb` and `logs`:

```ts
createFunctionBuilder().environmentEncryption(ref<KeyBuilderResult>("envKey").get("key"));
```

### The `IKey`/`IKeyRef` wrinkle #375 deferred

AWS is migrating key-consuming props from `kms.IKey` to the wider `kms.IKeyRef` ([reference interfaces](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kms.IKeyRef.html), aws-cdk-lib 2.215.0). `FunctionProps.environmentEncryption` moved in exactly that release — verified against the CDK source at each tag, 2.214.0 has `IKey` and 2.215.0 has `IKeyRef` — while this package's floor is 2.168.0, where `IKeyRef` does not exist. Neither interface can be named without the builder disagreeing with the CDK it is installed against: `IKey` rejects an `IKeyRef` that CDK itself accepts, and `IKeyRef` does not compile at the floor.

So the re-declared prop names neither, and reads the type from the consumer's own aws-cdk-lib:

```ts
environmentEncryption?: Resolvable<NonNullable<FunctionProps["environmentEncryption"]>>;
```

This is what the surrounding `Omit<FunctionProps, …>` already does for every prop the builder does not re-declare — the widening now tracks upstream for this one too, resolving to `Resolvable<IKey>` at the floor and `Resolvable<IKeyRef>` above 2.215.0. Verified by typechecking the declaration against real installs at both ends (2.168.0 and 2.263.0), accepting a concrete `Key`, an `IKey`, and a `Ref` to either.

The alternative — raising the floor to 2.215.0 — would cost lambda consumers ten months of CDK releases (2.168.0 shipped 2024-11-20) to accept a type no caller in this library produces. **The lambda floor is unchanged at 2.168.0**, `cdk-floors check` is green, and no new aws-cdk-lib API is named.

### `logs` had already picked up the narrowing

`LogGroupProps.encryptionKey` moved to `IKeyRef` in 2.215.0 as well, so #375's `Resolvable<IKey>` had already narrowed it for consumers above that release. It gets the same treatment here. The other four widened props (`s3`, `sns`, `sqs`, `dynamodb`) are still `IKey` upstream and keep the literal spelling until CDK moves them.

### Guarding it

Nothing in CI defends a floor-gated *type*: `cdk-floors enforce` runs the unit suites, which vitest does not typecheck, and `build`/`typecheck` run against the latest devDependency — so "simplifying" this back to `IKey` would break only in a consumer's own `tsc`. Two cheap guards, both where a maintainer already looks:

- `cdk-floors.json` records the constraint on the `lambda` and `logs` entries, in the shape the `kms` entry already uses for `IKey.grantSign`.
- `docs/architecture.md`'s Ref-support recipe now says to take `T` from the CDK prop when the widening is an `Omit`-and-re-declare — that recipe is what the next key-prop widening will follow, and CDK is mid-migration.

No ADR: per [when to write an ADR](docs/adr/README.md#when-to-write-an-adr) this is how one prop type is spelled in two packages, not a change to the library's shape.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix) — Closes #379
- [ ] `npm run verify` passes locally — every stage passes except `actionlint`, which cannot run in this environment: the pinned `shellcheck` devDependency downloads its binary at install time and the network here returns 403. No workflow files are touched by this PR. `format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate` and `test` were each run and are green.
- [x] Tests added/updated for the change — concrete-key and resolve-from-context cases for `environmentEncryption`, following `packages/s3/test/bucket-builder.test.ts`
- [x] If it adds an example stack — n/a

Closes #379

---
_Generated by [Claude Code](https://claude.ai/code/session_015kWvJ3e7UfPg8Uwmge4WpZ)_