### PR TITLE
fix(s3): pass the build context to the access-log sub-builder

### DIFF
--- a/packages/s3/README.md
+++ b/packages/s3/README.md
@@ -103,6 +103,8 @@ createBucketBuilder().serverAccessLogs({ destination: myBucket, prefix: "x/" });
 
 `destination` and `configure` cannot be combined — the destination bucket is user-managed and is not built by this builder.
 
+The `configure` callback receives the build context, so anything `IBucketBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the bucket.
+
 ## Recommended Alarms
 
 The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#S3) automatically when [CloudWatch request metrics](https://docs.aws.amazon.com/AmazonS3/latest/userguide/configure-request-metrics-bucket.html) are configured on the bucket via `.metrics()`. One alarm per metric is created for each metrics configuration entry. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.

--- a/packages/s3/src/bucket-builder.ts
+++ b/packages/s3/src/bucket-builder.ts
@@ -27,6 +27,10 @@ export type ServerAccessLogsConfig =
        * Customize the auto-created logging sub-builder. Receives a builder
        * pre-seeded with `versioned: false`, `removalPolicy: RETAIN`, and
        * recursive access logging disabled.
+       *
+       * The callback receives the build context, so anything `IBucketBuilder`
+       * accepts as a `Resolvable` can be a `ref` to a sibling component.
+       * Declare that component as a dependency.
        */
       configure?: (b: IBucketBuilder) => IBucketBuilder;
     };
@@ -149,7 +153,7 @@ class BucketBuilder implements Lifecycle<BucketBuilderResult> {
     const { serverAccessLogs: defaultServerAccessLogs, ...cdkDefaults } = BUCKET_DEFAULTS;
     const cfg = serverAccessLogs ?? defaultServerAccessLogs;
 
-    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg);
+    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg, context);
 
     const mergedProps = {
       ...cdkDefaults,
@@ -182,6 +186,7 @@ function resolveAccessLogs(
   scope: IConstruct,
   id: string,
   cfg: ServerAccessLogsConfig | undefined,
+  context?: Record<string, object>,
 ): { accessLogsBucket?: Bucket; accessLogProps: Partial<BucketProps> } {
   if (cfg === false || cfg === undefined) {
     return { accessLogProps: {} };
@@ -210,7 +215,11 @@ function resolveAccessLogs(
   if (cfg.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`).bucket;
+  // Pass the build context down: `IBucketBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`, context).bucket;
 
   return {
     accessLogsBucket,

--- a/packages/s3/test/bucket-builder.test.ts
+++ b/packages/s3/test/bucket-builder.test.ts
@@ -431,6 +431,30 @@ describe("BucketBuilder", () => {
         encryption.ServerSideEncryptionConfiguration[0].ServerSideEncryptionByDefault.SSEAlgorithm,
       ).toBe("aws:kms");
     });
+
+    it("configure callback can reach a sibling component through a ref", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const key = new Key(stack, "LogsKey");
+
+      createBucketBuilder()
+        .bucketName("main")
+        .serverAccessLogs({
+          configure: (sub) => sub.encryptionKey(ref<{ key: Key }>("logsKey").get("key")),
+        })
+        .build(stack, "TestBucket", { logsKey: { key } });
+
+      const encryption = findLogBucket(Template.fromStack(stack)).Properties.BucketEncryption as {
+        ServerSideEncryptionConfiguration: {
+          ServerSideEncryptionByDefault: { SSEAlgorithm: string; KMSMasterKeyID: unknown };
+        }[];
+      };
+      const byDefault =
+        encryption.ServerSideEncryptionConfiguration[0].ServerSideEncryptionByDefault;
+      expect(byDefault.SSEAlgorithm).toBe("aws:kms");
+      expect(byDefault.KMSMasterKeyID).toMatchObject({
+        "Fn::GetAtt": [expect.stringContaining("LogsKey"), "Arn"],
+      });
+    });
   });
 
   describe("autoDeleteObjects", () => {


### PR DESCRIPTION
## What & why

Refs #386 — one of five per-package PRs for the sub-builder call sites that drop the build context.

**This call site is not in issue #386's table**, which surveyed `route53`, `ec2`, `cloudfront` and `apigateway`. It is the same class of bug and reachable the same way, so it belongs with the set.

`resolveAccessLogs` built the bucket's auto-managed server-access-log bucket with `subBuilder.build(scope, id)`, dropping the build context. #375 widened `BucketBuilderProps.encryptionKey` to a `Resolvable`, so a caller reaching for a composed KMS key through the documented `configure` escape hatch:

```ts
createBucketBuilder()
  .serverAccessLogs({ configure: (sub) => sub.encryptionKey(ref("logsKey", ...)) });
```

got `resolve(ref, undefined)` → resolved against `{}` → **`Ref to "logsKey" cannot be resolved: component not found in context`**.

What made this one easy to miss: the bucket's *own* `encryptionKey` resolved correctly the whole time — `build` already had the context and passed it to `encryptionKeyProps`. Only the logging sub-builder was affected, so the failure looked like a KMS problem rather than a context-threading one.

`BucketBuilder.build` already declared the `context` parameter; it is now threaded through `resolveAccessLogs` to the sub-builder. **No signature change** — this is a pure bug fix with no surface impact. Also documents the capability on `ServerAccessLogsConfig.configure` and in the package README.

### The lint rule does not cover this

`lifecycle-build-context-required` keys on `Resolvable<` appearing in the builder's own class body. The resolvable here lives one delegation away in the sub-builder's props, so the rule does not catch it. Extending it is issue #386's open question and is deliberately out of scope here.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one exception, see below
- [x] Tests added/updated for the change
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

**On `npm run verify`:** every gate passes (`format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test`) except `actionlint`, which could not run — its shellcheck binary download returns 403 through this environment's proxy. No file under `.github/workflows/` is touched by this PR. I also re-ran the full gate set with all five sibling PRs merged together; all green.

**Regression test:** the new test was confirmed to fail without the source change, with the exact error from the issue.

### Not changed here

`bucket-deployment-builder.ts:136` builds a `createLogGroupBuilder()` the same way but exposes no `configure` hook, so nothing can be stranded — it is not a bug and I left it alone. Same shape as `lambda/src/function-builder.ts:345`. Applying the "always forward context" convention uniformly across those is worth deciding separately (issue #386's option b).

---
_Generated by [Claude Code](https://claude.ai/code/session_015VGDJbohu3kANTxUXcQc3A)_