### PR TITLE
chore(release): v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.9.5 (2026-08-21)
+
+### 🚀 Features
+
+- **cloudformation:** add templateTextPolicy, an opt-in guard for template text ([14df9b8](https://github.com/laazyj/composureCDK/commit/14df9b8))
+- **eslint-plugin:** ban realm-bound instanceof in dual-published source ([#404](https://github.com/laazyj/composureCDK/pull/404))
+
+### 🩹 Fixes
+
+- **cloudformation:** keep the policy tests inside the 2.1.0 CDK floor ([7bed666](https://github.com/laazyj/composureCDK/commit/7bed666))
+- **cloudfront:** read certificate and keyValueStore types from CDK's own props ([#411](https://github.com/laazyj/composureCDK/pull/411), [#402](https://github.com/laazyj/composureCDK/issues/402))
+- **events:** read RuleBuilderProps.eventBus type from CDK's own prop ([#410](https://github.com/laazyj/composureCDK/pull/410), [#401](https://github.com/laazyj/composureCDK/issues/401))
+
+### 💀 Thank You
+
+- Claude
+- Jason Duffett
+
 ## 0.9.4 (2026-08-15)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -9101,7 +9101,7 @@
     },
     "packages/acm": {
       "name": "@composurecdk/acm",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9123,7 +9123,7 @@
     },
     "packages/apigateway": {
       "name": "@composurecdk/apigateway",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9146,7 +9146,7 @@
     },
     "packages/budgets": {
       "name": "@composurecdk/budgets",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9168,7 +9168,7 @@
     },
     "packages/cloudformation": {
       "name": "@composurecdk/cloudformation",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9188,7 +9188,7 @@
     },
     "packages/cloudfront": {
       "name": "@composurecdk/cloudfront",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9211,7 +9211,7 @@
     },
     "packages/cloudwatch": {
       "name": "@composurecdk/cloudwatch",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9231,7 +9231,7 @@
     },
     "packages/core": {
       "name": "@composurecdk/core",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1"
@@ -9250,7 +9250,7 @@
     },
     "packages/custom-resources": {
       "name": "@composurecdk/custom-resources",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9270,7 +9270,7 @@
     },
     "packages/dynamodb": {
       "name": "@composurecdk/dynamodb",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9292,7 +9292,7 @@
     },
     "packages/ec2": {
       "name": "@composurecdk/ec2",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9315,7 +9315,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@composurecdk/eslint-plugin",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/estree": "^1.0.6",
@@ -9331,7 +9331,7 @@
     },
     "packages/events": {
       "name": "@composurecdk/events",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9352,7 +9352,7 @@
     },
     "packages/examples": {
       "name": "@composurecdk/examples",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9386,7 +9386,7 @@
     },
     "packages/iam": {
       "name": "@composurecdk/iam",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9407,7 +9407,7 @@
     },
     "packages/kms": {
       "name": "@composurecdk/kms",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9429,7 +9429,7 @@
     },
     "packages/lambda": {
       "name": "@composurecdk/lambda",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@composurecdk/iam": "^0.9.0",
@@ -9454,7 +9454,7 @@
     },
     "packages/logs": {
       "name": "@composurecdk/logs",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9475,7 +9475,7 @@
     },
     "packages/module-compat": {
       "name": "@composurecdk/module-compat",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9514,7 +9514,7 @@
     },
     "packages/neptune": {
       "name": "@composurecdk/neptune",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/aws-neptune-alpha": "2.257.0-alpha.0",
@@ -9538,7 +9538,7 @@
     },
     "packages/route53": {
       "name": "@composurecdk/route53",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9561,7 +9561,7 @@
     },
     "packages/s3": {
       "name": "@composurecdk/s3",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9584,7 +9584,7 @@
     },
     "packages/ses": {
       "name": "@composurecdk/ses",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9605,7 +9605,7 @@
     },
     "packages/sns": {
       "name": "@composurecdk/sns",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -9627,7 +9627,7 @@
     },
     "packages/sqs": {
       "name": "@composurecdk/sqs",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",

--- a/packages/acm/package.json
+++ b/packages/acm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/acm",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable AWS Certificate Manager builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/apigateway/package.json
+++ b/packages/apigateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/apigateway",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable API Gateway REST API builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/budgets/package.json
+++ b/packages/budgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/budgets",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable AWS Budgets builder with well-architected defaults and automatic SNS topic policies",
   "repository": {
     "type": "git",

--- a/packages/cloudformation/package.json
+++ b/packages/cloudformation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudformation",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable CloudFormation stack builder and stack assignment strategies",
   "repository": {
     "type": "git",

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudfront",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable CloudFront distribution builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/cloudwatch/package.json
+++ b/packages/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/cloudwatch",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable CloudWatch alarm primitives for composureCDK resource packages",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/core",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable CDK component system — lifecycle, dependency resolution, and builder pattern",
   "repository": {
     "type": "git",

--- a/packages/custom-resources/package.json
+++ b/packages/custom-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/custom-resources",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Compose-native AwsCustomResource builder for AWS operations with no CloudFormation resource",
   "repository": {
     "type": "git",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/dynamodb",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable DynamoDB table builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/ec2/package.json
+++ b/packages/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ec2",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable EC2 instance and VPC builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/eslint-plugin",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Internal ESLint plugin encoding ComposureCDK architectural invariants (tagged builders, lifecycle context, builder copy state).",
   "private": true,
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/events",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable EventBridge rule builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/examples",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Example applications exercising the ComposureCDK public API",
   "private": true,
   "scripts": {

--- a/packages/iam/package.json
+++ b/packages/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/iam",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable IAM role, policy, and statement builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/kms/package.json
+++ b/packages/kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/kms",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable AWS KMS customer-managed key builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/lambda",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable Lambda function builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/logs",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable CloudWatch log group builder with secure defaults",
   "repository": {
     "type": "git",

--- a/packages/module-compat/package.json
+++ b/packages/module-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/module-compat",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Executable consumption tests asserting every @composurecdk/* package resolves under both ESM import and CommonJS require",
   "private": true,
   "repository": {

--- a/packages/neptune/package.json
+++ b/packages/neptune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/neptune",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable Amazon Neptune cluster builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/route53/package.json
+++ b/packages/route53/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/route53",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable Route53 hosted zone and record builders with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/s3",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable S3 bucket builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/ses",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Compose-native builders for AWS SES — email identities, receipt rule sets, filters, and rule actions",
   "repository": {
     "type": "git",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sns",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable SNS topic builder with well-architected defaults",
   "repository": {
     "type": "git",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composurecdk/sqs",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Composable SQS queue builder with well-architected defaults",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release **v0.9.5**.

Generated by `release-prepare` workflow run [#32510098990](https://github.com/laazyj/composureCDK/actions/runs/32510098990).

## Merge checklist

- [ ] CI is green
- [ ] **Deploy Test** is green — it deploys this branch's examples to the sandbox and smoke-tests them
- [ ] Changelog reads correctly
- [ ] Version bumps match expectations

On merge, the `release-tag` workflow pushes tag `v0.9.5`, which triggers `release.yml` (GitHub Release → npm publish). Neither re-runs the deploy — merging this PR is the release decision.