### PR TITLE
docs: record the npm 11 pin for local installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ npm run actionlint
 
 Use npx nx to run build/test scripts — this is an nx monorepo.
 
+**Install dependencies with npm 11** (`npm install -g npm@11`). npm 10 and 11 disagree on how optional peer deps are pinned in the lockfile, and ours is generated under npm 11 — so under npm 10 `npm ci` fails with `Missing: yaml@2.9.0 from lock file`, and `npm install` "fixes" it by rewriting the lockfile, stripping `libc` fields npm 11 wrote. Neither is a defect in the lockfile and neither wants committing: CI pins npm 11 across the whole Node matrix for exactly this reason (see the `Pin npm` step in [ci.yml](.github/workflows/ci.yml)). Node 20 and 22 ship npm 10, so a default install on either needs the pin.
+
 Lint is an nx target too: `npm run lint` runs `nx run-many -t lint`, which caches per project so unchanged packages fast-succeed. Each package carries a `"lint": "eslint ."` script, so nx infers a `lint` target the same way it infers `build`/`test`/`typecheck` from package.json scripts — add that line when you create a package. Three things make this correct rather than merely fast:
 
 - **Loose top-level files** (`eslint.config.mjs`, `scripts/**`, `vitest.config.base.ts`) belong to no package, so they are linted by the `workspace-root` project defined in the root [`project.json`](project.json). If you add a source file outside `packages/` and outside those globs, extend that project's `lint` target so it stays covered.


### PR DESCRIPTION
## What & why

Two lines in `AGENTS.md`'s Build system section, saying to install with npm 11 and why.

npm 10 and 11 disagree on how optional peer deps are pinned in the lockfile, and ours is generated under npm 11. Under npm 10, `npm ci` fails with `Missing: yaml@2.9.0 from lock file`, and `npm install` appears to fix it by rewriting the lockfile — stripping the `libc` fields npm 11 wrote, which then shows up as an unrelated modified file that looks like it wants committing. Committing it would degrade the lockfile.

`ci.yml`'s `Pin npm` step has handled this since the dual ESM/CJS work and explains the reasoning well, but only where someone reading the workflow would find it. Nothing said so where someone setting up locally looks, so the failure reads as a broken lockfile and invites a "fix" that makes it worse. Node 20 and 22 ship npm 10, so a default install on either hits it.

This came out of #391/#392, where I hit exactly that and initially reported the lockfile as out of sync before finding the workflow comment.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix) — small, obvious fix; no code change
- [x] `npm run verify` passes locally — `format:check` covers this file; the change is documentation only, no source or workflow touched
- [x] Tests added/updated for the change — n/a, documentation
- [x] If it adds an example stack: n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01HszU5PFP6cxtAe5ZD1E2Qb)_