### PR TITLE
fix(events): read RuleBuilderProps.eventBus type from CDK's own prop

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -31,7 +31,7 @@
     },
     "events": {
       "floor": "2.93.0",
-      "gatedBy": "Annotations.addWarningV2 reached transitively via @composurecdk/cloudwatch's alarm-threshold-basis.ts (introduced 2.93.0); also aws-stepfunctions.DefinitionBody used by target-helpers.test (2.85.0) and Match.stringLikeRegexp used by rule-alarms.test (2.9.0). Note RuleBuilderProps.eventBus deliberately re-declares the prop as Resolvable<NonNullable<RuleProps[\"eventBus\"]>> rather than naming a bus interface: CDK widened this prop from events.IEventBus to events.IEventBusRef in 2.235.0, so IEventBus narrows what a consumer above that release can pass and IEventBusRef does not exist at this floor. Do not 'simplify' it to either interface without raising the floor — `enforce` runs the unit suite, which does not typecheck, so nothing catches it here"
+      "gatedBy": "Annotations.addWarningV2 reached transitively via @composurecdk/cloudwatch's alarm-threshold-basis.ts (introduced 2.93.0); also aws-stepfunctions.DefinitionBody used by target-helpers.test (2.85.0) and Match.stringLikeRegexp used by rule-alarms.test (2.9.0). Note RuleBuilderProps.eventBus deliberately re-declares the prop as Resolvable<NonNullable<RuleProps[\"eventBus\"]>> rather than naming a bus interface: CDK widened this prop from events.IEventBus to events.IEventBusRef in 2.235.0, so IEventBus narrows what a consumer above that release can pass and IEventBusRef does not exist at this floor. Do not 'simplify' it to either interface without raising the floor; the type-level guard in test/rule-builder.test.ts is what catches that, at typecheck time"
     },
     "budgets": {
       "floor": "2.93.0",

--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -31,7 +31,7 @@
     },
     "events": {
       "floor": "2.93.0",
-      "gatedBy": "Annotations.addWarningV2 reached transitively via @composurecdk/cloudwatch's alarm-threshold-basis.ts (introduced 2.93.0); also aws-stepfunctions.DefinitionBody used by target-helpers.test (2.85.0) and Match.stringLikeRegexp used by rule-alarms.test (2.9.0)"
+      "gatedBy": "Annotations.addWarningV2 reached transitively via @composurecdk/cloudwatch's alarm-threshold-basis.ts (introduced 2.93.0); also aws-stepfunctions.DefinitionBody used by target-helpers.test (2.85.0) and Match.stringLikeRegexp used by rule-alarms.test (2.9.0). Note RuleBuilderProps.eventBus deliberately re-declares the prop as Resolvable<NonNullable<RuleProps[\"eventBus\"]>> rather than naming a bus interface: CDK widened this prop from events.IEventBus to events.IEventBusRef in 2.235.0, so IEventBus narrows what a consumer above that release can pass and IEventBusRef does not exist at this floor. Do not 'simplify' it to either interface without raising the floor — `enforce` runs the unit suite, which does not typecheck, so nothing catches it here"
     },
     "budgets": {
       "floor": "2.93.0",

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -23,7 +23,7 @@ Every [RuleProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ev
 
 ### Cross-component event bus
 
-The `eventBus` property accepts a `Resolvable<IEventBus>` so the rule can attach to a custom bus built by another component:
+The `eventBus` property accepts a concrete bus or a `Ref` to one, so the rule can attach to a custom bus built by another component:
 
 ```ts
 import { compose, ref } from "@composurecdk/core";
@@ -40,6 +40,8 @@ compose(
 ```
 
 When omitted, the rule attaches to the account default bus, matching CDK's `RuleProps.eventBus` default.
+
+The prop's inner type is read from CDK's own `RuleProps.eventBus` rather than pinned to `IEventBus`, so it accepts whatever the `aws-cdk-lib` you have installed accepts — including the broader [`events.IEventBusRef`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.IEventBusRef.html) where CDK has widened the prop.
 
 ## Recommended Alarms
 
@@ -179,6 +181,8 @@ This package ships small free-function helpers that wrap the corresponding [`aws
 | `sfnStateMachineTarget`    | `SfnStateMachine`    | `IStateMachine`     |
 | `eventBusTarget`           | `EventBus`           | `IEventBus`         |
 | `cloudWatchLogGroupTarget` | `CloudWatchLogGroup` | `ILogGroup`         |
+
+`eventBusTarget` is pinned to `IEventBus`, because CDK's own `EventBus` target still is, so a bus that is only an `IEventBusRef` reaches a rule's `eventBus` but not a target.
 
 The second argument is the matching CDK target props type (`LambdaFunctionProps`, `SqsQueueProps`, …) — refer to the CDK docs for available options. Common ones include `deadLetterQueue` (concrete `IQueue`), `retryAttempts`, `maxEventAge`, and target-specific input transforms (`event` / `input` / `message`).
 

--- a/packages/events/src/rule-builder.ts
+++ b/packages/events/src/rule-builder.ts
@@ -1,11 +1,5 @@
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
-import {
-  type IEventBus,
-  type IRule,
-  type IRuleTarget,
-  Rule,
-  type RuleProps,
-} from "aws-cdk-lib/aws-events";
+import { type IRule, type IRuleTarget, Rule, type RuleProps } from "aws-cdk-lib/aws-events";
 import { type IConstruct } from "constructs";
 import {
   Builder,
@@ -31,12 +25,16 @@ import { createRuleAlarms } from "./rule-alarms.js";
  */
 export interface RuleBuilderProps extends Omit<RuleProps, "targets" | "eventBus"> {
   /**
-   * The event bus the rule listens on. Accepts a concrete {@link IEventBus} or
-   * a {@link Ref} to another component's output. When omitted, the rule
+   * The event bus the rule listens on. Accepts a concrete bus or a
+   * {@link Ref} to another component's output. When omitted, the rule
    * attaches to the account default bus, matching CDK's `RuleProps.eventBus`
    * default.
+   *
+   * The inner type is read from CDK's own prop rather than named as
+   * `IEventBus`, so it tracks the `events.IEventBus` → `events.IEventBusRef`
+   * migration in either direction — see the note in this package's README.
    */
-  eventBus?: Resolvable<IEventBus>;
+  eventBus?: Resolvable<NonNullable<RuleProps["eventBus"]>>;
 
   /**
    * Configuration for AWS-recommended CloudWatch alarms.

--- a/packages/events/test/rule-builder.test.ts
+++ b/packages/events/test/rule-builder.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { App, Duration, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { EventBus, Schedule } from "aws-cdk-lib/aws-events";
+import { EventBus, type RuleProps, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { Code, Function as LambdaFn, Runtime } from "aws-cdk-lib/aws-lambda";
 import { ref } from "@composurecdk/core";
-import { createRuleBuilder } from "../src/rule-builder.js";
+import { createRuleBuilder, type RuleBuilderProps } from "../src/rule-builder.js";
 
 function newStack(): Stack {
   return new Stack(new App(), "TestStack");
@@ -147,8 +147,20 @@ describe("RuleBuilder", () => {
     });
   });
 
+  describe("props", () => {
+    it("accept everything CDK's own RuleProps accepts, bar targets (type-level guard)", () => {
+      // Every re-declared prop must widen what CDK takes, never narrow it:
+      // pinning `eventBus` to `IEventBus` rejected a bus CDK itself takes,
+      // once CDK widened `RuleProps.eventBus` to `IEventBusRef` in 2.235.0.
+      // Asserted over the whole interface so a prop re-declared later — CDK
+      // has widened `role` the same way — cannot reintroduce the narrowing.
+      const props: RuleBuilderProps = undefined as unknown as Omit<RuleProps, "targets">;
+      void props;
+    });
+  });
+
   describe("eventBus", () => {
-    it("resolves a Resolvable<IEventBus> from the compose context", () => {
+    it("resolves a Resolvable event bus from the compose context", () => {
       const stack = newStack();
       const fn = makeFn(stack);
       const bus = new EventBus(stack, "Bus", { eventBusName: "my-bus" });

--- a/packages/events/test/rule-builder.test.ts
+++ b/packages/events/test/rule-builder.test.ts
@@ -154,7 +154,10 @@ describe("RuleBuilder", () => {
       // once CDK widened `RuleProps.eventBus` to `IEventBusRef` in 2.235.0.
       // Asserted over the whole interface so a prop re-declared later — CDK
       // has widened `role` the same way — cannot reintroduce the narrowing.
-      const props: RuleBuilderProps = undefined as unknown as Omit<RuleProps, "targets">;
+      // Structural assignment ignores `targets`, which the builder replaces
+      // outright, so it needs no exemption here — and a prop that is merely
+      // widened must never be given one.
+      const props: RuleBuilderProps = undefined as unknown as RuleProps;
       void props;
     });
   });

--- a/packages/events/test/targets/target-helpers.test.ts
+++ b/packages/events/test/targets/target-helpers.test.ts
@@ -7,6 +7,7 @@ import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import { DefinitionBody, Pass, StateMachine } from "aws-cdk-lib/aws-stepfunctions";
+import { EventBus as EventBusTarget } from "aws-cdk-lib/aws-events-targets";
 import { isRef, ref } from "@composurecdk/core";
 import { createRuleBuilder } from "../../src/rule-builder.js";
 import { lambdaTarget } from "../../src/targets/lambda-target.js";
@@ -226,6 +227,16 @@ describe("target helpers", () => {
           Statement: Match.arrayWith([Match.objectLike({ Action: "events:PutEvents" })]),
         }),
       });
+    });
+
+    it("accepts every bus CDK's own EventBus target accepts (type-level guard)", () => {
+      // The helper is pinned to `IEventBus` because CDK's target still is.
+      // If CDK widens the target the way it widened `RuleProps.eventBus` in
+      // 2.235.0, this stops compiling — the pin, and the README note about
+      // it, become the narrowing that issue #401 was about.
+      const bus: Parameters<typeof eventBusTarget>[0] =
+        undefined as unknown as ConstructorParameters<typeof EventBusTarget>[0];
+      void bus;
     });
 
     it("returns a Ref<IRuleTarget> for a Ref<IEventBus> and synths the rule", () => {


### PR DESCRIPTION
## What & why

Closes #401. Sibling of #411 (which fixes #402 the same way in `@composurecdk/cloudfront`).

`RuleBuilderProps` re-declares `eventBus` to widen it to `Resolvable`, and pinned the inner type to the L2 interface:

```ts
eventBus?: Resolvable<IEventBus>;
```

CDK widened `RuleProps.eventBus` from `IEventBus` to the broader `IEventBusRef` in **aws-cdk-lib 2.235.0**, as part of the reference-interfaces migration. I confirmed the boundary against real installs: 2.234.0 has `readonly eventBus?: IEventBus`, 2.235.0 has `readonly eventBus?: IEventBusRef`. Since `IEventBus extends IResource, IEventBusRef`, the builder accepted strictly *less* than the CDK construct it wraps — a `CfnEventBus`, or a reference from the L1 static importers, was rejected by the builder and accepted by `new Rule(...)`, with no workaround but a cast.

The prop now names neither interface and reads the type from the consumer's own `aws-cdk-lib`, the same shape `lambda`'s `environmentEncryption` and `logs`' `encryptionKey` use:

```ts
eventBus?: Resolvable<NonNullable<RuleProps["eventBus"]>>;
```

It resolves to `Resolvable<IEventBus>` at the package's 2.93.0 floor (where `IEventBusRef` does not exist) and `Resolvable<IEventBusRef>` above 2.235.0. Verified by typechecking the declaration against real installs at both ends.

### The guard

Nothing caught this because the class of defect is type-level — vitest does not typecheck, and `typecheck` runs against the latest devDependency, where the narrow spelling still compiles. So the guard is a typechecked assertion over the **whole props interface** rather than this one prop:

```ts
const props: RuleBuilderProps = undefined as unknown as RuleProps;
```

CDK has widened `RuleProps.role` the same way, so a prop re-declared later must not be able to reintroduce the narrowing on a prop a per-prop guard would not be watching. Structural assignment already ignores `targets`, which the builder replaces outright, so there is no exemption list to keep in sync — and none to weaken instead of fixing a future narrowing. Re-pinning `eventBus` to `IEventBus` fails the guard with `Type 'RuleProps' is not assignable to type 'RuleBuilderProps'` — checked by reverting the fix locally.

The guard runs at every floor, not just at head: nx's `test` target depends on `typecheck`, `cdk-floors enforce` runs the test target, and this package's tsconfig includes `test`.

A second guard in `target-helpers.test.ts` pins `eventBusTarget` to CDK's own `EventBus` target constructor. That helper stays `IEventBus` deliberately — CDK's target has not moved — but the README now says so, and this makes that claim fail to compile the day it stops being true rather than rot silently.

The events floor is unchanged at 2.93.0 and `cdk-floors check` stays green; its manifest entry now records the deliberate spelling, following `logs`, `lambda` and `neptune`, and names the guard rather than repeating their "nothing catches it here" clause, which predates the `test` → `typecheck` dependency.

No runtime behaviour changes — `build()` still resolves and forwards the prop exactly as before.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a