### PR TITLE
fix(apigateway): forward the build context to the access-log sub-builder

### DIFF
--- a/packages/apigateway/src/deploy-options.ts
+++ b/packages/apigateway/src/deploy-options.ts
@@ -25,6 +25,7 @@ export function resolveDeployOptions(
   accessLogging: boolean | undefined,
   defaults: StageOptions,
   userDeployOptions: StageOptions,
+  context?: Record<string, object>,
 ): AccessLoggingResult {
   const autoAccessLog = (accessLogging ?? true) && !userDeployOptions.accessLogDestination;
 
@@ -32,7 +33,12 @@ export function resolveDeployOptions(
   let accessLogProps = {};
 
   if (autoAccessLog) {
-    accessLogGroup = createLogGroupBuilder().build(scope, `${id}AccessLogs`).logGroup;
+    // Forward the build context even though this sub-builder is currently
+    // seeded with no user input: `accessLogging` is a boolean, so there is no
+    // `configure` hook through which a caller could hand it a `ref()` today.
+    // Threading it now means the call site does not silently become the
+    // "component not found in context" bug the moment such a hook is added.
+    accessLogGroup = createLogGroupBuilder().build(scope, `${id}AccessLogs`, context).logGroup;
     accessLogProps = {
       accessLogDestination: new LogGroupLogDestination(accessLogGroup),
       accessLogFormat: AccessLogFormat.jsonWithStandardFields(),

--- a/packages/apigateway/src/rest-api-builder.ts
+++ b/packages/apigateway/src/rest-api-builder.ts
@@ -121,6 +121,7 @@ class RestApiBuilder implements Lifecycle<RestApiBuilderResult> {
       accessLogging,
       REST_API_DEFAULTS.deployOptions,
       restApiProps.deployOptions ?? {},
+      context,
     );
 
     const api = new RestApi(scope, id, {

--- a/packages/apigateway/src/spec-rest-api-builder.ts
+++ b/packages/apigateway/src/spec-rest-api-builder.ts
@@ -124,6 +124,7 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
       accessLogging,
       SPEC_REST_API_DEFAULTS.deployOptions,
       specRestApiProps.deployOptions ?? {},
+      context,
     );
 
     const api = new SpecRestApi(scope, id, {


### PR DESCRIPTION
## What & why

Refs #386 — one of five per-package PRs for the sub-builder call sites that drop the build context.

`resolveDeployOptions` built the API's auto-managed access-log group with `createLogGroupBuilder().build(scope, id)`, dropping the build context that both `RestApiBuilder.build` and `SpecRestApiBuilder.build` already receive.

### This one is not a reachable bug, and has no test

Unlike the sibling PRs for `route53` (#390), `ec2` (#393), `s3` (#394) and `cloudfront` (#395), nothing is broken here today. `accessLogging` is a plain `boolean`, so there is no `configure` hook through which a caller could hand the sub-builder a `ref()`. The builder is always constructed fresh with no user input, leaving nothing to strand — hence no regression test, because there is no failing behaviour to pin.

The context is forwarded so the call site does not silently become the "component not found in context" bug the moment `accessLogging` grows a `configure` hook — the shape every other logging config in the library already has (`queryLogging`, `flowLogs`, `serverAccessLogs`, `accessLogs`, `providerLogging`). A comment at the call site records why the argument is there, so a future "unused param?" cleanup does not remove it.

If you would rather not carry forward-looking changes, this is the one PR in the set to drop — the other four fix live bugs.

Both `resolveDeployOptions` callers pass their context; the parameter is optional and trailing, so there is no surface change.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one exception, see below
- [ ] Tests added/updated for the change — none possible; see above
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

**On `npm run verify`:** every gate passes (`format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test`) except `actionlint`, which could not run — its shellcheck binary download returns 403 through this environment's proxy. No file under `.github/workflows/` is touched by this PR. I also re-ran the full gate set with all five sibling PRs merged together; all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VGDJbohu3kANTxUXcQc3A)_