### PR TITLE
feat(cloudformation): check AWS::CloudFront::Function functionCode by default

### DIFF
--- a/packages/cloudformation/README.md
+++ b/packages/cloudformation/README.md
@@ -159,12 +159,15 @@ The stack's own `Description`, every `CfnOutput` / `CfnParameter` description, a
 
 | Resource type                                                                             | Property           |
 | ----------------------------------------------------------------------------------------- | ------------------ |
+| `AWS::CloudFront::Function`                                                               | `functionCode`     |
 | `AWS::CloudWatch::Alarm`, `AWS::CloudWatch::CompositeAlarm`                               | `alarmDescription` |
 | `AWS::Lambda::Function`, `AWS::Events::Rule`, `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` | `description`      |
 | `AWS::ApiGateway::RestApi`, `Stage`, `Deployment`, `UsagePlan`, `ApiKey`                  | `description`      |
 | `AWS::Neptune::DBClusterParameterGroup`, `AWS::Neptune::DBParameterGroup`                 | `description`      |
 | `AWS::EC2::SecurityGroup`                                                                 | `groupDescription` |
 | `AWS::SNS::Topic`                                                                         | `displayName`      |
+
+`functionCode` is the odd one out: a whole JavaScript body rather than a line of prose, so the policy checks a source file. That is deliberate — it is usually the largest block of free text in a template, and often the only one built from external data, such as a redirect map read at synth. It also means a legitimately non-ASCII string literal in a CloudFront Function — a `€` in a redirect target, a non-Latin `Location` header — moves from a silent bad deploy to a synth failure. `"warn"` is the adoption path, and the right long-term mode if you have one of those: `fields` unions with the built-in registry rather than replacing it, so a built-in entry cannot be dropped from config. Avoid `sanitize` on a function body — substituting a `?` into a string literal rewrites deployed source, which is a behaviour change rather than a cosmetic one.
 
 That is a seed list, not the whole of CloudFormation — several hundred resource types declare a free-text property. Add the ones you use:
 
