### PR TITLE
fix(route53): pass the build context to the query-log sub-builder

### DIFF
--- a/packages/route53/README.md
+++ b/packages/route53/README.md
@@ -50,6 +50,8 @@ createHostedZoneBuilder()
   .queryLogging({ configure: (lg) => lg.retention(RetentionDays.SIX_MONTHS) });
 ```
 
+The callback receives the build context, so anything `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the hosted zone.
+
 Bring your own log group (you own the resource policy too):
 
 ```ts

--- a/packages/route53/src/hosted-zone-builder.ts
+++ b/packages/route53/src/hosted-zone-builder.ts
@@ -70,7 +70,7 @@ export type IHostedZoneBuilder = ITaggedBuilder<HostedZoneBuilderProps, HostedZo
 class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
   props: Partial<HostedZoneBuilderProps> = {};
 
-  build(scope: IConstruct, id: string): HostedZoneBuilderResult {
+  build(scope: IConstruct, id: string, context?: Record<string, object>): HostedZoneBuilderResult {
     if (!this.props.zoneName) {
       throw new Error(
         `HostedZoneBuilder "${id}" requires a zoneName. ` +
@@ -88,6 +88,7 @@ class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
       id,
       this.props.zoneName,
       queryLogging,
+      context,
     );
 
     const hostedZone = new PublicHostedZone(scope, id, {

--- a/packages/route53/src/query-logging.ts
+++ b/packages/route53/src/query-logging.ts
@@ -36,6 +36,10 @@ export type QueryLoggingConfig =
        * {@link createLogGroupBuilder} are merged in at `build()` time and
        * are overridable by anything set on the builder here. Cannot be
        * combined with {@link logGroupArn}.
+       *
+       * The callback receives the build context, so anything
+       * `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a
+       * sibling component. Declare that component as a dependency.
        */
       configure?: (b: ILogGroupBuilder) => ILogGroupBuilder;
 
@@ -77,6 +81,7 @@ export function resolveQueryLogging(
   id: string,
   zoneName: string,
   cfg: QueryLoggingConfig | undefined,
+  context?: Record<string, object>,
 ): ResolvedQueryLogging {
   if (cfg === false) return {};
 
@@ -99,7 +104,11 @@ export function resolveQueryLogging(
     subBuilder = cfg.configure(subBuilder);
   }
 
-  const queryLogGroup = subBuilder.build(scope, `${id}QueryLogs`).logGroup;
+  // Pass the build context down: `ILogGroupBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const queryLogGroup = subBuilder.build(scope, `${id}QueryLogs`, context).logGroup;
   warnIfLogGroupNameOutsidePrefix(scope, id, subBuilder.logGroupName());
 
   return {

--- a/packages/route53/test/hosted-zone-builder.test.ts
+++ b/packages/route53/test/hosted-zone-builder.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
+import { ref } from "@composurecdk/core";
 import { createHostedZoneBuilder } from "../src/hosted-zone-builder.js";
 import {
   QUERY_LOGGING_LOG_GROUP_NAME_PREFIX,
@@ -149,6 +151,22 @@ describe("HostedZoneBuilder query logging", () => {
       RetentionInDays: RetentionDays.ONE_YEAR,
     });
     template.resourceCountIs("AWS::Logs::ResourcePolicy", 1);
+  });
+
+  it("configure callback can reach a sibling component through a ref", () => {
+    const stack = newStack({ region: "us-east-1" });
+    const key = new Key(stack, "LogsKey");
+
+    createHostedZoneBuilder()
+      .zoneName("example.com")
+      .queryLogging({
+        configure: (lg) => lg.encryptionKey(ref<{ key: Key }>("logsKey").get("key")),
+      })
+      .build(stack, "TestZone", { logsKey: { key } });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Logs::LogGroup", {
+      KmsKeyId: { "Fn::GetAtt": [Match.stringLikeRegexp("LogsKey"), "Arn"] },
+    });
   });
 
   it("disabled with queryLogging(false) creates no log group, no resource policy, no QueryLoggingConfig", () => {


### PR DESCRIPTION
## What & why

Refs #386 — one of five per-package PRs for the sub-builder call sites that drop the build context. This is the issue's motivating repro.

`resolveQueryLogging` built the hosted zone's auto-managed query-log group with `subBuilder.build(scope, id)`, dropping the build context. #375 widened `LogGroupBuilderProps.encryptionKey` to a `Resolvable`, so a caller reaching for a composed KMS key through the documented `configure` escape hatch:

```ts
createHostedZoneBuilder()
  .zoneName("example.com")
  .queryLogging({ configure: (lg) => lg.encryptionKey(ref("logsKey", ...)) });
```

got `resolve(ref, undefined)` → resolved against `{}` → **`Ref to "logsKey" cannot be resolved: component not found in context`**. The one thing the widened prop exists to allow was the thing that failed.

`HostedZoneBuilder.build` now takes the optional `context` third parameter `Lifecycle` already declares, and threads it through `resolveQueryLogging` to the sub-builder — the same shape as the sibling delegation-provider log group already in this package (`cross-account-delegation-provider-logging.ts`, #381). Adding the parameter is source-compatible for standalone callers, and `compose` already passes context to every component.

Also documents the capability on `QueryLoggingConfig.configure` and in the package README, mirroring the wording already used for `providerLogging` — that README previously documented refs for one of its two structurally identical `configure` callbacks and not the other.

### The lint rule does not cover this

`lifecycle-build-context-required` keys on `Resolvable<` appearing in the builder's own class body. `HostedZoneBuilder` has none — the resolvable lives one delegation away in the sub-builder's props — so the rule never would have caught this and still won't catch a recurrence. Extending it is issue #386's open question and is deliberately out of scope here, so this PR should not be read as closing that gap.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one exception, see below
- [x] Tests added/updated for the change
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

**On `npm run verify`:** every gate passes (`format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test`) except `actionlint`, which could not run — its shellcheck binary download returns 403 through this environment's proxy. No file under `.github/workflows/` is touched by this PR. I also re-ran the full gate set with all five sibling PRs merged together; all green.

**Regression test:** the new test was confirmed to fail without the source change, with the exact error from the issue.