### PR TITLE
fix(cloudfront): read certificate and keyValueStore types from CDK's own props

### DIFF
--- a/cdk-floors.json
+++ b/cdk-floors.json
@@ -51,7 +51,7 @@
     },
     "cloudfront": {
       "floor": "2.124.0",
-      "gatedBy": "aws-cloudfront.FunctionProps.keyValueStore association wiring (introduced 2.124.0); also peers @composurecdk/s3 at 2.123.0. Builder tags reaching CloudFront Functions degrade gracefully below 2.251.0 and are not floor-gating."
+      "gatedBy": "aws-cloudfront.FunctionProps.keyValueStore association wiring (introduced 2.124.0); also peers @composurecdk/s3 at 2.123.0. Builder tags reaching CloudFront Functions degrade gracefully below 2.251.0 and are not floor-gating. Note DistributionBuilderProps.certificate and InlineFunctionDefinition.keyValueStore deliberately re-declare their props as NonNullable<DistributionProps[\"certificate\"]> and NonNullable<FunctionProps[\"keyValueStore\"]> rather than naming an interface: CDK widened both in 2.235.0 — acm.ICertificate to acm.ICertificateRef, IKeyValueStore to IKeyValueStoreRef — so the L2 interface narrows what a consumer above that release can pass and the Ref interface does not exist at this floor. Do not 'simplify' either to an interface without raising the floor; the type-level guards in test/distribution-builder.test.ts are what catch that, at typecheck time."
     },
     "acm": {
       "floor": "2.119.0",

--- a/packages/cloudfront/README.md
+++ b/packages/cloudfront/README.md
@@ -33,6 +33,8 @@ const cdn = createDistributionBuilder().origin(
 compose({ site: createBucketBuilder(), cdn }, { site: [], cdn: ["site"] }).build(stack, "Website");
 ```
 
+`.certificate(...)` takes a `Ref` the same way, so an [`@composurecdk/acm`](../acm/README.md) certificate (issued in `us-east-1`) can be a component of the same system. Its inner type is read from CDK's own `DistributionProps.certificate` rather than pinned to `ICertificate`, so it accepts whatever the `aws-cdk-lib` you have installed accepts — including the broader [`acm.ICertificateRef`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager.ICertificateRef.html) where CDK has widened the prop.
+
 ## Secure Defaults
 
 `createDistributionBuilder` applies the following defaults. Each can be overridden via the builder's fluent API.

--- a/packages/cloudfront/src/distribution-builder.ts
+++ b/packages/cloudfront/src/distribution-builder.ts
@@ -1,16 +1,14 @@
 import {
   Distribution,
   type DistributionProps,
-  type IOrigin,
   type AddBehaviorOptions,
   type BehaviorOptions,
   type Function as CfFunction,
   type FunctionCode,
   type FunctionEventType,
+  type FunctionProps,
   type FunctionRuntime,
-  type IKeyValueStore,
 } from "aws-cdk-lib/aws-cloudfront";
-import { type ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 import { type Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { type Bucket, type IBucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
 import { RemovalPolicy } from "aws-cdk-lib";
@@ -97,8 +95,13 @@ export interface InlineFunctionDefinition {
   /**
    * Key-value store to associate with the function. Only supported on the
    * `cloudfront-js-2.0` runtime.
+   *
+   * Read from CDK's own prop rather than named as `IKeyValueStore`, so it
+   * tracks the `IKeyValueStore` → `IKeyValueStoreRef` migration in either
+   * direction, the same way {@link DistributionBuilderProps.certificate}
+   * does.
    */
-  keyValueStore?: IKeyValueStore;
+  keyValueStore?: NonNullable<FunctionProps["keyValueStore"]>;
 
   /**
    * Per-function alarm configuration. Defaults to the three AWS-recommended
@@ -138,15 +141,15 @@ export interface DefaultBehaviorConfig extends Omit<AddBehaviorOptions, "functio
  * via {@link IDistributionBuilder.behavior}.
  *
  * Unlike {@link DefaultBehaviorConfig}, `origin` is required. It may be a
- * concrete {@link IOrigin} or a {@link Resolvable} (typically a {@link ref})
- * for cross-component wiring.
+ * concrete `IOrigin` or a {@link Resolvable} (typically a {@link ref}) for
+ * cross-component wiring.
  */
 export interface AdditionalBehaviorConfig extends Omit<
   BehaviorOptions,
   "origin" | "functionAssociations"
 > {
   /** The origin for this behavior, concrete or resolved at build time. */
-  origin: Resolvable<IOrigin>;
+  origin: Resolvable<BehaviorOptions["origin"]>;
 
   /**
    * CloudFront Functions to associate with this behavior. At most one
@@ -211,11 +214,16 @@ export interface DistributionBuilderProps extends Omit<
   /**
    * The ACM certificate to associate with the distribution for HTTPS.
    *
-   * Accepts a concrete {@link ICertificate} or a {@link Resolvable} —
-   * typically a {@link Ref} produced by a composed `@composurecdk/acm`
-   * certificate builder. The certificate must be issued in `us-east-1`.
+   * Accepts a concrete certificate or a {@link Ref} to one — typically the
+   * output of a composed `@composurecdk/acm` certificate builder. The
+   * certificate must be issued in `us-east-1`.
+   *
+   * The inner type is read from CDK's own prop rather than named as
+   * `ICertificate`, so it tracks the `acm.ICertificate` →
+   * `acm.ICertificateRef` migration in either direction — see the note in
+   * this package's README.
    */
-  certificate?: Resolvable<ICertificate>;
+  certificate?: Resolvable<NonNullable<DistributionProps["certificate"]>>;
 
   /**
    * Configuration for the default cache behavior. The origin is set via
@@ -316,7 +324,7 @@ export interface DistributionBuilderResult {
  *
  * Properties from CDK {@link DistributionProps} are exposed as overloaded
  * getter/setter methods. The origin is set via {@link origin}, which accepts
- * a concrete {@link IOrigin} or a {@link Ref} for cross-component wiring.
+ * a concrete `IOrigin` or a {@link Ref} for cross-component wiring.
  * Additional cache behaviors are added via {@link behavior}, which takes a
  * path pattern and a config including its own origin and inline functions.
  *
@@ -349,7 +357,7 @@ export type IDistributionBuilder = ITaggedBuilder<DistributionBuilderProps, Dist
 
 class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
   props: Partial<DistributionBuilderProps> = {};
-  #origin?: Resolvable<IOrigin>;
+  #origin?: Resolvable<BehaviorOptions["origin"]>;
   readonly #additionalBehaviors = new Map<string, AdditionalBehaviorConfig>();
   readonly #behaviorSlugs = new Map<string, string>();
   readonly #customAlarms: AlarmDefinitionBuilder<Distribution>[] = [];
@@ -367,13 +375,13 @@ class DistributionBuilder implements Lifecycle<DistributionBuilderResult> {
   /**
    * Sets the default origin for the distribution.
    *
-   * Accepts a concrete {@link IOrigin} or a {@link Ref} that resolves to one
+   * Accepts a concrete `IOrigin` or a {@link Ref} that resolves to one
    * at build time — enabling cross-component wiring with S3 buckets.
    *
    * @param origin - The origin or a Ref to one.
    * @returns This builder for chaining.
    */
-  origin(origin: Resolvable<IOrigin>): this {
+  origin(origin: Resolvable<BehaviorOptions["origin"]>): this {
     this.#origin = origin;
     return this;
   }

--- a/packages/cloudfront/src/resolve-behaviors.ts
+++ b/packages/cloudfront/src/resolve-behaviors.ts
@@ -5,7 +5,6 @@ import {
   type FunctionAssociation,
   type FunctionEventType,
   FunctionRuntime,
-  type IOrigin,
 } from "aws-cdk-lib/aws-cloudfront";
 import type { IConstruct } from "constructs";
 import { resolve } from "@composurecdk/core";
@@ -37,7 +36,7 @@ export interface ResolveBehaviorsInput {
   context: Record<string, object>;
 
   /** The already-resolved default origin. */
-  defaultOrigin: IOrigin;
+  defaultOrigin: BehaviorOptions["origin"];
 
   /** User-provided default-behavior config (may be undefined). */
   defaultBehavior: DefaultBehaviorConfig | undefined;

--- a/packages/cloudfront/test/distribution-builder.test.ts
+++ b/packages/cloudfront/test/distribution-builder.test.ts
@@ -7,6 +7,8 @@ import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import {
   CachePolicy,
   type Distribution,
+  type DistributionProps,
+  type FunctionProps,
   PriceClass,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
@@ -15,7 +17,11 @@ import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { ref } from "@composurecdk/core";
 import { assertCopyPreservesState } from "@composurecdk/core/testing";
 import { type BucketBuilderResult } from "@composurecdk/s3";
-import { createDistributionBuilder } from "../src/distribution-builder.js";
+import {
+  createDistributionBuilder,
+  type DistributionBuilderProps,
+  type InlineFunctionDefinition,
+} from "../src/distribution-builder.js";
 
 function synthTemplate(
   configureFn: (builder: ReturnType<typeof createDistributionBuilder>, stack: Stack) => void,
@@ -34,6 +40,27 @@ function withBucketOrigin(stack: Stack) {
 }
 
 describe("DistributionBuilder", () => {
+  describe("props", () => {
+    it("accept everything CDK's own DistributionProps accepts (type-level guard)", () => {
+      // A re-declared prop must widen what CDK takes, never narrow it: pinning
+      // `certificate` to `ICertificate` rejected a certificate CDK itself
+      // takes, once CDK widened `DistributionProps.certificate` to
+      // `ICertificateRef` in 2.235.0. Asserted over the whole interface, so a
+      // prop re-declared later cannot reintroduce the narrowing. Structural
+      // assignment ignores the props the builder replaces outright, so they
+      // need no exemption here — and a prop that is merely widened must never
+      // be given one.
+      const props: DistributionBuilderProps = undefined as unknown as DistributionProps;
+      void props;
+    });
+
+    it("accept every key-value store CDK's own FunctionProps accepts (type-level guard)", () => {
+      const keyValueStore: NonNullable<InlineFunctionDefinition["keyValueStore"]> =
+        undefined as unknown as NonNullable<FunctionProps["keyValueStore"]>;
+      void keyValueStore;
+    });
+  });
+
   describe("build", () => {
     it("returns a DistributionBuilderResult with a distribution property", () => {
       const app = new App();


### PR DESCRIPTION
## What & why

Closes #402. Sibling of #410 (which fixes #401 the same way in `@composurecdk/events`).

`DistributionBuilderProps` re-declares `certificate` to widen it to `Resolvable`, and pinned the inner type to the L2 interface:

```ts
certificate?: Resolvable<ICertificate>;
```

CDK widened `DistributionProps.certificate` from `acm.ICertificate` to the broader `acm.ICertificateRef` in **aws-cdk-lib 2.235.0** — confirmed against real installs: 2.234.0 has `readonly certificate?: acm.ICertificate`, 2.235.0 has `readonly certificate?: ICertificateRef`. Since `ICertificate extends IResource, ICertificateRef`, the builder accepted strictly *less* than the CDK construct it wraps, with no workaround but a cast.

The prop now names neither interface and reads the type from the consumer's own `aws-cdk-lib`:

```ts
certificate?: Resolvable<NonNullable<DistributionProps["certificate"]>>;
```

It resolves to `Resolvable<ICertificate>` at the package's 2.124.0 floor (where `ICertificateRef` does not exist) and `Resolvable<ICertificateRef>` above 2.235.0. Verified by typechecking the declarations against real installs at both ends.

### One more live instance, in the same package

The issue's audit cleared the rest of cloudfront, but `InlineFunctionDefinition.keyValueStore` has the identical defect and is not a `DistributionProps` re-declaration, so it wasn't in scope of that sweep. CDK widened `FunctionProps.keyValueStore` from `IKeyValueStore` to `IKeyValueStoreRef` in the **same 2.235.0 release**, so a consumer holding a store reference that `new cloudfront.Function(...)` accepts cannot pass it to an inline function declaration. Fixed here alongside `certificate` — same one-line shape, same floor behaviour.

`AdditionalBehaviorConfig.origin`, the `origin()` setter and `ResolveBehaviorsInput.defaultOrigin` are **not** narrowed today (`BehaviorOptions.origin` is still `IOrigin`, as the issue says), but they now read their type from CDK's prop as well. That is a no-op at every version and means the pin cannot silently become the next instance when CDK moves it — cheaper than the guard test it replaces.

### The guard

Nothing caught this because the class of defect is type-level: vitest does not typecheck, and `typecheck` runs against the latest devDependency, where the narrow spelling still compiles. So the guard is a typechecked assertion over the **whole props interface** rather than the one prop:

```ts
const props: DistributionBuilderProps = undefined as unknown as DistributionProps;
```

Structural assignment ignores the props the builder replaces outright (`defaultBehavior`, `logBucket`, …), so there is no exemption list to keep in sync — and no exemption list to weaken instead of fixing a future narrowing. Re-pinning `certificate` fails it with `Type 'DistributionProps' is not assignable to type 'DistributionBuilderProps'`, and re-pinning `keyValueStore` fails the second guard with `Type 'IKeyValueStoreRef | undefined' is not assignable to type 'IKeyValueStore | undefined'` — both checked by reverting the fixes locally.

These run at every floor, not just the latest: nx's `test` target depends on `typecheck`, and `cdk-floors enforce` runs the test target. (Worth noting because the `gatedBy` notes on `logs`, `lambda` and `neptune` say the opposite — "nothing catches it here" — which was true when they were written but no longer is. I left those entries alone; the cloudfront note added here states the current mechanism.)

The cloudfront floor is unchanged at 2.124.0 and `cdk-floors check` stays green. No runtime behaviour changes.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change
- [ ] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLM7Q4TQPHpktWDuVVsx4j)_