### PR TITLE
feat(eslint-plugin): ban realm-bound instanceof in dual-published source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Lint is an nx target too: `npm run lint` runs `nx run-many -t lint`, which cache
 Every publishable package ships dual ESM/CJS, built by `tshy` — see [ADR-0007](docs/adr/0007-dual-esm-cjs-publishing.md). When touching a builder package:
 
 - Do not use `import.meta` or top-level `await` in `src/` — neither emits to CommonJS. The `composurecdk/no-cjs-incompatible-syntax` ESLint rule enforces this.
-- Cross-realm identity checks must use a `Symbol.for(...)` brand, never `instanceof` — the ESM and CommonJS copies of a package can both load in one process.
+- Cross-realm identity checks must use a `Symbol.for(...)` brand, never `instanceof` — the ESM and CommonJS copies of a package can both load in one process. The `composurecdk/no-realm-bound-instanceof` ESLint rule enforces this, for imports from a relative path as much as a bare specifier. For a CDK construct, brand the L2 you cannot modify by reading its L1 instead (`CfnResource.isCfnResource` + `cfnResourceType`, [ADR-0011](docs/adr/0011-cross-component-relationship-guards.md)).
 - Run `npm run verify` before pushing. It chains the same gate CI runs — build, `check:exports` (`attw` + `publint`), lint, test — and a husky `pre-push` hook runs it automatically.
 - A new package must be added to `@composurecdk/module-compat`'s `DUAL_PACKAGES` list and `peerDependencies`.
 

--- a/docs/adr/0007-dual-esm-cjs-publishing.md
+++ b/docs/adr/0007-dual-esm-cjs-publishing.md
@@ -56,6 +56,7 @@ _lives_. A maintainer running `npm run verify` gets the exact gate CI runs.
 | Mechanism                                             | What it catches                                                                                  | Feedback point                             |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------ |
 | `composurecdk/no-cjs-incompatible-syntax` ESLint rule | `import.meta` / top-level `await` in `src/` — no CJS emit                                        | In-editor, instant                         |
+| `composurecdk/no-realm-bound-instanceof` ESLint rule  | `instanceof` against an imported class in `src/` — realm-bound, silently false across the hazard | In-editor, instant                         |
 | `attw` + `publint` (`check:exports` nx target)        | Broken/masquerading exports, dual-package issues, packaging mistakes                             | `npm run check:exports` / `npm run verify` |
 | `@composurecdk/module-compat` consumption tests       | A package failing to resolve under `require()` or `import`, or the CJS `cdk synth` path breaking | `npm test` / `npm run verify`              |
 | husky `pre-push` hook                                 | Any of the above reaching GitHub                                                                 | Automatic, before push                     |

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -30,6 +30,7 @@ File-level overrides (e.g. disabling a rule on a specific file) belong in the co
 | `composurecdk/lifecycle-build-must-forward-context` | A two-argument `builder.build(scope, id)` call — the sub-builder gets no context, so refs passed through a `configure` callback cannot resolve.                     |
 | `composurecdk/no-cdk-api-above-floor`               | `aws-cdk-lib` APIs newer than the supported peer floor (e.g. the per-resource `isCfn<Resource>` L1 static guards) — they throw on older versions in the peer range. |
 | `composurecdk/no-cjs-incompatible-syntax`           | `import.meta` / top-level `await` in library `src/` — neither emits to CommonJS (ADR-0007).                                                                         |