@@ -178,7 +181,7 @@ Keys are CloudFormation resource types; values are **CDK L1 property names** (ca
 
 - Values that resolve to a CloudFormation intrinsic (`Ref`, `Fn::ImportValue`) — the text is not knowable at synth. A `Lazy` that resolves to a plain string **is** checked.
 - Values written through `addPropertyOverride`, or set on a bare `CfnResource`'s `properties`. Both bypass the typed L1 accessor the policy reads.
-- Nested properties such as `DistributionConfig.Comment`.
+- Nested properties such as `DistributionConfig.Comment` and `FunctionConfig.Comment`. CloudFront is covered at `AWS::CloudFront::Function`'s `functionCode` only — the distribution and function `Comment` fields sit inside an object-valued L1 property, so registering `distributionConfig` or a dotted `"distributionConfig.comment"` silently no-ops.
 - Resource types and properties not in the table above, until you add them. A property name that does not match an L1 accessor is skipped silently — the same outcome as not listing it.
 
 To check a single value directly rather than a whole tree, use `constraints.validate.templateText` / `constraints.sanitize.templateText` ([catalogue](../../docs/constraints.md)).

--- a/packages/cloudformation/README.md
+++ b/packages/cloudformation/README.md
@@ -147,6 +147,8 @@ templateTextPolicy(app, {
 });
 ```
 
+One field is not cosmetic: `AWS::CloudFront::Function`'s `functionCode` is executable source, so a `?` substituted into a string literal there is a behaviour change rather than a tidier template. Use `"throw"` or `"warn"` for an estate with CloudFront Functions.
+
 ### Why it is opt-in
 
 Enforcing this inside every builder would turn a working — if diff-noisy — deployment into a synth failure for anyone who has been living with the transliteration. Installing the policy is how you say you would rather know. Constraints whose violation fails the _deploy_ rather than merely the diff, such as an EC2 `GroupDescription`, stay enforced at the builder regardless ([ADR-0010](../../docs/adr/0010-aws-property-constraints.md)).
@@ -167,7 +169,7 @@ The stack's own `Description`, every `CfnOutput` / `CfnParameter` description, a
 | `AWS::EC2::SecurityGroup`                                                                 | `groupDescription` |
 | `AWS::SNS::Topic`                                                                         | `displayName`      |
 
-`functionCode` is the odd one out: a whole JavaScript body rather than a line of prose, so the policy checks a source file. That is deliberate — it is usually the largest block of free text in a template, and often the only one built from external data, such as a redirect map read at synth. It also means a legitimately non-ASCII string literal in a CloudFront Function — a `€` in a redirect target, a non-Latin `Location` header — moves from a silent bad deploy to a synth failure. `"warn"` is the adoption path, and the right long-term mode if you have one of those: `fields` unions with the built-in registry rather than replacing it, so a built-in entry cannot be dropped from config. Avoid `sanitize` on a function body — substituting a `?` into a string literal rewrites deployed source, which is a behaviour change rather than a cosmetic one.
+`functionCode` is the odd one out: a whole JavaScript body rather than a line of prose. It is in the list because it is usually the largest block of free text in a template, and often the only one built from external data — a redirect map read at synth carries whatever was pasted into it. The cost is a wider blast radius than another `description`: a legitimately non-ASCII string literal in a function — a `€` in a redirect target, a non-Latin `Location` header — becomes a synth failure rather than a silent bad deploy. Run `"warn"` first if that might be you.
 
 That is a seed list, not the whole of CloudFormation — several hundred resource types declare a free-text property. Add the ones you use:
 
@@ -175,13 +177,13 @@ That is a seed list, not the whole of CloudFormation — several hundred resourc
 templateTextPolicy(app, { fields: { "AWS::Custom::Widget": ["notes"] } });
 ```
 
-Keys are CloudFormation resource types; values are **CDK L1 property names** (camelCase — `alarmDescription`, not `AlarmDescription`).
+Keys are CloudFormation resource types; values are **CDK L1 property names** (camelCase — `alarmDescription`, not `AlarmDescription`). `fields` is merged over the built-in registry, never replacing it, so a built-in entry cannot be narrowed away from config.
 
 ### What it does not cover
 
 - Values that resolve to a CloudFormation intrinsic (`Ref`, `Fn::ImportValue`) — the text is not knowable at synth. A `Lazy` that resolves to a plain string **is** checked.
 - Values written through `addPropertyOverride`, or set on a bare `CfnResource`'s `properties`. Both bypass the typed L1 accessor the policy reads.
-- Nested properties such as `DistributionConfig.Comment` and `FunctionConfig.Comment`. CloudFront is covered at `AWS::CloudFront::Function`'s `functionCode` only — the distribution and function `Comment` fields sit inside an object-valued L1 property, so registering `distributionConfig` or a dotted `"distributionConfig.comment"` silently no-ops.
+- Nested properties such as `DistributionConfig.Comment` and `FunctionConfig.Comment` — so CloudFront is covered at `functionCode` only, not wherever a comment can be typed.
 - Resource types and properties not in the table above, until you add them. A property name that does not match an L1 accessor is skipped silently — the same outcome as not listing it.
 
 To check a single value directly rather than a whole tree, use `constraints.validate.templateText` / `constraints.sanitize.templateText` ([catalogue](../../docs/constraints.md)).

--- a/packages/cloudformation/src/policies/template-text-fields.ts
+++ b/packages/cloudformation/src/policies/template-text-fields.ts
@@ -20,8 +20,11 @@ export type TemplateTextFields = Readonly<Record<string, readonly string[]>>;
  * Only top-level scalar properties are listed. Nested paths
  * (`DistributionConfig.Comment`, `HostedZoneConfig.Comment`) need a resolve on
  * the way in and an `addPropertyOverride` on the way out; they are a separate
- * change. A field earns a place here if a consumer can put arbitrary prose in
- * it.
+ * change. A field earns a place here if a consumer can put arbitrary text in
+ * it that CloudFormation stores verbatim — prose in the usual case, but
+ * `AWS::CloudFront::Function`'s `functionCode` is a whole JS body, which is
+ * both the largest free-text field in a typical template and the one most
+ * often fed from external data.
  */
 export const TEMPLATE_TEXT_FIELDS: TemplateTextFields = {
   "AWS::ApiGateway::ApiKey": ["description"],
@@ -29,6 +32,7 @@ export const TEMPLATE_TEXT_FIELDS: TemplateTextFields = {
   "AWS::ApiGateway::RestApi": ["description"],
   "AWS::ApiGateway::Stage": ["description"],
   "AWS::ApiGateway::UsagePlan": ["description"],
+  "AWS::CloudFront::Function": ["functionCode"],
   "AWS::CloudWatch::Alarm": ["alarmDescription"],
   "AWS::CloudWatch::CompositeAlarm": ["alarmDescription"],
   "AWS::EC2::SecurityGroup": ["groupDescription"],

--- a/packages/cloudformation/src/policies/template-text-fields.ts
+++ b/packages/cloudformation/src/policies/template-text-fields.ts
@@ -21,10 +21,7 @@ export type TemplateTextFields = Readonly<Record<string, readonly string[]>>;
  * (`DistributionConfig.Comment`, `HostedZoneConfig.Comment`) need a resolve on
  * the way in and an `addPropertyOverride` on the way out; they are a separate
  * change. A field earns a place here if a consumer can put arbitrary text in
- * it that CloudFormation stores verbatim — prose in the usual case, but
- * `AWS::CloudFront::Function`'s `functionCode` is a whole JS body, which is
- * both the largest free-text field in a typical template and the one most
- * often fed from external data.
+ * it that CloudFormation stores verbatim — usually prose, but not necessarily.
  */
 export const TEMPLATE_TEXT_FIELDS: TemplateTextFields = {
   "AWS::ApiGateway::ApiKey": ["description"],
@@ -32,7 +29,7 @@ export const TEMPLATE_TEXT_FIELDS: TemplateTextFields = {
   "AWS::ApiGateway::RestApi": ["description"],
   "AWS::ApiGateway::Stage": ["description"],
   "AWS::ApiGateway::UsagePlan": ["description"],
-  "AWS::CloudFront::Function": ["functionCode"],
+  "AWS::CloudFront::Function": ["functionCode"], // a whole JS body, not prose
   "AWS::CloudWatch::Alarm": ["alarmDescription"],
   "AWS::CloudWatch::CompositeAlarm": ["alarmDescription"],
   "AWS::EC2::SecurityGroup": ["groupDescription"],

--- a/packages/cloudformation/test/template-text-policy.test.ts
+++ b/packages/cloudformation/test/template-text-policy.test.ts
@@ -10,7 +10,7 @@ import {
   Stack,
 } from "aws-cdk-lib";
 import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
-import { CfnDistribution, CfnFunction } from "aws-cdk-lib/aws-cloudfront";
+import { CfnFunction } from "aws-cdk-lib/aws-cloudfront";
 import type { IConstruct } from "constructs";
 import { Template } from "aws-cdk-lib/assertions";
 import {
@@ -31,12 +31,16 @@ function alarm(scope: Stack, id: string, description: string): Alarm {
   });
 }
 
-/** A CloudFront Function whose inline source carries `code` in a comment. */
-function cloudFrontFunction(scope: Stack, id: string, code: string): CfnFunction {
+/**
+ * A CloudFront Function carrying `text` in one of its two free-text positions:
+ * a comment in the inline source, which the registry reaches, or the nested
+ * `FunctionConfig.Comment`, which it does not.
+ */
+function cloudFrontFunction(scope: Stack, id: string, where: "code" | "comment", text: string) {
   return new CfnFunction(scope, id, {
     name: id,
-    functionCode: `function handler(event) { /* ${code} */ return event.request; }`,
-    functionConfig: { comment: id, runtime: "cloudfront-js-1.0" },
+    functionCode: `function handler(event) { /* ${where === "code" ? text : id} */ return event.request; }`,
+    functionConfig: { comment: where === "comment" ? text : id, runtime: "cloudfront-js-1.0" },
   });
 }
 
@@ -117,14 +121,6 @@ describe("templateTextPolicy — sanitize mode", () => {
     templateTextPolicy(app, { onViolation: "sanitize" });
     app.synth();
     expect(url.description).toBe(CLEAN);
-  });
-
-  it("rewrites a CloudFront Function's inline source through the L1 setter", () => {
-    const { app, stack } = tree();
-    const fn = cloudFrontFunction(stack, "Redirects", DIRTY);
-    templateTextPolicy(app, { onViolation: "sanitize" });
-    app.synth();
-    expect(fn.functionCode).toContain(CLEAN);
   });
 
   it("honours a custom replacement", () => {
@@ -256,23 +252,20 @@ describe("templateTextPolicy — coverage", () => {
 
   it("checks a CloudFront Function's inline source", () => {
     const { app, stack } = tree();
-    cloudFrontFunction(stack, "Redirects", DIRTY);
+    cloudFrontFunction(stack, "Redirects", "code", DIRTY);
     templateTextPolicy(app);
     expect(() => app.synth()).toThrow("AWS::CloudFront::Function functionCode contains");
   });
 
-  it("leaves a nested Comment unchecked, CloudFront being covered at functionCode only", () => {
+  it("cannot reach a nested Comment, even on a registered type, even if asked to", () => {
     const { app, stack } = tree();
-    new CfnDistribution(stack, "Cdn", {
-      distributionConfig: {
-        enabled: false,
-        comment: DIRTY,
-        defaultCacheBehavior: { targetOriginId: "origin", viewerProtocolPolicy: "https-only" },
-      },
+    cloudFrontFunction(stack, "Redirects", "comment", DIRTY);
+    templateTextPolicy(app, {
+      fields: { "AWS::CloudFront::Function": ["functionConfig.comment"] },
     });
-    templateTextPolicy(app);
-    // `distributionConfig` is object-valued, so the comment sits behind a
-    // nested path the registry cannot reach — the boundary the README states.
+    // `functionConfig` is object-valued, so its `Comment` sits behind a nested
+    // path no property name reaches — registering the dotted path no-ops
+    // rather than erroring. CloudFront is covered at `functionCode` only.
     expect(() => app.synth()).not.toThrow();
   });
 

--- a/packages/cloudformation/test/template-text-policy.test.ts
+++ b/packages/cloudformation/test/template-text-policy.test.ts
@@ -10,6 +10,7 @@ import {
   Stack,
 } from "aws-cdk-lib";
 import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnDistribution, CfnFunction } from "aws-cdk-lib/aws-cloudfront";
 import type { IConstruct } from "constructs";
 import { Template } from "aws-cdk-lib/assertions";
 import {
@@ -27,6 +28,15 @@ function alarm(scope: Stack, id: string, description: string): Alarm {
     threshold: 1,
     evaluationPeriods: 1,
     alarmDescription: description,
+  });
+}
+
+/** A CloudFront Function whose inline source carries `code` in a comment. */
+function cloudFrontFunction(scope: Stack, id: string, code: string): CfnFunction {
+  return new CfnFunction(scope, id, {
+    name: id,
+    functionCode: `function handler(event) { /* ${code} */ return event.request; }`,
+    functionConfig: { comment: id, runtime: "cloudfront-js-1.0" },
   });
 }
 
@@ -107,6 +117,14 @@ describe("templateTextPolicy — sanitize mode", () => {
     templateTextPolicy(app, { onViolation: "sanitize" });
     app.synth();
     expect(url.description).toBe(CLEAN);
+  });
+
+  it("rewrites a CloudFront Function's inline source through the L1 setter", () => {
+    const { app, stack } = tree();
+    const fn = cloudFrontFunction(stack, "Redirects", DIRTY);
+    templateTextPolicy(app, { onViolation: "sanitize" });
+    app.synth();
+    expect(fn.functionCode).toContain(CLEAN);
   });
 
   it("honours a custom replacement", () => {
@@ -233,6 +251,28 @@ describe("templateTextPolicy — coverage", () => {
     const { app, stack } = tree();
     alarm(stack, "Alarm", Fn.importValue("SomeExport"));
     templateTextPolicy(app);
+    expect(() => app.synth()).not.toThrow();
+  });
+
+  it("checks a CloudFront Function's inline source", () => {
+    const { app, stack } = tree();
+    cloudFrontFunction(stack, "Redirects", DIRTY);
+    templateTextPolicy(app);
+    expect(() => app.synth()).toThrow("AWS::CloudFront::Function functionCode contains");
+  });
+
+  it("leaves a nested Comment unchecked, CloudFront being covered at functionCode only", () => {
+    const { app, stack } = tree();
+    new CfnDistribution(stack, "Cdn", {
+      distributionConfig: {
+        enabled: false,
+        comment: DIRTY,
+        defaultCacheBehavior: { targetOriginId: "origin", viewerProtocolPolicy: "https-only" },
+      },
+    });
+    templateTextPolicy(app);
+    // `distributionConfig` is object-valued, so the comment sits behind a
+    // nested path the registry cannot reach — the boundary the README states.
     expect(() => app.synth()).not.toThrow();
   });
 


### PR DESCRIPTION
## What & why

Closes #414.

Adds one entry to `TEMPLATE_TEXT_FIELDS`:

```ts
"AWS::CloudFront::Function": ["functionCode"], // a whole JS body, not prose
```

`functionCode` is a top-level L1 property the registry can already reach — `CfnFunction` exposes it directly and `FunctionCode.fromInline()` renders a token-free string, so `concrete()` returns it as-is with no nested-path resolve and no `addPropertyOverride`. It is the "one line in `TEMPLATE_TEXT_FIELDS`" case ADR-0017's consequences describe, not the separate change the registry docstring reserves for nested paths. It is also usually the largest body of free text in a template and often the only one built from external data (a redirect map JSON-stringified into the body at synth), plus hand-written comments — where an em dash or a curly quote gets typed without thinking. Uncovered, such a character surfaced only as "this stack isn't pure ASCII" from a whole-template test, naming neither field nor code point.

**The trade, made deliberately.** The policy now checks a whole JS source file, so anyone with a legitimately non-ASCII string literal in a CloudFront Function moves from a silent bad deploy to a synth failure — a wider blast radius than another `description` entry. That is the intended trade under ADR-0017 §2, with `warn` as the documented adoption path.

`sanitize` is the mode that needed a warning rather than a mention: substituting `?` into a string literal rewrites deployed source, which is a behaviour change and not a tidier template. That caveat is filed under **Modes**, where the mode is chosen, since a reader picking `sanitize` off that table for a large estate would never reach a note buried in the coverage section.

**Coverage honesty.** The nested `DistributionConfig.Comment` and `FunctionConfig.Comment` fields remain unreachable, so "What it does not cover" now says CloudFront is covered at `functionCode` only — otherwise "CloudFront is covered" reads as whole. A test pins that: it puts the dirty character in `FunctionConfig.Comment` on a *registered* type and registers the dotted `"functionConfig.comment"` path explicitly, showing it no-ops rather than errors.

No ADR. ADR-0017 already records that a newly-discovered field is one line in the registry, and AGENTS.md reserves ADRs for decisions that change the library's shape; ADR-0017's own account of `sanitize` is left alone because ADRs here are append-only. `TEMPLATE_TEXT_FIELDS` stays unexported, so the registry's shape remains changeable without a breaking release.

### Verification

Checked against the package's declared `aws-cdk-lib` floor: `CfnFunction.functionCode` exists at 2.1.0 (as a plain field there, a getter/setter pair today — the policy reads and writes both fine), and `name` is the only required prop, so the test fixture holds at the floor. The library's own inline CloudFront Function (`static-website`) is ASCII-clean and already guarded by `packages/examples/test/ascii-templates.test.ts`, so no example changes behaviour.

Also ran a quality pass over the change (second commit): dropped a sanitize-mode test that re-proved a field-agnostic write-back already pinned three times, and rewrote the nested-`Comment` test, which had used an *unregistered* `CfnDistribution` and so passed for the same reason as the existing "ignores resource types outside the registry" case — proving nothing about nesting.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change
- [x] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

---
_Generated by [Claude Code](https://claude.ai/code/session_011FziK9nvGshtrkes8aYG9o)_