### PR TITLE
fix(iam): brand StatementBuilder so the wildcard guard survives a realm crossing

### DIFF
--- a/docs/adr/0007-dual-esm-cjs-publishing.md
+++ b/docs/adr/0007-dual-esm-cjs-publishing.md
@@ -71,6 +71,15 @@ used `value instanceof Ref`. It now brands every `Ref` with
 `Symbol.for("composurecdk.ref")` and `isRef` checks that brand (see
 [architecture.md](../architecture.md#ref)).
 
+`StatementBuilder` needed the same treatment later (#385), and it is the
+class most exposed to the hazard: a consumer constructs one and hands it back
+across a public API. Every exported class a consumer can pass **into** library
+code and that the library then **type-tests** needs a brand. As of #385 that is
+`Ref` and `StatementBuilder`. Errors are the remaining gap: a consumer's
+`catch (e) { e instanceof WildcardResourceError }` is realm-bound the same way,
+so the library's error classes set `name` and that — not `instanceof` — is the
+cross-realm-safe discriminator.
+
 ## Consequences
 
 - CommonJS consumers — including the `cdk synth` path from issue #119 — can use

--- a/packages/iam/src/index.ts
+++ b/packages/iam/src/index.ts
@@ -14,6 +14,7 @@ export {
 export { createServiceRoleBuilder } from "./service-role-builder.js";
 export {
   createStatementBuilder,
+  isStatementBuilder,
   StatementBuilder,
   WildcardResourceError,
 } from "./statement-builder.js";

--- a/packages/iam/src/managed-policy-builder.ts
+++ b/packages/iam/src/managed-policy-builder.ts
@@ -1,7 +1,7 @@
 import { ManagedPolicy, type ManagedPolicyProps, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { IConstruct } from "constructs";
 import { Builder, COPY_STATE, type IBuilder, type Lifecycle } from "@composurecdk/core";
-import { StatementBuilder } from "./statement-builder.js";
+import { isStatementBuilder, type StatementBuilder } from "./statement-builder.js";
 
 /**
  * Configuration properties for the customer-managed IAM policy builder.
@@ -64,7 +64,7 @@ class ManagedPolicyBuilder implements Lifecycle<ManagedPolicyBuilderResult> {
 
   build(scope: IConstruct, id: string): ManagedPolicyBuilderResult {
     const resolvedExtras = this.#extraStatements.map((s) =>
-      s instanceof StatementBuilder ? s.build() : s,
+      isStatementBuilder(s) ? s.build() : s,
     );
 
     const mergedProps: ManagedPolicyProps = {

--- a/packages/iam/src/role-builder.ts
+++ b/packages/iam/src/role-builder.ts
@@ -18,7 +18,7 @@ import {
 } from "@composurecdk/core";
 import { type ITaggedBuilder, taggedBuilder } from "@composurecdk/cloudformation";
 import { ROLE_DEFAULTS } from "./role-defaults.js";
-import { StatementBuilder } from "./statement-builder.js";
+import { isStatementBuilder, type StatementBuilder } from "./statement-builder.js";
 
 /**
  * Configuration properties for the IAM role builder.
@@ -189,7 +189,7 @@ class RoleBuilder implements Lifecycle<RoleBuilderResult> {
     const addedInlinePolicies: Record<string, PolicyDocument> = {};
     for (const entry of this.#inlinePolicies) {
       const resolvedStatements = entry.statements.map((s) =>
-        s instanceof StatementBuilder ? s.build() : s,
+        isStatementBuilder(s) ? s.build() : s,
       );
       addedInlinePolicies[entry.name] = new PolicyDocument({ statements: resolvedStatements });
     }

--- a/packages/iam/src/statement-builder.ts
+++ b/packages/iam/src/statement-builder.ts
@@ -13,6 +13,10 @@ import {
  * Wildcard-resource allow statements grant the widest possible permission
  * surface and should be an intentional choice, not an accident.
  *
+ * Catch this by `name`, not `instanceof`: under the dual ESM/CJS build
+ * (ADR-0007) the copy that threw may not be the copy the catching module
+ * imported, and `instanceof` is realm-bound.
+ *
  * @see https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/permissions-management.html
  */
 export class WildcardResourceError extends Error {
@@ -24,6 +28,17 @@ export class WildcardResourceError extends Error {
     this.name = "WildcardResourceError";
   }
 }
+
+/**
+ * @internal Brands every {@link StatementBuilder} instance so
+ * {@link isStatementBuilder} can recognise one without `instanceof`.
+ * `instanceof` is realm-bound: when `@composurecdk/iam` is loaded as both ESM
+ * and CommonJS in the same process (the dual-package hazard — ADR-0007), each
+ * copy has its own `StatementBuilder` class and `instanceof` fails across the
+ * boundary. A `Symbol.for(...)` brand is registered in the global symbol
+ * registry, so a builder minted by either copy is still recognised by either.
+ */
+export const STATEMENT_BUILDER_BRAND = Symbol.for("composurecdk.statement-builder");
 
 /**
  * Fluent wrapper around the CDK {@link PolicyStatement}.
@@ -53,6 +68,9 @@ export class WildcardResourceError extends Error {
  * ```
  */
 export class StatementBuilder {
+  /** @internal Realm-agnostic brand — see {@link STATEMENT_BUILDER_BRAND}. */
+  readonly [STATEMENT_BUILDER_BRAND] = true;
+
   #sid?: string;
   #effect: Effect = Effect.ALLOW;
   #actions: string[] = [];
@@ -164,6 +182,21 @@ export class StatementBuilder {
 
     return new PolicyStatement(props);
   }
+}
+
+/**
+ * Type guard distinguishing a {@link StatementBuilder} from an already-built
+ * {@link PolicyStatement}.
+ *
+ * Recognises a builder by its {@link STATEMENT_BUILDER_BRAND} symbol rather
+ * than `instanceof`, so it works across the dual-package boundary — a builder
+ * produced by the ESM copy of `@composurecdk/iam` is still recognised by the
+ * CommonJS copy and vice versa. Getting this wrong is not merely a type
+ * confusion: the discrimination decides whether {@link StatementBuilder.build}
+ * runs, and `build()` is where the wildcard-resource guard lives.
+ */
+export function isStatementBuilder(value: unknown): value is StatementBuilder {
+  return typeof value === "object" && value !== null && STATEMENT_BUILDER_BRAND in value;
 }
 
 /**

--- a/packages/iam/test/foreign-realm.ts
+++ b/packages/iam/test/foreign-realm.ts
@@ -1,0 +1,22 @@
+import type { StatementBuilder } from "../src/statement-builder.js";
+
+/**
+ * Re-parents a {@link StatementBuilder} onto a copy of its own prototype, so it
+ * behaves exactly like one minted by the other realm's copy of
+ * `@composurecdk/iam` under the dual-package hazard (ADR-0007): every method
+ * present and working, the instance-level brand intact, but
+ * `instanceof StatementBuilder` false.
+ *
+ * Both halves matter. The private fields `build()` reads live on the instance,
+ * so swapping the prototype leaves the builder fully functional — a cross-realm
+ * builder is not broken, merely unrecognisable to `instanceof`. And the brand
+ * is a class field, also on the instance, so it survives the swap: the guard
+ * still sees it where `instanceof` does not, which is the whole difference
+ * these tests exercise.
+ */
+export function asForeignRealm(builder: StatementBuilder): StatementBuilder {
+  const proto = Object.getPrototypeOf(builder) as object;
+  const clonedProto = Object.defineProperties({}, Object.getOwnPropertyDescriptors(proto));
+  Object.setPrototypeOf(builder, clonedProto);
+  return builder;
+}

--- a/packages/iam/test/managed-policy-builder.test.ts
+++ b/packages/iam/test/managed-policy-builder.test.ts
@@ -1,10 +1,11 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createManagedPolicyBuilder } from "../src/managed-policy-builder.js";
-import { createStatementBuilder } from "../src/statement-builder.js";
+import { createStatementBuilder, WildcardResourceError } from "../src/statement-builder.js";
+import { asForeignRealm } from "./foreign-realm.js";
 
 function synth(configureFn: (b: ReturnType<typeof createManagedPolicyBuilder>) => void): Template {
   const app = new App();
@@ -66,6 +67,38 @@ describe("ManagedPolicyBuilder", () => {
         ]),
       }),
     });
+  });
+
+  // See the matching case on RoleBuilder: `addStatements` is public API a
+  // consumer calls with builders it constructed itself, so the ESM/CJS realm
+  // boundary (ADR-0007) can sit across this call.
+  it("builds StatementBuilders that came from another realm, guard included", () => {
+    const template = synth((b) =>
+      b.addStatements([
+        asForeignRealm(
+          createStatementBuilder()
+            .allow()
+            .actions(["s3:PutObject"])
+            .resources(["arn:aws:s3:::bucket-b/*"]),
+        ),
+      ]),
+    );
+
+    template.hasResourceProperties("AWS::IAM::ManagedPolicy", {
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([Match.objectLike({ Action: "s3:PutObject" })]),
+      }),
+    });
+
+    expect(() =>
+      synth((b) =>
+        b.addStatements([
+          asForeignRealm(
+            createStatementBuilder().allow().actions(["ec2:DescribeInstances"]).resources(["*"]),
+          ),
+        ]),
+      ),
+    ).toThrow(WildcardResourceError);
   });
 
   describe("[COPY_STATE]", () => {

--- a/packages/iam/test/role-builder.test.ts
+++ b/packages/iam/test/role-builder.test.ts
@@ -11,6 +11,7 @@ import { compose, type Lifecycle, ref } from "@composurecdk/core";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { createRoleBuilder } from "../src/role-builder.js";
 import { createStatementBuilder, WildcardResourceError } from "../src/statement-builder.js";
+import { asForeignRealm } from "./foreign-realm.js";
 
 function synth(configureFn?: (builder: ReturnType<typeof createRoleBuilder>) => void): Template {
   const app = new App();
@@ -125,6 +126,31 @@ describe("RoleBuilder", () => {
       });
     });
 
+    // A StatementBuilder is public API the consumer constructs and hands back
+    // in, so under the dual ESM/CJS build (ADR-0007) the realm boundary can sit
+    // directly across this call. `instanceof` misses such a builder, which both
+    // skips the wildcard guard below and hands CDK an unbuilt object.
+    it("builds StatementBuilders that came from another realm", () => {
+      const template = synth((b) =>
+        b.addInlinePolicyStatements("StopEC2", [
+          asForeignRealm(
+            createStatementBuilder().allow().actions(["ec2:StopInstances"]).resources(["*"]),
+          ).allowWildcardResources(true),
+        ]),
+      );
+
+      template.hasResourceProperties("AWS::IAM::Role", {
+        Policies: Match.arrayWith([
+          Match.objectLike({
+            PolicyName: "StopEC2",
+            PolicyDocument: Match.objectLike({
+              Statement: Match.arrayWith([Match.objectLike({ Action: "ec2:StopInstances" })]),
+            }),
+          }),
+        ]),
+      });
+    });
+
     it("propagates StatementBuilder wildcard errors at build time", () => {
       const app = new App();
       const stack = new Stack(app, "TestStack");
@@ -132,6 +158,20 @@ describe("RoleBuilder", () => {
         .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
         .addInlinePolicyStatements("TooBroad", [
           createStatementBuilder().allow().actions(["ec2:DescribeInstances"]).resources(["*"]),
+        ]);
+
+      expect(() => builder.build(stack, "TestRole")).toThrow(WildcardResourceError);
+    });
+
+    it("still enforces the wildcard guard on a StatementBuilder from another realm", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const builder = createRoleBuilder()
+        .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+        .addInlinePolicyStatements("TooBroad", [
+          asForeignRealm(
+            createStatementBuilder().allow().actions(["ec2:DescribeInstances"]).resources(["*"]),
+          ),
         ]);
 
       expect(() => builder.build(stack, "TestRole")).toThrow(WildcardResourceError);

--- a/packages/iam/test/statement-builder.test.ts
+++ b/packages/iam/test/statement-builder.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { ArnPrincipal, Effect, ServicePrincipal } from "aws-cdk-lib/aws-iam";
-import { createStatementBuilder, WildcardResourceError } from "../src/statement-builder.js";
+import { ArnPrincipal, Effect, PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import {
+  createStatementBuilder,
+  isStatementBuilder,
+  StatementBuilder,
+  WildcardResourceError,
+} from "../src/statement-builder.js";
+import { asForeignRealm } from "./foreign-realm.js";
 
 describe("StatementBuilder", () => {
   describe("build", () => {
@@ -128,5 +134,22 @@ describe("StatementBuilder", () => {
         StringEquals: { "aws:ResourceTag/Env": "dev" },
       });
     });
+  });
+});
+
+describe("isStatementBuilder", () => {
+  it("recognises a StatementBuilder", () => {
+    expect(isStatementBuilder(createStatementBuilder())).toBe(true);
+  });
+
+  it("rejects a raw PolicyStatement", () => {
+    expect(isStatementBuilder(new PolicyStatement({ actions: ["s3:GetObject"] }))).toBe(false);
+  });
+
+  it("recognises a builder from another realm, which instanceof does not", () => {
+    const foreign = asForeignRealm(createStatementBuilder().allow().actions(["s3:GetObject"]));
+
+    expect(foreign instanceof StatementBuilder).toBe(false);
+    expect(isStatementBuilder(foreign)).toBe(true);
   });
 });

--- a/packages/module-compat/test/dual-realm.test.ts
+++ b/packages/module-compat/test/dual-realm.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from "vitest";
+import { runFixture } from "./run-fixture.js";
+
+/**
+ * The resolution and synth suites load each package under one module syntax at
+ * a time. These fixtures load a package under **both at once** in a single
+ * process — the dual-package hazard proper (ADR-0007), where a value minted by
+ * one copy is handed to the other and every `instanceof` across that boundary
+ * is false. A fixture per class we brand with `Symbol.for(...)`.
+ */
+describe("both realms loaded in one process", () => {
+  it("recognises a StatementBuilder across the boundary, guard included", () => {
+    runFixture("dual-realm/statement-builder.js");
+  });
+});

--- a/packages/module-compat/test/fixtures/dual-realm/package.json
+++ b/packages/module-compat/test/fixtures/dual-realm/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/module-compat/test/fixtures/dual-realm/statement-builder.js
+++ b/packages/module-compat/test/fixtures/dual-realm/statement-builder.js
@@ -1,0 +1,59 @@
+// Loads `@composurecdk/iam` through BOTH export conditions in one process —
+// the dual-package hazard itself (ADR-0007), not a stand-in for it. A
+// StatementBuilder is constructed with the ESM copy and handed to a role
+// builder and a managed-policy builder from the CommonJS copy, which is the
+// shape a real app takes when its ESM entrypoint assembles statements and a
+// CJS module builds the role.
+
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { App, Stack } from "aws-cdk-lib";
+import { ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { createStatementBuilder, StatementBuilder } from "@composurecdk/iam";
+
+const cjs = createRequire(import.meta.url)("@composurecdk/iam");
+
+// Without this, everything below could pass for the wrong reason.
+assert.notEqual(cjs.StatementBuilder, StatementBuilder);
+assert.equal(createStatementBuilder() instanceof cjs.StatementBuilder, false);
+assert.equal(cjs.isStatementBuilder(createStatementBuilder()), true);
+
+const app = new App();
+const stack = new Stack(app, "ComposureCDK-ModuleCompatDualRealm");
+
+cjs
+  .createRoleBuilder()
+  .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+  .addInlinePolicyStatements("FromEsm", [
+    createStatementBuilder().allow().actions(["s3:GetObject"]).resources(["arn:aws:s3:::bucket/*"]),
+  ])
+  .build(stack, "Role");
+
+cjs
+  .createManagedPolicyBuilder()
+  .addStatements([
+    createStatementBuilder().allow().actions(["s3:PutObject"]).resources(["arn:aws:s3:::bucket/*"]),
+  ])
+  .build(stack, "Policy");
+
+const template = JSON.stringify(
+  app.synth().getStackByName("ComposureCDK-ModuleCompatDualRealm").template,
+);
+assert.ok(template.includes("s3:GetObject"), "ESM statement missing from the CJS-built role");
+assert.ok(template.includes("s3:PutObject"), "ESM statement missing from the CJS-built policy");
+
+// The wildcard guard lives in StatementBuilder.build(), so it only fires if the
+// CJS builder recognised the ESM builder and called it. The error is thrown by
+// the ESM copy, so it is not an instance of `cjs.WildcardResourceError` —
+// match on the name, which both copies share.
+assert.throws(
+  () =>
+    cjs
+      .createRoleBuilder()
+      .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+      .addInlinePolicyStatements("TooBroad", [
+        createStatementBuilder().allow().actions(["ec2:DescribeInstances"]).resources(["*"]),
+      ])
+      .build(new Stack(new App(), "Wildcard"), "Role"),
+  (error) => error.name === "WildcardResourceError",
+);

--- a/packages/module-compat/test/fixtures/failing/exit-nonzero.js
+++ b/packages/module-compat/test/fixtures/failing/exit-nonzero.js
@@ -1,0 +1,7 @@
+// Deliberately fails, to prove `runFixture` surfaces a child's stderr rather
+// than passing silently. Every other fixture's value depends on that: a
+// harness that swallowed a non-zero exit would report a green suite no matter
+// what the fixtures did.
+
+process.stderr.write("fixture failed on purpose\n");
+process.exit(1);

--- a/packages/module-compat/test/fixtures/failing/silent.js
+++ b/packages/module-compat/test/fixtures/failing/silent.js
@@ -1,0 +1,4 @@
+// Fails without writing anything, so `runFixture` has no stderr to quote and
+// must fall back to the exec error to say anything useful at all.
+
+process.exit(3);

--- a/packages/module-compat/test/run-fixture.test.ts
+++ b/packages/module-compat/test/run-fixture.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { runFixture } from "./run-fixture.js";
+
+/**
+ * Every other suite in this package trusts `runFixture` to turn a child's
+ * non-zero exit into a test failure. If it ever swallowed one, the fixtures
+ * would all report green while proving nothing — so assert the failure path
+ * directly, including that the child's stderr reaches the message.
+ */
+describe("runFixture", () => {
+  it("fails the test with the child's stderr when the fixture exits non-zero", () => {
+    expect(() => {
+      runFixture("failing/exit-nonzero.js");
+    }).toThrow(/failing\/exit-nonzero\.js" failed:[\s\S]*fixture failed on purpose/);
+  });
+
+  it("falls back to the exec error when the fixture fails silently", () => {
+    expect(() => {
+      runFixture("failing/silent.js");
+    }).toThrow(/failing\/silent\.js" failed:[\s\S]*Command failed/);
+  });
+});

--- a/packages/module-compat/test/run-fixture.ts
+++ b/packages/module-compat/test/run-fixture.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
+
+/**
+ * Runs a fixture app, named relative to `test/fixtures/`, in a fresh `node` —
+ * failing the calling test with the child's stderr if it exits non-zero.
+ * Spawning rather than importing is the point: only a real process exercises
+ * the `require`/`import` export conditions and the module resolution they
+ * drive.
+ *
+ * `cdk.out` (written by any fixture that calls `app.synth()`) goes to a
+ * throwaway temp dir, so the test leaves no trace.
+ */
+export function runFixture(fixture: string): void {
+  const outDir = mkdtempSync(join(tmpdir(), "composurecdk-module-compat-"));
+  try {
+    execFileSync(process.execPath, [join(fixturesDir, fixture)], {
+      cwd: outDir,
+      stdio: ["ignore", "ignore", "pipe"],
+      // Generous: a cold `node` loading aws-cdk-lib plus a full synth.
+      timeout: 60_000,
+    });
+  } catch (error) {
+    // A child that fails without saying anything (or a spawn that never
+    // produced a child at all) leaves nothing useful in stderr, so fall back to
+    // the exec error — which at least carries the exit code or signal.
+    const stderr = (error as { stderr?: Buffer }).stderr?.toString().trim();
+    const detail = stderr === undefined || stderr === "" ? String(error) : stderr;
+    throw new Error(`fixture "${fixture}" failed:\n${detail}`, { cause: error });
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}

--- a/packages/module-compat/test/synth.test.ts
+++ b/packages/module-compat/test/synth.test.ts
@@ -1,15 +1,9 @@
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, it } from "vitest";
-
-const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
+import { runFixture } from "./run-fixture.js";
 
 const FIXTURES = [
-  { syntax: "CommonJS require()", entry: join(fixturesDir, "cjs", "synth.js") },
-  { syntax: "ESM import", entry: join(fixturesDir, "esm", "synth.js") },
+  { syntax: "CommonJS require()", fixture: "cjs/synth.js" },
+  { syntax: "ESM import", fixture: "esm/synth.js" },
 ] as const;
 
 /**
@@ -17,26 +11,10 @@ const FIXTURES = [
  * `compose(...).build(app, id)` + `app.synth()` — the real `cdk synth` path
  * from issue #119. Spawning a fresh `node` per fixture exercises actual module
  * resolution (the `require`/`import` export conditions) and the `Ref` brand
- * across the dual-package boundary. `cdk.out` is written to a throwaway temp
- * dir so the test leaves no trace.
+ * across the dual-package boundary.
  */
-describe.each(FIXTURES)("cdk synth via $syntax", ({ entry }) => {
+describe.each(FIXTURES)("cdk synth via $syntax", ({ fixture }) => {
   it("synthesizes a ref-wired composed system", () => {
-    const outDir = mkdtempSync(join(tmpdir(), "composurecdk-module-compat-"));
-    try {
-      execFileSync(process.execPath, [entry], {
-        cwd: outDir,
-        stdio: ["ignore", "ignore", "pipe"],
-        // Generous: a cold `node` loading aws-cdk-lib plus a full synth.
-        timeout: 60_000,
-      });
-    } catch (error) {
-      const stderr = (error as { stderr?: Buffer }).stderr?.toString().trim();
-      throw new Error(`cdk synth fixture "${entry}" failed:\n${stderr ?? String(error)}`, {
-        cause: error,
-      });
-    } finally {
-      rmSync(outDir, { recursive: true, force: true });
-    }
+    runFixture(fixture);
   });
 });


### PR DESCRIPTION
## What & why

Closes #385. Independent of #391 (the same class of bug in `@composurecdk/route53`, which takes the L1 `cfnResourceType` fix because its subject is a CDK construct). This one carries the security consequence.

`RoleBuilder.addInlinePolicyStatements` and `ManagedPolicyBuilder.addStatements` discriminated a `StatementBuilder` from a raw `PolicyStatement` with `instanceof`. That is realm-bound, and `@composurecdk/iam` ships dual ESM/CJS (ADR-0007). `StatementBuilder` is unusually exposed to it: both call sites take `(PolicyStatement | StatementBuilder)[]` as **public API**, so the consumer constructs the builder and hands it back in — the realm boundary sits directly across the API surface, and an app whose ESM entrypoint assembles statements while a CJS module builds the role is enough to cross it.

The `instanceof` was not just a type test. It was the dispatch deciding whether `.build()` runs, and `build()` is where the wildcard-resource guard lives. A cross-realm builder took the `: s` branch, so `WildcardResourceError` never fired and a statement the library is meant to reject — `Effect=Allow` on `"*"` without `allowWildcardResources(true)` — passed by accident. The guard is opt-out by design; this made it opt-out by module format. The same miss also handed CDK an unbuilt object; I reproduced that half, and it dies mid-synth with `TypeError: statement.freeze is not a function` from inside `PolicyDocument`, naming nothing in this codebase.

`StatementBuilder` now carries a `Symbol.for("composurecdk.statement-builder")` brand, with a new exported `isStatementBuilder` guard both call sites use — the mechanism `Ref`/`isRef` already uses, including the registered-symbol detail that makes it work across realms. The guard takes `unknown` rather than the narrower union: it is public API, so its `typeof`/null checks stay meaningful for untyped callers (and under the narrow type they trip `no-unnecessary-condition`, which is the type being wrong rather than the checks).

### Tests, at two levels

- **`packages/iam`** — `asForeignRealm` re-parents a builder onto a clone of its own prototype, which is what a foreign-realm builder actually looks like: instance state and brand intact, `instanceof` false. Confirmed all three cases fail against the old dispatch and pass against the brand.
- **`packages/module-compat`** — a fixture loads `@composurecdk/iam` through **both** export conditions in one process, so it exercises the hazard rather than simulating it. It asserts the two class objects really do differ before relying on that, then checks an ESM-built statement reaches a CJS-built role and managed policy, and that a wildcard `Allow` still throws. This is the test that would have caught the bug.

The spawn plumbing `synth.test.ts` had inline moved to a shared `runFixture` helper, now used by three suites. Since it left the `*.test.ts` coverage exclusion, it comes with its own tests — two fixtures that fail on purpose, asserting the harness surfaces a child's stderr rather than passing silently. That is worth having independently: a harness that swallowed a non-zero exit would report every module-compat fixture green while proving nothing.

### Is the brand list closed?

The issue asked. I enumerated every class exported from a dual-published package that a consumer can construct and pass back in:

- `Ref` and `StatementBuilder` are the only two the library **type-tests**, and both are now branded.
- `AlarmDefinitionBuilder` is consumer-constructible and crosses package boundaries (`customAlarms` on the budgets/cloudfront/route53 alarm builders), but nothing discriminates it — consumers just call `.resolve(construct)`. Realm-safe today by not needing a type test; branding now would be speculative.
- **The error classes are the real remaining gap.** A consumer's `catch (e) { e instanceof WildcardResourceError }` is realm-bound exactly the same way — this PR's own fixture had to work around it and match on `error.name` instead. All three error classes already set `name`, so it works, but it was undocumented. `WildcardResourceError`'s TSDoc now says so, and ADR-0007's dual-package-hazard note — which named `Ref` as the sole exception, implying a closed list — now records both branded classes and this gap.

A `brand()` helper in `@composurecdk/core` is not worth it at two call sites, and the durable answer to recurrence is a lint rule, not more pre-emptive brands. Both noted as follow-ups rather than done here.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [ ] `npm run verify` passes locally — every step passes **except** `actionlint`, which cannot run in this environment: the pinned shellcheck binary's download is blocked (403), and the wrapper correctly refuses to report a clean run it didn't perform. No workflow files are touched by this PR. Please confirm the gate on a machine where shellcheck installs.
- [x] Tests added/updated for the change
- [x] If it adds an example stack: n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01HszU5PFP6cxtAe5ZD1E2Qb)_