+| `composurecdk/no-realm-bound-instanceof`            | `instanceof` against an imported class in library `src/` — realm-bound, so it silently returns false across the dual-package boundary (ADR-0007).                   |
 
 The `recommended` preset also bans the TypeScript `private` modifier via `no-restricted-syntax` (use ECMAScript `#field` instead — TS `private` leaks through `keyof T` into emitted `.d.ts`, producing TS4094 downstream).
 

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -16,6 +16,7 @@ export const recommended: Linter.Config = {
     "composurecdk/lifecycle-build-must-forward-context": "error",
     "composurecdk/no-cdk-api-above-floor": "error",
     "composurecdk/no-cjs-incompatible-syntax": "error",
+    "composurecdk/no-realm-bound-instanceof": "error",
     // Bans the TypeScript `private` modifier in favour of ECMAScript private
     // fields (#field). TS `private` members appear in `keyof T` and leak into
     // emitted .d.ts files via mapped types (builder types), producing TS4094

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -5,6 +5,7 @@ import { rule as lifecycleBuildContextRequired } from "./lifecycle-build-context
 import { rule as lifecycleBuildMustForwardContext } from "./lifecycle-build-must-forward-context.js";
 import { rule as noCdkApiAboveFloor } from "./no-cdk-api-above-floor.js";
 import { rule as noCjsIncompatibleSyntax } from "./no-cjs-incompatible-syntax.js";
+import { rule as noRealmBoundInstanceof } from "./no-realm-bound-instanceof.js";
 
 export const rules = {
   "builder-must-be-tagged": builderMustBeTagged,
@@ -14,4 +15,5 @@ export const rules = {
   "lifecycle-build-must-forward-context": lifecycleBuildMustForwardContext,
   "no-cdk-api-above-floor": noCdkApiAboveFloor,
   "no-cjs-incompatible-syntax": noCjsIncompatibleSyntax,
+  "no-realm-bound-instanceof": noRealmBoundInstanceof,
 };

--- a/packages/eslint-plugin/src/rules/lib/imports.ts
+++ b/packages/eslint-plugin/src/rules/lib/imports.ts
@@ -1,0 +1,86 @@
+import type { Scope } from "eslint";
+import type { Identifier, MemberExpression } from "estree";
+
+/**
+ * Loose shape used to walk MemberExpression + TS-wrapper nodes uniformly.
+ * estree's static types don't model the typescript-eslint-specific wrappers
+ * (`TSAsExpression`, `TSNonNullExpression`, `TSSatisfiesExpression`,
+ * `TSTypeAssertion`) or `ChainExpression`, so the walk checks `.type` at
+ * runtime.
+ */
+interface WalkNode {
+  type: string;
+  object?: unknown;
+  expression?: unknown;
+}
+
+/**
+ * TS-only wrappers a developer might use to silence types. Peeled by
+ * {@link unwrapWrappers} and {@link chainRoot} so they cannot smuggle an
+ * expression past a rule.
+ */
+const TS_WRAPPERS = new Set([
+  "ChainExpression",
+  "TSAsExpression",
+  "TSNonNullExpression",
+  "TSSatisfiesExpression",
+  "TSTypeAssertion",
+]);
+
+/** Strip any TS-only wrappers from an expression, returning the node inside. */
+export function unwrapWrappers<T>(expr: T): T {
+  let current = expr as unknown as WalkNode;
+  while (TS_WRAPPERS.has(current.type)) {
+    current = current.expression as WalkNode;
+  }
+  return current as unknown as T;
+}
+
+/**
+ * The leftmost identifier a member chain reads from — `CfnAlarm` in
+ * `cdk.aws_cloudwatch.CfnAlarm`, unwrapping TS wrappers as it goes.
+ *
+ * Returns `undefined` when a call or other expression breaks the chain:
+ * `f().CfnAlarm` reads a runtime value rather than the imported binding, so no
+ * rule that reasons about imports should fire on it.
+ */
+export function chainRoot(expr: MemberExpression["object"]): Identifier | undefined {
+  let current = unwrapWrappers(expr) as unknown as WalkNode;
+  while (current.type === "MemberExpression") {
+    current = unwrapWrappers(current.object) as WalkNode;
+  }
+  return current.type === "Identifier" ? (current as unknown as Identifier) : undefined;
+}
+
+/**
+ * The module specifier `name` was imported from, or `undefined` when it
+ * resolves to anything else — a global, a local declaration, a parameter.
+ *
+ * Walks outward through the scope chain so a local that shadows an import name
+ * wins, matching what the runtime would do.
+ */
+export function importSourceOf(scope: Scope.Scope, name: string): string | undefined {
+  for (let current: Scope.Scope | null = scope; current !== null; current = current.upper) {
+    const variable = current.set.get(name);
+    if (variable === undefined) continue;
+    // `.at(0)` (not `[0]`) — defs can be empty at runtime for predefined
+    // globals (e.g. `console`), even though `Variable.defs: Definition[]` says
+    // otherwise; `.at` gives us the honest `Definition | undefined`.
+    const def = variable.defs.at(0);
+    if (def?.type !== "ImportBinding") return undefined;
+    // `def.parent` is typed as `ImportDeclaration` but at runtime
+    // typescript-eslint also reports `ImportBinding` for `import x =
+    // require(...)`, whose parent is a `TSImportEqualsDeclaration` with no
+    // `.source`. Widen and check the discriminator before reading `source`.
+    const parent = def.parent as { type: string; source?: { value?: unknown } };
+    if (parent.type !== "ImportDeclaration") return undefined;
+    const source = parent.source?.value;
+    return typeof source === "string" ? source : undefined;
+  }
+  return undefined;
+}
+
+/** True for `aws-cdk-lib` and any submodule of it. */
+export function isCdkSource(source: string): boolean {
+  return source === "aws-cdk-lib" || source.startsWith("aws-cdk-lib/");
+}

--- a/packages/eslint-plugin/src/rules/no-cdk-api-above-floor.ts
+++ b/packages/eslint-plugin/src/rules/no-cdk-api-above-floor.ts
@@ -1,5 +1,6 @@
-import type { Rule, Scope } from "eslint";
-import type { Identifier, MemberExpression } from "estree";
+import type { Rule } from "eslint";
+import type { MemberExpression } from "estree";
+import { chainRoot, importSourceOf, isCdkSource } from "./lib/imports.js";
 
 /**
  * An `aws-cdk-lib` API that postdates @composurecdk's supported peer-dependency
@@ -38,18 +39,6 @@ const ALLOWED_CFN_GUARDS = new Set(["isCfnResource", "isCfnElement"]);
  * them (e.g. `CfnAlarm.isCfnAlarm(node)`) throws `TypeError` on the older
  * versions in our `^2` peer range — see issue #146.
  */
-/**
- * Loose shape used by `chainRoot` to walk MemberExpression + TS-wrapper nodes
- * uniformly. estree's static types don't model the typescript-eslint-specific
- * wrappers (`TSAsExpression`, `TSNonNullExpression`, `TSSatisfiesExpression`,
- * `TSTypeAssertion`) or `ChainExpression`, so the walk checks `.type` at runtime.
- */
-interface WalkNode {
-  type: string;
-  object?: unknown;
-  expression?: unknown;
-}
-
 const FORBIDDEN: ForbiddenMember[] = [
   {
     matches: (name) => /^isCfn[A-Z]/.test(name) && !ALLOWED_CFN_GUARDS.has(name),
@@ -94,63 +83,14 @@ export const rule: Rule.RuleModule = {
     },
   },
   create(ctx) {
-    // The leftmost identifier a member chain reads from, peeling MemberExpression
-    // and the TS-only wrappers typescript-eslint produces (`as`, `!`, `satisfies`,
-    // angle-bracket assertion, `?.` ChainExpression). Returns undefined if a call
-    // or other expression breaks the chain — `f().isCfnX` reads a runtime value
-    // rather than the imported class.
-    const TS_WRAPPERS = new Set([
-      "ChainExpression",
-      "TSAsExpression",
-      "TSNonNullExpression",
-      "TSSatisfiesExpression",
-      "TSTypeAssertion",
-    ]);
-    const chainRoot = (expr: MemberExpression["object"]): Identifier | undefined => {
-      let current = expr as unknown as WalkNode;
-      while (current.type === "MemberExpression" || TS_WRAPPERS.has(current.type)) {
-        current = (
-          current.type === "MemberExpression" ? current.object : current.expression
-        ) as WalkNode;
-      }
-      return current.type === "Identifier" ? (current as unknown as Identifier) : undefined;
-    };
-
-    // True when `name` resolves, in the current scope chain, to a binding from
-    // an `aws-cdk-lib` ImportDeclaration. This is scope-aware: a local that
-    // shadows the import name (e.g. a function parameter named `CfnAlarm`)
-    // resolves to its own binding and is NOT treated as the cdk class.
-    const rootIsCdkImport = (scope: Scope.Scope, name: string): boolean => {
-      for (let current: Scope.Scope | null = scope; current !== null; current = current.upper) {
-        const variable = current.set.get(name);
-        if (variable === undefined) continue;
-        // `.at(0)` (not `[0]`) — defs can be empty at runtime for predefined
-        // globals (e.g. `console`), even though `Variable.defs: Definition[]`
-        // says otherwise; `.at` gives us the honest `Definition | undefined`.
-        const def = variable.defs.at(0);
-        if (def?.type !== "ImportBinding") return false;
-        // `def.parent` is typed as `ImportDeclaration` but at runtime
-        // typescript-eslint also reports `ImportBinding` for `import x =
-        // require(...)`, whose parent is a `TSImportEqualsDeclaration` with no
-        // `.source`. Widen and check the discriminator before reading `source`.
-        const parent = def.parent as { type: string; source?: { value?: unknown } };
-        if (parent.type !== "ImportDeclaration") return false;
-        const source = parent.source?.value;
-        return (
-          source === "aws-cdk-lib" ||
-          (typeof source === "string" && source.startsWith("aws-cdk-lib/"))
-        );
-      }
-      return false;
-    };
-
     return {
       MemberExpression(node: MemberExpression) {
         if (node.property.type !== "Identifier") return;
         const property = node.property;
         const root = chainRoot(node.object);
         if (root === undefined) return;
-        if (!rootIsCdkImport(ctx.sourceCode.getScope(node), root.name)) return;
+        const source = importSourceOf(ctx.sourceCode.getScope(node), root.name);
+        if (source === undefined || !isCdkSource(source)) return;
 
         const forbidden = FORBIDDEN.find((entry) => entry.matches(property.name));
         if (forbidden === undefined) return;

--- a/packages/eslint-plugin/src/rules/no-realm-bound-instanceof.ts
+++ b/packages/eslint-plugin/src/rules/no-realm-bound-instanceof.ts
@@ -1,0 +1,83 @@
+import type { Rule } from "eslint";
+import type { BinaryExpression } from "estree";
+import { chainRoot, importSourceOf, isCdkSource, unwrapWrappers } from "./lib/imports.js";
+
+/**
+ * Bans `instanceof` against a class reached through an `import`, because
+ * `instanceof` is realm-bound and library `src/` is published dual ESM/CJS
+ * (ADR-0007).
+ *
+ * When both copies of a package load in one process — the dual-package hazard —
+ * each copy has its own class objects. An instance minted by one copy fails
+ * `instanceof` against the other copy's class, so the check returns `false` for
+ * a value that is plainly of that type. That has already shipped as two bugs:
+ * #384 (a stack-singleton dedup silently skipped, colliding on a construct id)
+ * and #385 (a `StatementBuilder` unrecognised, which skipped the
+ * wildcard-resource security guard).
+ *
+ * **Every import is in scope, relative ones included.** A relative import is
+ * not a same-realm guarantee: `./statement-builder.js` resolves separately in
+ * each copy of the package, which is exactly how #385 happened.
+ *
+ * Not flagged, because neither can be duplicated by the hazard:
+ * - **Globals and intrinsics** — `x instanceof RegExp`, `instanceof Error`.
+ *   They resolve to no import binding, so the scope walk skips them.
+ * - **Classes declared in the same module** — the class and every `new` of it
+ *   come from one evaluation of that module.
+ *
+ * Resolution is scope-aware, so a local that shadows an import name is
+ * correctly treated as a non-import binding, and TS-only wrappers (`as`, `!`,
+ * `satisfies`, angle-bracket assertion) are unwrapped rather than trusted.
+ *
+ * Known gaps, both uncommon in our ESM src: `import = require()` bindings, and
+ * an intermediate call that breaks the chain (`getClasses().Bucket`), which
+ * reads a runtime value rather than the import.
+ */
+export const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Ban realm-bound `instanceof` against imported classes in dual-published source",
+    },
+    schema: [],
+    messages: {
+      cdkClass:
+        "`instanceof {{name}}` is realm-bound and silently returns false across the ESM/CJS copy " +
+        "boundary (ADR-0007). Identify the construct by its L1 instead: `CfnResource.isCfnResource` " +
+        "+ `cfnResourceType === Cfn{{name}}.CFN_RESOURCE_TYPE_NAME` (ADR-0011).",
+      ownClass:
+        "`instanceof {{name}}` is realm-bound — `{{source}}` can load twice in one process " +
+        "(ADR-0007). Brand the class with `Symbol.for(...)` and test that instead, as `isRef` in " +
+        "@composurecdk/core does.",
+    },
+  },
+  create(ctx) {
+    return {
+      BinaryExpression(node: BinaryExpression) {
+        if (node.operator !== "instanceof") return;
+        const root = chainRoot(node.right);
+        if (root === undefined) return;
+
+        const source = importSourceOf(ctx.sourceCode.getScope(node), root.name);
+        if (source === undefined) return;
+
+        // Name the class, not the namespace it was reached through:
+        // `cdk.aws_s3.Bucket` is "Bucket", and the cdk message interpolates
+        // that into `Cfn<name>.CFN_RESOURCE_TYPE_NAME`.
+        const target = unwrapWrappers(node.right);
+        const name =
+          target.type === "MemberExpression" && target.property.type === "Identifier"
+            ? target.property.name
+            : root.name;
+
+        // Report on the class reference, not the whole expression: the fix
+        // replaces the right-hand side, and a narrow squiggle points at it.
+        ctx.report({
+          node: node.right,
+          messageId: isCdkSource(source) ? "cdkClass" : "ownClass",
+          data: { name, source },
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/test/rules/no-realm-bound-instanceof.test.ts
+++ b/packages/eslint-plugin/test/rules/no-realm-bound-instanceof.test.ts
@@ -1,0 +1,118 @@
+import { rule } from "../../src/rules/no-realm-bound-instanceof.js";
+import { ruleTester } from "../rule-tester.js";
+
+ruleTester.run("no-realm-bound-instanceof", rule, {
+  valid: [
+    {
+      // Intrinsics are shared across realms — the dual-package hazard cannot
+      // duplicate them. This is the live case in @composurecdk/cloudwatch's
+      // policy-matcher, which must keep working.
+      name: "an intrinsic global",
+      code: `const matched = matcher instanceof RegExp;`,
+    },
+    {
+      // The class and every `new` of it come from one evaluation of this
+      // module, so there is no second copy to fail against.
+      name: "a class declared in the same module",
+      code: `
+        class Local {}
+        const ok = value instanceof Local;
+      `,
+    },
+    {
+      // Scope-aware: the parameter shadows the import, so this reads the
+      // parameter, exactly as the runtime would.
+      name: "a local binding that shadows an import name",
+      code: `
+        import { Bucket } from "aws-cdk-lib/aws-s3";
+        function check(Bucket: unknown, value: unknown) {
+          return value instanceof Bucket;
+        }
+      `,
+    },
+    {
+      // A call breaks the chain: this reads a runtime value, not the import.
+      name: "a call breaks the chain to the import",
+      code: `
+        import * as cdk from "aws-cdk-lib";
+        const ok = value instanceof cdk.getClass().Bucket;
+      `,
+    },
+    {
+      name: "instanceof is not involved at all",
+      code: `
+        import { Bucket } from "aws-cdk-lib/aws-s3";
+        const b = new Bucket(scope, "B");
+      `,
+    },
+  ],
+  invalid: [
+    {
+      // #384: the realm-bound dedup that collided on a construct id.
+      name: "a named aws-cdk-lib import",
+      code: `
+        import { ResourcePolicy } from "aws-cdk-lib/aws-logs";
+        if (existing instanceof ResourcePolicy) return existing;
+      `,
+      errors: [{ messageId: "cdkClass", data: { name: "ResourcePolicy" } }],
+    },
+    {
+      name: "an aws-cdk-lib root import",
+      code: `
+        import { Stack } from "aws-cdk-lib";
+        const ok = value instanceof Stack;
+      `,
+      errors: [{ messageId: "cdkClass", data: { name: "Stack" } }],
+    },
+    {
+      // Reached through a namespace: the diagnostic must name the class, not
+      // the namespace the chain is rooted at.
+      name: "a namespaced aws-cdk-lib import",
+      code: `
+        import * as cdk from "aws-cdk-lib";
+        const ok = value instanceof cdk.aws_s3.Bucket;
+      `,
+      errors: [{ messageId: "cdkClass", data: { name: "Bucket" } }],
+    },
+    {
+      // #385: the relative import. This is the case that makes "relative means
+      // same realm" wrong — each copy of the package resolves it separately.
+      name: "a relative import of our own class",
+      code: `
+        import { StatementBuilder } from "./statement-builder.js";
+        const built = s instanceof StatementBuilder ? s.build() : s;
+      `,
+      errors: [
+        {
+          messageId: "ownClass",
+          data: { name: "StatementBuilder", source: "./statement-builder.js" },
+        },
+      ],
+    },
+    {
+      name: "a sibling @composurecdk package import",
+      code: `
+        import { Ref } from "@composurecdk/core";
+        const ok = value instanceof Ref;
+      `,
+      errors: [{ messageId: "ownClass", data: { name: "Ref", source: "@composurecdk/core" } }],
+    },
+    {
+      // The TS-only wrappers must not smuggle the check past the rule.
+      name: "an import behind a TS assertion",
+      code: `
+        import { Bucket } from "aws-cdk-lib/aws-s3";
+        const ok = value instanceof (Bucket as any);
+      `,
+      errors: [{ messageId: "cdkClass" }],
+    },
+    {
+      name: "an aliased import",
+      code: `
+        import { Bucket as S3Bucket } from "aws-cdk-lib/aws-s3";
+        const ok = value instanceof S3Bucket;
+      `,
+      errors: [{ messageId: "cdkClass", data: { name: "S3Bucket" } }],
+    },
+  ],
+});

--- a/packages/examples/src/clean-desk-policy.ts
+++ b/packages/examples/src/clean-desk-policy.ts
@@ -1,6 +1,7 @@
 import {
   Aspects,
   CfnDeletionPolicy,
+  CfnResource,
   Duration,
   PropertyInjectors,
   RemovalPolicy,
@@ -168,35 +169,52 @@ class KeyRemovalPolicyInjector implements IPropertyInjector {
  */
 const DISABLE_LOGGING_CR_ID = "CleanDeskDisableLogging";
 
+/**
+ * Recognise an S3 bucket L2 by its L1's `cfnResourceType`.
+ *
+ * Deliberately not `instanceof Bucket`, which is realm-bound and is banned by
+ * the `composurecdk/no-realm-bound-instanceof` rule: an Aspect visits whatever
+ * is in the tree, including buckets built by another realm's copy of
+ * aws-cdk-lib (ADR-0007), and `instanceof` would silently skip those — leaving
+ * exactly the delete-order race this Aspect exists to prevent. Reading the L1's
+ * resource type is the jsii-safe idiom (ADR-0011).
+ */
+function asBucket(node: IConstruct): Bucket | undefined {
+  const l1 = node.node.defaultChild;
+  if (!CfnResource.isCfnResource(l1)) return undefined;
+  if (l1.cfnResourceType !== CfnBucket.CFN_RESOURCE_TYPE_NAME) return undefined;
+  return node as Bucket;
+}
+
 class DisableSourceLoggingOnDeleteAspect implements IAspect {
   visit(node: IConstruct): void {
-    if (!(node instanceof Bucket)) return;
+    const bucket = asBucket(node);
+    if (!bucket) return;
 
-    const cfn = node.node.defaultChild as CfnBucket | undefined;
-    if (!cfn) return;
+    const cfn = bucket.node.defaultChild as CfnBucket;
     if (cfn.cfnOptions.deletionPolicy !== CfnDeletionPolicy.DELETE) return;
 
     const logging = cfn.loggingConfiguration as CfnBucket.LoggingConfigurationProperty | undefined;
     if (!logging?.destinationBucketName) return;
 
-    const logsBucket = resolveLogsBucketInStack(node, logging.destinationBucketName);
+    const logsBucket = resolveLogsBucketInStack(bucket, logging.destinationBucketName);
     if (!logsBucket) return;
 
-    if (node.node.tryFindChild(DISABLE_LOGGING_CR_ID)) return;
+    if (bucket.node.tryFindChild(DISABLE_LOGGING_CR_ID)) return;
 
-    const disableLoggingCr = new AwsCustomResource(node, DISABLE_LOGGING_CR_ID, {
+    const disableLoggingCr = new AwsCustomResource(bucket, DISABLE_LOGGING_CR_ID, {
       resourceType: "Custom::DisableBucketLogging",
       onDelete: {
         service: "S3",
         action: "putBucketLogging",
         parameters: {
-          Bucket: node.bucketName,
+          Bucket: bucket.bucketName,
           BucketLoggingStatus: {},
         },
-        physicalResourceId: PhysicalResourceId.of(`${node.node.addr}-disable-logging`),
+        physicalResourceId: PhysicalResourceId.of(`${bucket.node.addr}-disable-logging`),
         ignoreErrorCodesMatching: "NoSuchBucket",
       },
-      policy: AwsCustomResourcePolicy.fromSdkCalls({ resources: [node.bucketArn] }),
+      policy: AwsCustomResourcePolicy.fromSdkCalls({ resources: [bucket.bucketArn] }),
       installLatestAwsSdk: false,
     });
 
@@ -206,7 +224,7 @@ class DisableSourceLoggingOnDeleteAspect implements IAspect {
     // CDK wires `autoDeleteObjects: true` as a child construct with id
     // "AutoDeleteObjectsCustomResource" — fragile if CDK renames it, but this
     // is sandbox-only and regressions surface at synth-time in the tests.
-    const sourceAutoDelete = node.node.tryFindChild("AutoDeleteObjectsCustomResource");
+    const sourceAutoDelete = bucket.node.tryFindChild("AutoDeleteObjectsCustomResource");
     if (sourceAutoDelete) {
       disableLoggingCr.node.addDependency(sourceAutoDelete);
     }
@@ -230,10 +248,10 @@ function resolveLogsBucketInStack(
   const destinationToken = JSON.stringify(stack.resolve(destinationBucketName));
 
   for (const candidate of stack.node.findAll()) {
-    if (!(candidate instanceof Bucket)) continue;
-    if (candidate === source) continue;
-    if (JSON.stringify(stack.resolve(candidate.bucketName)) === destinationToken) {
-      return candidate;
+    const bucket = asBucket(candidate);
+    if (!bucket || bucket === source) continue;
+    if (JSON.stringify(stack.resolve(bucket.bucketName)) === destinationToken) {
+      return bucket;
     }
   }
   return undefined;


### PR DESCRIPTION
## What & why

The follow-up flagged in #391 and #392. ADR-0007 has required cross-realm identity checks to use a `Symbol.for(...)` brand rather than `instanceof` since the dual ESM/CJS work — but only in prose. Nothing enforced it, and it recurred twice: #384 (a stack-singleton dedup silently skipped, colliding on a construct id) and #385 (an unrecognised `StatementBuilder`, which skipped the wildcard-resource security guard). Both were found by reading, not by a gate. ADR-0007's own enforcement table listed five mechanisms and none of them caught this.

`composurecdk/no-realm-bound-instanceof` flags `instanceof` against any class reached through an import. When both copies of a package load in one process, each has its own class objects, so the check returns `false` for a value plainly of that type.

**Relative imports count.** A relative specifier is not a same-realm guarantee — `./statement-builder.js` resolves separately in each copy of the package, which is exactly how #385 happened. A rule watching only bare specifiers would have missed the worse of the two bugs.

**Globals and same-module classes are not flagged.** Intrinsics resolve to no import binding, and a class declared in the module is one evaluation with every `new` of it. That keeps `matcher instanceof RegExp` in `@composurecdk/cloudwatch` valid — the shape most likely to be a false positive.

**The diagnostic differs by what was imported, because the right fix does.** An `aws-cdk-lib` class points at the L1 `cfnResourceType` idiom (ADR-0011); one of ours points at the `Symbol.for(...)` brand. Both are the remediations #391 and #392 actually applied.

### Verified against the bugs it exists to prevent

Reverting either fix makes the rule fire on that exact line, with the right advice for its kind:

```
route53/src/query-logging.ts
  128:27  error  `instanceof ResourcePolicy` is realm-bound and silently returns false across
                 the ESM/CJS copy boundary (ADR-0007). Identify the construct by its L1 instead:
                 `CfnResource.isCfnResource` + `cfnResourceType ===
                 CfnResourcePolicy.CFN_RESOURCE_TYPE_NAME` (ADR-0011)

iam/src/role-builder.ts
  192:22  error  `instanceof StatementBuilder` is realm-bound — `./statement-builder.js` can load
                 twice in one process (ADR-0007). Brand the class with `Symbol.for(...)` and test
                 that instead, as `isRef` in @composurecdk/core does
```

### Also in this PR

- **The two sites it surfaces in `packages/examples`.** `clean-desk-policy.ts` used `instanceof Bucket` inside an Aspect. An Aspect visits whatever is in the tree, so a bucket from another realm's copy of aws-cdk-lib would have been skipped — leaving exactly the delete-order race the Aspect exists to prevent. Now identified by L1 type via an `asBucket` helper, matching `findExistingLogGroup`/`findExistingResourcePolicy` in `@composurecdk/route53`. The package's existing tests pass unchanged.
- **Shared import resolution.** The scope-aware resolver and member-chain walk move to `rules/lib/imports.ts`, shared with `no-cdk-api-above-floor`, which grew them first. Two copies of that walk would have drifted, and both carry the same subtle notes about empty `defs` and `import = require()`. That rule's behaviour is unchanged and its tests still pass.
- **Docs**: a row in ADR-0007's enforcement table (the gap this closes), the plugin README's rule table, and the `AGENTS.md` bullet that stated the invariant with nothing behind it.

### Base

Both prerequisite fixes are now on `main` (#391 and #392), and `main` has been merged in — the README rule table needed combining with the row #398 added. This diff is now just the rule, the `examples` fix, the shared extraction, and the docs.

### Noted, not done

The "recognise an L2 by its L1's `cfnResourceType`" idiom is now hand-rolled in four places (route53 ×2, examples, cloudwatch's `policy-matcher`). A shared `isL2OfType(node, type)` would collapse them, but `@composurecdk/core` deliberately has no `aws-cdk-lib` peer dep, so it needs a home — worth a follow-up issue rather than widening this PR.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix) — follow-up to #384/#385, raised in both PRs
- [x] `npm run verify` passes locally — including `actionlint`, now that #368 takes shellcheck from `PATH`
- [x] Tests added/updated for the change — 12 `RuleTester` cases covering both `messageId`s, the valid shapes (intrinsics, same-module classes, shadowing locals, chain-breaking calls), and the resolution edges (namespaced, aliased, TS-assertion-wrapped)
- [x] If it adds an example stack: n/a