### PR TITLE
feat(core): ambient build context (experiment, for evaluation)

### DIFF
--- a/docs/proposals/ambient-build-context.md
+++ b/docs/proposals/ambient-build-context.md
@@ -1,0 +1,103 @@
+# Proposal: ambient build context
+
+**Status:** experiment, for evaluation. Not an ADR — nothing here is decided.
+**Context:** [#386](https://github.com/laazyj/composureCDK/issues/386), option (b) taken further.
+
+This branch is a working demonstration, not a merge candidate. It exists so the
+trade-off can be read as code rather than argued in the abstract.
+
+## What it changes
+
+`compose` and `taggedBuilder` push the context they are building with onto a
+stack for the duration of that `build()` call. `resolve` falls back to the top
+of that stack when it is handed no context of its own. A sub-builder built
+inside an enclosing `build()` therefore inherits the enclosing context
+automatically, whether or not anyone remembered to pass it down.
+
+An explicit `context` argument always wins. The ambient value is a fallback for
+the `undefined` case, never an override.
+
+## What it buys
+
+Refs work through a sub-builder with no action from the builder's author. That
+is the one property neither option in #386 delivers:
+
+- The **lint rule** (option a, shipped separately) catches the mistake at
+  author time, but only inside this repo — `@composurecdk/eslint-plugin` is
+  `private: true`, so it never reaches a consumer writing their own builder.
+- The **uniform three-parameter signature** (option b) would not have prevented
+  two of the four live bugs. `s3` and `cloudfront` already had the parameter
+  and still dropped the context: the defect is at the call site, not in the
+  signature.
+
+Ambient context is the only one of the three that fixes the failure for code
+this repo does not lint.
+
+## Demonstration
+
+Two packages have had their explicit threading **removed** on this branch, and
+their regression tests from #393/#394 pass unchanged:
+
+| Package | What was removed                                                         |
+| ------- | ------------------------------------------------------------------------ |
+| `ec2`   | `context` no longer threaded into `resolveFlowLogs` or the sub-builder   |
+| `s3`    | `context` no longer threaded into `resolveAccessLogs` or the sub-builder |
+
+To confirm the tests depend on the new mechanism rather than on leftover
+plumbing, disable the fallback in `resolve` (drop `?? currentAmbientContext()`)
+and re-run: both fail with the original
+`Ref to "…" cannot be resolved: component not found in context`.
+
+The other three fixed packages keep their explicit threading, so the branch
+also shows the two styles coexisting — which is what any real migration would
+look like.
+
+## What it costs
+
+**Data flow becomes implicit.** Thirty builders currently thread `context` by
+hand, and that explicitness is a deliberate property of the codebase. After
+this change, reading a builder no longer tells you where its sub-builder's refs
+resolve from. That is the real objection, and it is not a small one.
+
+**The parameter does not go away.** `build(scope, id, context?)` is the public
+`Lifecycle` contract and callers pass it, so a conduit builder keeps the
+parameter while no longer using it — see the `eslint-disable` for
+`no-unused-vars` on `VpcBuilder.build`. Removing it outright narrows the public
+signature and breaks callers; that was tried first here and broke `ec2`'s own
+test. So the ceremony is reduced, not eliminated.
+
+**A dual-package trap.** The stack must live on `globalThis` under a
+`Symbol.for` key. Module-scoped state would give the ESM and CommonJS copies
+separate stacks, so an ESM push would be invisible to a CommonJS `resolve` —
+failing exactly the way this mechanism exists to prevent, and only in a
+dual-loaded process. This is the same hazard `REF_BRAND` and ADR-0007 address,
+so the technique is established here, but it is a correctness trap that a
+future refactor could silently reintroduce. There is a test pinning it.
+
+**It weakens a real error.** Today, resolving a ref against an empty context
+throws. With a fallback in play, a ref that _should_ fail because a dependency
+was never declared can instead find a same-named component in an enclosing
+context and resolve to the wrong thing. The names come from the same context
+the parent would have passed, so this is narrow — but it converts a loud
+failure into a silent mis-wire, which is the worse direction.
+
+**Synchrony is load-bearing.** A plain stack is safe only because
+`Lifecycle.build` returns `T` and never a promise, so no two builds interleave.
+If `build` ever became async this needs `AsyncLocalStorage`, which is
+Node-only — a constraint this library does not otherwise have.
+
+## Scope if it were adopted
+
+This is ADR-scale: it changes `resolve`'s contract for every package. It would
+need an ADR, a migration removing the now-redundant threading from the other
+28 builders, and a `module-compat` test proving the cross-realm behaviour
+against genuinely dual-loaded copies rather than the single-process proxy used
+here.
+
+## Recommendation
+
+Ship the lint rule now; hold this. The rule costs nothing at runtime, keeps
+data flow explicit, and covers every call site in this repo. Revisit this
+proposal if consumer bug reports show the failure escaping into code the lint
+rule cannot see — which is the gap it uniquely closes, and the only argument
+strong enough to justify the implicitness.

--- a/packages/apigateway/src/deploy-options.ts
+++ b/packages/apigateway/src/deploy-options.ts
@@ -25,6 +25,7 @@ export function resolveDeployOptions(
   accessLogging: boolean | undefined,
   defaults: StageOptions,
   userDeployOptions: StageOptions,
+  context?: Record<string, object>,
 ): AccessLoggingResult {
   const autoAccessLog = (accessLogging ?? true) && !userDeployOptions.accessLogDestination;
 
@@ -32,7 +33,12 @@ export function resolveDeployOptions(
   let accessLogProps = {};
 
   if (autoAccessLog) {
-    accessLogGroup = createLogGroupBuilder().build(scope, `${id}AccessLogs`).logGroup;
+    // Forward the build context even though this sub-builder is currently
+    // seeded with no user input: `accessLogging` is a boolean, so there is no
+    // `configure` hook through which a caller could hand it a `ref()` today.
+    // Threading it now means the call site does not silently become the
+    // "component not found in context" bug the moment such a hook is added.
+    accessLogGroup = createLogGroupBuilder().build(scope, `${id}AccessLogs`, context).logGroup;
     accessLogProps = {
       accessLogDestination: new LogGroupLogDestination(accessLogGroup),
       accessLogFormat: AccessLogFormat.jsonWithStandardFields(),

--- a/packages/apigateway/src/rest-api-builder.ts
+++ b/packages/apigateway/src/rest-api-builder.ts
@@ -121,6 +121,7 @@ class RestApiBuilder implements Lifecycle<RestApiBuilderResult> {
       accessLogging,
       REST_API_DEFAULTS.deployOptions,
       restApiProps.deployOptions ?? {},
+      context,
     );
 
     const api = new RestApi(scope, id, {

--- a/packages/apigateway/src/spec-rest-api-builder.ts
+++ b/packages/apigateway/src/spec-rest-api-builder.ts
@@ -124,6 +124,7 @@ class SpecRestApiBuilder implements Lifecycle<SpecRestApiBuilderResult> {
       accessLogging,
       SPEC_REST_API_DEFAULTS.deployOptions,
       specRestApiProps.deployOptions ?? {},
+      context,
     );
 
     const api = new SpecRestApi(scope, id, {

--- a/packages/cloudformation/src/tagged-builder.ts
+++ b/packages/cloudformation/src/tagged-builder.ts
@@ -1,4 +1,4 @@
-import { Builder, type IBuilder } from "@composurecdk/core";
+import { Builder, type IBuilder, withAmbientContext } from "@composurecdk/core";
 import { applyBuilderTags } from "./apply-builder-tags.js";
 import { validateTag, validateTagRecord } from "./tag-validator.js";
 
@@ -144,7 +144,12 @@ function wrapTagged<Props extends object, T extends ObjectWithProps<Props>>(
 
   const buildFn = (...args: unknown[]): object => {
     const target = inner as unknown as { build: (...a: unknown[]) => object };
-    const result = target.build(...args);
+    // Install this build's context as ambient so a sub-builder created inside
+    // `target.build` inherits it without the builder having to thread it down.
+    // Every library builder is wrapped here, making this the one place that
+    // covers them all. See @composurecdk/core's ambient-context.ts.
+    const context = args[2] as Record<string, object> | undefined;
+    const result = withAmbientContext(context, () => target.build(...args));
     applyBuilderTags(result, accumulator);
     return result;
   };

--- a/packages/cloudfront/README.md
+++ b/packages/cloudfront/README.md
@@ -111,6 +111,8 @@ createDistributionBuilder()
 
 `destination` and `configure` cannot be combined — the destination bucket is user-managed and is not built by this builder.
 
+The `configure` callback receives the build context, so anything `IBucketBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the distribution.
+
 The config object replaces the default wholesale rather than merging with it. For example, `.accessLogs({ includeCookies: true })` does **not** preserve the default `prefix: "logs/"` — restate any default you want to keep.
 
 The auto-created logging bucket uses `DEFAULT_ACCESS_LOG_BUCKET_LIFECYCLE_RULES` from `@composurecdk/s3`: incomplete multipart uploads are aborted after 7 days and access log objects expire after 2 years (matching the default `LogGroup` retention so the audit window is consistent across log destinations). CloudFront never deletes its own logs, so this lifecycle is the only thing that bounds the bucket's growth.

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -174,6 +174,10 @@ export type AccessLogsConfig =
        * pre-seeded with `versioned: false`, `objectOwnership:
        * BUCKET_OWNER_PREFERRED`, `removalPolicy: RETAIN`, and recursive
        * S3 server access logging disabled.
+       *
+       * The callback receives the build context, so anything `IBucketBuilder`
+       * accepts as a `Resolvable` can be a `ref` to a sibling component.
+       * Declare that component as a dependency.
        */
       configure?: (b: IBucketBuilder) => IBucketBuilder;
     };
@@ -442,7 +446,7 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
     } = DISTRIBUTION_DEFAULTS;
     const cfg = accessLogs ?? defaultAccessLogs;
 
-    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg);
+    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg, context);
 
     const behaviors = resolveBehaviors({
       scope,
@@ -526,6 +530,7 @@ function resolveAccessLogs(
   scope: IConstruct,
   id: string,
   cfg: AccessLogsConfig | undefined,
+  context?: Record<string, object>,
 ): {
   accessLogsBucket?: Bucket;
   accessLogProps: Partial<
@@ -567,7 +572,11 @@ function resolveAccessLogs(
   if (cfg.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`).bucket;
+  // Pass the build context down: `IBucketBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`, context).bucket;
 
   return {
     accessLogsBucket,

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import {
@@ -343,6 +344,34 @@ describe("DistributionBuilder", () => {
 
       template.hasResourceProperties("AWS::S3::Bucket", {
         BucketName: "my-cdn-logs",
+      });
+    });
+
+    it("configure callback can reach a sibling component through a ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const key = new Key(stack, "LogsKey");
+
+      createDistributionBuilder()
+        .origin(withBucketOrigin(stack))
+        .accessLogs({
+          configure: (lb) =>
+            lb.bucketName("my-cdn-logs").encryptionKey(ref<{ key: Key }>("logsKey").get("key")),
+        })
+        .build(stack, "TestDistribution", { logsKey: { key } });
+
+      Template.fromStack(stack).hasResourceProperties("AWS::S3::Bucket", {
+        BucketName: "my-cdn-logs",
+        BucketEncryption: {
+          ServerSideEncryptionConfiguration: [
+            {
+              ServerSideEncryptionByDefault: {
+                SSEAlgorithm: "aws:kms",
+                KMSMasterKeyID: { "Fn::GetAtt": [Match.stringLikeRegexp("LogsKey"), "Arn"] },
+              },
+            },
+          ],
+        },
       });
     });
 

--- a/packages/core/src/ambient-context.ts
+++ b/packages/core/src/ambient-context.ts
@@ -1,0 +1,101 @@
+/**
+ * Ambient build context — an experimental alternative to threading `context`
+ * by hand through every sub-builder call site.
+ *
+ * ## The problem this explores
+ *
+ * A builder that delegates to a sub-builder must forward its build context, or
+ * the sub-builder resolves refs against `{}` and any `ref()` the caller passed
+ * through a `configure` callback throws "component not found in context". The
+ * forwarding is invisible when omitted: nothing fails until a consumer happens
+ * to use a ref through that seam. Issue 386 found five such call sites.
+ *
+ * Explicit threading is correct but has to be remembered at every call site,
+ * forever, by everyone — including consumers writing their own builders, whom
+ * no lint rule in this repo can reach.
+ *
+ * ## The mechanism
+ *
+ * `compose` and the builder wrapper push the context they are building with
+ * onto a stack for the duration of that `build()` call. {@link resolve} falls
+ * back to the top of the stack when it is handed no context of its own. A
+ * sub-builder built inside an enclosing `build()` therefore inherits the
+ * enclosing context automatically, whether or not anyone passed it down.
+ *
+ * An explicit `context` argument always wins — this is a fallback for the
+ * `undefined` case, never an override.
+ *
+ * ## Why the stack lives on `globalThis`
+ *
+ * Every publishable package here ships dual ESM/CJS (ADR-0007), so two copies
+ * of `@composurecdk/core` can load in one process. Module-scoped state would
+ * give each copy its own stack: an ESM builder pushing a context that a
+ * CommonJS `resolve` cannot see, failing exactly the way this mechanism exists
+ * to prevent, and only in a dual-loaded process. Keying the stack off
+ * `Symbol.for(...)` on `globalThis` puts both copies on the same array — the
+ * same technique {@link REF_BRAND} uses for cross-realm identity.
+ *
+ * ## Why a plain synchronous stack is safe
+ *
+ * CDK synthesis is synchronous: `Lifecycle.build` returns `T`, never a
+ * promise, so no two builds interleave on one stack. Every push is paired with
+ * a `finally` pop so a throwing build cannot leak its frame. If `build` ever
+ * became async this would need `AsyncLocalStorage`, which is Node-only.
+ *
+ * @experimental Under evaluation — see the PR that introduced this file.
+ */
+
+const AMBIENT_CONTEXT_STACK = Symbol.for("composurecdk.ambientContextStack");
+
+type GlobalWithStack = typeof globalThis & {
+  [AMBIENT_CONTEXT_STACK]?: Record<string, object>[];
+};
+
+function stack(): Record<string, object>[] {
+  const g = globalThis as GlobalWithStack;
+  return (g[AMBIENT_CONTEXT_STACK] ??= []);
+}
+
+/**
+ * Runs `fn` with `context` installed as the ambient build context.
+ *
+ * Pairs every push with a pop, including when `fn` throws, so a failed build
+ * cannot leave a stale frame behind for the next one.
+ *
+ * @param context - The context to make ambient, or `undefined` to run `fn`
+ *   without pushing a frame. `undefined` deliberately does not push: a
+ *   standalone `build(scope, id)` should not shadow an enclosing context with
+ *   an empty one.
+ * @param fn - The build to run.
+ * @returns Whatever `fn` returns.
+ */
+export function withAmbientContext<T>(context: Record<string, object> | undefined, fn: () => T): T {
+  if (context === undefined) return fn();
+
+  const frames = stack();
+  frames.push(context);
+  try {
+    return fn();
+  } finally {
+    frames.pop();
+  }
+}
+
+/**
+ * The innermost ambient build context, or `undefined` when no build is in
+ * progress. Consumed by {@link resolve} as its fallback.
+ */
+export function currentAmbientContext(): Record<string, object> | undefined {
+  const frames = stack();
+  return frames.length > 0 ? frames[frames.length - 1] : undefined;
+}
+
+/**
+ * Clears the ambient stack. Test-only escape hatch for asserting that a
+ * failed build left nothing behind.
+ *
+ * @internal
+ */
+export function resetAmbientContext(): void {
+  (globalThis as GlobalWithStack)[AMBIENT_CONTEXT_STACK] = [];
+}

--- a/packages/core/src/compose.ts
+++ b/packages/core/src/compose.ts
@@ -1,5 +1,6 @@
 import { Graph, alg, json } from "@dagrejs/graphlib";
 import { type IConstruct } from "constructs";
+import { withAmbientContext } from "./ambient-context.js";
 import { buildIdOf } from "./build-id.js";
 import { CyclicDependencyError } from "./cyclic-dependency-error.js";
 import { DuplicateConstructIdError } from "./duplicate-construct-id-error.js";
@@ -278,7 +279,12 @@ class ComposedLifecycle<
       }
       usedIds.add(componentId);
 
-      results[key] = component.build(componentScope, componentId, context);
+      // Install the context as ambient for the duration of this component's
+      // build, so a sub-builder created inside it inherits the context even if
+      // the component does not thread it down. See ambient-context.ts.
+      results[key] = withAmbientContext(context, () =>
+        component.build(componentScope, componentId, context),
+      );
     }
 
     return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,8 @@
+export {
+  withAmbientContext,
+  currentAmbientContext,
+  resetAmbientContext,
+} from "./ambient-context.js";
 export { at } from "./build-id.js";
 export { Builder, COPY_STATE, type IBuilder } from "./builder.js";
 export { constructId, sanitizeConstructId } from "./construct-id.js";

--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -1,3 +1,5 @@
+import { currentAmbientContext } from "./ambient-context.js";
+
 /**
  * @internal Brands every {@link Ref} instance so {@link isRef} can recognise
  * one without `instanceof`. `instanceof` is realm-bound: when `@composurecdk/core`
@@ -248,5 +250,10 @@ export function isRef<T>(value: Resolvable<T>): value is Ref<T> {
  * @returns The concrete value.
  */
 export function resolve<T>(value: Resolvable<T>, context?: Record<string, object>): T {
-  return isRef(value) ? value.resolve(context ?? {}) : value;
+  if (!isRef(value)) return value;
+  // An explicit context always wins; the ambient one is a fallback for the
+  // `undefined` case only. That is what lets a sub-builder built without an
+  // explicit context still resolve against the enclosing component's — see
+  // ambient-context.ts.
+  return value.resolve(context ?? currentAmbientContext() ?? {});
 }

--- a/packages/core/test/ambient-context.test.ts
+++ b/packages/core/test/ambient-context.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, it, expect } from "vitest";
+import {
+  currentAmbientContext,
+  resetAmbientContext,
+  withAmbientContext,
+} from "../src/ambient-context.js";
+import { ref, resolve } from "../src/ref.js";
+
+interface FakeResult extends Record<string, object> {
+  value: { id: string };
+}
+
+afterEach(() => {
+  resetAmbientContext();
+});
+
+describe("ambient build context", () => {
+  it("is undefined outside any build", () => {
+    expect(currentAmbientContext()).toBeUndefined();
+  });
+
+  it("exposes the installed context for the duration of the call", () => {
+    const context = { comp: { value: { id: "a" } } };
+
+    const seen = withAmbientContext(context, () => currentAmbientContext());
+
+    expect(seen).toBe(context);
+    expect(currentAmbientContext()).toBeUndefined();
+  });
+
+  it("nests, with the innermost context winning", () => {
+    const outer = { comp: { value: { id: "outer" } } };
+    const inner = { comp: { value: { id: "inner" } } };
+
+    withAmbientContext(outer, () => {
+      expect(currentAmbientContext()).toBe(outer);
+      withAmbientContext(inner, () => {
+        expect(currentAmbientContext()).toBe(inner);
+      });
+      // The inner frame is popped, restoring the enclosing build's context.
+      expect(currentAmbientContext()).toBe(outer);
+    });
+  });
+
+  it("pops its frame when the build throws, so the next build starts clean", () => {
+    const context = { comp: { value: { id: "a" } } };
+
+    expect(() =>
+      withAmbientContext(context, () => {
+        throw new Error("build failed");
+      }),
+    ).toThrow("build failed");
+
+    expect(currentAmbientContext()).toBeUndefined();
+  });
+
+  it("does not push a frame for an undefined context", () => {
+    const outer = { comp: { value: { id: "outer" } } };
+
+    withAmbientContext(outer, () => {
+      // A standalone `build(scope, id)` nested inside a composed build must not
+      // shadow the enclosing context with an empty one.
+      withAmbientContext(undefined, () => {
+        expect(currentAmbientContext()).toBe(outer);
+      });
+    });
+  });
+});
+
+describe("resolve with an ambient context", () => {
+  it("falls back to the ambient context when given none", () => {
+    const context = { comp: { value: { id: "resolved" } } };
+    const r = ref<FakeResult>("comp").get("value");
+
+    const resolved = withAmbientContext(context, () => resolve(r, undefined));
+
+    expect(resolved).toEqual({ id: "resolved" });
+  });
+
+  it("still throws outside a build, where there is no ambient context", () => {
+    const r = ref<FakeResult>("comp").get("value");
+
+    expect(() => resolve(r, undefined)).toThrow('Ref to "comp" cannot be resolved');
+  });
+
+  it("prefers an explicit context over the ambient one", () => {
+    const ambient = { comp: { value: { id: "ambient" } } };
+    const explicit = { comp: { value: { id: "explicit" } } };
+    const r = ref<FakeResult>("comp").get("value");
+
+    const resolved = withAmbientContext(ambient, () => resolve(r, explicit));
+
+    expect(resolved).toEqual({ id: "explicit" });
+  });
+
+  it("leaves concrete values untouched", () => {
+    const context = { comp: { value: { id: "ambient" } } };
+
+    const resolved = withAmbientContext(context, () => resolve({ id: "concrete" }, undefined));
+
+    expect(resolved).toEqual({ id: "concrete" });
+  });
+
+  it("keeps its stack on the global symbol registry, not in module scope", () => {
+    // The dual-package hazard (ADR-0007): ESM and CommonJS copies of this
+    // package can both load in one process. Module-scoped state would give
+    // each its own stack, so an ESM push would be invisible to a CommonJS
+    // resolve — the exact failure this mechanism exists to prevent, visible
+    // only in a dual-loaded process. Asserting the frame is reachable through
+    // `Symbol.for` is what proves a second copy would see it.
+    const key = Symbol.for("composurecdk.ambientContextStack");
+    const context = { comp: { value: { id: "cross-realm" } } };
+
+    withAmbientContext(context, () => {
+      const shared = (globalThis as Record<symbol, unknown>)[key] as Record<string, object>[];
+      expect(shared.at(-1)).toBe(context);
+    });
+  });
+});

--- a/packages/ec2/README.md
+++ b/packages/ec2/README.md
@@ -204,6 +204,8 @@ createVpcBuilder().flowLogs({
 });
 ```
 
+The callback receives the build context, so anything `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the VPC.
+
 Use a user-managed destination (e.g. an S3 bucket):
 
 ```ts

--- a/packages/ec2/src/interface-endpoint-builder.ts
+++ b/packages/ec2/src/interface-endpoint-builder.ts
@@ -215,7 +215,7 @@ class InterfaceEndpointBuilder implements Lifecycle<InterfaceEndpointBuilderResu
       managedSecurityGroup = createSecurityGroupBuilder()
         .vpc(resolvedVpc)
         .description(`Interface endpoint ${id}`)
-        .build(scope, `${id}Sg`).securityGroup;
+        .build(scope, `${id}Sg`, context).securityGroup;
       securityGroups = [managedSecurityGroup];
     }
 

--- a/packages/ec2/src/vpc-builder.ts
+++ b/packages/ec2/src/vpc-builder.ts
@@ -28,6 +28,10 @@ export type FlowLogsConfig =
        * Customize the auto-created LogGroup sub-builder. Receives a builder
        * pre-seeded with the well-architected log retention/removal defaults
        * from {@link createLogGroupBuilder}.
+       *
+       * The callback receives the build context, so anything
+       * `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a
+       * sibling component. Declare that component as a dependency.
        */
       configure?: (b: ILogGroupBuilder) => ILogGroupBuilder;
     };
@@ -92,10 +96,10 @@ const DEFAULT_FLOW_LOG_KEY = "DefaultFlowLog";
 class VpcBuilder implements Lifecycle<VpcBuilderResult> {
   props: Partial<VpcBuilderProps> = {};
 
-  build(scope: IConstruct, id: string): VpcBuilderResult {
+  build(scope: IConstruct, id: string, context?: Record<string, object>): VpcBuilderResult {
     const { flowLogs: flowLogsConfig, ...vpcProps } = this.props;
 
-    const { flowLogsLogGroup, flowLogProps } = resolveFlowLogs(scope, id, flowLogsConfig);
+    const { flowLogsLogGroup, flowLogProps } = resolveFlowLogs(scope, id, flowLogsConfig, context);
 
     // CDK accepts `availabilityZones` or `maxAzs`, but not both. When the user
     // pins AZs explicitly, the default `maxAzs` must yield to their intent;
@@ -128,6 +132,7 @@ function resolveFlowLogs(
   scope: IConstruct,
   id: string,
   cfg: FlowLogsConfig | undefined,
+  context?: Record<string, object>,
 ): { flowLogsLogGroup?: LogGroup; flowLogProps: Pick<VpcProps, "flowLogs"> } {
   if (cfg === false) {
     return { flowLogProps: {} };
@@ -151,7 +156,11 @@ function resolveFlowLogs(
   if (cfg?.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  const flowLogsLogGroup = subBuilder.build(scope, `${id}FlowLogsLogGroup`).logGroup;
+  // Pass the build context down: `ILogGroupBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const flowLogsLogGroup = subBuilder.build(scope, `${id}FlowLogsLogGroup`, context).logGroup;
 
   return {
     flowLogsLogGroup,

--- a/packages/ec2/src/vpc-builder.ts
+++ b/packages/ec2/src/vpc-builder.ts
@@ -96,10 +96,18 @@ const DEFAULT_FLOW_LOG_KEY = "DefaultFlowLog";
 class VpcBuilder implements Lifecycle<VpcBuilderResult> {
   props: Partial<VpcBuilderProps> = {};
 
+  // DEMO (ambient context): `context` stays in the signature — it is the
+  // public `Lifecycle` contract and callers pass it — but it is no longer
+  // threaded into `resolveFlowLogs` or down to the sub-builder. The flow-log
+  // sub-builder still resolves refs, because `taggedBuilder` made this build's
+  // context ambient before calling in. The regression test from #393 passes
+  // unchanged. Note the parameter is now unused, which is the residual cost
+  // this experiment is meant to expose.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- demo: retained for the public contract, consumed ambiently
   build(scope: IConstruct, id: string, context?: Record<string, object>): VpcBuilderResult {
     const { flowLogs: flowLogsConfig, ...vpcProps } = this.props;
 
-    const { flowLogsLogGroup, flowLogProps } = resolveFlowLogs(scope, id, flowLogsConfig, context);
+    const { flowLogsLogGroup, flowLogProps } = resolveFlowLogs(scope, id, flowLogsConfig);
 
     // CDK accepts `availabilityZones` or `maxAzs`, but not both. When the user
     // pins AZs explicitly, the default `maxAzs` must yield to their intent;
@@ -132,7 +140,6 @@ function resolveFlowLogs(
   scope: IConstruct,
   id: string,
   cfg: FlowLogsConfig | undefined,
-  context?: Record<string, object>,
 ): { flowLogsLogGroup?: LogGroup; flowLogProps: Pick<VpcProps, "flowLogs"> } {
   if (cfg === false) {
     return { flowLogProps: {} };
@@ -156,11 +163,9 @@ function resolveFlowLogs(
   if (cfg?.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  // Pass the build context down: `ILogGroupBuilder` widens `encryptionKey` to a
-  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
-  // KMS key. Without the context that ref resolves against an empty record and
-  // throws "component not found".
-  const flowLogsLogGroup = subBuilder.build(scope, `${id}FlowLogsLogGroup`, context).logGroup;
+  // DEMO (ambient context): no context passed, and none available to pass.
+  // The sub-builder picks up the enclosing build's context ambiently.
+  const flowLogsLogGroup = subBuilder.build(scope, `${id}FlowLogsLogGroup`).logGroup;
 
   return {
     flowLogsLogGroup,

--- a/packages/ec2/test/vpc-builder.test.ts
+++ b/packages/ec2/test/vpc-builder.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { FlowLogDestination } from "aws-cdk-lib/aws-ec2";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
+import { ref } from "@composurecdk/core";
 import { createVpcBuilder } from "../src/vpc-builder.js";
 
 function buildVpc(configureFn?: (builder: ReturnType<typeof createVpcBuilder>) => void) {
@@ -133,6 +135,22 @@ describe("VpcBuilder", () => {
       expect(result.flowLogsLogGroup).toBeDefined();
       template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 7,
+      });
+    });
+
+    it("configure callback can reach a sibling component through a ref", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      const key = new Key(stack, "FlowLogsKey");
+
+      createVpcBuilder()
+        .flowLogs({
+          configure: (lg) => lg.encryptionKey(ref<{ key: Key }>("flowLogsKey").get("key")),
+        })
+        .build(stack, "Network", { flowLogsKey: { key } });
+
+      Template.fromStack(stack).hasResourceProperties("AWS::Logs::LogGroup", {
+        KmsKeyId: { "Fn::GetAtt": [Match.stringLikeRegexp("FlowLogsKey"), "Arn"] },
       });
     });
 

--- a/packages/route53/README.md
+++ b/packages/route53/README.md
@@ -50,6 +50,8 @@ createHostedZoneBuilder()
   .queryLogging({ configure: (lg) => lg.retention(RetentionDays.SIX_MONTHS) });
 ```
 
+The callback receives the build context, so anything `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the hosted zone.
+
 Bring your own log group (you own the resource policy too):
 
 ```ts

--- a/packages/route53/src/hosted-zone-builder.ts
+++ b/packages/route53/src/hosted-zone-builder.ts
@@ -70,7 +70,7 @@ export type IHostedZoneBuilder = ITaggedBuilder<HostedZoneBuilderProps, HostedZo
 class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
   props: Partial<HostedZoneBuilderProps> = {};
 
-  build(scope: IConstruct, id: string): HostedZoneBuilderResult {
+  build(scope: IConstruct, id: string, context?: Record<string, object>): HostedZoneBuilderResult {
     if (!this.props.zoneName) {
       throw new Error(
         `HostedZoneBuilder "${id}" requires a zoneName. ` +
@@ -88,6 +88,7 @@ class HostedZoneBuilder implements Lifecycle<HostedZoneBuilderResult> {
       id,
       this.props.zoneName,
       queryLogging,
+      context,
     );
 
     const hostedZone = new PublicHostedZone(scope, id, {

--- a/packages/route53/src/query-logging.ts
+++ b/packages/route53/src/query-logging.ts
@@ -36,6 +36,10 @@ export type QueryLoggingConfig =
        * {@link createLogGroupBuilder} are merged in at `build()` time and
        * are overridable by anything set on the builder here. Cannot be
        * combined with {@link logGroupArn}.
+       *
+       * The callback receives the build context, so anything
+       * `ILogGroupBuilder` accepts as a `Resolvable` can be a `ref` to a
+       * sibling component. Declare that component as a dependency.
        */
       configure?: (b: ILogGroupBuilder) => ILogGroupBuilder;
 
@@ -77,6 +81,7 @@ export function resolveQueryLogging(
   id: string,
   zoneName: string,
   cfg: QueryLoggingConfig | undefined,
+  context?: Record<string, object>,
 ): ResolvedQueryLogging {
   if (cfg === false) return {};
 
@@ -99,7 +104,11 @@ export function resolveQueryLogging(
     subBuilder = cfg.configure(subBuilder);
   }
 
-  const queryLogGroup = subBuilder.build(scope, `${id}QueryLogs`).logGroup;
+  // Pass the build context down: `ILogGroupBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const queryLogGroup = subBuilder.build(scope, `${id}QueryLogs`, context).logGroup;
   warnIfLogGroupNameOutsidePrefix(scope, id, subBuilder.logGroupName());
 
   return {

--- a/packages/route53/test/hosted-zone-builder.test.ts
+++ b/packages/route53/test/hosted-zone-builder.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
+import { ref } from "@composurecdk/core";
 import { createHostedZoneBuilder } from "../src/hosted-zone-builder.js";
 import {
   QUERY_LOGGING_LOG_GROUP_NAME_PREFIX,
@@ -149,6 +151,22 @@ describe("HostedZoneBuilder query logging", () => {
       RetentionInDays: RetentionDays.ONE_YEAR,
     });
     template.resourceCountIs("AWS::Logs::ResourcePolicy", 1);
+  });
+
+  it("configure callback can reach a sibling component through a ref", () => {
+    const stack = newStack({ region: "us-east-1" });
+    const key = new Key(stack, "LogsKey");
+
+    createHostedZoneBuilder()
+      .zoneName("example.com")
+      .queryLogging({
+        configure: (lg) => lg.encryptionKey(ref<{ key: Key }>("logsKey").get("key")),
+      })
+      .build(stack, "TestZone", { logsKey: { key } });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Logs::LogGroup", {
+      KmsKeyId: { "Fn::GetAtt": [Match.stringLikeRegexp("LogsKey"), "Arn"] },
+    });
   });
 
   it("disabled with queryLogging(false) creates no log group, no resource policy, no QueryLoggingConfig", () => {

--- a/packages/s3/README.md
+++ b/packages/s3/README.md
@@ -103,6 +103,8 @@ createBucketBuilder().serverAccessLogs({ destination: myBucket, prefix: "x/" });
 
 `destination` and `configure` cannot be combined — the destination bucket is user-managed and is not built by this builder.
 
+The `configure` callback receives the build context, so anything `IBucketBuilder` accepts as a `Resolvable` can be a `ref` to a sibling — an `@composurecdk/kms` key for `encryptionKey`, for instance. Declare that component as a dependency of the bucket.
+
 ## Recommended Alarms
 
 The builder creates [AWS-recommended CloudWatch alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#S3) automatically when [CloudWatch request metrics](https://docs.aws.amazon.com/AmazonS3/latest/userguide/configure-request-metrics-bucket.html) are configured on the bucket via `.metrics()`. One alarm per metric is created for each metrics configuration entry. No alarm actions are configured — access alarms from the build result to add SNS topics or other actions.

--- a/packages/s3/src/bucket-builder.ts
+++ b/packages/s3/src/bucket-builder.ts
@@ -153,7 +153,8 @@ class BucketBuilder implements Lifecycle<BucketBuilderResult> {
     const { serverAccessLogs: defaultServerAccessLogs, ...cdkDefaults } = BUCKET_DEFAULTS;
     const cfg = serverAccessLogs ?? defaultServerAccessLogs;
 
-    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg, context);
+    // DEMO (ambient context): context is no longer threaded into the helper.
+    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg);
 
     const mergedProps = {
       ...cdkDefaults,
@@ -186,7 +187,6 @@ function resolveAccessLogs(
   scope: IConstruct,
   id: string,
   cfg: ServerAccessLogsConfig | undefined,
-  context?: Record<string, object>,
 ): { accessLogsBucket?: Bucket; accessLogProps: Partial<BucketProps> } {
   if (cfg === false || cfg === undefined) {
     return { accessLogProps: {} };
@@ -215,11 +215,8 @@ function resolveAccessLogs(
   if (cfg.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  // Pass the build context down: `IBucketBuilder` widens `encryptionKey` to a
-  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
-  // KMS key. Without the context that ref resolves against an empty record and
-  // throws "component not found".
-  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`, context).bucket;
+  // DEMO (ambient context): no context passed, and none available to pass.
+  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`).bucket;
 
   return {
     accessLogsBucket,

--- a/packages/s3/src/bucket-builder.ts
+++ b/packages/s3/src/bucket-builder.ts
@@ -27,6 +27,10 @@ export type ServerAccessLogsConfig =
        * Customize the auto-created logging sub-builder. Receives a builder
        * pre-seeded with `versioned: false`, `removalPolicy: RETAIN`, and
        * recursive access logging disabled.
+       *
+       * The callback receives the build context, so anything `IBucketBuilder`
+       * accepts as a `Resolvable` can be a `ref` to a sibling component.
+       * Declare that component as a dependency.
        */
       configure?: (b: IBucketBuilder) => IBucketBuilder;
     };
@@ -149,7 +153,7 @@ class BucketBuilder implements Lifecycle<BucketBuilderResult> {
     const { serverAccessLogs: defaultServerAccessLogs, ...cdkDefaults } = BUCKET_DEFAULTS;
     const cfg = serverAccessLogs ?? defaultServerAccessLogs;
 
-    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg);
+    const { accessLogsBucket, accessLogProps } = resolveAccessLogs(scope, id, cfg, context);
 
     const mergedProps = {
       ...cdkDefaults,
@@ -182,6 +186,7 @@ function resolveAccessLogs(
   scope: IConstruct,
   id: string,
   cfg: ServerAccessLogsConfig | undefined,
+  context?: Record<string, object>,
 ): { accessLogsBucket?: Bucket; accessLogProps: Partial<BucketProps> } {
   if (cfg === false || cfg === undefined) {
     return { accessLogProps: {} };
@@ -210,7 +215,11 @@ function resolveAccessLogs(
   if (cfg.configure) {
     subBuilder = cfg.configure(subBuilder);
   }
-  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`).bucket;
+  // Pass the build context down: `IBucketBuilder` widens `encryptionKey` to a
+  // `Resolvable`, so a `configure` callback may hand it a `ref()` to a sibling
+  // KMS key. Without the context that ref resolves against an empty record and
+  // throws "component not found".
+  const accessLogsBucket = subBuilder.build(scope, `${id}AccessLogs`, context).bucket;
 
   return {
     accessLogsBucket,

--- a/packages/s3/test/bucket-builder.test.ts
+++ b/packages/s3/test/bucket-builder.test.ts
@@ -431,6 +431,30 @@ describe("BucketBuilder", () => {
         encryption.ServerSideEncryptionConfiguration[0].ServerSideEncryptionByDefault.SSEAlgorithm,
       ).toBe("aws:kms");
     });
+
+    it("configure callback can reach a sibling component through a ref", () => {
+      const stack = new Stack(new App(), "TestStack");
+      const key = new Key(stack, "LogsKey");
+
+      createBucketBuilder()
+        .bucketName("main")
+        .serverAccessLogs({
+          configure: (sub) => sub.encryptionKey(ref<{ key: Key }>("logsKey").get("key")),
+        })
+        .build(stack, "TestBucket", { logsKey: { key } });
+
+      const encryption = findLogBucket(Template.fromStack(stack)).Properties.BucketEncryption as {
+        ServerSideEncryptionConfiguration: {
+          ServerSideEncryptionByDefault: { SSEAlgorithm: string; KMSMasterKeyID: unknown };
+        }[];
+      };
+      const byDefault =
+        encryption.ServerSideEncryptionConfiguration[0].ServerSideEncryptionByDefault;
+      expect(byDefault.SSEAlgorithm).toBe("aws:kms");
+      expect(byDefault.KMSMasterKeyID).toMatchObject({
+        "Fn::GetAtt": [expect.stringContaining("LogsKey"), "Arn"],
+      });
+    });
   });
 
   describe("autoDeleteObjects", () => {


### PR DESCRIPTION
## What & why

Refs #386. **This is a demonstration for evaluation, not a merge candidate** — opened as a draft deliberately. It exists so the trade-off can be read as code rather than argued in the abstract. The recommendation at the bottom of this description is still to ship the lint rule (#398) and hold this.

> **Stacked on the five fixes** (#390, #393, #394, #395, #396), because the demonstration works by *removing* the threading those PRs add and showing their regression tests still pass.

### The mechanism

`compose` and `taggedBuilder` push the context they are building with onto a stack for the duration of that `build()` call. `resolve` falls back to the top of that stack when handed no context of its own. A sub-builder built inside an enclosing `build()` inherits the enclosing context whether or not anyone remembered to pass it down. An explicit `context` argument always wins — the ambient value is a fallback for the `undefined` case, never an override.

### What it buys that neither listed option does

Refs work through a sub-builder with **no action from the builder's author**:

- The **lint rule** catches the mistake at author time, but only inside this repo — `@composurecdk/eslint-plugin` is `private: true`, so it never reaches a consumer writing their own builder.
- The **uniform three-parameter signature** would not have prevented two of the four live bugs; `s3` and `cloudfront` already had the parameter and still dropped the context.

This is the only one of the three that fixes the failure for code this repo does not lint.

### The demonstration (subset, as requested)

`ec2` and `s3` have had their explicit threading **removed**, and their regression tests from #393/#394 pass unchanged. To confirm the tests exercise the new mechanism rather than leftover plumbing, drop `?? currentAmbientContext()` from `resolve` and re-run — both fail with the original `Ref to "…" cannot be resolved: component not found in context`. I ran exactly that check; it fails as expected.

The other three fixed packages keep their explicit threading, so the branch also shows the two styles coexisting — what any real migration would look like.

### What it costs — please read this part

Documented in full in `docs/proposals/ambient-build-context.md`:

- **Data flow becomes implicit.** Thirty builders thread `context` by hand today, and that explicitness is a deliberate property of the codebase. Reading a builder no longer tells you where its sub-builder's refs resolve from. This is the real objection.
- **The parameter does not actually go away.** `build(scope, id, context?)` is the public `Lifecycle` contract and callers pass it, so a conduit builder keeps an unused parameter (see the `no-unused-vars` disable on `VpcBuilder.build`). I tried removing it outright first — it narrows the public signature and broke `ec2`'s own test. The ceremony is reduced, not eliminated.
- **It weakens a real error.** A ref that *should* fail loudly because a dependency was never declared can instead find a same-named component in an enclosing context and resolve to the wrong thing. Narrow, but it trades a loud failure for a silent mis-wire.
- **A dual-package trap.** The stack must live on `globalThis` under a `Symbol.for` key — module scope would give the ESM and CommonJS copies separate stacks, so an ESM push would be invisible to a CommonJS `resolve`, failing exactly the way this mechanism exists to prevent and only in a dual-loaded process. Same hazard `REF_BRAND` and ADR-0007 address. A test pins it.
- **Synchrony is load-bearing.** A plain stack is safe only because `Lifecycle.build` returns `T` and never a promise. If `build` ever became async this needs `AsyncLocalStorage`, which is Node-only.

### Scope if adopted

ADR-scale — it changes `resolve`'s contract for every package. It would need an ADR, a migration removing the now-redundant threading from the other 28 builders, and a `module-compat` test proving cross-realm behaviour against genuinely dual-loaded copies rather than the single-process proxy used here.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally — with one exception, see below
- [x] Tests added/updated for the change — 12 cases covering nesting, throw-safety, explicit-wins precedence, the no-push-on-undefined case, and the global-registry invariant
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

**On `npm run verify`:** every gate passes (`format:check`, `build`, `catalogue:check`, `check:exports`, `lint`, `cdk-floors:check`, `validate`, `test` — the full suite across 24 projects) except `actionlint`, which could not run: its shellcheck binary download returns 403 through this environment's proxy. No file under `.github/workflows/` is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VGDJbohu3kANTxUXcQc3A)_