### PR TITLE
feat(cloudformation): check AWS::CloudFront::KeyValueStore comment by default

### DIFF
--- a/packages/cloudformation/README.md
+++ b/packages/cloudformation/README.md
@@ -162,6 +162,7 @@ The stack's own `Description`, every `CfnOutput` / `CfnParameter` description, a
 | Resource type                                                                             | Property           |
 | ----------------------------------------------------------------------------------------- | ------------------ |
 | `AWS::CloudFront::Function`                                                               | `functionCode`     |
+| `AWS::CloudFront::KeyValueStore`                                                          | `comment`          |
 | `AWS::CloudWatch::Alarm`, `AWS::CloudWatch::CompositeAlarm`                               | `alarmDescription` |
 | `AWS::Lambda::Function`, `AWS::Events::Rule`, `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` | `description`      |
 | `AWS::ApiGateway::RestApi`, `Stage`, `Deployment`, `UsagePlan`, `ApiKey`                  | `description`      |
@@ -183,7 +184,7 @@ Keys are CloudFormation resource types; values are **CDK L1 property names** (ca
 
 - Values that resolve to a CloudFormation intrinsic (`Ref`, `Fn::ImportValue`) — the text is not knowable at synth. A `Lazy` that resolves to a plain string **is** checked.
 - Values written through `addPropertyOverride`, or set on a bare `CfnResource`'s `properties`. Both bypass the typed L1 accessor the policy reads.
-- Nested properties such as `DistributionConfig.Comment` and `FunctionConfig.Comment` — so CloudFront is covered at `functionCode` only, not wherever a comment can be typed.
+- Nested properties such as `DistributionConfig.Comment` and `FunctionConfig.Comment`. The two CloudFront rows above are the whole of what is reachable in that service — every other free-text field it declares sits behind a `*Config` object — so CloudFront is covered where the registry can see, not wherever a comment can be typed.
 - Resource types and properties not in the table above, until you add them. A property name that does not match an L1 accessor is skipped silently — the same outcome as not listing it.
 
 To check a single value directly rather than a whole tree, use `constraints.validate.templateText` / `constraints.sanitize.templateText` ([catalogue](../../docs/constraints.md)).

--- a/packages/cloudformation/src/policies/template-text-fields.ts
+++ b/packages/cloudformation/src/policies/template-text-fields.ts
@@ -30,6 +30,7 @@ export const TEMPLATE_TEXT_FIELDS: TemplateTextFields = {
   "AWS::ApiGateway::Stage": ["description"],
   "AWS::ApiGateway::UsagePlan": ["description"],
   "AWS::CloudFront::Function": ["functionCode"], // a whole JS body, not prose
+  "AWS::CloudFront::KeyValueStore": ["comment"],
   "AWS::CloudWatch::Alarm": ["alarmDescription"],
   "AWS::CloudWatch::CompositeAlarm": ["alarmDescription"],
   "AWS::EC2::SecurityGroup": ["groupDescription"],

--- a/packages/cloudformation/test/template-text-policy.test.ts
+++ b/packages/cloudformation/test/template-text-policy.test.ts
@@ -257,6 +257,21 @@ describe("templateTextPolicy — coverage", () => {
     expect(() => app.synth()).toThrow("AWS::CloudFront::Function functionCode contains");
   });
 
+  it("checks a CloudFront KeyValueStore comment", () => {
+    const { app, stack } = tree();
+    // Stubbed rather than built from `CfnKeyValueStore`: that L1 does not exist
+    // at this package's 2.1.0 floor (absent at 2.110.0, present by 2.124.0,
+    // which is where @composurecdk/cloudfront floors), and the floor shard runs
+    // this suite. The policy reads `cfnResourceType` then the property off the
+    // instance, which is exactly what this stands in for.
+    const store = new CfnResource(stack, "Redirects", {
+      type: "AWS::CloudFront::KeyValueStore",
+    });
+    (store as unknown as Record<string, unknown>).comment = DIRTY;
+    templateTextPolicy(app);
+    expect(() => app.synth()).toThrow("AWS::CloudFront::KeyValueStore comment contains");
+  });
+
   it("cannot reach a nested Comment, even on a registered type, even if asked to", () => {
     const { app, stack } = tree();
     cloudFrontFunction(stack, "Redirects", "comment", DIRTY);


### PR DESCRIPTION
## What & why

Closes #416.

Adds one entry to `TEMPLATE_TEXT_FIELDS`:

```ts
"AWS::CloudFront::KeyValueStore": ["comment"],
```

`comment` is a top-level L1 property the registry can already reach — `CfnKeyValueStore` exposes it directly, set from a plain literal via the L2's `comment` prop, so `concrete()` returns it as-is with no nested-path resolve and no `addPropertyOverride`. It is the "one line in `TEMPLATE_TEXT_FIELDS`" case ADR-0017's consequences describe.

**No trade to weigh this time.** #415 needed a paragraph about blast radius because `functionCode` is executable source. `Comment` is a human-readable label and nothing else, so there is no class of consumer holding a legitimately non-ASCII value that would move from a working deploy to a synth failure. It is the ordinary case the registry docstring describes — a field a consumer can put arbitrary prose in — and being prose is exactly what makes it likely to break: it attracts the arrow between the old and new shape of a mapping, and the em dash before an aside. The one I hit had both.

**Coverage honesty.** This completes the reachable CloudFront surface, so the "What it does not cover" bullet no longer names `functionCode` alone. I enumerated the top-level `comment` / `description` / `displayName` accessors across all 20 `Cfn*` classes in `aws-cloudfront/lib/cloudfront.generated.d.ts`: `functionCode` and `KeyValueStore.comment` are the only top-level free text in the service. Everything else sits behind a `*Config` object — `DistributionConfig.Comment`, `FunctionConfig.Comment`, `CachePolicyConfig.Comment`, `OriginRequestPolicyConfig.Comment`, `ResponseHeadersPolicyConfig.Comment`, `PublicKeyConfig.Comment`, `KeyGroupConfig.Comment`, `OriginAccessControlConfig.Description`. The existing nested-`Comment` test already pins that boundary, so it needed no change.

No ADR, per ADR-0017 and AGENTS.md: a newly-discovered field is one line in the registry, not a decision that changes the library's shape. `TEMPLATE_TEXT_FIELDS` stays unexported.

### Verification

**The floor is the interesting part of this one.** `CfnKeyValueStore` does **not** exist at this package's declared 2.1.0 floor, so the test stubs the resource from a bare `CfnResource` and assigns `comment` onto the instance — the same idiom the neighbouring "checks a consumer-supplied field" and "ignores resource types outside the registry" tests already use. The policy reads `cfnResourceType` and then the property off the instance, which is exactly what the stub stands in for, and the registry entry itself is a plain string key needing no symbol at all.

Checked against real installs rather than assumed:

| aws-cdk-lib | `CfnFunction` | `CfnKeyValueStore` |
| --- | --- | --- |
| 2.1.0 (this package's floor) | present | **absent** |
| 2.110.0 | present | **absent** |
| 2.124.0 (where `cloudfront` floors) | present | present |

The diff adds no import, and every symbol the suite already pulls from `aws-cdk-lib` was confirmed present at a real 2.1.0 install.

- `npm run verify` passes locally (exit 0, all nine gates including `actionlint` and `cdk-floors:check`).
- `npm run cdk-floors:enforce 2.1.0 --force` passes — the suite runs green against a real aws-cdk-lib 2.1.0 install, and the workspace restored with `package-lock.json` byte-identical.
- The new test was run in isolation to confirm it actually executes and fails for the right reason, rather than passing vacuously.

## Checklist

- [x] Linked to an issue (or it's a small, obvious fix)
- [x] `npm run verify` passes locally
- [x] Tests added/updated for the change
- [x] If it adds an example stack: registered, listed in the examples README, and covered by a smoke test that exercises its runtime behaviour — n/a, no example stack

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5wE28t4rxcLyQpMwGLwTu)_