### PR TITLE
fix(cloudfront): pass the build context to the access-log sub-builder

### DIFF
--- a/packages/cloudfront/README.md
+++ b/packages/cloudfront/README.md
@@ -111,6 +111,8 @@ createDistributionBuilder()
 
 `destination` and `configure` cannot be combined — the destination bucket is user-managed and is not built by this builder.
 
+The `configure` callback receives the build context, so anything `IBucketBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the distribution.
+
 The config object replaces the default wholesale rather than merging with it. For example, `.accessLogs({ includeCookies: true })` does **not** preserve the default `prefix: "logs/"` — restate any default you want to keep.
 
 The auto-created logging bucket uses `DEFAULT_ACCESS_LOG_BUCKET_LIFECYCLE_RULES` from `@composurecdk/s3`: incomplete multipart uploads are aborted after 7 days and access log objects expire after 2 years (matching the default `LogGroup` retention so the audit window is consistent across log destinations). CloudFront never deletes its own logs, so this lifecycle is the only thing that bounds the bucket's growth.

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -174,6 +174,10 @@ export type AccessLogsConfig =
        * pre-seeded with `versioned: false`, `objectOwnership:
        * BUCKET_OWNER_PREFERRED`, `removalPolicy: RETAIN`, and recursive
        * S3 server access logging disabled.
+       *
+       * The callback receives the build context, so anything `IBucketBuilder`
+       * accepts as a `Resolvable` can be a `ref` to a sibling component.
+       * Declare that component as a dependency.
        */
       configure?: (b: IBucketBuilder) => IBucketBuilder;
     };
@@ -442,7 +446,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
     } = DISTRIBUTION_DEFAULTS;
     const cfg = accessLogs ?? defaultAccessLogs;
 
-    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg);
+    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg, context);
 
     const behaviors = resolveBehaviors({
       scope,
@@ -526,6 +530,7 @@ function resolveAccessLogs(
   scope: IConstruct,
   id: string,
   cfg: AccessLogsConfig | undefined,
+  context?: Record<string, object>,
 ): {
   accessLogsBucket?: Bucket;
   accessLogProps: Partial<
@@ -567,7 +572,11 @@ function resolveAccessLogs(
   if (cfg.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`).bucket;
+  // Pass the build context down: `IBucketBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`, context).bucket;
 
   return {
     accessLogsBucket,

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import {
@@ -343,6 +344,34 @@ describe("DistributionBuilder", () => {
 
       template.hasResourceProperties("AWS::S3::Bucket", {
         BucketName: "my-cdn-logs",
+      });
+    });
+
+    it("configure callback can reach a sibling component through a ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const key = new Key(stack, "LogsKey");
+
+      createDistributionBuilder()
+        .origin(withBucketOrigin(stack))
+        .accessLogs({
+          configure: (lb) =>
+            lb.bucketName("my-cdn-logs").encryptionKey(ref<{ key: Key }>("logsKey").get("key")),
+        })
+        .build(stack, "TestDistribution", { logsKey: { key } });
+
+      Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+        BucketName: "my-cdn-logs",
+        BucketEncryption: {
+          ServerSideEncryptionConfiguration: [
+            {
+              ServerSideEncryptionByDefault: {
+                SSEAlgorithm: "aws:kms",
+                KMSMasterKeyID: { "Fn::GetAtt": [Match.stringLikeRegexp("LogsKey"), "Arn"] },
+              },
+            },
+          ],
+        },
       });
     });
 


### PR DESCRIPTION
## What & why

Refs #386 — one of five per-package PRs for the sub-builder call sites that drop the build context.

`resolveAccessLogs` built the distribution's auto-managed standard-logging bucket with `subBuilder.build(scope, id)`, dropping the build context. #375 widened `BucketBuilderProps.encryptionKey` to a `Resolvable`, so a caller reaching for a composed KMS key through the documented `configure` escape hatch:

```ts
createDistributionBuilder()
  .accessLogs({ configure: (lb) => lb.encryptionKey(ref("logsKey", ...)) });
```

got `resolve(ref, undefined)` → resolved against `{}` → **`Ref to "logsKey" cannot be resolved: component not found in context`**.

`DistributionBuilder.build` already declared the `context` parameter and used it for its own `origin`; it is now threaded through `resolveAccessLogs` to the sub-builder. **No signature change** — this is a pure bug fix with no surface impact. Also documents the capability on `AccessLogsConfig.configure` and in the package README.

### The lint rule does not cover this

`lifecycle-build-context-required` keys on `Resolvable<` appearing in the builder's own class body. The resolvable here lives one delegation away in the sub-builder's props, so the rule does not catch it. Extending it is issue #386's open question and is deliberately out of scope here.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one exception, see below
- [x] Tests added/updated for the change
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

**On `npm run verify`:** every gate passes (`format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test`) except `actionlint`, which could not run — its shellcheck binary download returns 403 through this environment's proxy. No file under `.github/workflows/` is touched by this PR. I also re-ran the full gate set with all five sibling PRs merged together; all green.

**Regression test:** the new test was confirmed to fail without the source change, with the exact error from the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VGDJbohu3kANTxUXcQc3A)_