### PR TITLE
chore(release): v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 0.9.4 (2026-08-15)
+
+### 🚀 Features
+
+- **eslint-plugin:** add lifecycle-build-must-forward-context ([#398](https://github.com/laazyj/composureCDK/pull/398))
+- **examples:** encrypt the crud-api table with a composed customer-managed key ([#383](https://github.com/laazyj/composureCDK/pull/383))
+- **kms:** add @composurecdk/kms and widen key-consuming props to Resolvable ([#375](https://github.com/laazyj/composureCDK/pull/375), [#373](https://github.com/laazyj/composureCDK/issues/373))
+- **lambda:** widen environmentEncryption to Resolvable so a composed CMK can be referenced ([#387](https://github.com/laazyj/composureCDK/pull/387), [#379](https://github.com/laazyj/composureCDK/issues/379))
+- **neptune:** widen kmsKey to Resolvable so a composed CMK can be referenced ([#389](https://github.com/laazyj/composureCDK/pull/389), [#380](https://github.com/laazyj/composureCDK/issues/380))
+- **route53:** add consumer-side hostedZoneGrants.delegation ([#376](https://github.com/laazyj/composureCDK/pull/376), [#374](https://github.com/laazyj/composureCDK/issues/374))
+- **route53:** add a CrossAccountZoneDelegationRecord builder ([#381](https://github.com/laazyj/composureCDK/pull/381), [#378](https://github.com/laazyj/composureCDK/issues/378))
+
+### 🩹 Fixes
+
+- **apigateway:** forward the build context to the access-log sub-builder ([#396](https://github.com/laazyj/composureCDK/pull/396))
+- **cloudfront:** pass the build context to the access-log sub-builder ([#395](https://github.com/laazyj/composureCDK/pull/395))
+- **ec2:** pass the build context to the flow-log and endpoint sub-builders ([#393](https://github.com/laazyj/composureCDK/pull/393))
+- **iam:** brand StatementBuilder so the wildcard guard survives a realm crossing ([#392](https://github.com/laazyj/composureCDK/pull/392), [#385](https://github.com/laazyj/composureCDK/issues/385))
+- **route53:** pass the build context to the query-log sub-builder ([#390](https://github.com/laazyj/composureCDK/pull/390))
+- **route53:** dedup the shared query-logging policy by L1 type, not instanceof ([#391](https://github.com/laazyj/composureCDK/pull/391), [#381](https://github.com/laazyj/composureCDK/issues/381), [#384](https://github.com/laazyj/composureCDK/issues/384))
+- **s3:** pass the build context to the access-log sub-builder ([#394](https://github.com/laazyj/composureCDK/pull/394))
+- **scripts:** restore the workspace after a local cdk-floors enforce ([#367](https://github.com/laazyj/composureCDK/pull/367))
+
+### 💀 Thank You
+
+- Jason Duffett
+
 ## 0.9.3 (2026-08-04)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -2672,7 +2672,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2690,7 +2689,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2708,7 +2706,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2726,7 +2723,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2744,7 +2740,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2762,7 +2757,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2780,7 +2774,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2798,7 +2791,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2816,7 +2808,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2834,7 +2825,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2852,7 +2842,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2870,7 +2859,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2885,7 +2873,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
@@ -2902,7 +2889,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -2922,7 +2908,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2940,7 +2925,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2958,7 +2942,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5450,7 +5433,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -6151,7 +6133,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6173,7 +6154,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6195,7 +6175,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6217,7 +6196,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6239,7 +6217,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6261,7 +6238,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6283,7 +6259,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6305,7 +6280,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6327,7 +6301,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6349,7 +6322,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6371,7 +6343,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8904,24 +8875,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -9148,7 +9101,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9170,7 +9123,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9193,7 +9146,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9215,7 +9168,7 @@
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9235,7 +9188,7 @@
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9258,7 +9211,7 @@
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9278,7 +9231,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -9297,7 +9250,7 @@
     },
     "packages/custom-resources": {
       "name": "@composurecdk/custom-resources",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9317,7 +9270,7 @@
     },
     "packages/dynamodb": {
       "name": "@composurecdk/dynamodb",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9339,7 +9292,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9362,7 +9315,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/estree": "^1.0.6",
@@ -9378,7 +9331,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9399,7 +9352,7 @@
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9433,7 +9386,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9454,7 +9407,7 @@
     },
     "packages/kms": {
       "name": "@composurecdk/kms",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9476,7 +9429,7 @@
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@composurecdk/iam": "^0.9.0",
@@ -9501,7 +9454,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9522,7 +9475,7 @@
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9561,7 +9514,7 @@
     },
     "packages/neptune": {
       "name": "@composurecdk/neptune",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9585,7 +9538,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9608,7 +9561,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9631,7 +9584,7 @@
     },
     "packages/ses": {
       "name": "@composurecdk/ses",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9652,7 +9605,7 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9674,7 +9627,7 @@
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/custom-resources/package.json
+++ b/packages/custom-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/custom-resources",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Compose-native AwsCustomResource builder for AWS operations with no CloudFormation resource",
   "repository": {
     "type": "git",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/dynamodb",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable DynamoDB table builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/kms/package.json
+++ b/packages/kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/kms",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable AWS KMS customer-managed key builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/neptune",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable Amazon Neptune cluster builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ses",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Compose-native builders for AWS SES — email identities, receipt rule sets, filters, and rule actions",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.9.4**.

Generated by `release-prepare` workflow run [#31900540490](https://github.com/laazyj/composureCDK/actions/runs/31900540490).

## Merge checklist

- [ ] CI is green
- [ ] **Deploy Test** is green — it deploys this branch's examples to the sandbox and smoke-tests them
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow pushes tag `v0.9.4`, which triggers `release.yml` (GitHub Release → npm publish). Neither re-runs the deploy — merging this PR is the release decision.