### PR TITLE
fix(ec2): pass the build context to the flow-log and endpoint sub-builders

### DIFF
--- a/packages/ec2/README.md
+++ b/packages/ec2/README.md
@@ -204,6 +204,8 @@ createVpcBuilder().flowLogs({
 });
 ```
 
+The callback receives the build context, so anything `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the VPC.
+
 Use a user-managed destination (e.g. an S3 bucket):
 
 ```ts

--- a/packages/ec2/src/interface-endpoint-builder.ts
+++ b/packages/ec2/src/interface-endpoint-builder.ts
@@ -215,7 +215,7 @@ class InterfaceEndpointBuilder implements Lifecycle<InterfaceEndpointBuilderResu
       managedSecurityGroup = createSecurityGroupBuilder()
         .vpc(resolvedVpc)
         .description(`Interface endpoint ${id}`)
-        .build(scope, `${id}Sg`).securityGroup;
+        .build(scope, `${id}Sg`, context).securityGroup;
       securityGroups = [managedSecurityGroup];
     }
 

--- a/packages/ec2/src/vpc-builder.ts
+++ b/packages/ec2/src/vpc-builder.ts
@@ -28,6 +28,10 @@ export type FlowLogsConfig =
        * Customize the auto-created LogGroup sub-builder. Receives a builder
        * pre-seeded with the well-architected log retention/removal defaults
        * from {@link createLogGroupBuilder}.
+       *
+       * The callback receives the build context, so anything
+       * `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a
+       * sibling component. Declare that component as a dependency.
        */
       configure?: (b: ILogGroupBuilder) => ILogGroupBuilder;
     };
@@ -92,10 +96,10 @@ const DEFAULT_FLOW_LOG_KEY = "DefaultFlowLog";
 class VpcBuilder implements Lifecycle<VpcBuilderResult> {
   props: Partial<VpcBuilderProps> = {};
 
-  build(scope: IConstruct, id: string): VpcBuilderResult {
+  build(scope: IConstruct, id: string, context?: Record<string, object>): VpcBuilderResult {
     const { flowLogs: flowLogsConfig, ...vpcProps } = this.props;
 
-    const { flowLogsLogGroup, flowLogProps } = resolveFlowLogs(scope, id, flowLogsConfig);
+    const { flowLogsLogGroup, flowLogProps } = resolveFlowLogs(scope, id, flowLogsConfig, context);
 
     // CDK accepts `availabilityZones` or `maxAzs`, but not both. When the user
     // pins AZs explicitly, the default `maxAzs` must yield to their intent;
@@ -128,6 +132,7 @@ function resolveFlowLogs(
   scope: IConstruct,
   id: string,
   cfg: FlowLogsConfig | undefined,
+  context?: Record<string, object>,
 ): { flowLogsLogGroup?: LogGroup; flowLogProps: Pick<VpcProps, "flowLogs"> } {
   if (cfg === false) {
     return { flowLogProps: {} };
@@ -151,7 +156,11 @@ function resolveFlowLogs(
   if (cfg?.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  const flowLogsLogGroup = subBuilder.build(scope, `${id}FlowLogsLogGroup`).logGroup;
+  // Pass the build context down: `ILogGroupBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const flowLogsLogGroup = subBuilder.build(scope, `${id}FlowLogsLogGroup`, context).logGroup;
 
   return {
     flowLogsLogGroup,

--- a/packages/ec2/test/vpc-builder.test.ts
+++ b/packages/ec2/test/vpc-builder.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { FlowLogDestination } from "aws-cdk-lib/aws-ec2";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
+import { ref } from "@composurecdk/core";
 import { createVpcBuilder } from "../src/vpc-builder.js";
 
 function buildVpc(configureFn?: (builder: ReturnType<typeof createVpcBuilder>) => void) {
@@ -133,6 +135,22 @@ describe("VpcBuilder", () => {
       expect(result.flowLogsLogGroup).toBeDefined();
       template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 7,
+      });
+    });
+
+    it("configure callback can reach a sibling component through a ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const key = new Key(stack, "FlowLogsKey");
+
+      createVpcBuilder()
+        .flowLogs({
+          configure: (lg) => lg.encryptionKey(ref<{ key: Key }>("flowLogsKey").get("key")),
+        })
+        .build(stack, "Network", { flowLogsKey: { key } });
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Logs::LogGroup", {
+        KmsKeyId: { "Fn::GetAtt": [Match.stringLikeRegexp("FlowLogsKey"), "Arn"] },
       });
     });
 


### PR DESCRIPTION
## What & why

Refs #386 — one of five per-package PRs for the sub-builder call sites that drop the build context.

`resolveFlowLogs` built the VPC's auto-managed flow-log group with `subBuilder.build(scope, id)`, dropping the build context. #375 widened `LogGroupBuilderProps.encryptionKey` to a `Resolvable`, so a caller reaching for a composed KMS key through the documented `configure` escape hatch:

```ts
createVpcBuilder()
  .flowLogs({ configure: (lg) => lg.encryptionKey(ref("flowLogsKey", ...)) });
```

got `resolve(ref, undefined)` → resolved against `{}` → **`Ref to "flowLogsKey" cannot be resolved: component not found in context`**.

`VpcBuilder.build` now takes the optional `context` third parameter `Lifecycle` already declares, and threads it through `resolveFlowLogs` to the sub-builder. Adding the parameter is source-compatible for standalone callers, and `compose` already passes context to every component. Also documents the capability on `FlowLogsConfig.configure` and in the package README.

### `InterfaceEndpointBuilder` — forwarded, but not a bug today

The issue's table lists `interface-endpoint-builder.ts:218` as stranding `vpc` and the `addIngressRule`/`addEgressRule` peers. **That is not reachable as the code stands**, and I want to be explicit rather than imply a fix that wasn't needed:

- the managed `SecurityGroupBuilder` is constructed internally from an **already-resolved** `IVpc`, and
- the `allowDefaultPortFrom` peers are resolved by the parent against its own context before use, and
- there is no `configure` hook exposing that sub-builder to a caller.

So there is nothing a ref could be stranded on, no behaviour change, and nothing to regression-test. The context is forwarded anyway so the call site does not become a bug the moment the security group gains a `configure` hook or a ref'd prop.

### The lint rule does not cover this

`lifecycle-build-context-required` keys on `Resolvable<` appearing in the builder's own class body. `VpcBuilder` has none — the resolvable lives one delegation away in the sub-builder's props — so the rule never would have caught this and still won't catch a recurrence. Extending it is issue #386's open question and is deliberately out of scope here.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one exception, see below
- [x] Tests added/updated for the change — for the flow-log fix; see above for why the interface-endpoint change has none
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

**On `npm run verify`:** every gate passes (`format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test`) except `actionlint`, which could not run — its shellcheck binary download returns 403 through this environment's proxy. No file under `.github/workflows/` is touched by this PR. I also re-ran the full gate set with all five sibling PRs merged together; all green.

**Regression test:** the new flow-log test was confirmed to fail without the source change, with the exact error from the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VGDJbohu3kANTxUXcQc3A)_